### PR TITLE
records: CMS 2011 MC generator information

### DIFF
--- a/cernopendata/jsonschemas/records/record-v1.0.0.json
+++ b/cernopendata/jsonschemas/records/record-v1.0.0.json
@@ -233,22 +233,6 @@
       "description": "The name of the experiment the author is part of",
       "type": "string"
     },
-    "generator": {
-      "properties": {
-        "global_tag": {
-          "description": "The global tag for the generator",
-          "type": "string"
-        },
-        "names": {
-          "items": {
-            "description": "The names of the generator",
-            "type": "string"
-          },
-          "type": "array"
-        }
-      },
-      "type": "object"
-    },
     "keywords": {
       "items": {
         "description": "Relevant keywords for the record",

--- a/cernopendata/modules/fixtures/data/records/cms-simulated-datasets-Run2011A.json
+++ b/cernopendata/modules/fixtures/data/records/cms-simulated-datasets-Run2011A.json
@@ -63,13 +63,6 @@
         "uri": "root://eospublic.cern.ch//eos/opendata/cms/MonteCarlo2011/Summer11LegDR/GluGluToHToZZTo4L_M-550_7TeV-minloHJJ-pythia6-tauola/AODSIM/PU_S13_START53_LV6-v1/file-indexes/CMS_MonteCarlo2011_Summer11LegDR_GluGluToHToZZTo4L_M-550_7TeV-minloHJJ-pythia6-tauola_AODSIM_PU_S13_START53_LV6-v1_30000_file_index.txt"
       }
     ],
-    "generator": {
-      "global_tag": "START53_LV6",
-      "names": [
-        "pythia6",
-        "powheg-minlo"
-      ]
-    },
     "license": {
       "attribution": "CC0"
     },
@@ -97,6 +90,10 @@
               "recid": "3051",
               "title": "Configuration file for SIM step HIG-Summer11Leg-00197_1_cfg.py"
             }
+          ],
+          "generators": [
+            "pythia6",
+            "powheg-minlo"
           ],
           "global_tag": "START53_LV4::All",
           "output_dataset": "/GluGluToHToZZTo4L_M-550_7TeV-minloHJJ-pythia6-tauola/Summer11Leg-START53_LV4-v1/GEN-SIM",
@@ -218,13 +215,6 @@
         "uri": "root://eospublic.cern.ch//eos/opendata/cms/MonteCarlo2011/Summer11LegDR/GluGluToHToZZTo4L_M-550_7TeV-powheg15-pythia6/AODSIM/PU_S13_START53_LV6-v1/file-indexes/CMS_MonteCarlo2011_Summer11LegDR_GluGluToHToZZTo4L_M-550_7TeV-powheg15-pythia6_AODSIM_PU_S13_START53_LV6-v1_20000_file_index.txt"
       }
     ],
-    "generator": {
-      "global_tag": "START53_LV6",
-      "names": [
-        "powheg15",
-        "pythia6"
-      ]
-    },
     "license": {
       "attribution": "CC0"
     },
@@ -252,6 +242,10 @@
               "recid": "3229",
               "title": "Configuration file for SIM step HIG-Summer11Leg-00328_1_cfg.py"
             }
+          ],
+          "generators": [
+            "powheg15",
+            "pythia6"
           ],
           "global_tag": "START53_LV4::All",
           "output_dataset": "/GluGluToHToZZTo4L_M-550_7TeV-powheg15-pythia6/Summer11Leg-START53_LV4-v1/GEN-SIM",
@@ -385,13 +379,6 @@
         "uri": "root://eospublic.cern.ch//eos/opendata/cms/MonteCarlo2011/Summer11LegDR/VBFToHToZZTo2L2Nu_M-300_7TeV-powheg15-pythia6/AODSIM/PU_S13_START53_LV6-v1/file-indexes/CMS_MonteCarlo2011_Summer11LegDR_VBFToHToZZTo2L2Nu_M-300_7TeV-powheg15-pythia6_AODSIM_PU_S13_START53_LV6-v1_010000_file_index.txt"
       }
     ],
-    "generator": {
-      "global_tag": "START53_LV6",
-      "names": [
-        "powheg15",
-        "pythia6"
-      ]
-    },
     "license": {
       "attribution": "CC0"
     },
@@ -419,6 +406,10 @@
               "recid": "3118",
               "title": "Configuration file for SIM step HIG-Summer11Leg-00057_1_cfg.py"
             }
+          ],
+          "generators": [
+            "powheg15",
+            "pythia6"
           ],
           "global_tag": "START53_LV4::All",
           "output_dataset": "/VBFToHToZZTo2L2Nu_M-300_7TeV-powheg15-pythia6/Summer11Leg-START53_LV4-v2/GEN-SIM",
@@ -552,13 +543,6 @@
         "uri": "root://eospublic.cern.ch//eos/opendata/cms/MonteCarlo2011/Summer11LegDR/VBFToHToZZTo2L2Nu_M-350_7TeV-powheg15-pythia6/AODSIM/PU_S13_START53_LV6-v1/file-indexes/CMS_MonteCarlo2011_Summer11LegDR_VBFToHToZZTo2L2Nu_M-350_7TeV-powheg15-pythia6_AODSIM_PU_S13_START53_LV6-v1_010000_file_index.txt"
       }
     ],
-    "generator": {
-      "global_tag": "START53_LV6",
-      "names": [
-        "powheg15",
-        "pythia6"
-      ]
-    },
     "license": {
       "attribution": "CC0"
     },
@@ -586,6 +570,10 @@
               "recid": "3118",
               "title": "Configuration file for SIM step HIG-Summer11Leg-00057_1_cfg.py"
             }
+          ],
+          "generators": [
+            "powheg15",
+            "pythia6"
           ],
           "global_tag": "START53_LV4::All",
           "output_dataset": "/VBFToHToZZTo2L2Nu_M-350_7TeV-powheg15-pythia6/Summer11Leg-START53_LV4-v3/GEN-SIM",
@@ -707,13 +695,6 @@
         "uri": "root://eospublic.cern.ch//eos/opendata/cms/MonteCarlo2011/Summer11LegDR/VBFToHToZZTo2L2Nu_M-225_7TeV-powheg15-pythia6/AODSIM/PU_S13_START53_LV6-v1/file-indexes/CMS_MonteCarlo2011_Summer11LegDR_VBFToHToZZTo2L2Nu_M-225_7TeV-powheg15-pythia6_AODSIM_PU_S13_START53_LV6-v1_00000_file_index.txt"
       }
     ],
-    "generator": {
-      "global_tag": "START53_LV6",
-      "names": [
-        "powheg15",
-        "pythia6"
-      ]
-    },
     "license": {
       "attribution": "CC0"
     },
@@ -741,6 +722,10 @@
               "recid": "3118",
               "title": "Configuration file for SIM step HIG-Summer11Leg-00057_1_cfg.py"
             }
+          ],
+          "generators": [
+            "powheg15",
+            "pythia6"
           ],
           "global_tag": "START53_LV4::All",
           "output_dataset": "/VBFToHToZZTo2L2Nu_M-225_7TeV-powheg15-pythia6/Summer11Leg-START53_LV4-v3/GEN-SIM",
@@ -874,13 +859,6 @@
         "uri": "root://eospublic.cern.ch//eos/opendata/cms/MonteCarlo2011/Summer11LegDR/GluGluToHToZZTo4L_M-600_7TeV-minloHJJ-pythia6-tauola/AODSIM/PU_S13_START53_LV6-v1/file-indexes/CMS_MonteCarlo2011_Summer11LegDR_GluGluToHToZZTo4L_M-600_7TeV-minloHJJ-pythia6-tauola_AODSIM_PU_S13_START53_LV6-v1_30000_file_index.txt"
       }
     ],
-    "generator": {
-      "global_tag": "START53_LV6",
-      "names": [
-        "pythia6",
-        "powheg-minlo"
-      ]
-    },
     "license": {
       "attribution": "CC0"
     },
@@ -908,6 +886,10 @@
               "recid": "3051",
               "title": "Configuration file for SIM step HIG-Summer11Leg-00197_1_cfg.py"
             }
+          ],
+          "generators": [
+            "pythia6",
+            "powheg-minlo"
           ],
           "global_tag": "START53_LV4::All",
           "output_dataset": "/GluGluToHToZZTo4L_M-600_7TeV-minloHJJ-pythia6-tauola/Summer11Leg-START53_LV4-v2/GEN-SIM",
@@ -1041,13 +1023,6 @@
         "uri": "root://eospublic.cern.ch//eos/opendata/cms/MonteCarlo2011/Summer11LegDR/GluGluToHToZZTo4L_M-600_7TeV-powheg15-pythia6/AODSIM/PU_S13_START53_LV6-v1/file-indexes/CMS_MonteCarlo2011_Summer11LegDR_GluGluToHToZZTo4L_M-600_7TeV-powheg15-pythia6_AODSIM_PU_S13_START53_LV6-v1_30000_file_index.txt"
       }
     ],
-    "generator": {
-      "global_tag": "START53_LV6",
-      "names": [
-        "powheg15",
-        "pythia6"
-      ]
-    },
     "license": {
       "attribution": "CC0"
     },
@@ -1075,6 +1050,10 @@
               "recid": "3229",
               "title": "Configuration file for SIM step HIG-Summer11Leg-00328_1_cfg.py"
             }
+          ],
+          "generators": [
+            "powheg15",
+            "pythia6"
           ],
           "global_tag": "START53_LV4::All",
           "output_dataset": "/GluGluToHToZZTo4L_M-600_7TeV-powheg15-pythia6/Summer11Leg-START53_LV4-v1/GEN-SIM",
@@ -1208,13 +1187,6 @@
         "uri": "root://eospublic.cern.ch//eos/opendata/cms/MonteCarlo2011/Summer11LegDR/VBFToHToZZTo2L2Nu_M-400_7TeV-powheg15-pythia6/AODSIM/PU_S13_START53_LV6-v1/file-indexes/CMS_MonteCarlo2011_Summer11LegDR_VBFToHToZZTo2L2Nu_M-400_7TeV-powheg15-pythia6_AODSIM_PU_S13_START53_LV6-v1_010000_file_index.txt"
       }
     ],
-    "generator": {
-      "global_tag": "START53_LV6",
-      "names": [
-        "powheg15",
-        "pythia6"
-      ]
-    },
     "license": {
       "attribution": "CC0"
     },
@@ -1242,6 +1214,10 @@
               "recid": "3118",
               "title": "Configuration file for SIM step HIG-Summer11Leg-00057_1_cfg.py"
             }
+          ],
+          "generators": [
+            "powheg15",
+            "pythia6"
           ],
           "global_tag": "START53_LV4::All",
           "output_dataset": "/VBFToHToZZTo2L2Nu_M-400_7TeV-powheg15-pythia6/Summer11Leg-START53_LV4-v2/GEN-SIM",
@@ -1363,12 +1339,6 @@
         "uri": "root://eospublic.cern.ch//eos/opendata/cms/MonteCarlo2011/Summer11LegDR/ZZJetsTo2L2Q_TuneZ2_7TeV-madgraph-tauola/AODSIM/PU_S13_START53_LV6-v2/file-indexes/CMS_MonteCarlo2011_Summer11LegDR_ZZJetsTo2L2Q_TuneZ2_7TeV-madgraph-tauola_AODSIM_PU_S13_START53_LV6-v2_00000_file_index.txt"
       }
     ],
-    "generator": {
-      "global_tag": "START53_LV6",
-      "names": [
-        "madgraph"
-      ]
-    },
     "license": {
       "attribution": "CC0"
     },
@@ -1396,6 +1366,9 @@
               "recid": "3020",
               "title": "Configuration file for SIM step HIG-Summer11Leg-00010_1_cfg.py"
             }
+          ],
+          "generators": [
+            "madgraph"
           ],
           "global_tag": "START53_LV4::All",
           "output_dataset": "/ZZJetsTo2L2Q_TuneZ2_7TeV-madgraph-tauola/Summer11Leg-START53_LV4-v2/GEN-SIM",
@@ -1529,12 +1502,6 @@
         "uri": "root://eospublic.cern.ch//eos/opendata/cms/MonteCarlo2011/Summer11LegDR/ZZJetsTo2L2Nu_TuneZ2_7TeV-madgraph-tauola/AODSIM/PU_S13_START53_LV6-v1/file-indexes/CMS_MonteCarlo2011_Summer11LegDR_ZZJetsTo2L2Nu_TuneZ2_7TeV-madgraph-tauola_AODSIM_PU_S13_START53_LV6-v1_020000_file_index.txt"
       }
     ],
-    "generator": {
-      "global_tag": "START53_LV6",
-      "names": [
-        "madgraph"
-      ]
-    },
     "license": {
       "attribution": "CC0"
     },
@@ -1562,6 +1529,9 @@
               "recid": "3164",
               "title": "Configuration file for SIM step HIG-Summer11Leg-00011_1_cfg.py"
             }
+          ],
+          "generators": [
+            "madgraph"
           ],
           "global_tag": "START53_LV4::All",
           "output_dataset": "/ZZJetsTo2L2Nu_TuneZ2_7TeV-madgraph-tauola/Summer11Leg-START53_LV4-v2/GEN-SIM",
@@ -1695,13 +1665,6 @@
         "uri": "root://eospublic.cern.ch//eos/opendata/cms/MonteCarlo2011/Summer11LegDR/GluGluToHToZZTo4L_M-650_7TeV-minloHJJ-pythia6-tauola/AODSIM/PU_S13_START53_LV6-v1/file-indexes/CMS_MonteCarlo2011_Summer11LegDR_GluGluToHToZZTo4L_M-650_7TeV-minloHJJ-pythia6-tauola_AODSIM_PU_S13_START53_LV6-v1_410000_file_index.txt"
       }
     ],
-    "generator": {
-      "global_tag": "START53_LV6",
-      "names": [
-        "pythia6",
-        "powheg-minlo"
-      ]
-    },
     "license": {
       "attribution": "CC0"
     },
@@ -1729,6 +1692,10 @@
               "recid": "3051",
               "title": "Configuration file for SIM step HIG-Summer11Leg-00197_1_cfg.py"
             }
+          ],
+          "generators": [
+            "pythia6",
+            "powheg-minlo"
           ],
           "global_tag": "START53_LV4::All",
           "output_dataset": "/GluGluToHToZZTo4L_M-650_7TeV-minloHJJ-pythia6-tauola/Summer11Leg-START53_LV4-v1/GEN-SIM",
@@ -1874,13 +1841,6 @@
         "uri": "root://eospublic.cern.ch//eos/opendata/cms/MonteCarlo2011/Summer11LegDR/GluGluToHToZZTo4L_M-650_7TeV-powheg15-pythia6/AODSIM/PU_S13_START53_LV6-v1/file-indexes/CMS_MonteCarlo2011_Summer11LegDR_GluGluToHToZZTo4L_M-650_7TeV-powheg15-pythia6_AODSIM_PU_S13_START53_LV6-v1_40000_file_index.txt"
       }
     ],
-    "generator": {
-      "global_tag": "START53_LV6",
-      "names": [
-        "powheg15",
-        "pythia6"
-      ]
-    },
     "license": {
       "attribution": "CC0"
     },
@@ -1908,6 +1868,10 @@
               "recid": "3229",
               "title": "Configuration file for SIM step HIG-Summer11Leg-00328_1_cfg.py"
             }
+          ],
+          "generators": [
+            "powheg15",
+            "pythia6"
           ],
           "global_tag": "START53_LV4::All",
           "output_dataset": "/GluGluToHToZZTo4L_M-650_7TeV-powheg15-pythia6/Summer11Leg-START53_LV4-v1/GEN-SIM",
@@ -2029,13 +1993,6 @@
         "uri": "root://eospublic.cern.ch//eos/opendata/cms/MonteCarlo2011/Summer11LegDR/GluGluToHToZZTo4L_M-700_7TeV-minloHJJ-pythia6-tauola/AODSIM/PU_S13_START53_LV6-v2/file-indexes/CMS_MonteCarlo2011_Summer11LegDR_GluGluToHToZZTo4L_M-700_7TeV-minloHJJ-pythia6-tauola_AODSIM_PU_S13_START53_LV6-v2_40000_file_index.txt"
       }
     ],
-    "generator": {
-      "global_tag": "START53_LV6",
-      "names": [
-        "pythia6",
-        "powheg-minlo"
-      ]
-    },
     "license": {
       "attribution": "CC0"
     },
@@ -2063,6 +2020,10 @@
               "recid": "3051",
               "title": "Configuration file for SIM step HIG-Summer11Leg-00197_1_cfg.py"
             }
+          ],
+          "generators": [
+            "pythia6",
+            "powheg-minlo"
           ],
           "global_tag": "START53_LV4::All",
           "output_dataset": "/GluGluToHToZZTo4L_M-700_7TeV-minloHJJ-pythia6-tauola/Summer11Leg-START53_LV4-v1/GEN-SIM",
@@ -2208,13 +2169,6 @@
         "uri": "root://eospublic.cern.ch//eos/opendata/cms/MonteCarlo2011/Summer11LegDR/GluGluToHToZZTo4L_M-700_7TeV-powheg15-pythia6/AODSIM/PU_S13_START53_LV6-v1/file-indexes/CMS_MonteCarlo2011_Summer11LegDR_GluGluToHToZZTo4L_M-700_7TeV-powheg15-pythia6_AODSIM_PU_S13_START53_LV6-v1_20000_file_index.txt"
       }
     ],
-    "generator": {
-      "global_tag": "START53_LV6",
-      "names": [
-        "powheg15",
-        "pythia6"
-      ]
-    },
     "license": {
       "attribution": "CC0"
     },
@@ -2242,6 +2196,10 @@
               "recid": "3229",
               "title": "Configuration file for SIM step HIG-Summer11Leg-00328_1_cfg.py"
             }
+          ],
+          "generators": [
+            "powheg15",
+            "pythia6"
           ],
           "global_tag": "START53_LV4::All",
           "output_dataset": "/GluGluToHToZZTo4L_M-700_7TeV-powheg15-pythia6/Summer11Leg-START53_LV4-v1/GEN-SIM",
@@ -2375,13 +2333,6 @@
         "uri": "root://eospublic.cern.ch//eos/opendata/cms/MonteCarlo2011/Summer11LegDR/GluGluToHToZZTo4L_M-750_7TeV-minloHJJ-pythia6-tauola/AODSIM/PU_S13_START53_LV6-v1/file-indexes/CMS_MonteCarlo2011_Summer11LegDR_GluGluToHToZZTo4L_M-750_7TeV-minloHJJ-pythia6-tauola_AODSIM_PU_S13_START53_LV6-v1_40000_file_index.txt"
       }
     ],
-    "generator": {
-      "global_tag": "START53_LV6",
-      "names": [
-        "pythia6",
-        "powheg-minlo"
-      ]
-    },
     "license": {
       "attribution": "CC0"
     },
@@ -2409,6 +2360,10 @@
               "recid": "3051",
               "title": "Configuration file for SIM step HIG-Summer11Leg-00197_1_cfg.py"
             }
+          ],
+          "generators": [
+            "pythia6",
+            "powheg-minlo"
           ],
           "global_tag": "START53_LV4::All",
           "output_dataset": "/GluGluToHToZZTo4L_M-750_7TeV-minloHJJ-pythia6-tauola/Summer11Leg-START53_LV4-v1/GEN-SIM",
@@ -2542,13 +2497,6 @@
         "uri": "root://eospublic.cern.ch//eos/opendata/cms/MonteCarlo2011/Summer11LegDR/GluGluToHToZZTo4L_M-800_7TeV-minloHJJ-pythia6-tauola/AODSIM/PU_S13_START53_LV6-v1/file-indexes/CMS_MonteCarlo2011_Summer11LegDR_GluGluToHToZZTo4L_M-800_7TeV-minloHJJ-pythia6-tauola_AODSIM_PU_S13_START53_LV6-v1_30000_file_index.txt"
       }
     ],
-    "generator": {
-      "global_tag": "START53_LV6",
-      "names": [
-        "pythia6",
-        "powheg-minlo"
-      ]
-    },
     "license": {
       "attribution": "CC0"
     },
@@ -2576,6 +2524,10 @@
               "recid": "3051",
               "title": "Configuration file for SIM step HIG-Summer11Leg-00197_1_cfg.py"
             }
+          ],
+          "generators": [
+            "pythia6",
+            "powheg-minlo"
           ],
           "global_tag": "START53_LV4::All",
           "output_dataset": "/GluGluToHToZZTo4L_M-800_7TeV-minloHJJ-pythia6-tauola/Summer11Leg-START53_LV4-v1/GEN-SIM",
@@ -2709,13 +2661,6 @@
         "uri": "root://eospublic.cern.ch//eos/opendata/cms/MonteCarlo2011/Summer11LegDR/GluGluToHToZZTo4L_M-800_7TeV-powheg15-pythia6/AODSIM/PU_S13_START53_LV6-v1/file-indexes/CMS_MonteCarlo2011_Summer11LegDR_GluGluToHToZZTo4L_M-800_7TeV-powheg15-pythia6_AODSIM_PU_S13_START53_LV6-v1_40000_file_index.txt"
       }
     ],
-    "generator": {
-      "global_tag": "START53_LV6",
-      "names": [
-        "powheg15",
-        "pythia6"
-      ]
-    },
     "license": {
       "attribution": "CC0"
     },
@@ -2743,6 +2688,10 @@
               "recid": "3229",
               "title": "Configuration file for SIM step HIG-Summer11Leg-00328_1_cfg.py"
             }
+          ],
+          "generators": [
+            "powheg15",
+            "pythia6"
           ],
           "global_tag": "START53_LV4::All",
           "output_dataset": "/GluGluToHToZZTo4L_M-800_7TeV-powheg15-pythia6/Summer11Leg-START53_LV4-v1/GEN-SIM",
@@ -2864,13 +2813,6 @@
         "uri": "root://eospublic.cern.ch//eos/opendata/cms/MonteCarlo2011/Summer11LegDR/GluGluToHToZZTo4L_M-850_7TeV-minloHJJ-pythia6-tauola/AODSIM/PU_S13_START53_LV6-v1/file-indexes/CMS_MonteCarlo2011_Summer11LegDR_GluGluToHToZZTo4L_M-850_7TeV-minloHJJ-pythia6-tauola_AODSIM_PU_S13_START53_LV6-v1_410000_file_index.txt"
       }
     ],
-    "generator": {
-      "global_tag": "START53_LV6",
-      "names": [
-        "pythia6",
-        "powheg-minlo"
-      ]
-    },
     "license": {
       "attribution": "CC0"
     },
@@ -2898,6 +2840,10 @@
               "recid": "3051",
               "title": "Configuration file for SIM step HIG-Summer11Leg-00197_1_cfg.py"
             }
+          ],
+          "generators": [
+            "pythia6",
+            "powheg-minlo"
           ],
           "global_tag": "START53_LV4::All",
           "output_dataset": "/GluGluToHToZZTo4L_M-850_7TeV-minloHJJ-pythia6-tauola/Summer11Leg-START53_LV4-v1/GEN-SIM",
@@ -3043,13 +2989,6 @@
         "uri": "root://eospublic.cern.ch//eos/opendata/cms/MonteCarlo2011/Summer11LegDR/GluGluToHToZZTo4L_M-900_7TeV-minloHJJ-pythia6-tauola/AODSIM/PU_S13_START53_LV6-v1/file-indexes/CMS_MonteCarlo2011_Summer11LegDR_GluGluToHToZZTo4L_M-900_7TeV-minloHJJ-pythia6-tauola_AODSIM_PU_S13_START53_LV6-v1_40000_file_index.txt"
       }
     ],
-    "generator": {
-      "global_tag": "START53_LV6",
-      "names": [
-        "pythia6",
-        "powheg-minlo"
-      ]
-    },
     "license": {
       "attribution": "CC0"
     },
@@ -3077,6 +3016,10 @@
               "recid": "3051",
               "title": "Configuration file for SIM step HIG-Summer11Leg-00197_1_cfg.py"
             }
+          ],
+          "generators": [
+            "pythia6",
+            "powheg-minlo"
           ],
           "global_tag": "START53_LV4::All",
           "output_dataset": "/GluGluToHToZZTo4L_M-900_7TeV-minloHJJ-pythia6-tauola/Summer11Leg-START53_LV4-v1/GEN-SIM",
@@ -3222,13 +3165,6 @@
         "uri": "root://eospublic.cern.ch//eos/opendata/cms/MonteCarlo2011/Summer11LegDR/GluGluToHToZZTo4L_M-900_7TeV-powheg15-pythia6/AODSIM/PU_S13_START53_LV6-v1/file-indexes/CMS_MonteCarlo2011_Summer11LegDR_GluGluToHToZZTo4L_M-900_7TeV-powheg15-pythia6_AODSIM_PU_S13_START53_LV6-v1_40000_file_index.txt"
       }
     ],
-    "generator": {
-      "global_tag": "START53_LV6",
-      "names": [
-        "powheg15",
-        "pythia6"
-      ]
-    },
     "license": {
       "attribution": "CC0"
     },
@@ -3256,6 +3192,10 @@
               "recid": "3229",
               "title": "Configuration file for SIM step HIG-Summer11Leg-00328_1_cfg.py"
             }
+          ],
+          "generators": [
+            "powheg15",
+            "pythia6"
           ],
           "global_tag": "START53_LV4::All",
           "output_dataset": "/GluGluToHToZZTo4L_M-900_7TeV-powheg15-pythia6/Summer11Leg-START53_LV4-v1/GEN-SIM",
@@ -3377,13 +3317,6 @@
         "uri": "root://eospublic.cern.ch//eos/opendata/cms/MonteCarlo2011/Summer11LegDR/GluGluToHToZZTo4L_M-950_7TeV-minloHJJ-pythia6-tauola/AODSIM/PU_S13_START53_LV6-v1/file-indexes/CMS_MonteCarlo2011_Summer11LegDR_GluGluToHToZZTo4L_M-950_7TeV-minloHJJ-pythia6-tauola_AODSIM_PU_S13_START53_LV6-v1_00000_file_index.txt"
       }
     ],
-    "generator": {
-      "global_tag": "START53_LV6",
-      "names": [
-        "pythia6",
-        "powheg-minlo"
-      ]
-    },
     "license": {
       "attribution": "CC0"
     },
@@ -3411,6 +3344,10 @@
               "recid": "3051",
               "title": "Configuration file for SIM step HIG-Summer11Leg-00197_1_cfg.py"
             }
+          ],
+          "generators": [
+            "pythia6",
+            "powheg-minlo"
           ],
           "global_tag": "START53_LV4::All",
           "output_dataset": "/GluGluToHToZZTo4L_M-950_7TeV-minloHJJ-pythia6-tauola/Summer11Leg-START53_LV4-v1/GEN-SIM",
@@ -3532,13 +3469,6 @@
         "uri": "root://eospublic.cern.ch//eos/opendata/cms/MonteCarlo2011/Summer11LegDR/Graviton2PH6ToZZTo4L_M-125p6_7TeV-JHUGenV3-pythia6/AODSIM/PU_S13_START53_LV6-v1/file-indexes/CMS_MonteCarlo2011_Summer11LegDR_Graviton2PH6ToZZTo4L_M-125p6_7TeV-JHUGenV3-pythia6_AODSIM_PU_S13_START53_LV6-v1_30000_file_index.txt"
       }
     ],
-    "generator": {
-      "global_tag": "START53_LV6",
-      "names": [
-        "powheg15",
-        "pythia6"
-      ]
-    },
     "license": {
       "attribution": "CC0"
     },
@@ -3566,6 +3496,10 @@
               "recid": "3132",
               "title": "Configuration file for SIM step HIG-Summer11Leg-00151_1_cfg.py"
             }
+          ],
+          "generators": [
+            "powheg15",
+            "pythia6"
           ],
           "global_tag": "START53_LV4::All",
           "output_dataset": "/Graviton2PH6ToZZTo4L_M-125p6_7TeV-JHUGenV3-pythia6/Summer11Leg-START53_LV4-v1/GEN-SIM",
@@ -3699,13 +3633,6 @@
         "uri": "root://eospublic.cern.ch//eos/opendata/cms/MonteCarlo2011/Summer11LegDR/Higgs0MToGGTo4L_M-125p6_7TeV-powheg15-JHUgenV4/AODSIM/PU_S13_START53_LV6-v1/file-indexes/CMS_MonteCarlo2011_Summer11LegDR_Higgs0MToGGTo4L_M-125p6_7TeV-powheg15-JHUgenV4_AODSIM_PU_S13_START53_LV6-v1_20000_file_index.txt"
       }
     ],
-    "generator": {
-      "global_tag": "START53_LV6",
-      "names": [
-        "powheg15",
-        "pythia6"
-      ]
-    },
     "license": {
       "attribution": "CC0"
     },
@@ -3733,6 +3660,10 @@
               "recid": "3245",
               "title": "Configuration file for SIM step HIG-Summer11Leg-00270_1_cfg.py"
             }
+          ],
+          "generators": [
+            "powheg15",
+            "pythia6"
           ],
           "global_tag": "START53_LV4::All",
           "output_dataset": "/Higgs0MToGGTo4L_M-125p6_7TeV-powheg15-JHUgenV4/Summer11Leg-START53_LV4-v1/GEN-SIM",
@@ -3854,13 +3785,6 @@
         "uri": "root://eospublic.cern.ch//eos/opendata/cms/MonteCarlo2011/Summer11LegDR/Higgs0MToZGTo4L_M-125p6_7TeV-powheg15-JHUgenV4/AODSIM/PU_S13_START53_LV6-v2/file-indexes/CMS_MonteCarlo2011_Summer11LegDR_Higgs0MToZGTo4L_M-125p6_7TeV-powheg15-JHUgenV4_AODSIM_PU_S13_START53_LV6-v2_40000_file_index.txt"
       }
     ],
-    "generator": {
-      "global_tag": "START53_LV6",
-      "names": [
-        "powheg15",
-        "pythia6"
-      ]
-    },
     "license": {
       "attribution": "CC0"
     },
@@ -3888,6 +3812,10 @@
               "recid": "3245",
               "title": "Configuration file for SIM step HIG-Summer11Leg-00270_1_cfg.py"
             }
+          ],
+          "generators": [
+            "powheg15",
+            "pythia6"
           ],
           "global_tag": "START53_LV4::All",
           "output_dataset": "/Higgs0MToZGTo4L_M-125p6_7TeV-powheg15-JHUgenV4/Summer11Leg-START53_LV4-v1/GEN-SIM",
@@ -4021,13 +3949,6 @@
         "uri": "root://eospublic.cern.ch//eos/opendata/cms/MonteCarlo2011/Summer11LegDR/VBFToHToZZTo2L2Nu_M-450_7TeV-powheg15-pythia6/AODSIM/PU_S13_START53_LV6-v1/file-indexes/CMS_MonteCarlo2011_Summer11LegDR_VBFToHToZZTo2L2Nu_M-450_7TeV-powheg15-pythia6_AODSIM_PU_S13_START53_LV6-v1_010000_file_index.txt"
       }
     ],
-    "generator": {
-      "global_tag": "START53_LV6",
-      "names": [
-        "powheg15",
-        "pythia6"
-      ]
-    },
     "license": {
       "attribution": "CC0"
     },
@@ -4055,6 +3976,10 @@
               "recid": "3118",
               "title": "Configuration file for SIM step HIG-Summer11Leg-00057_1_cfg.py"
             }
+          ],
+          "generators": [
+            "powheg15",
+            "pythia6"
           ],
           "global_tag": "START53_LV4::All",
           "output_dataset": "/VBFToHToZZTo2L2Nu_M-450_7TeV-powheg15-pythia6/Summer11Leg-START53_LV4-v2/GEN-SIM",
@@ -4188,13 +4113,6 @@
         "uri": "root://eospublic.cern.ch//eos/opendata/cms/MonteCarlo2011/Summer11LegDR/VBFToHToZZTo2L2Nu_M-500_7TeV-powheg15-pythia6/AODSIM/PU_S13_START53_LV6-v1/file-indexes/CMS_MonteCarlo2011_Summer11LegDR_VBFToHToZZTo2L2Nu_M-500_7TeV-powheg15-pythia6_AODSIM_PU_S13_START53_LV6-v1_010000_file_index.txt"
       }
     ],
-    "generator": {
-      "global_tag": "START53_LV6",
-      "names": [
-        "powheg15",
-        "pythia6"
-      ]
-    },
     "license": {
       "attribution": "CC0"
     },
@@ -4222,6 +4140,10 @@
               "recid": "3118",
               "title": "Configuration file for SIM step HIG-Summer11Leg-00057_1_cfg.py"
             }
+          ],
+          "generators": [
+            "powheg15",
+            "pythia6"
           ],
           "global_tag": "START53_LV4::All",
           "output_dataset": "/VBFToHToZZTo2L2Nu_M-500_7TeV-powheg15-pythia6/Summer11Leg-START53_LV4-v2/GEN-SIM",
@@ -4355,13 +4277,6 @@
         "uri": "root://eospublic.cern.ch//eos/opendata/cms/MonteCarlo2011/Summer11LegDR/VBFToHToZZTo2L2Nu_M-550_7TeV-powheg15-pythia6/AODSIM/PU_S13_START53_LV6-v1/file-indexes/CMS_MonteCarlo2011_Summer11LegDR_VBFToHToZZTo2L2Nu_M-550_7TeV-powheg15-pythia6_AODSIM_PU_S13_START53_LV6-v1_010000_file_index.txt"
       }
     ],
-    "generator": {
-      "global_tag": "START53_LV6",
-      "names": [
-        "powheg15",
-        "pythia6"
-      ]
-    },
     "license": {
       "attribution": "CC0"
     },
@@ -4389,6 +4304,10 @@
               "recid": "3118",
               "title": "Configuration file for SIM step HIG-Summer11Leg-00057_1_cfg.py"
             }
+          ],
+          "generators": [
+            "powheg15",
+            "pythia6"
           ],
           "global_tag": "START53_LV4::All",
           "output_dataset": "/VBFToHToZZTo2L2Nu_M-550_7TeV-powheg15-pythia6/Summer11Leg-START53_LV4-v2/GEN-SIM",
@@ -4522,13 +4441,6 @@
         "uri": "root://eospublic.cern.ch//eos/opendata/cms/MonteCarlo2011/Summer11LegDR/Higgs0Mf01ph0ToZZTo4L_M-125p6_7TeV-powheg15-JHUgenV3/AODSIM/PU_S13_START53_LV6-v1/file-indexes/CMS_MonteCarlo2011_Summer11LegDR_Higgs0Mf01ph0ToZZTo4L_M-125p6_7TeV-powheg15-JHUgenV3_AODSIM_PU_S13_START53_LV6-v1_40000_file_index.txt"
       }
     ],
-    "generator": {
-      "global_tag": "START53_LV6",
-      "names": [
-        "powheg15",
-        "pythia6"
-      ]
-    },
     "license": {
       "attribution": "CC0"
     },
@@ -4556,6 +4468,10 @@
               "recid": "3245",
               "title": "Configuration file for SIM step HIG-Summer11Leg-00270_1_cfg.py"
             }
+          ],
+          "generators": [
+            "powheg15",
+            "pythia6"
           ],
           "global_tag": "START53_LV4::All",
           "output_dataset": "/Higgs0Mf01ph0ToZZTo4L_M-125p6_7TeV-powheg15-JHUgenV3/Summer11Leg-START53_LV4-v1/GEN-SIM",
@@ -4677,13 +4593,6 @@
         "uri": "root://eospublic.cern.ch//eos/opendata/cms/MonteCarlo2011/Summer11LegDR/Higgs0PMToZGTo4L_M-125p6_7TeV-powheg15-JHUgenV4/AODSIM/PU_S13_START53_LV6-v2/file-indexes/CMS_MonteCarlo2011_Summer11LegDR_Higgs0PMToZGTo4L_M-125p6_7TeV-powheg15-JHUgenV4_AODSIM_PU_S13_START53_LV6-v2_40000_file_index.txt"
       }
     ],
-    "generator": {
-      "global_tag": "START53_LV6",
-      "names": [
-        "powheg15",
-        "pythia6"
-      ]
-    },
     "license": {
       "attribution": "CC0"
     },
@@ -4711,6 +4620,10 @@
               "recid": "3245",
               "title": "Configuration file for SIM step HIG-Summer11Leg-00270_1_cfg.py"
             }
+          ],
+          "generators": [
+            "powheg15",
+            "pythia6"
           ],
           "global_tag": "START53_LV4::All",
           "output_dataset": "/Higgs0PMToZGTo4L_M-125p6_7TeV-powheg15-JHUgenV4/Summer11Leg-START53_LV4-v2/GEN-SIM",
@@ -4844,13 +4757,6 @@
         "uri": "root://eospublic.cern.ch//eos/opendata/cms/MonteCarlo2011/Summer11LegDR/Higgs0PMToZZTo4L_M-125p6_7TeV-powheg15-JHUgenV3/AODSIM/PU_S13_START53_LV6-v1/file-indexes/CMS_MonteCarlo2011_Summer11LegDR_Higgs0PMToZZTo4L_M-125p6_7TeV-powheg15-JHUgenV3_AODSIM_PU_S13_START53_LV6-v1_40000_file_index.txt"
       }
     ],
-    "generator": {
-      "global_tag": "START53_LV6",
-      "names": [
-        "powheg15",
-        "pythia6"
-      ]
-    },
     "license": {
       "attribution": "CC0"
     },
@@ -4878,6 +4784,10 @@
               "recid": "3245",
               "title": "Configuration file for SIM step HIG-Summer11Leg-00270_1_cfg.py"
             }
+          ],
+          "generators": [
+            "powheg15",
+            "pythia6"
           ],
           "global_tag": "START53_LV4::All",
           "output_dataset": "/Higgs0PMToZZTo4L_M-125p6_7TeV-powheg15-JHUgenV3/Summer11Leg-START53_LV4-v1/GEN-SIM",
@@ -4999,13 +4909,6 @@
         "uri": "root://eospublic.cern.ch//eos/opendata/cms/MonteCarlo2011/Summer11LegDR/JJHiggs0MToGG_M-125p6_7TeV-JHUGenV4-pythia6-tauola/AODSIM/PU_S13_START53_LV6-v1/file-indexes/CMS_MonteCarlo2011_Summer11LegDR_JJHiggs0MToGG_M-125p6_7TeV-JHUGenV4-pythia6-tauola_AODSIM_PU_S13_START53_LV6-v1_00000_file_index.txt"
       }
     ],
-    "generator": {
-      "global_tag": "START53_LV6",
-      "names": [
-        "JHUGen4",
-        "pythia6"
-      ]
-    },
     "license": {
       "attribution": "CC0"
     },
@@ -5033,6 +4936,10 @@
               "recid": "3332",
               "title": "Configuration file for SIM step HIG-Summer11Leg-00096_1_cfg.py"
             }
+          ],
+          "generators": [
+            "JHUGen4",
+            "pythia6"
           ],
           "global_tag": "START53_LV4::All",
           "output_dataset": "/JJHiggs0MToGG_M-125p6_7TeV-JHUGenV4-pythia6-tauola/Summer11Leg-START53_LV4-v1/GEN-SIM",
@@ -5178,13 +5085,6 @@
         "uri": "root://eospublic.cern.ch//eos/opendata/cms/MonteCarlo2011/Summer11LegDR/JJHiggs0MToZZTo4L_M-125p6_7TeV-JHUGenV4/AODSIM/PU_S13_START53_LV6-v1/file-indexes/CMS_MonteCarlo2011_Summer11LegDR_JJHiggs0MToZZTo4L_M-125p6_7TeV-JHUGenV4_AODSIM_PU_S13_START53_LV6-v1_40000_file_index.txt"
       }
     ],
-    "generator": {
-      "global_tag": "START53_LV6",
-      "names": [
-        "powheg15",
-        "pythia6"
-      ]
-    },
     "license": {
       "attribution": "CC0"
     },
@@ -5212,6 +5112,10 @@
               "recid": "3132",
               "title": "Configuration file for SIM step HIG-Summer11Leg-00151_1_cfg.py"
             }
+          ],
+          "generators": [
+            "powheg15",
+            "pythia6"
           ],
           "global_tag": "START53_LV4::All",
           "output_dataset": "/JJHiggs0MToZZTo4L_M-125p6_7TeV-JHUGenV4/Summer11Leg-START53_LV4-v1/GEN-SIM",
@@ -5333,13 +5237,6 @@
         "uri": "root://eospublic.cern.ch//eos/opendata/cms/MonteCarlo2011/Summer11LegDR/JJHiggs0PToBB_M-125p6_7TeV-JHUGenV4-pythia6-tauola/AODSIM/PU_S13_START53_LV6-v1/file-indexes/CMS_MonteCarlo2011_Summer11LegDR_JJHiggs0PToBB_M-125p6_7TeV-JHUGenV4-pythia6-tauola_AODSIM_PU_S13_START53_LV6-v1_00000_file_index.txt"
       }
     ],
-    "generator": {
-      "global_tag": "START53_LV6",
-      "names": [
-        "JHUGen4",
-        "pythia6"
-      ]
-    },
     "license": {
       "attribution": "CC0"
     },
@@ -5367,6 +5264,10 @@
               "recid": "3030",
               "title": "Configuration file for SIM step HIG-Summer11Leg-00082_1_cfg.py"
             }
+          ],
+          "generators": [
+            "JHUGen4",
+            "pythia6"
           ],
           "global_tag": "START53_LV4::All",
           "output_dataset": "/JJHiggs0PToBB_M-125p6_7TeV-JHUGenV4-pythia6-tauola/Summer11Leg-START53_LV4-v1/GEN-SIM",
@@ -5488,13 +5389,6 @@
         "uri": "root://eospublic.cern.ch//eos/opendata/cms/MonteCarlo2011/Summer11LegDR/JJHiggs0PToGG_M-125p6_7TeV-JHUGenV4-pythia6-tauola/AODSIM/PU_S13_START53_LV6-v1/file-indexes/CMS_MonteCarlo2011_Summer11LegDR_JJHiggs0PToGG_M-125p6_7TeV-JHUGenV4-pythia6-tauola_AODSIM_PU_S13_START53_LV6-v1_00000_file_index.txt"
       }
     ],
-    "generator": {
-      "global_tag": "START53_LV6",
-      "names": [
-        "JHUGen4",
-        "pythia6"
-      ]
-    },
     "license": {
       "attribution": "CC0"
     },
@@ -5522,6 +5416,10 @@
               "recid": "3332",
               "title": "Configuration file for SIM step HIG-Summer11Leg-00096_1_cfg.py"
             }
+          ],
+          "generators": [
+            "JHUGen4",
+            "pythia6"
           ],
           "global_tag": "START53_LV4::All",
           "output_dataset": "/JJHiggs0PToGG_M-125p6_7TeV-JHUGenV4-pythia6-tauola/Summer11Leg-START53_LV4-v1/GEN-SIM",
@@ -5667,13 +5565,6 @@
         "uri": "root://eospublic.cern.ch//eos/opendata/cms/MonteCarlo2011/Summer11LegDR/JJHiggs0PToZZTo4L_M-125p6_7TeV-JHUGenV4/AODSIM/PU_S13_START53_LV6-v1/file-indexes/CMS_MonteCarlo2011_Summer11LegDR_JJHiggs0PToZZTo4L_M-125p6_7TeV-JHUGenV4_AODSIM_PU_S13_START53_LV6-v1_40000_file_index.txt"
       }
     ],
-    "generator": {
-      "global_tag": "START53_LV6",
-      "names": [
-        "powheg15",
-        "pythia6"
-      ]
-    },
     "license": {
       "attribution": "CC0"
     },
@@ -5701,6 +5592,10 @@
               "recid": "3041",
               "title": "Configuration file for SIM step HIG-Summer11Leg-00317_1_cfg.py"
             }
+          ],
+          "generators": [
+            "powheg15",
+            "pythia6"
           ],
           "global_tag": "START53_LV4::All",
           "output_dataset": "/JJHiggs0PToZZTo4L_M-125p6_7TeV-JHUGenV4/Summer11Leg-START53_LV4-v1/GEN-SIM",
@@ -5855,12 +5750,6 @@
         "uri": "root://eospublic.cern.ch//eos/opendata/cms/MonteCarlo2011/Summer11LegDR/JPsiToMuMu_2MuPEtaFilter_7TeV-pythia6-evtgen-v2/AODSIM/PU_S13_START53_LV6-v1/file-indexes/CMS_MonteCarlo2011_Summer11LegDR_JPsiToMuMu_2MuPEtaFilter_7TeV-pythia6-evtgen-v2_AODSIM_PU_S13_START53_LV6-v1_30000_file_index.txt"
       }
     ],
-    "generator": {
-      "global_tag": "START53_LV6",
-      "names": [
-        "pythia6"
-      ]
-    },
     "license": {
       "attribution": "CC0"
     },
@@ -5874,6 +5763,9 @@
               "recid": "3390",
               "title": "Configuration file for SIM step SMP-Summer11Leg-00015_1_cfg.py"
             }
+          ],
+          "generators": [
+            "pythia6"
           ],
           "global_tag": "START53_LV4::All",
           "output_dataset": "/JPsiToMuMu_2MuPEtaFilter_7TeV-pythia6-evtgen-v2/Summer11Leg-START53_LV4-v1/GEN-SIM",
@@ -6004,13 +5896,6 @@
         "uri": "root://eospublic.cern.ch//eos/opendata/cms/MonteCarlo2011/Summer11LegDR/LambdaBToJPsiLambda_lambdaFilter_7TeV-pythia6-evtgen/AODSIM/PU_S13_START53_LV6-v1/file-indexes/CMS_MonteCarlo2011_Summer11LegDR_LambdaBToJPsiLambda_lambdaFilter_7TeV-pythia6-evtgen_AODSIM_PU_S13_START53_LV6-v1_60000_file_index.txt"
       }
     ],
-    "generator": {
-      "global_tag": "START53_LV6",
-      "names": [
-        "pythia6",
-        "evtGen"
-      ]
-    },
     "license": {
       "attribution": "CC0"
     },
@@ -6024,6 +5909,10 @@
               "recid": "3127",
               "title": "Configuration file for SIM step BPH-Summer11Leg-00020_1_cfg.py"
             }
+          ],
+          "generators": [
+            "pythia6",
+            "evtGen"
           ],
           "global_tag": "START53_LV4::All",
           "output_dataset": "/LambdaBToJPsiLambda_lambdaFilter_7TeV-pythia6-evtgen/Summer11Leg-START53_LV4-v1/GEN-SIM",
@@ -6142,13 +6031,6 @@
         "uri": "root://eospublic.cern.ch//eos/opendata/cms/MonteCarlo2011/Summer11LegDR/LambdaBToLambdaJpsi_EtaPtFilter_7TeV-pythia6-evtgen/AODSIM/PU_S13_START53_LV6-v1/file-indexes/CMS_MonteCarlo2011_Summer11LegDR_LambdaBToLambdaJpsi_EtaPtFilter_7TeV-pythia6-evtgen_AODSIM_PU_S13_START53_LV6-v1_00000_file_index.txt"
       }
     ],
-    "generator": {
-      "global_tag": "START53_LV6",
-      "names": [
-        "Pythia6",
-        "EvtGen"
-      ]
-    },
     "license": {
       "attribution": "CC0"
     },
@@ -6162,6 +6044,10 @@
               "recid": "3016",
               "title": "Configuration file for SIM step BPH-Summer11Leg-00006_1_cfg.py"
             }
+          ],
+          "generators": [
+            "Pythia6",
+            "EvtGen"
           ],
           "global_tag": "START53_LV4::All",
           "output_dataset": "/LambdaBToLambdaJpsi_EtaPtFilter_7TeV-pythia6-evtgen/Summer11Leg-START53_LV4-v1/GEN-SIM",
@@ -6280,13 +6166,6 @@
         "uri": "root://eospublic.cern.ch//eos/opendata/cms/MonteCarlo2011/Summer11LegDR/LambdaBToLambdaMuMu_EtaPtFilter_7TeV-pythia6-evtgen/AODSIM/PU_S13_START53_LV6-v1/file-indexes/CMS_MonteCarlo2011_Summer11LegDR_LambdaBToLambdaMuMu_EtaPtFilter_7TeV-pythia6-evtgen_AODSIM_PU_S13_START53_LV6-v1_00000_file_index.txt"
       }
     ],
-    "generator": {
-      "global_tag": "START53_LV6",
-      "names": [
-        "PYTHIA",
-        "EvtGen"
-      ]
-    },
     "license": {
       "attribution": "CC0"
     },
@@ -6300,6 +6179,10 @@
               "recid": "3395",
               "title": "Configuration file for SIM step BPH-Summer11Leg-00009_1_cfg.py"
             }
+          ],
+          "generators": [
+            "PYTHIA",
+            "EvtGen"
           ],
           "global_tag": "START53_LV4::All",
           "output_dataset": "/LambdaBToLambdaMuMu_EtaPtFilter_7TeV-pythia6-evtgen/Summer11Leg-START53_LV4-v1/GEN-SIM",
@@ -6418,13 +6301,6 @@
         "uri": "root://eospublic.cern.ch//eos/opendata/cms/MonteCarlo2011/Summer11LegDR/LambdaBToLambdaPsi_EtaPtFilter_7TeV-pythia6-evtgen/AODSIM/PU_S13_START53_LV6-v1/file-indexes/CMS_MonteCarlo2011_Summer11LegDR_LambdaBToLambdaPsi_EtaPtFilter_7TeV-pythia6-evtgen_AODSIM_PU_S13_START53_LV6-v1_00000_file_index.txt"
       }
     ],
-    "generator": {
-      "global_tag": "START53_LV6",
-      "names": [
-        "PYTHIA6",
-        "EvtGen"
-      ]
-    },
     "license": {
       "attribution": "CC0"
     },
@@ -6438,6 +6314,10 @@
               "recid": "3029",
               "title": "Configuration file for SIM step BPH-Summer11Leg-00007_1_cfg.py"
             }
+          ],
+          "generators": [
+            "PYTHIA6",
+            "EvtGen"
           ],
           "global_tag": "START53_LV4::All",
           "output_dataset": "/LambdaBToLambdaPsi_EtaPtFilter_7TeV-pythia6-evtgen/Summer11Leg-START53_LV4-v3/GEN-SIM",
@@ -6559,12 +6439,6 @@
         "uri": "root://eospublic.cern.ch//eos/opendata/cms/MonteCarlo2011/Summer11LegDR/QCD_Pt-0to5_TuneZ2_7TeV_pythia6/AODSIM/PU_S13_START53_LV6-v1/file-indexes/CMS_MonteCarlo2011_Summer11LegDR_QCD_Pt-0to5_TuneZ2_7TeV_pythia6_AODSIM_PU_S13_START53_LV6-v1_00000_file_index.txt"
       }
     ],
-    "generator": {
-      "global_tag": "START53_LV6",
-      "names": [
-        "pythia6"
-      ]
-    },
     "license": {
       "attribution": "CC0"
     },
@@ -6578,6 +6452,9 @@
               "recid": "3049",
               "title": "Configuration file for SIM step JME-Summer11Leg-00001_1_cfg.py"
             }
+          ],
+          "generators": [
+            "pythia6"
           ],
           "global_tag": "START53_LV4::All",
           "output_dataset": "/QCD_Pt-0to5_TuneZ2_7TeV_pythia6/Summer11Leg-START53_LV4-v1/GEN-SIM",
@@ -6699,12 +6576,6 @@
         "uri": "root://eospublic.cern.ch//eos/opendata/cms/MonteCarlo2011/Summer11LegDR/QCD_Pt-1000_MuEnrichedPt5_TuneZ2_7TeV_pythia6/AODSIM/PU_S13_START53_LV6-v1/file-indexes/CMS_MonteCarlo2011_Summer11LegDR_QCD_Pt-1000_MuEnrichedPt5_TuneZ2_7TeV_pythia6_AODSIM_PU_S13_START53_LV6-v1_00000_file_index.txt"
       }
     ],
-    "generator": {
-      "global_tag": "START53_LV6",
-      "names": [
-        "pythia6"
-      ]
-    },
     "license": {
       "attribution": "CC0"
     },
@@ -6718,6 +6589,9 @@
               "recid": "3348",
               "title": "Configuration file for SIM step BTV-Summer11Leg-00012_1_cfg.py"
             }
+          ],
+          "generators": [
+            "pythia6"
           ],
           "global_tag": "START53_LV4::All",
           "output_dataset": "/QCD_Pt-1000_MuEnrichedPt5_TuneZ2_7TeV_pythia6/Summer11Leg-START53_LV4-v1/GEN-SIM",
@@ -6839,12 +6713,6 @@
         "uri": "root://eospublic.cern.ch//eos/opendata/cms/MonteCarlo2011/Summer11LegDR/QCD_Pt-1000to1400_TuneZ2_7TeV_pythia6/AODSIM/PU_S13_START53_LV6-v1/file-indexes/CMS_MonteCarlo2011_Summer11LegDR_QCD_Pt-1000to1400_TuneZ2_7TeV_pythia6_AODSIM_PU_S13_START53_LV6-v1_00000_file_index.txt"
       }
     ],
-    "generator": {
-      "global_tag": "START53_LV6",
-      "names": [
-        "pythia6"
-      ]
-    },
     "license": {
       "attribution": "CC0"
     },
@@ -6858,6 +6726,9 @@
               "recid": "3187",
               "title": "Configuration file for SIM step JME-Summer11Leg-00013_1_cfg.py"
             }
+          ],
+          "generators": [
+            "pythia6"
           ],
           "global_tag": "START53_LV4::All",
           "output_dataset": "/QCD_Pt-1000to1400_TuneZ2_7TeV_pythia6/Summer11Leg-START53_LV4-v1/GEN-SIM",
@@ -6991,12 +6862,6 @@
         "uri": "root://eospublic.cern.ch//eos/opendata/cms/MonteCarlo2011/Summer11LegDR/ZZJetsTo4L_TuneZ2_7TeV-madgraph-tauola/AODSIM/PU_S13_START53_LV6-v1/file-indexes/CMS_MonteCarlo2011_Summer11LegDR_ZZJetsTo4L_TuneZ2_7TeV-madgraph-tauola_AODSIM_PU_S13_START53_LV6-v1_020000_file_index.txt"
       }
     ],
-    "generator": {
-      "global_tag": "START53_LV6",
-      "names": [
-        "madgraph"
-      ]
-    },
     "license": {
       "attribution": "CC0"
     },
@@ -7024,6 +6889,9 @@
               "recid": "3164",
               "title": "Configuration file for SIM step HIG-Summer11Leg-00011_1_cfg.py"
             }
+          ],
+          "generators": [
+            "madgraph"
           ],
           "global_tag": "START53_LV4::All",
           "output_dataset": "/ZZJetsTo4L_TuneZ2_7TeV-madgraph-tauola/Summer11Leg-START53_LV4-v2/GEN-SIM",
@@ -7157,13 +7025,6 @@
         "uri": "root://eospublic.cern.ch//eos/opendata/cms/MonteCarlo2011/Summer11LegDR/ZZTo2e2muJJ_Contin_7TeV-phantom-pythia6/AODSIM/PU_S13_START53_LV6-v1/file-indexes/CMS_MonteCarlo2011_Summer11LegDR_ZZTo2e2muJJ_Contin_7TeV-phantom-pythia6_AODSIM_PU_S13_START53_LV6-v1_40000_file_index.txt"
       }
     ],
-    "generator": {
-      "global_tag": "START53_LV6",
-      "names": [
-        "pythia6",
-        "phantom"
-      ]
-    },
     "license": {
       "attribution": "CC0"
     },
@@ -7191,6 +7052,10 @@
               "recid": "3132",
               "title": "Configuration file for SIM step HIG-Summer11Leg-00151_1_cfg.py"
             }
+          ],
+          "generators": [
+            "pythia6",
+            "phantom"
           ],
           "global_tag": "START53_LV4::All",
           "output_dataset": "/ZZTo2e2muJJ_Contin_7TeV-phantom-pythia6/Summer11Leg-START53_LV4-v1/GEN-SIM",
@@ -7360,13 +7225,6 @@
         "uri": "root://eospublic.cern.ch//eos/opendata/cms/MonteCarlo2011/Summer11LegDR/ZZTo2e2mu_7TeV_mll8_mZZ95-160-powheg15-pythia6/AODSIM/PU_S13_START53_LV6-v1/file-indexes/CMS_MonteCarlo2011_Summer11LegDR_ZZTo2e2mu_7TeV_mll8_mZZ95-160-powheg15-pythia6_AODSIM_PU_S13_START53_LV6-v1_40000_file_index.txt"
       }
     ],
-    "generator": {
-      "global_tag": "START53_LV6",
-      "names": [
-        "powheg15",
-        "pythia6"
-      ]
-    },
     "license": {
       "attribution": "CC0"
     },
@@ -7394,6 +7252,10 @@
               "recid": "3176",
               "title": "Configuration file for SIM step HIG-Summer11Leg-00107_1_cfg.py"
             }
+          ],
+          "generators": [
+            "powheg15",
+            "pythia6"
           ],
           "global_tag": "START53_LV4::All",
           "output_dataset": "/ZZTo2e2mu_7TeV_mll8_mZZ95-160-powheg15-pythia6/Summer11Leg-START53_LV4-v1/GEN-SIM",
@@ -7527,13 +7389,6 @@
         "uri": "root://eospublic.cern.ch//eos/opendata/cms/MonteCarlo2011/Summer11LegDR/VBFToHToZZTo2L2Nu_M-600_7TeV-powheg15-pythia6/AODSIM/PU_S13_START53_LV6-v1/file-indexes/CMS_MonteCarlo2011_Summer11LegDR_VBFToHToZZTo2L2Nu_M-600_7TeV-powheg15-pythia6_AODSIM_PU_S13_START53_LV6-v1_010000_file_index.txt"
       }
     ],
-    "generator": {
-      "global_tag": "START53_LV6",
-      "names": [
-        "powheg15",
-        "pythia6"
-      ]
-    },
     "license": {
       "attribution": "CC0"
     },
@@ -7561,6 +7416,10 @@
               "recid": "3118",
               "title": "Configuration file for SIM step HIG-Summer11Leg-00057_1_cfg.py"
             }
+          ],
+          "generators": [
+            "powheg15",
+            "pythia6"
           ],
           "global_tag": "START53_LV4::All",
           "output_dataset": "/VBFToHToZZTo2L2Nu_M-600_7TeV-powheg15-pythia6/Summer11Leg-START53_LV4-v2/GEN-SIM",
@@ -7682,12 +7541,6 @@
         "uri": "root://eospublic.cern.ch//eos/opendata/cms/MonteCarlo2011/Summer11LegDR/QCD_Pt-120to170_MuEnrichedPt5_TuneZ2_7TeV_pythia6/AODSIM/PU_S13_START53_LV6-v1/file-indexes/CMS_MonteCarlo2011_Summer11LegDR_QCD_Pt-120to170_MuEnrichedPt5_TuneZ2_7TeV_pythia6_AODSIM_PU_S13_START53_LV6-v1_00000_file_index.txt"
       }
     ],
-    "generator": {
-      "global_tag": "START53_LV6",
-      "names": [
-        "pythia6"
-      ]
-    },
     "license": {
       "attribution": "CC0"
     },
@@ -7701,6 +7554,9 @@
               "recid": "3337",
               "title": "Configuration file for SIM step BTV-Summer11Leg-00006_1_cfg.py"
             }
+          ],
+          "generators": [
+            "pythia6"
           ],
           "global_tag": "START53_LV4::All",
           "output_dataset": "/QCD_Pt-120to170_MuEnrichedPt5_TuneZ2_7TeV_pythia6/Summer11Leg-START53_LV4-v2/GEN-SIM",
@@ -7822,12 +7678,6 @@
         "uri": "root://eospublic.cern.ch//eos/opendata/cms/MonteCarlo2011/Summer11LegDR/QCD_Pt-120to170_TuneZ2_7TeV_pythia6/AODSIM/PU_S13_START53_LV6-v1/file-indexes/CMS_MonteCarlo2011_Summer11LegDR_QCD_Pt-120to170_TuneZ2_7TeV_pythia6_AODSIM_PU_S13_START53_LV6-v1_00000_file_index.txt"
       }
     ],
-    "generator": {
-      "global_tag": "START53_LV6",
-      "names": [
-        "pythia6"
-      ]
-    },
     "license": {
       "attribution": "CC0"
     },
@@ -7841,6 +7691,9 @@
               "recid": "3402",
               "title": "Configuration file for SIM step JME-Summer11Leg-00007_1_cfg.py"
             }
+          ],
+          "generators": [
+            "pythia6"
           ],
           "global_tag": "START53_LV4::All",
           "output_dataset": "/QCD_Pt-120to170_TuneZ2_7TeV_pythia6/Summer11Leg-START53_LV4-v1/GEN-SIM",
@@ -7962,13 +7815,6 @@
         "uri": "root://eospublic.cern.ch//eos/opendata/cms/MonteCarlo2011/Summer11LegDR/VBFToHToZZTo2L2Nu_M-650_7TeV-powheg15-pythia6/AODSIM/PU_S13_START53_LV6-v1/file-indexes/CMS_MonteCarlo2011_Summer11LegDR_VBFToHToZZTo2L2Nu_M-650_7TeV-powheg15-pythia6_AODSIM_PU_S13_START53_LV6-v1_00000_file_index.txt"
       }
     ],
-    "generator": {
-      "global_tag": "START53_LV6",
-      "names": [
-        "powheg15",
-        "pythia6"
-      ]
-    },
     "license": {
       "attribution": "CC0"
     },
@@ -7996,6 +7842,10 @@
               "recid": "3118",
               "title": "Configuration file for SIM step HIG-Summer11Leg-00057_1_cfg.py"
             }
+          ],
+          "generators": [
+            "powheg15",
+            "pythia6"
           ],
           "global_tag": "START53_LV4::All",
           "output_dataset": "/VBFToHToZZTo2L2Nu_M-650_7TeV-powheg15-pythia6/Summer11Leg-START53_LV4-v3/GEN-SIM",
@@ -8117,13 +7967,6 @@
         "uri": "root://eospublic.cern.ch//eos/opendata/cms/MonteCarlo2011/Summer11LegDR/VBFHiggs0MToBB_M-125p6_7TeV-JHUGenV4-pythia6-tauola/AODSIM/PU_S13_START53_LV6-v1/file-indexes/CMS_MonteCarlo2011_Summer11LegDR_VBFHiggs0MToBB_M-125p6_7TeV-JHUGenV4-pythia6-tauola_AODSIM_PU_S13_START53_LV6-v1_00000_file_index.txt"
       }
     ],
-    "generator": {
-      "global_tag": "START53_LV6",
-      "names": [
-        "JHUGen4",
-        "pythia6"
-      ]
-    },
     "license": {
       "attribution": "CC0"
     },
@@ -8151,6 +7994,10 @@
               "recid": "3030",
               "title": "Configuration file for SIM step HIG-Summer11Leg-00082_1_cfg.py"
             }
+          ],
+          "generators": [
+            "JHUGen4",
+            "pythia6"
           ],
           "global_tag": "START53_LV4::All",
           "output_dataset": "/VBFHiggs0MToBB_M-125p6_7TeV-JHUGenV4-pythia6-tauola/Summer11Leg-START53_LV4-v1/GEN-SIM",
@@ -8284,13 +8131,6 @@
         "uri": "root://eospublic.cern.ch//eos/opendata/cms/MonteCarlo2011/Summer11LegDR/VBFHiggs0MToGG_M-125p6_7TeV-JHUGenV4-pythia6-tauola/AODSIM/PU_S13_START53_LV6-v2/file-indexes/CMS_MonteCarlo2011_Summer11LegDR_VBFHiggs0MToGG_M-125p6_7TeV-JHUGenV4-pythia6-tauola_AODSIM_PU_S13_START53_LV6-v2_30000_file_index.txt"
       }
     ],
-    "generator": {
-      "global_tag": "START53_LV6",
-      "names": [
-        "JHUGen4",
-        "pythia6"
-      ]
-    },
     "license": {
       "attribution": "CC0"
     },
@@ -8318,6 +8158,10 @@
               "recid": "3332",
               "title": "Configuration file for SIM step HIG-Summer11Leg-00096_1_cfg.py"
             }
+          ],
+          "generators": [
+            "JHUGen4",
+            "pythia6"
           ],
           "global_tag": "START53_LV4::All",
           "output_dataset": "/VBFHiggs0MToGG_M-125p6_7TeV-JHUGenV4-pythia6-tauola/Summer11Leg-START53_LV4-v1/GEN-SIM",
@@ -8439,13 +8283,6 @@
         "uri": "root://eospublic.cern.ch//eos/opendata/cms/MonteCarlo2011/Summer11LegDR/VBFHiggs0MToZZTo4L_M-125p6_7TeV-JHUGenV4/AODSIM/PU_S13_START53_LV6-v1/file-indexes/CMS_MonteCarlo2011_Summer11LegDR_VBFHiggs0MToZZTo4L_M-125p6_7TeV-JHUGenV4_AODSIM_PU_S13_START53_LV6-v1_00000_file_index.txt"
       }
     ],
-    "generator": {
-      "global_tag": "START53_LV6",
-      "names": [
-        "powheg15",
-        "pythia6"
-      ]
-    },
     "license": {
       "attribution": "CC0"
     },
@@ -8473,6 +8310,10 @@
               "recid": "3132",
               "title": "Configuration file for SIM step HIG-Summer11Leg-00151_1_cfg.py"
             }
+          ],
+          "generators": [
+            "powheg15",
+            "pythia6"
           ],
           "global_tag": "START53_LV4::All",
           "output_dataset": "/VBFHiggs0MToZZTo4L_M-125p6_7TeV-JHUGenV4/Summer11Leg-START53_LV4-v1/GEN-SIM",
@@ -8594,13 +8435,6 @@
         "uri": "root://eospublic.cern.ch//eos/opendata/cms/MonteCarlo2011/Summer11LegDR/VBFHiggs0Mf05ph0ToZZTo4L_M-125p6_7TeV-JHUGenV4/AODSIM/PU_S13_START53_LV6-v1/file-indexes/CMS_MonteCarlo2011_Summer11LegDR_VBFHiggs0Mf05ph0ToZZTo4L_M-125p6_7TeV-JHUGenV4_AODSIM_PU_S13_START53_LV6-v1_20000_file_index.txt"
       }
     ],
-    "generator": {
-      "global_tag": "START53_LV6",
-      "names": [
-        "powheg15",
-        "pythia6"
-      ]
-    },
     "license": {
       "attribution": "CC0"
     },
@@ -8628,6 +8462,10 @@
               "recid": "3132",
               "title": "Configuration file for SIM step HIG-Summer11Leg-00151_1_cfg.py"
             }
+          ],
+          "generators": [
+            "powheg15",
+            "pythia6"
           ],
           "global_tag": "START53_LV4::All",
           "output_dataset": "/VBFHiggs0Mf05ph0ToZZTo4L_M-125p6_7TeV-JHUGenV4/Summer11Leg-START53_LV4-v1/GEN-SIM",
@@ -8749,12 +8587,6 @@
         "uri": "root://eospublic.cern.ch//eos/opendata/cms/MonteCarlo2011/Summer11LegDR/Tbar_TuneZ2_tW-channel-DS_7TeV-powheg-tauola/AODSIM/PU_S13_START53_LV6-v1/file-indexes/CMS_MonteCarlo2011_Summer11LegDR_Tbar_TuneZ2_tW-channel-DS_7TeV-powheg-tauola_AODSIM_PU_S13_START53_LV6-v1_00000_file_index.txt"
       }
     ],
-    "generator": {
-      "global_tag": "START53_LV6",
-      "names": [
-        "pythia6"
-      ]
-    },
     "license": {
       "attribution": "CC0"
     },
@@ -8782,6 +8614,9 @@
               "recid": "3107",
               "title": "Configuration file for SIM step TOP-Summer11Leg-00003_1_cfg.py"
             }
+          ],
+          "generators": [
+            "pythia6"
           ],
           "global_tag": "START53_LV4::All",
           "output_dataset": "/Tbar_TuneZ2_tW-channel-DS_7TeV-powheg-tauola/Summer11Leg-START53_LV4-v1/GEN-SIM",
@@ -8903,12 +8738,6 @@
         "uri": "root://eospublic.cern.ch//eos/opendata/cms/MonteCarlo2011/Summer11LegDR/Tbar_TuneZ2_tW-channel-DR_7TeV-powheg-tauola/AODSIM/PU_S13_START53_LV6-v1/file-indexes/CMS_MonteCarlo2011_Summer11LegDR_Tbar_TuneZ2_tW-channel-DR_7TeV-powheg-tauola_AODSIM_PU_S13_START53_LV6-v1_00000_file_index.txt"
       }
     ],
-    "generator": {
-      "global_tag": "START53_LV6",
-      "names": [
-        "pythia6"
-      ]
-    },
     "license": {
       "attribution": "CC0"
     },
@@ -8936,6 +8765,9 @@
               "recid": "3107",
               "title": "Configuration file for SIM step TOP-Summer11Leg-00003_1_cfg.py"
             }
+          ],
+          "generators": [
+            "pythia6"
           ],
           "global_tag": "START53_LV4::All",
           "output_dataset": "/Tbar_TuneZ2_tW-channel-DR_7TeV-powheg-tauola/Summer11Leg-START53_LV4-v1/GEN-SIM",
@@ -9057,13 +8889,6 @@
         "uri": "root://eospublic.cern.ch//eos/opendata/cms/MonteCarlo2011/Summer11LegDR/T_TuneZ2_tW-channel-DS_7TeV-powheg-tauola/AODSIM/PU_S13_START53_LV6-v1/file-indexes/CMS_MonteCarlo2011_Summer11LegDR_T_TuneZ2_tW-channel-DS_7TeV-powheg-tauola_AODSIM_PU_S13_START53_LV6-v1_00000_file_index.txt"
       }
     ],
-    "generator": {
-      "global_tag": "START53_LV6",
-      "names": [
-        "powheg",
-        "pythia6"
-      ]
-    },
     "license": {
       "attribution": "CC0"
     },
@@ -9091,6 +8916,10 @@
               "recid": "3404",
               "title": "Configuration file for SIM step TOP-Summer11Leg-00004_1_cfg.py"
             }
+          ],
+          "generators": [
+            "powheg",
+            "pythia6"
           ],
           "global_tag": "START53_LV4::All",
           "output_dataset": "/T_TuneZ2_tW-channel-DS_7TeV-powheg-tauola/Summer11Leg-START53_LV4-v1/GEN-SIM",
@@ -9212,13 +9041,6 @@
         "uri": "root://eospublic.cern.ch//eos/opendata/cms/MonteCarlo2011/Summer11LegDR/T_TuneZ2_t-channel_7TeV-powheg-tauola/AODSIM/PU_S13_START53_LV6-v1/file-indexes/CMS_MonteCarlo2011_Summer11LegDR_T_TuneZ2_t-channel_7TeV-powheg-tauola_AODSIM_PU_S13_START53_LV6-v1_00000_file_index.txt"
       }
     ],
-    "generator": {
-      "global_tag": "START53_LV6",
-      "names": [
-        "powheg",
-        "pythia6"
-      ]
-    },
     "license": {
       "attribution": "CC0"
     },
@@ -9246,6 +9068,10 @@
               "recid": "3082",
               "title": "Configuration file for SIM step TOP-Summer11Leg-00001_1_cfg.py"
             }
+          ],
+          "generators": [
+            "powheg",
+            "pythia6"
           ],
           "global_tag": "START53_LV4::All",
           "output_dataset": "/T_TuneZ2_t-channel_7TeV-powheg-tauola/Summer11Leg-START53_LV4-v1/GEN-SIM",
@@ -9367,12 +9193,6 @@
         "uri": "root://eospublic.cern.ch//eos/opendata/cms/MonteCarlo2011/Summer11LegDR/TTbarH_HToZZTo4L_M-130_7TeV-pythia6/AODSIM/PU_S13_START53_LV6-v2/file-indexes/CMS_MonteCarlo2011_Summer11LegDR_TTbarH_HToZZTo4L_M-130_7TeV-pythia6_AODSIM_PU_S13_START53_LV6-v2_00000_file_index.txt"
       }
     ],
-    "generator": {
-      "global_tag": "START53_LV6",
-      "names": [
-        "pythia6"
-      ]
-    },
     "license": {
       "attribution": "CC0"
     },
@@ -9386,6 +9206,9 @@
               "recid": "3409",
               "title": "Configuration file for SIM step HIG-Summer11Leg-00235_1_cfg.py"
             }
+          ],
+          "generators": [
+            "pythia6"
           ],
           "global_tag": "START53_LV4::All",
           "output_dataset": "/TTbarH_HToZZTo4L_M-130_7TeV-pythia6/Summer11Leg-START53_LV4-v1/GEN-SIM",
@@ -9519,14 +9342,6 @@
         "uri": "root://eospublic.cern.ch//eos/opendata/cms/MonteCarlo2011/Summer11LegDR/TT_weights_CT10_TuneZ2_7TeV-powheg-pythia-tauola/AODSIM/PU_S13_START53_LV6-v2/file-indexes/CMS_MonteCarlo2011_Summer11LegDR_TT_weights_CT10_TuneZ2_7TeV-powheg-pythia-tauola_AODSIM_PU_S13_START53_LV6-v2_20000_file_index.txt"
       }
     ],
-    "generator": {
-      "global_tag": "START53_LV6",
-      "names": [
-        "powheg",
-        "pythia6",
-        "tauola"
-      ]
-    },
     "license": {
       "attribution": "CC0"
     },
@@ -9554,6 +9369,11 @@
               "recid": "3334",
               "title": "Configuration file for SIM step TOP-Summer11Leg-00027_1_cfg.py"
             }
+          ],
+          "generators": [
+            "powheg",
+            "pythia6",
+            "tauola"
           ],
           "global_tag": "START53_LV4::All",
           "output_dataset": "/TT_weights_CT10_TuneZ2_7TeV-powheg-pythia-tauola/Summer11Leg-START53_LV4-v1/GEN-SIM",
@@ -9675,13 +9495,6 @@
         "uri": "root://eospublic.cern.ch//eos/opendata/cms/MonteCarlo2011/Summer11LegDR/TTTo2L2Nu2B_7TeV-powheg-pythia6/AODSIM/PU_S13_START53_LV6-v1/file-indexes/CMS_MonteCarlo2011_Summer11LegDR_TTTo2L2Nu2B_7TeV-powheg-pythia6_AODSIM_PU_S13_START53_LV6-v1_00000_file_index.txt"
       }
     ],
-    "generator": {
-      "global_tag": "START53_LV6",
-      "names": [
-        "powheg",
-        "pythia6"
-      ]
-    },
     "license": {
       "attribution": "CC0"
     },
@@ -9709,6 +9522,10 @@
               "recid": "3167",
               "title": "Configuration file for SIM step HIG-Summer11Leg-00016_1_cfg.py"
             }
+          ],
+          "generators": [
+            "powheg",
+            "pythia6"
           ],
           "global_tag": "START53_LV4::All",
           "output_dataset": "/TTTo2L2Nu2B_7TeV-powheg-pythia6/Summer11Leg-START53_LV4-v1/GEN-SIM",
@@ -9854,15 +9671,6 @@
         "uri": "root://eospublic.cern.ch//eos/opendata/cms/MonteCarlo2011/Summer11LegDR/TTJets_MSDecays_matchingup_7TeV-madgraph-tauola/AODSIM/PU_S13_START53_LV6-v1/file-indexes/CMS_MonteCarlo2011_Summer11LegDR_TTJets_MSDecays_matchingup_7TeV-madgraph-tauola_AODSIM_PU_S13_START53_LV6-v1_30000_file_index.txt"
       }
     ],
-    "generator": {
-      "global_tag": "START53_LV6",
-      "names": [
-        "madgraph",
-        "madspin",
-        "pythia6",
-        "tauola"
-      ]
-    },
     "license": {
       "attribution": "CC0"
     },
@@ -9890,6 +9698,12 @@
               "recid": "3354",
               "title": "Configuration file for SIM step TOP-Summer11Leg-00021_1_cfg.py"
             }
+          ],
+          "generators": [
+            "madgraph",
+            "madspin",
+            "pythia6",
+            "tauola"
           ],
           "global_tag": "START53_LV4::All",
           "output_dataset": "/TTJets_MSDecays_matchingup_7TeV-madgraph-tauola/Summer11Leg-START53_LV4-v1/GEN-SIM",
@@ -10011,13 +9825,6 @@
         "uri": "root://eospublic.cern.ch//eos/opendata/cms/MonteCarlo2011/Summer11LegDR/TTJets_MSDecays_matchingdown_mt172_5_7TeV-madgraph/AODSIM/PU_S13_START53_LV6-v1/file-indexes/CMS_MonteCarlo2011_Summer11LegDR_TTJets_MSDecays_matchingdown_mt172_5_7TeV-madgraph_AODSIM_PU_S13_START53_LV6-v1_50000_file_index.txt"
       }
     ],
-    "generator": {
-      "global_tag": "START53_LV6",
-      "names": [
-        "madgraph",
-        "madspin"
-      ]
-    },
     "license": {
       "attribution": "CC0"
     },
@@ -10045,6 +9852,10 @@
               "recid": "3266",
               "title": "Configuration file for SIM step TOP-Summer11Leg-00041_1_cfg.py"
             }
+          ],
+          "generators": [
+            "madgraph",
+            "madspin"
           ],
           "global_tag": "START53_LV4::All",
           "output_dataset": "/TTJets_MSDecays_matchingdown_mt172_5_7TeV-madgraph/Summer11Leg-START53_LV4-v1/GEN-SIM",
@@ -10178,13 +9989,6 @@
         "uri": "root://eospublic.cern.ch//eos/opendata/cms/MonteCarlo2011/Summer11LegDR/VBFToHToZZTo2L2Nu_M-700_7TeV-powheg15-pythia6/AODSIM/PU_S13_START53_LV6-v1/file-indexes/CMS_MonteCarlo2011_Summer11LegDR_VBFToHToZZTo2L2Nu_M-700_7TeV-powheg15-pythia6_AODSIM_PU_S13_START53_LV6-v1_010000_file_index.txt"
       }
     ],
-    "generator": {
-      "global_tag": "START53_LV6",
-      "names": [
-        "powheg15",
-        "pythia6"
-      ]
-    },
     "license": {
       "attribution": "CC0"
     },
@@ -10212,6 +10016,10 @@
               "recid": "3118",
               "title": "Configuration file for SIM step HIG-Summer11Leg-00057_1_cfg.py"
             }
+          ],
+          "generators": [
+            "powheg15",
+            "pythia6"
           ],
           "global_tag": "START53_LV4::All",
           "output_dataset": "/VBFToHToZZTo2L2Nu_M-700_7TeV-powheg15-pythia6/Summer11Leg-START53_LV4-v2/GEN-SIM",
@@ -10333,12 +10141,6 @@
         "uri": "root://eospublic.cern.ch//eos/opendata/cms/MonteCarlo2011/Summer11LegDR/QCD_Pt-1400to1800_TuneZ2_7TeV_pythia6/AODSIM/PU_S13_START53_LV6-v1/file-indexes/CMS_MonteCarlo2011_Summer11LegDR_QCD_Pt-1400to1800_TuneZ2_7TeV_pythia6_AODSIM_PU_S13_START53_LV6-v1_00000_file_index.txt"
       }
     ],
-    "generator": {
-      "global_tag": "START53_LV6",
-      "names": [
-        "pythia6"
-      ]
-    },
     "license": {
       "attribution": "CC0"
     },
@@ -10352,6 +10154,9 @@
               "recid": "3251",
               "title": "Configuration file for SIM step JME-Summer11Leg-00014_1_cfg.py"
             }
+          ],
+          "generators": [
+            "pythia6"
           ],
           "global_tag": "START53_LV4::All",
           "output_dataset": "/QCD_Pt-1400to1800_TuneZ2_7TeV_pythia6/Summer11Leg-START53_LV4-v1/GEN-SIM",
@@ -10485,12 +10290,6 @@
         "uri": "root://eospublic.cern.ch//eos/opendata/cms/MonteCarlo2011/Summer11LegDR/QCD_Pt-15to20_MuEnrichedPt5_TuneZ2_7TeV_pythia6/AODSIM/PU_S13_START53_LV6-v1/file-indexes/CMS_MonteCarlo2011_Summer11LegDR_QCD_Pt-15to20_MuEnrichedPt5_TuneZ2_7TeV_pythia6_AODSIM_PU_S13_START53_LV6-v1_010000_file_index.txt"
       }
     ],
-    "generator": {
-      "global_tag": "START53_LV6",
-      "names": [
-        "pythia6"
-      ]
-    },
     "license": {
       "attribution": "CC0"
     },
@@ -10504,6 +10303,9 @@
               "recid": "3406",
               "title": "Configuration file for SIM step BTV-Summer11Leg-00001_1_cfg.py"
             }
+          ],
+          "generators": [
+            "pythia6"
           ],
           "global_tag": "START53_LV4::All",
           "output_dataset": "/QCD_Pt-15to20_MuEnrichedPt5_TuneZ2_7TeV_pythia6/Summer11Leg-START53_LV4-v2/GEN-SIM",
@@ -10709,12 +10511,6 @@
         "uri": "root://eospublic.cern.ch//eos/opendata/cms/MonteCarlo2011/Summer11LegDR/QCD_Pt-15to30_TuneZ2_7TeV_pythia6/AODSIM/PU_S13_START53_LV6-v1/file-indexes/CMS_MonteCarlo2011_Summer11LegDR_QCD_Pt-15to30_TuneZ2_7TeV_pythia6_AODSIM_PU_S13_START53_LV6-v1_010003_file_index.txt"
       }
     ],
-    "generator": {
-      "global_tag": "START53_LV6",
-      "names": [
-        "pythia6"
-      ]
-    },
     "license": {
       "attribution": "CC0"
     },
@@ -10728,6 +10524,9 @@
               "recid": "3123",
               "title": "Configuration file for SIM step JME-Summer11Leg-00003_1_cfg.py"
             }
+          ],
+          "generators": [
+            "pythia6"
           ],
           "global_tag": "START53_LV4::All",
           "output_dataset": "/QCD_Pt-15to30_TuneZ2_7TeV_pythia6/Summer11Leg-START53_LV4-v1/GEN-SIM",
@@ -10849,12 +10648,6 @@
         "uri": "root://eospublic.cern.ch//eos/opendata/cms/MonteCarlo2011/Summer11LegDR/QCD_Pt-170to250_EMEnriched_TuneZ2_7TeV-pythia6/AODSIM/PU_S13_START53_LV6-v1/file-indexes/CMS_MonteCarlo2011_Summer11LegDR_QCD_Pt-170to250_EMEnriched_TuneZ2_7TeV-pythia6_AODSIM_PU_S13_START53_LV6-v1_00000_file_index.txt"
       }
     ],
-    "generator": {
-      "global_tag": "START53_LV6",
-      "names": [
-        "pythia6"
-      ]
-    },
     "license": {
       "attribution": "CC0"
     },
@@ -10868,6 +10661,9 @@
               "recid": "3239",
               "title": "Configuration file for SIM step EWK-Summer11Leg-00009_1_cfg.py"
             }
+          ],
+          "generators": [
+            "pythia6"
           ],
           "global_tag": "START53_LV4::All",
           "output_dataset": "/QCD_Pt-170to250_EMEnriched_TuneZ2_7TeV-pythia6/Summer11Leg-START53_LV4-v1/GEN-SIM",
@@ -10989,12 +10785,6 @@
         "uri": "root://eospublic.cern.ch//eos/opendata/cms/MonteCarlo2011/Summer11LegDR/QCD_Pt-170to300_MuEnrichedPt5_TuneZ2_7TeV_pythia6/AODSIM/PU_S13_START53_LV6-v1/file-indexes/CMS_MonteCarlo2011_Summer11LegDR_QCD_Pt-170to300_MuEnrichedPt5_TuneZ2_7TeV_pythia6_AODSIM_PU_S13_START53_LV6-v1_00000_file_index.txt"
       }
     ],
-    "generator": {
-      "global_tag": "START53_LV6",
-      "names": [
-        "pythia6"
-      ]
-    },
     "license": {
       "attribution": "CC0"
     },
@@ -11008,6 +10798,9 @@
               "recid": "3212",
               "title": "Configuration file for SIM step BTV-Summer11Leg-00007_1_cfg.py"
             }
+          ],
+          "generators": [
+            "pythia6"
           ],
           "global_tag": "START53_LV4::All",
           "output_dataset": "/QCD_Pt-170to300_MuEnrichedPt5_TuneZ2_7TeV_pythia6/Summer11Leg-START53_LV4-v1/GEN-SIM",
@@ -11129,12 +10922,6 @@
         "uri": "root://eospublic.cern.ch//eos/opendata/cms/MonteCarlo2011/Summer11LegDR/QCD_Pt-170to300_TuneZ2_7TeV_pythia6/AODSIM/PU_S13_START53_LV6-v1/file-indexes/CMS_MonteCarlo2011_Summer11LegDR_QCD_Pt-170to300_TuneZ2_7TeV_pythia6_AODSIM_PU_S13_START53_LV6-v1_00000_file_index.txt"
       }
     ],
-    "generator": {
-      "global_tag": "START53_LV6",
-      "names": [
-        "pythia6"
-      ]
-    },
     "license": {
       "attribution": "CC0"
     },
@@ -11148,6 +10935,9 @@
               "recid": "3194",
               "title": "Configuration file for SIM step JME-Summer11Leg-00008_1_cfg.py"
             }
+          ],
+          "generators": [
+            "pythia6"
           ],
           "global_tag": "START53_LV4::All",
           "output_dataset": "/QCD_Pt-170to300_TuneZ2_7TeV_pythia6/Summer11Leg-START53_LV4-v1/GEN-SIM",
@@ -11269,12 +11059,6 @@
         "uri": "root://eospublic.cern.ch//eos/opendata/cms/MonteCarlo2011/Summer11LegDR/QCD_Pt-1800_TuneZ2_7TeV_pythia6/AODSIM/PU_S13_START53_LV6-v1/file-indexes/CMS_MonteCarlo2011_Summer11LegDR_QCD_Pt-1800_TuneZ2_7TeV_pythia6_AODSIM_PU_S13_START53_LV6-v1_00000_file_index.txt"
       }
     ],
-    "generator": {
-      "global_tag": "START53_LV6",
-      "names": [
-        "pythia6"
-      ]
-    },
     "license": {
       "attribution": "CC0"
     },
@@ -11288,6 +11072,9 @@
               "recid": "3103",
               "title": "Configuration file for SIM step JME-Summer11Leg-00015_1_cfg.py"
             }
+          ],
+          "generators": [
+            "pythia6"
           ],
           "global_tag": "START53_LV4::All",
           "output_dataset": "/QCD_Pt-1800_TuneZ2_7TeV_pythia6/Summer11Leg-START53_LV4-v1/GEN-SIM",
@@ -11409,12 +11196,6 @@
         "uri": "root://eospublic.cern.ch//eos/opendata/cms/MonteCarlo2011/Summer11LegDR/QCD_Pt-20_MuEnrichedPt-10_TuneZ2_7TeV-pythia6/AODSIM/PU_S13_START53_LV6-v1/file-indexes/CMS_MonteCarlo2011_Summer11LegDR_QCD_Pt-20_MuEnrichedPt-10_TuneZ2_7TeV-pythia6_AODSIM_PU_S13_START53_LV6-v1_00000_file_index.txt"
       }
     ],
-    "generator": {
-      "global_tag": "START53_LV6",
-      "names": [
-        "pythia6"
-      ]
-    },
     "license": {
       "attribution": "CC0"
     },
@@ -11428,6 +11209,9 @@
               "recid": "3399",
               "title": "Configuration file for SIM step EWK-Summer11Leg-00007_1_cfg.py"
             }
+          ],
+          "generators": [
+            "pythia6"
           ],
           "global_tag": "START53_LV4::All",
           "output_dataset": "/QCD_Pt-20_MuEnrichedPt-10_TuneZ2_7TeV-pythia6/Summer11Leg-START53_LV4-v1/GEN-SIM",
@@ -11549,12 +11333,6 @@
         "uri": "root://eospublic.cern.ch//eos/opendata/cms/MonteCarlo2011/Summer11LegDR/QCD_Pt-20_MuEnrichedPt-15_TuneZ2_7TeV-pythia6/AODSIM/PU_S13_START53_LV6-v1/file-indexes/CMS_MonteCarlo2011_Summer11LegDR_QCD_Pt-20_MuEnrichedPt-15_TuneZ2_7TeV-pythia6_AODSIM_PU_S13_START53_LV6-v1_00000_file_index.txt"
       }
     ],
-    "generator": {
-      "global_tag": "START53_LV6",
-      "names": [
-        "pythia6"
-      ]
-    },
     "license": {
       "attribution": "CC0"
     },
@@ -11568,6 +11346,9 @@
               "recid": "3022",
               "title": "Configuration file for SIM step EWK-Summer11Leg-00008_1_cfg.py"
             }
+          ],
+          "generators": [
+            "pythia6"
           ],
           "global_tag": "START53_LV4::All",
           "output_dataset": "/QCD_Pt-20_MuEnrichedPt-15_TuneZ2_7TeV-pythia6/Summer11Leg-START53_LV4-v1/GEN-SIM",
@@ -11689,12 +11470,6 @@
         "uri": "root://eospublic.cern.ch//eos/opendata/cms/MonteCarlo2011/Summer11LegDR/QCD_Pt-20to30_BCtoE_TuneZ2_7TeV-pythia6/AODSIM/PU_S13_START53_LV6-v1/file-indexes/CMS_MonteCarlo2011_Summer11LegDR_QCD_Pt-20to30_BCtoE_TuneZ2_7TeV-pythia6_AODSIM_PU_S13_START53_LV6-v1_00000_file_index.txt"
       }
     ],
-    "generator": {
-      "global_tag": "START53_LV6",
-      "names": [
-        "pythia6"
-      ]
-    },
     "license": {
       "attribution": "CC0"
     },
@@ -11708,6 +11483,9 @@
               "recid": "3150",
               "title": "Configuration file for SIM step EWK-Summer11Leg-00001_1_cfg.py"
             }
+          ],
+          "generators": [
+            "pythia6"
           ],
           "global_tag": "START53_LV4::All",
           "output_dataset": "/QCD_Pt-20to30_BCtoE_TuneZ2_7TeV-pythia6/Summer11Leg-START53_LV4-v1/GEN-SIM",
@@ -11829,12 +11607,6 @@
         "uri": "root://eospublic.cern.ch//eos/opendata/cms/MonteCarlo2011/Summer11LegDR/QCD_Pt-20to30_EMEnriched_TuneZ2_7TeV-pythia6/AODSIM/PU_S13_START53_LV6-v1/file-indexes/CMS_MonteCarlo2011_Summer11LegDR_QCD_Pt-20to30_EMEnriched_TuneZ2_7TeV-pythia6_AODSIM_PU_S13_START53_LV6-v1_00000_file_index.txt"
       }
     ],
-    "generator": {
-      "global_tag": "START53_LV6",
-      "names": [
-        "pythia6"
-      ]
-    },
     "license": {
       "attribution": "CC0"
     },
@@ -11848,6 +11620,9 @@
               "recid": "3376",
               "title": "Configuration file for SIM step EWK-Summer11Leg-00002_1_cfg.py"
             }
+          ],
+          "generators": [
+            "pythia6"
           ],
           "global_tag": "START53_LV4::All",
           "output_dataset": "/QCD_Pt-20to30_EMEnriched_TuneZ2_7TeV-pythia6/Summer11Leg-START53_LV4-v1/GEN-SIM",
@@ -11969,12 +11744,6 @@
         "uri": "root://eospublic.cern.ch//eos/opendata/cms/MonteCarlo2011/Summer11LegDR/QCD_Pt-20to30_MuEnrichedPt5_TuneZ2_7TeV_pythia6/AODSIM/PU_S13_START53_LV6-v1/file-indexes/CMS_MonteCarlo2011_Summer11LegDR_QCD_Pt-20to30_MuEnrichedPt5_TuneZ2_7TeV_pythia6_AODSIM_PU_S13_START53_LV6-v1_00000_file_index.txt"
       }
     ],
-    "generator": {
-      "global_tag": "START53_LV6",
-      "names": [
-        "pythia6"
-      ]
-    },
     "license": {
       "attribution": "CC0"
     },
@@ -11988,6 +11757,9 @@
               "recid": "3094",
               "title": "Configuration file for SIM step BTV-Summer11Leg-00002_1_cfg.py"
             }
+          ],
+          "generators": [
+            "pythia6"
           ],
           "global_tag": "START53_LV4::All",
           "output_dataset": "/QCD_Pt-20to30_MuEnrichedPt5_TuneZ2_7TeV_pythia6/Summer11Leg-START53_LV4-v1/GEN-SIM",
@@ -12109,12 +11881,6 @@
         "uri": "root://eospublic.cern.ch//eos/opendata/cms/MonteCarlo2011/Summer11LegDR/QCD_Pt-250to350_EMEnriched_TuneZ2_7TeV-pythia6/AODSIM/PU_S13_START53_LV6-v1/file-indexes/CMS_MonteCarlo2011_Summer11LegDR_QCD_Pt-250to350_EMEnriched_TuneZ2_7TeV-pythia6_AODSIM_PU_S13_START53_LV6-v1_00000_file_index.txt"
       }
     ],
-    "generator": {
-      "global_tag": "START53_LV6",
-      "names": [
-        "pythia6"
-      ]
-    },
     "license": {
       "attribution": "CC0"
     },
@@ -12128,6 +11894,9 @@
               "recid": "3092",
               "title": "Configuration file for SIM step EWK-Summer11Leg-00010_1_cfg.py"
             }
+          ],
+          "generators": [
+            "pythia6"
           ],
           "global_tag": "START53_LV4::All",
           "output_dataset": "/QCD_Pt-250to350_EMEnriched_TuneZ2_7TeV-pythia6/Summer11Leg-START53_LV4-v1/GEN-SIM",
@@ -12249,12 +12018,6 @@
         "uri": "root://eospublic.cern.ch//eos/opendata/cms/MonteCarlo2011/Summer11LegDR/QCD_Pt-300to470_MuEnrichedPt5_TuneZ2_7TeV_pythia6/AODSIM/PU_S13_START53_LV6-v1/file-indexes/CMS_MonteCarlo2011_Summer11LegDR_QCD_Pt-300to470_MuEnrichedPt5_TuneZ2_7TeV_pythia6_AODSIM_PU_S13_START53_LV6-v1_00000_file_index.txt"
       }
     ],
-    "generator": {
-      "global_tag": "START53_LV6",
-      "names": [
-        "pythia6"
-      ]
-    },
     "license": {
       "attribution": "CC0"
     },
@@ -12268,6 +12031,9 @@
               "recid": "3277",
               "title": "Configuration file for SIM step BTV-Summer11Leg-00008_1_cfg.py"
             }
+          ],
+          "generators": [
+            "pythia6"
           ],
           "global_tag": "START53_LV4::All",
           "output_dataset": "/QCD_Pt-300to470_MuEnrichedPt5_TuneZ2_7TeV_pythia6/Summer11Leg-START53_LV4-v2/GEN-SIM",
@@ -12389,13 +12155,6 @@
         "uri": "root://eospublic.cern.ch//eos/opendata/cms/MonteCarlo2011/Summer11LegDR/VBFToHToZZTo2L2Nu_M-200_7TeV-powheg15-pythia6/AODSIM/PU_S13_START53_LV6-v1/file-indexes/CMS_MonteCarlo2011_Summer11LegDR_VBFToHToZZTo2L2Nu_M-200_7TeV-powheg15-pythia6_AODSIM_PU_S13_START53_LV6-v1_00000_file_index.txt"
       }
     ],
-    "generator": {
-      "global_tag": "START53_LV6",
-      "names": [
-        "powheg15",
-        "pythia6"
-      ]
-    },
     "license": {
       "attribution": "CC0"
     },
@@ -12423,6 +12182,10 @@
               "recid": "3306",
               "title": "Configuration file for SIM step HIG-Summer11Leg-00049_1_cfg.py"
             }
+          ],
+          "generators": [
+            "powheg15",
+            "pythia6"
           ],
           "global_tag": "START53_LV4::All",
           "output_dataset": "/VBFToHToZZTo2L2Nu_M-200_7TeV-powheg15-pythia6/Summer11Leg-START53_LV4-v4/GEN-SIM",
@@ -12544,13 +12307,6 @@
         "uri": "root://eospublic.cern.ch//eos/opendata/cms/MonteCarlo2011/Summer11LegDR/VBFToHToZZTo2L2Nu_M-800_7TeV-powheg15-pythia6/AODSIM/PU_S13_START53_LV6-v1/file-indexes/CMS_MonteCarlo2011_Summer11LegDR_VBFToHToZZTo2L2Nu_M-800_7TeV-powheg15-pythia6_AODSIM_PU_S13_START53_LV6-v1_00000_file_index.txt"
       }
     ],
-    "generator": {
-      "global_tag": "START53_LV6",
-      "names": [
-        "powheg15",
-        "pythia6"
-      ]
-    },
     "license": {
       "attribution": "CC0"
     },
@@ -12578,6 +12334,10 @@
               "recid": "3118",
               "title": "Configuration file for SIM step HIG-Summer11Leg-00057_1_cfg.py"
             }
+          ],
+          "generators": [
+            "powheg15",
+            "pythia6"
           ],
           "global_tag": "START53_LV4::All",
           "output_dataset": "/VBFToHToZZTo2L2Nu_M-800_7TeV-powheg15-pythia6/Summer11Leg-START53_LV4-v2/GEN-SIM",
@@ -12711,13 +12471,6 @@
         "uri": "root://eospublic.cern.ch//eos/opendata/cms/MonteCarlo2011/Summer11LegDR/VBFToHToZZTo2L2Nu_M-900_7TeV-powheg15-pythia6/AODSIM/PU_S13_START53_LV6-v1/file-indexes/CMS_MonteCarlo2011_Summer11LegDR_VBFToHToZZTo2L2Nu_M-900_7TeV-powheg15-pythia6_AODSIM_PU_S13_START53_LV6-v1_010000_file_index.txt"
       }
     ],
-    "generator": {
-      "global_tag": "START53_LV6",
-      "names": [
-        "powheg15",
-        "pythia6"
-      ]
-    },
     "license": {
       "attribution": "CC0"
     },
@@ -12745,6 +12498,10 @@
               "recid": "3118",
               "title": "Configuration file for SIM step HIG-Summer11Leg-00057_1_cfg.py"
             }
+          ],
+          "generators": [
+            "powheg15",
+            "pythia6"
           ],
           "global_tag": "START53_LV4::All",
           "output_dataset": "/VBFToHToZZTo2L2Nu_M-900_7TeV-powheg15-pythia6/Summer11Leg-START53_LV4-v2/GEN-SIM",
@@ -12866,13 +12623,6 @@
         "uri": "root://eospublic.cern.ch//eos/opendata/cms/MonteCarlo2011/Summer11LegDR/VBFToHToZZTo2L2Q_M-1000_7TeV-powheg15-pythia6/AODSIM/PU_S13_START53_LV6-v1/file-indexes/CMS_MonteCarlo2011_Summer11LegDR_VBFToHToZZTo2L2Q_M-1000_7TeV-powheg15-pythia6_AODSIM_PU_S13_START53_LV6-v1_00000_file_index.txt"
       }
     ],
-    "generator": {
-      "global_tag": "START53_LV6",
-      "names": [
-        "powheg15",
-        "pythia6"
-      ]
-    },
     "license": {
       "attribution": "CC0"
     },
@@ -12900,6 +12650,10 @@
               "recid": "3196",
               "title": "Configuration file for SIM step HIG-Summer11Leg-00017_1_cfg.py"
             }
+          ],
+          "generators": [
+            "powheg15",
+            "pythia6"
           ],
           "global_tag": "START53_LV4::All",
           "output_dataset": "/VBFToHToZZTo2L2Q_M-1000_7TeV-powheg15-pythia6/Summer11Leg-START53_LV4-v1/GEN-SIM",
@@ -13045,13 +12799,6 @@
         "uri": "root://eospublic.cern.ch//eos/opendata/cms/MonteCarlo2011/Summer11LegDR/ZZTo2e2mu_mll4_7TeV-powheg-pythia6/AODSIM/PU_S13_START53_LV6-v1/file-indexes/CMS_MonteCarlo2011_Summer11LegDR_ZZTo2e2mu_mll4_7TeV-powheg-pythia6_AODSIM_PU_S13_START53_LV6-v1_40000_file_index.txt"
       }
     ],
-    "generator": {
-      "global_tag": "START53_LV6",
-      "names": [
-        "powheg15",
-        "pythia6"
-      ]
-    },
     "license": {
       "attribution": "CC0"
     },
@@ -13079,6 +12826,10 @@
               "recid": "3310",
               "title": "Configuration file for SIM step HIG-Summer11Leg-00113_1_cfg.py"
             }
+          ],
+          "generators": [
+            "powheg15",
+            "pythia6"
           ],
           "global_tag": "START53_LV4::All",
           "output_dataset": "/ZZTo2e2mu_mll4_7TeV-powheg-pythia6/Summer11Leg-START53_LV4-v1/GEN-SIM",
@@ -13200,12 +12951,6 @@
         "uri": "root://eospublic.cern.ch//eos/opendata/cms/MonteCarlo2011/Summer11LegDR/Tbar_TuneZ2_t-channel_7TeV-powheg-tauola/AODSIM/PU_S13_START53_LV6-v1/file-indexes/CMS_MonteCarlo2011_Summer11LegDR_Tbar_TuneZ2_t-channel_7TeV-powheg-tauola_AODSIM_PU_S13_START53_LV6-v1_00000_file_index.txt"
       }
     ],
-    "generator": {
-      "global_tag": "START53_LV6",
-      "names": [
-        "pythia6"
-      ]
-    },
     "license": {
       "attribution": "CC0"
     },
@@ -13233,6 +12978,9 @@
               "recid": "3107",
               "title": "Configuration file for SIM step TOP-Summer11Leg-00003_1_cfg.py"
             }
+          ],
+          "generators": [
+            "pythia6"
           ],
           "global_tag": "START53_LV4::All",
           "output_dataset": "/Tbar_TuneZ2_t-channel_7TeV-powheg-tauola/Summer11Leg-START53_LV4-v1/GEN-SIM",
@@ -13363,13 +13111,6 @@
         "uri": "root://eospublic.cern.ch//eos/opendata/cms/MonteCarlo2011/Summer11LegDR/BuToKMuMu_BFilter_7TeV-pythia6-evtgen/AODSIM/PU_S13_START53_LV6-v1/file-indexes/CMS_MonteCarlo2011_Summer11LegDR_BuToKMuMu_BFilter_7TeV-pythia6-evtgen_AODSIM_PU_S13_START53_LV6-v1_30000_file_index.txt"
       }
     ],
-    "generator": {
-      "global_tag": "START53_LV6",
-      "names": [
-        "Pythia6",
-        "EvtGen"
-      ]
-    },
     "license": {
       "attribution": "CC0"
     },
@@ -13383,6 +13124,10 @@
               "recid": "3088",
               "title": "Configuration file for SIM step BPH-Summer11Leg-00016_1_cfg.py"
             }
+          ],
+          "generators": [
+            "Pythia6",
+            "EvtGen"
           ],
           "global_tag": "START53_LV4::All",
           "output_dataset": "/BuToKMuMu_BFilter_7TeV-pythia6-evtgen/Summer11Leg-START53_LV4-v1/GEN-SIM",
@@ -13501,13 +13246,6 @@
         "uri": "root://eospublic.cern.ch//eos/opendata/cms/MonteCarlo2011/Summer11LegDR/BuToKstarJPsiV2_EtaPtFilter_7TeV-pythia6-evtgen/AODSIM/PU_S13_START53_LV6-v1/file-indexes/CMS_MonteCarlo2011_Summer11LegDR_BuToKstarJPsiV2_EtaPtFilter_7TeV-pythia6-evtgen_AODSIM_PU_S13_START53_LV6-v1_00000_file_index.txt"
       }
     ],
-    "generator": {
-      "global_tag": "START53_LV6",
-      "names": [
-        "PYTHIA6",
-        "EvtGen"
-      ]
-    },
     "license": {
       "attribution": "CC0"
     },
@@ -13521,6 +13259,10 @@
               "recid": "3069",
               "title": "Configuration file for SIM step BPH-Summer11Leg-00014_1_cfg.py"
             }
+          ],
+          "generators": [
+            "PYTHIA6",
+            "EvtGen"
           ],
           "global_tag": "START53_LV4::All",
           "output_dataset": "/BuToKstarJPsiV2_EtaPtFilter_7TeV-pythia6-evtgen/Summer11Leg-START53_LV4-v1/GEN-SIM",
@@ -13651,13 +13393,6 @@
         "uri": "root://eospublic.cern.ch//eos/opendata/cms/MonteCarlo2011/Summer11LegDR/BuToKstarMuMuV2_EtaPtFilter_7TeV-pythia6-evtgen/AODSIM/PU_S13_START53_LV6-v1/file-indexes/CMS_MonteCarlo2011_Summer11LegDR_BuToKstarMuMuV2_EtaPtFilter_7TeV-pythia6-evtgen_AODSIM_PU_S13_START53_LV6-v1_00001_file_index.txt"
       }
     ],
-    "generator": {
-      "global_tag": "START53_LV6",
-      "names": [
-        "Pythia6",
-        "EvtGen"
-      ]
-    },
     "license": {
       "attribution": "CC0"
     },
@@ -13671,6 +13406,10 @@
               "recid": "3157",
               "title": "Configuration file for SIM step BPH-Summer11Leg-00013_1_cfg.py"
             }
+          ],
+          "generators": [
+            "Pythia6",
+            "EvtGen"
           ],
           "global_tag": "START53_LV4::All",
           "output_dataset": "/BuToKstarMuMuV2_EtaPtFilter_7TeV-pythia6-evtgen/Summer11Leg-START53_LV4-v1/GEN-SIM",
@@ -13789,13 +13528,6 @@
         "uri": "root://eospublic.cern.ch//eos/opendata/cms/MonteCarlo2011/Summer11LegDR/BuToKstarPsi2SV2_EtaPtFilter_7TeV-pythia6-evtgen/AODSIM/PU_S13_START53_LV6-v1/file-indexes/CMS_MonteCarlo2011_Summer11LegDR_BuToKstarPsi2SV2_EtaPtFilter_7TeV-pythia6-evtgen_AODSIM_PU_S13_START53_LV6-v1_00000_file_index.txt"
       }
     ],
-    "generator": {
-      "global_tag": "START53_LV6",
-      "names": [
-        "Pythia6",
-        "EvtGen"
-      ]
-    },
     "license": {
       "attribution": "CC0"
     },
@@ -13809,6 +13541,10 @@
               "recid": "3002",
               "title": "Configuration file for SIM step BPH-Summer11Leg-00015_1_cfg.py"
             }
+          ],
+          "generators": [
+            "Pythia6",
+            "EvtGen"
           ],
           "global_tag": "START53_LV4::All",
           "output_dataset": "/BuToKstarPsi2SV2_EtaPtFilter_7TeV-pythia6-evtgen/Summer11Leg-START53_LV4-v1/GEN-SIM",
@@ -13939,13 +13675,6 @@
         "uri": "root://eospublic.cern.ch//eos/opendata/cms/MonteCarlo2011/Summer11LegDR/BuToPsiK_KFilter_TuneZ2star_SVS_7TeV-pythia6-evtgen/AODSIM/PU_S13_START53_LV6-v1/file-indexes/CMS_MonteCarlo2011_Summer11LegDR_BuToPsiK_KFilter_TuneZ2star_SVS_7TeV-pythia6-evtgen_AODSIM_PU_S13_START53_LV6-v1_30000_file_index.txt"
       }
     ],
-    "generator": {
-      "global_tag": "START53_LV6",
-      "names": [
-        "Pythia6",
-        "EvtGen"
-      ]
-    },
     "license": {
       "attribution": "CC0"
     },
@@ -13959,6 +13688,10 @@
               "recid": "3301",
               "title": "Configuration file for SIM step BPH-Summer11Leg-00017_1_cfg.py"
             }
+          ],
+          "generators": [
+            "Pythia6",
+            "EvtGen"
           ],
           "global_tag": "START53_LV4::All",
           "output_dataset": "/BuToPsiK_KFilter_TuneZ2star_SVS_7TeV-pythia6-evtgen/Summer11Leg-START53_LV4-v1/GEN-SIM",
@@ -14116,12 +13849,6 @@
         "uri": "root://eospublic.cern.ch//eos/opendata/cms/MonteCarlo2011/Summer11LegDR/DY1JetToLL_M-10To50_TuneZ2_7TeV-madgraph/AODSIM/PU_S13_START53_LV6-v1/file-indexes/CMS_MonteCarlo2011_Summer11LegDR_DY1JetToLL_M-10To50_TuneZ2_7TeV-madgraph_AODSIM_PU_S13_START53_LV6-v1_020002_file_index.txt"
       }
     ],
-    "generator": {
-      "global_tag": "START53_LV6",
-      "names": [
-        "madgraph"
-      ]
-    },
     "license": {
       "attribution": "CC0"
     },
@@ -14149,6 +13876,9 @@
               "recid": "3164",
               "title": "Configuration file for SIM step HIG-Summer11Leg-00011_1_cfg.py"
             }
+          ],
+          "generators": [
+            "madgraph"
           ],
           "global_tag": "START53_LV4::All",
           "output_dataset": "/DY1JetToLL_M-10To50_TuneZ2_7TeV-madgraph/Summer11Leg-START53_LV4-v2/GEN-SIM",
@@ -14366,12 +14096,6 @@
         "uri": "root://eospublic.cern.ch//eos/opendata/cms/MonteCarlo2011/Summer11LegDR/DY2Jets_M-10To50_TuneZ2_7TeV-madgraph/AODSIM/PU_S13_START53_LV6-v1/file-indexes/CMS_MonteCarlo2011_Summer11LegDR_DY2Jets_M-10To50_TuneZ2_7TeV-madgraph_AODSIM_PU_S13_START53_LV6-v1_010007_file_index.txt"
       }
     ],
-    "generator": {
-      "global_tag": "START53_LV6",
-      "names": [
-        "madgraph"
-      ]
-    },
     "license": {
       "attribution": "CC0"
     },
@@ -14399,6 +14123,9 @@
               "recid": "3373",
               "title": "Configuration file for SIM step HIG-Summer11Leg-00003_1_cfg.py"
             }
+          ],
+          "generators": [
+            "madgraph"
           ],
           "global_tag": "START53_LV4::All",
           "output_dataset": "/DY2Jets_M-10To50_TuneZ2_7TeV-madgraph/Summer11Leg-START53_LV4-v2/GEN-SIM",
@@ -14556,12 +14283,6 @@
         "uri": "root://eospublic.cern.ch//eos/opendata/cms/MonteCarlo2011/Summer11LegDR/DY3Jets_M-10To50_TuneZ2_7TeV-madgraph/AODSIM/PU_S13_START53_LV6-v1/file-indexes/CMS_MonteCarlo2011_Summer11LegDR_DY3Jets_M-10To50_TuneZ2_7TeV-madgraph_AODSIM_PU_S13_START53_LV6-v1_010002_file_index.txt"
       }
     ],
-    "generator": {
-      "global_tag": "START53_LV6",
-      "names": [
-        "madgraph"
-      ]
-    },
     "license": {
       "attribution": "CC0"
     },
@@ -14589,6 +14310,9 @@
               "recid": "3205",
               "title": "Configuration file for SIM step HIG-Summer11Leg-00004_1_cfg.py"
             }
+          ],
+          "generators": [
+            "madgraph"
           ],
           "global_tag": "START53_LV4::All",
           "output_dataset": "/DY3Jets_M-10To50_TuneZ2_7TeV-madgraph/Summer11Leg-START53_LV4-v1/GEN-SIM",
@@ -14722,12 +14446,6 @@
         "uri": "root://eospublic.cern.ch//eos/opendata/cms/MonteCarlo2011/Summer11LegDR/DY4Jets_M-10To50_TuneZ2_7TeV-madgraph/AODSIM/PU_S13_START53_LV6-v1/file-indexes/CMS_MonteCarlo2011_Summer11LegDR_DY4Jets_M-10To50_TuneZ2_7TeV-madgraph_AODSIM_PU_S13_START53_LV6-v1_010000_file_index.txt"
       }
     ],
-    "generator": {
-      "global_tag": "START53_LV6",
-      "names": [
-        "madgraph"
-      ]
-    },
     "license": {
       "attribution": "CC0"
     },
@@ -14755,6 +14473,9 @@
               "recid": "3164",
               "title": "Configuration file for SIM step HIG-Summer11Leg-00011_1_cfg.py"
             }
+          ],
+          "generators": [
+            "madgraph"
           ],
           "global_tag": "START53_LV4::All",
           "output_dataset": "/DY4Jets_M-10To50_TuneZ2_7TeV-madgraph/Summer11Leg-START53_LV4-v2/GEN-SIM",
@@ -14876,12 +14597,6 @@
         "uri": "root://eospublic.cern.ch//eos/opendata/cms/MonteCarlo2011/Summer11LegDR/DYJetsToLL_M-10To50_TuneZ2_7TeV-pythia6/AODSIM/PU_S13_START53_LV6-v1/file-indexes/CMS_MonteCarlo2011_Summer11LegDR_DYJetsToLL_M-10To50_TuneZ2_7TeV-pythia6_AODSIM_PU_S13_START53_LV6-v1_00000_file_index.txt"
       }
     ],
-    "generator": {
-      "global_tag": "START53_LV6",
-      "names": [
-        "pythia6"
-      ]
-    },
     "license": {
       "attribution": "CC0"
     },
@@ -14895,6 +14610,9 @@
               "recid": "3286",
               "title": "Configuration file for SIM step BTV-Summer11Leg-00013_1_cfg.py"
             }
+          ],
+          "generators": [
+            "pythia6"
           ],
           "global_tag": "START53_LV4::All",
           "output_dataset": "/DYJetsToLL_M-10To50_TuneZ2_7TeV-pythia6/Summer11Leg-START53_LV4-v1/GEN-SIM",
@@ -15112,13 +14830,6 @@
         "uri": "root://eospublic.cern.ch//eos/opendata/cms/MonteCarlo2011/Summer11LegDR/DYJetsToLL_M-50_7TeV-madgraph-pythia6-tauola/AODSIM/PU_S13_START53_LV6-v1/file-indexes/CMS_MonteCarlo2011_Summer11LegDR_DYJetsToLL_M-50_7TeV-madgraph-pythia6-tauola_AODSIM_PU_S13_START53_LV6-v1_010005_file_index.txt"
       }
     ],
-    "generator": {
-      "global_tag": "START53_LV6",
-      "names": [
-        "madgraph",
-        "pythia6"
-      ]
-    },
     "license": {
       "attribution": "CC0"
     },
@@ -15146,6 +14857,10 @@
               "recid": "3200",
               "title": "Configuration file for SIM step SMP-Summer11Leg-00001_1_cfg.py"
             }
+          ],
+          "generators": [
+            "madgraph",
+            "pythia6"
           ],
           "global_tag": "START53_LV4::All",
           "output_dataset": "/DYJetsToLL_M-50_7TeV-madgraph-pythia6-tauola/Summer11Leg-START53_LV4-v1/GEN-SIM",
@@ -15459,12 +15174,6 @@
         "uri": "root://eospublic.cern.ch//eos/opendata/cms/MonteCarlo2011/Summer11LegDR/DYJetsToLL_TuneZ2_M-50_7TeV-madgraph-tauola/AODSIM/PU_S13_START53_LV6-v1/file-indexes/CMS_MonteCarlo2011_Summer11LegDR_DYJetsToLL_TuneZ2_M-50_7TeV-madgraph-tauola_AODSIM_PU_S13_START53_LV6-v1_010015_file_index.txt"
       }
     ],
-    "generator": {
-      "global_tag": "START53_LV6",
-      "names": [
-        "madgraph"
-      ]
-    },
     "license": {
       "attribution": "CC0"
     },
@@ -15492,6 +15201,9 @@
               "recid": "3317",
               "title": "Configuration file for SIM step TOP-Summer11Leg-00013_1_cfg.py"
             }
+          ],
+          "generators": [
+            "madgraph"
           ],
           "global_tag": "START53_LV4::All",
           "output_dataset": "/DYJetsToLL_TuneZ2_M-50_7TeV-madgraph-tauola/Summer11Leg-START53_LV4-v1/GEN-SIM",
@@ -15613,12 +15325,6 @@
         "uri": "root://eospublic.cern.ch//eos/opendata/cms/MonteCarlo2011/Summer11LegDR/GJet_Pt-20_doubleEMEnriched_TuneZ2_7TeV-pythia6/AODSIM/PU_S13_START53_LV6-v1/file-indexes/CMS_MonteCarlo2011_Summer11LegDR_GJet_Pt-20_doubleEMEnriched_TuneZ2_7TeV-pythia6_AODSIM_PU_S13_START53_LV6-v1_00000_file_index.txt"
       }
     ],
-    "generator": {
-      "global_tag": "START53_LV6",
-      "names": [
-        "pythia6"
-      ]
-    },
     "license": {
       "attribution": "CC0"
     },
@@ -15632,6 +15338,9 @@
               "recid": "3316",
               "title": "Configuration file for SIM step HIG-Summer11Leg-00001_1_cfg.py"
             }
+          ],
+          "generators": [
+            "pythia6"
           ],
           "global_tag": "START53_LV4::All",
           "output_dataset": "/GJet_Pt-20_doubleEMEnriched_TuneZ2_7TeV-pythia6/Summer11Leg-START53_LV4-v1/GEN-SIM",
@@ -15753,12 +15462,6 @@
         "uri": "root://eospublic.cern.ch//eos/opendata/cms/MonteCarlo2011/Summer11LegDR/GJets_TuneZ2_100_HT_200_7TeV-madgraph/AODSIM/PU_S13_START53_LV6-v3/file-indexes/CMS_MonteCarlo2011_Summer11LegDR_GJets_TuneZ2_100_HT_200_7TeV-madgraph_AODSIM_PU_S13_START53_LV6-v3_00000_file_index.txt"
       }
     ],
-    "generator": {
-      "global_tag": "START53_LV6",
-      "names": [
-        "madgraph"
-      ]
-    },
     "license": {
       "attribution": "CC0"
     },
@@ -15786,6 +15489,9 @@
               "recid": "3315",
               "title": "Configuration file for SIM step SUS-Summer11Leg-00005_1_cfg.py"
             }
+          ],
+          "generators": [
+            "madgraph"
           ],
           "global_tag": "START53_LV4::All",
           "output_dataset": "/GJets_TuneZ2_100_HT_200_7TeV-madgraph/Summer11Leg-START53_LV4-v1/GEN-SIM",
@@ -15919,12 +15625,6 @@
         "uri": "root://eospublic.cern.ch//eos/opendata/cms/MonteCarlo2011/Summer11LegDR/GJets_TuneZ2_200_HT_inf_7TeV-madgraph/AODSIM/PU_S13_START53_LV6-v1/file-indexes/CMS_MonteCarlo2011_Summer11LegDR_GJets_TuneZ2_200_HT_inf_7TeV-madgraph_AODSIM_PU_S13_START53_LV6-v1_30000_file_index.txt"
       }
     ],
-    "generator": {
-      "global_tag": "START53_LV6",
-      "names": [
-        "madgraph"
-      ]
-    },
     "license": {
       "attribution": "CC0"
     },
@@ -15952,6 +15652,9 @@
               "recid": "3226",
               "title": "Configuration file for SIM step SUS-Summer11Leg-00002_1_cfg.py"
             }
+          ],
+          "generators": [
+            "madgraph"
           ],
           "global_tag": "START53_LV4::All",
           "output_dataset": "/GJets_TuneZ2_200_HT_inf_7TeV-madgraph/Summer11Leg-START53_LV4-v1/GEN-SIM",
@@ -16073,12 +15776,6 @@
         "uri": "root://eospublic.cern.ch//eos/opendata/cms/MonteCarlo2011/Summer11LegDR/GJets_TuneZ2_40_HT_100_7TeV-madgraph/AODSIM/PU_S13_START53_LV6-v1/file-indexes/CMS_MonteCarlo2011_Summer11LegDR_GJets_TuneZ2_40_HT_100_7TeV-madgraph_AODSIM_PU_S13_START53_LV6-v1_00000_file_index.txt"
       }
     ],
-    "generator": {
-      "global_tag": "START53_LV6",
-      "names": [
-        "madgraph"
-      ]
-    },
     "license": {
       "attribution": "CC0"
     },
@@ -16106,6 +15803,9 @@
               "recid": "3360",
               "title": "Configuration file for SIM step SUS-Summer11Leg-00004_1_cfg.py"
             }
+          ],
+          "generators": [
+            "madgraph"
           ],
           "global_tag": "START53_LV4::All",
           "output_dataset": "/GJets_TuneZ2_40_HT_100_7TeV-madgraph/Summer11Leg-START53_LV4-v1/GEN-SIM",
@@ -16263,13 +15963,6 @@
         "uri": "root://eospublic.cern.ch//eos/opendata/cms/MonteCarlo2011/Summer11LegDR/GluGluTo2L2Lprime_Contin_7TeV-gg2vv315-pythia6/AODSIM/PU_S13_START53_LV6-v1/file-indexes/CMS_MonteCarlo2011_Summer11LegDR_GluGluTo2L2Lprime_Contin_7TeV-gg2vv315-pythia6_AODSIM_PU_S13_START53_LV6-v1_40000_file_index.txt"
       }
     ],
-    "generator": {
-      "global_tag": "START53_LV6",
-      "names": [
-        "gg2VV",
-        "pythia6"
-      ]
-    },
     "license": {
       "attribution": "CC0"
     },
@@ -16297,6 +15990,10 @@
               "recid": "3101",
               "title": "Configuration file for SIM step HIG-Summer11Leg-00156_1_cfg.py"
             }
+          ],
+          "generators": [
+            "gg2VV",
+            "pythia6"
           ],
           "global_tag": "START53_LV4::All",
           "output_dataset": "/GluGluTo2L2Lprime_Contin_7TeV-gg2vv315-pythia6/Summer11Leg-START53_LV4-v1/GEN-SIM",
@@ -16418,13 +16115,6 @@
         "uri": "root://eospublic.cern.ch//eos/opendata/cms/MonteCarlo2011/Summer11LegDR/GluGluTo2L2Lprime_H_M-125p6_7TeV-gg2vv315-pythia6/AODSIM/PU_S13_START53_LV6-v1/file-indexes/CMS_MonteCarlo2011_Summer11LegDR_GluGluTo2L2Lprime_H_M-125p6_7TeV-gg2vv315-pythia6_AODSIM_PU_S13_START53_LV6-v1_10000_file_index.txt"
       }
     ],
-    "generator": {
-      "global_tag": "START53_LV6",
-      "names": [
-        "gg2VV",
-        "pythia6"
-      ]
-    },
     "license": {
       "attribution": "CC0"
     },
@@ -16452,6 +16142,10 @@
               "recid": "3101",
               "title": "Configuration file for SIM step HIG-Summer11Leg-00156_1_cfg.py"
             }
+          ],
+          "generators": [
+            "gg2VV",
+            "pythia6"
           ],
           "global_tag": "START53_LV4::All",
           "output_dataset": "/GluGluTo2L2Lprime_H_M-125p6_7TeV-gg2vv315-pythia6/Summer11Leg-START53_LV4-v1/GEN-SIM",
@@ -16609,13 +16303,6 @@
         "uri": "root://eospublic.cern.ch//eos/opendata/cms/MonteCarlo2011/Summer11LegDR/GluGluTo2e2mu_Contin_7TeV-MCFM67-pythia6/AODSIM/PU_S13_START53_LV6-v1/file-indexes/CMS_MonteCarlo2011_Summer11LegDR_GluGluTo2e2mu_Contin_7TeV-MCFM67-pythia6_AODSIM_PU_S13_START53_LV6-v1_30000_file_index.txt"
       }
     ],
-    "generator": {
-      "global_tag": "START53_LV6",
-      "names": [
-        "MCFM",
-        "pythia6"
-      ]
-    },
     "license": {
       "attribution": "CC0"
     },
@@ -16643,6 +16330,10 @@
               "recid": "3132",
               "title": "Configuration file for SIM step HIG-Summer11Leg-00151_1_cfg.py"
             }
+          ],
+          "generators": [
+            "MCFM",
+            "pythia6"
           ],
           "global_tag": "START53_LV4::All",
           "output_dataset": "/GluGluTo2e2mu_Contin_7TeV-MCFM67-pythia6/Summer11Leg-START53_LV4-v1/GEN-SIM",
@@ -16800,13 +16491,6 @@
         "uri": "root://eospublic.cern.ch//eos/opendata/cms/MonteCarlo2011/Summer11LegDR/GluGluTo2e2mu_SMH_M-125p6_7TeV-MCFM67-pythia6/AODSIM/PU_S13_START53_LV6-v1/file-indexes/CMS_MonteCarlo2011_Summer11LegDR_GluGluTo2e2mu_SMH_M-125p6_7TeV-MCFM67-pythia6_AODSIM_PU_S13_START53_LV6-v1_40000_file_index.txt"
       }
     ],
-    "generator": {
-      "global_tag": "START53_LV6",
-      "names": [
-        "MCFM",
-        "pythia6"
-      ]
-    },
     "license": {
       "attribution": "CC0"
     },
@@ -16834,6 +16518,10 @@
               "recid": "3132",
               "title": "Configuration file for SIM step HIG-Summer11Leg-00151_1_cfg.py"
             }
+          ],
+          "generators": [
+            "MCFM",
+            "pythia6"
           ],
           "global_tag": "START53_LV4::All",
           "output_dataset": "/GluGluTo2e2mu_SMH_M-125p6_7TeV-MCFM67-pythia6/Summer11Leg-START53_LV4-v1/GEN-SIM",
@@ -16979,13 +16667,6 @@
         "uri": "root://eospublic.cern.ch//eos/opendata/cms/MonteCarlo2011/Summer11LegDR/GluGluTo4L_Contin_7TeV-gg2vv315-pythia6/AODSIM/PU_S13_START53_LV6-v1/file-indexes/CMS_MonteCarlo2011_Summer11LegDR_GluGluTo4L_Contin_7TeV-gg2vv315-pythia6_AODSIM_PU_S13_START53_LV6-v1_40000_file_index.txt"
       }
     ],
-    "generator": {
-      "global_tag": "START53_LV6",
-      "names": [
-        "gg2VV",
-        "pythia6"
-      ]
-    },
     "license": {
       "attribution": "CC0"
     },
@@ -17013,6 +16694,10 @@
               "recid": "3101",
               "title": "Configuration file for SIM step HIG-Summer11Leg-00156_1_cfg.py"
             }
+          ],
+          "generators": [
+            "gg2VV",
+            "pythia6"
           ],
           "global_tag": "START53_LV4::All",
           "output_dataset": "/GluGluTo4L_Contin_7TeV-gg2vv315-pythia6/Summer11Leg-START53_LV4-v1/GEN-SIM",
@@ -17134,13 +16819,6 @@
         "uri": "root://eospublic.cern.ch//eos/opendata/cms/MonteCarlo2011/Summer11LegDR/GluGluTo4L_H_M-125p6_7TeV-gg2vv315-pythia6/AODSIM/PU_S13_START53_LV6-v1/file-indexes/CMS_MonteCarlo2011_Summer11LegDR_GluGluTo4L_H_M-125p6_7TeV-gg2vv315-pythia6_AODSIM_PU_S13_START53_LV6-v1_00000_file_index.txt"
       }
     ],
-    "generator": {
-      "global_tag": "START53_LV6",
-      "names": [
-        "gg2VV",
-        "pythia6"
-      ]
-    },
     "license": {
       "attribution": "CC0"
     },
@@ -17168,6 +16846,10 @@
               "recid": "3101",
               "title": "Configuration file for SIM step HIG-Summer11Leg-00156_1_cfg.py"
             }
+          ],
+          "generators": [
+            "gg2VV",
+            "pythia6"
           ],
           "global_tag": "START53_LV4::All",
           "output_dataset": "/GluGluTo4L_H_M-125p6_7TeV-gg2vv315-pythia6/Summer11Leg-START53_LV4-v1/GEN-SIM",
@@ -17289,13 +16971,6 @@
         "uri": "root://eospublic.cern.ch//eos/opendata/cms/MonteCarlo2011/Summer11LegDR/GluGluTo4e_Contin_7TeV-MCFM67-pythia6/AODSIM/PU_S13_START53_LV6-v1/file-indexes/CMS_MonteCarlo2011_Summer11LegDR_GluGluTo4e_Contin_7TeV-MCFM67-pythia6_AODSIM_PU_S13_START53_LV6-v1_00000_file_index.txt"
       }
     ],
-    "generator": {
-      "global_tag": "START53_LV6",
-      "names": [
-        "MCFM",
-        "pythia6"
-      ]
-    },
     "license": {
       "attribution": "CC0"
     },
@@ -17323,6 +16998,10 @@
               "recid": "3132",
               "title": "Configuration file for SIM step HIG-Summer11Leg-00151_1_cfg.py"
             }
+          ],
+          "generators": [
+            "MCFM",
+            "pythia6"
           ],
           "global_tag": "START53_LV4::All",
           "output_dataset": "/GluGluTo4e_Contin_7TeV-MCFM67-pythia6/Summer11Leg-START53_LV4-v1/GEN-SIM",
@@ -17444,13 +17123,6 @@
         "uri": "root://eospublic.cern.ch//eos/opendata/cms/MonteCarlo2011/Summer11LegDR/GluGluTo4e_SMH_M-125p6_7TeV-MCFM67-pythia6/AODSIM/PU_S13_START53_LV6-v2/file-indexes/CMS_MonteCarlo2011_Summer11LegDR_GluGluTo4e_SMH_M-125p6_7TeV-MCFM67-pythia6_AODSIM_PU_S13_START53_LV6-v2_40000_file_index.txt"
       }
     ],
-    "generator": {
-      "global_tag": "START53_LV6",
-      "names": [
-        "MCFM",
-        "pythia6"
-      ]
-    },
     "license": {
       "attribution": "CC0"
     },
@@ -17478,6 +17150,10 @@
               "recid": "3132",
               "title": "Configuration file for SIM step HIG-Summer11Leg-00151_1_cfg.py"
             }
+          ],
+          "generators": [
+            "MCFM",
+            "pythia6"
           ],
           "global_tag": "START53_LV4::All",
           "output_dataset": "/GluGluTo4e_SMH_M-125p6_7TeV-MCFM67-pythia6/Summer11Leg-START53_LV4-v1/GEN-SIM",
@@ -17611,13 +17287,6 @@
         "uri": "root://eospublic.cern.ch//eos/opendata/cms/MonteCarlo2011/Summer11LegDR/GluGluTo4mu_Contin_7TeV-MCFM67-pythia6/AODSIM/PU_S13_START53_LV6-v1/file-indexes/CMS_MonteCarlo2011_Summer11LegDR_GluGluTo4mu_Contin_7TeV-MCFM67-pythia6_AODSIM_PU_S13_START53_LV6-v1_420000_file_index.txt"
       }
     ],
-    "generator": {
-      "global_tag": "START53_LV6",
-      "names": [
-        "MCFM",
-        "pythia6"
-      ]
-    },
     "license": {
       "attribution": "CC0"
     },
@@ -17645,6 +17314,10 @@
               "recid": "3132",
               "title": "Configuration file for SIM step HIG-Summer11Leg-00151_1_cfg.py"
             }
+          ],
+          "generators": [
+            "MCFM",
+            "pythia6"
           ],
           "global_tag": "START53_LV4::All",
           "output_dataset": "/GluGluTo4mu_Contin_7TeV-MCFM67-pythia6/Summer11Leg-START53_LV4-v1/GEN-SIM",
@@ -17790,13 +17463,6 @@
         "uri": "root://eospublic.cern.ch//eos/opendata/cms/MonteCarlo2011/Summer11LegDR/GluGluTo4mu_SMH_M-125p6_7TeV-MCFM67-pythia6/AODSIM/PU_S13_START53_LV6-v1/file-indexes/CMS_MonteCarlo2011_Summer11LegDR_GluGluTo4mu_SMH_M-125p6_7TeV-MCFM67-pythia6_AODSIM_PU_S13_START53_LV6-v1_30000_file_index.txt"
       }
     ],
-    "generator": {
-      "global_tag": "START53_LV6",
-      "names": [
-        "MCFM",
-        "pythia6"
-      ]
-    },
     "license": {
       "attribution": "CC0"
     },
@@ -17824,6 +17490,10 @@
               "recid": "3132",
               "title": "Configuration file for SIM step HIG-Summer11Leg-00151_1_cfg.py"
             }
+          ],
+          "generators": [
+            "MCFM",
+            "pythia6"
           ],
           "global_tag": "START53_LV4::All",
           "output_dataset": "/GluGluTo4mu_SMH_M-125p6_7TeV-MCFM67-pythia6/Summer11Leg-START53_LV4-v1/GEN-SIM",
@@ -17957,13 +17627,6 @@
         "uri": "root://eospublic.cern.ch//eos/opendata/cms/MonteCarlo2011/Summer11LegDR/GluGluToHToZZTo2L2Nu_M-1000_7TeV-powheg15-pythia6/AODSIM/PU_S13_START53_LV6-v1/file-indexes/CMS_MonteCarlo2011_Summer11LegDR_GluGluToHToZZTo2L2Nu_M-1000_7TeV-powheg15-pythia6_AODSIM_PU_S13_START53_LV6-v1_010000_file_index.txt"
       }
     ],
-    "generator": {
-      "global_tag": "START53_LV6",
-      "names": [
-        "powheg15",
-        "pythia6"
-      ]
-    },
     "license": {
       "attribution": "CC0"
     },
@@ -17991,6 +17654,10 @@
               "recid": "3306",
               "title": "Configuration file for SIM step HIG-Summer11Leg-00049_1_cfg.py"
             }
+          ],
+          "generators": [
+            "powheg15",
+            "pythia6"
           ],
           "global_tag": "START53_LV4::All",
           "output_dataset": "/GluGluToHToZZTo2L2Nu_M-1000_7TeV-powheg15-pythia6/Summer11Leg-START53_LV4-v2/GEN-SIM",
@@ -18124,13 +17791,6 @@
         "uri": "root://eospublic.cern.ch//eos/opendata/cms/MonteCarlo2011/Summer11LegDR/GluGluToHToZZTo2L2Nu_M-200_7TeV-powheg15-pythia6/AODSIM/PU_S13_START53_LV6-v1/file-indexes/CMS_MonteCarlo2011_Summer11LegDR_GluGluToHToZZTo2L2Nu_M-200_7TeV-powheg15-pythia6_AODSIM_PU_S13_START53_LV6-v1_010000_file_index.txt"
       }
     ],
-    "generator": {
-      "global_tag": "START53_LV6",
-      "names": [
-        "powheg15",
-        "pythia6"
-      ]
-    },
     "license": {
       "attribution": "CC0"
     },
@@ -18158,6 +17818,10 @@
               "recid": "3306",
               "title": "Configuration file for SIM step HIG-Summer11Leg-00049_1_cfg.py"
             }
+          ],
+          "generators": [
+            "powheg15",
+            "pythia6"
           ],
           "global_tag": "START53_LV4::All",
           "output_dataset": "/GluGluToHToZZTo2L2Nu_M-200_7TeV-powheg15-pythia6/Summer11Leg-START53_LV4-v2/GEN-SIM",
@@ -18279,13 +17943,6 @@
         "uri": "root://eospublic.cern.ch//eos/opendata/cms/MonteCarlo2011/Summer11LegDR/GluGluToHToZZTo2L2Nu_M-225_7TeV-powheg15-pythia6/AODSIM/PU_S13_START53_LV6-v1/file-indexes/CMS_MonteCarlo2011_Summer11LegDR_GluGluToHToZZTo2L2Nu_M-225_7TeV-powheg15-pythia6_AODSIM_PU_S13_START53_LV6-v1_00000_file_index.txt"
       }
     ],
-    "generator": {
-      "global_tag": "START53_LV6",
-      "names": [
-        "powheg15",
-        "pythia6"
-      ]
-    },
     "license": {
       "attribution": "CC0"
     },
@@ -18313,6 +17970,10 @@
               "recid": "3306",
               "title": "Configuration file for SIM step HIG-Summer11Leg-00049_1_cfg.py"
             }
+          ],
+          "generators": [
+            "powheg15",
+            "pythia6"
           ],
           "global_tag": "START53_LV4::All",
           "output_dataset": "/GluGluToHToZZTo2L2Nu_M-225_7TeV-powheg15-pythia6/Summer11Leg-START53_LV4-v3/GEN-SIM",
@@ -18446,13 +18107,6 @@
         "uri": "root://eospublic.cern.ch//eos/opendata/cms/MonteCarlo2011/Summer11LegDR/GluGluToHToZZTo2L2Nu_M-250_7TeV-powheg15-pythia6/AODSIM/PU_S13_START53_LV6-v1/file-indexes/CMS_MonteCarlo2011_Summer11LegDR_GluGluToHToZZTo2L2Nu_M-250_7TeV-powheg15-pythia6_AODSIM_PU_S13_START53_LV6-v1_010000_file_index.txt"
       }
     ],
-    "generator": {
-      "global_tag": "START53_LV6",
-      "names": [
-        "powheg15",
-        "pythia6"
-      ]
-    },
     "license": {
       "attribution": "CC0"
     },
@@ -18480,6 +18134,10 @@
               "recid": "3306",
               "title": "Configuration file for SIM step HIG-Summer11Leg-00049_1_cfg.py"
             }
+          ],
+          "generators": [
+            "powheg15",
+            "pythia6"
           ],
           "global_tag": "START53_LV4::All",
           "output_dataset": "/GluGluToHToZZTo2L2Nu_M-250_7TeV-powheg15-pythia6/Summer11Leg-START53_LV4-v2/GEN-SIM",
@@ -18601,13 +18259,6 @@
         "uri": "root://eospublic.cern.ch//eos/opendata/cms/MonteCarlo2011/Summer11LegDR/GluGluToHToZZTo2L2Nu_M-275_7TeV-powheg15-pythia6/AODSIM/PU_S13_START53_LV6-v1/file-indexes/CMS_MonteCarlo2011_Summer11LegDR_GluGluToHToZZTo2L2Nu_M-275_7TeV-powheg15-pythia6_AODSIM_PU_S13_START53_LV6-v1_00000_file_index.txt"
       }
     ],
-    "generator": {
-      "global_tag": "START53_LV6",
-      "names": [
-        "powheg15",
-        "pythia6"
-      ]
-    },
     "license": {
       "attribution": "CC0"
     },
@@ -18635,6 +18286,10 @@
               "recid": "3306",
               "title": "Configuration file for SIM step HIG-Summer11Leg-00049_1_cfg.py"
             }
+          ],
+          "generators": [
+            "powheg15",
+            "pythia6"
           ],
           "global_tag": "START53_LV4::All",
           "output_dataset": "/GluGluToHToZZTo2L2Nu_M-275_7TeV-powheg15-pythia6/Summer11Leg-START53_LV4-v3/GEN-SIM",
@@ -18768,13 +18423,6 @@
         "uri": "root://eospublic.cern.ch//eos/opendata/cms/MonteCarlo2011/Summer11LegDR/GluGluToHToZZTo2L2Nu_M-300_7TeV-powheg15-pythia6/AODSIM/PU_S13_START53_LV6-v1/file-indexes/CMS_MonteCarlo2011_Summer11LegDR_GluGluToHToZZTo2L2Nu_M-300_7TeV-powheg15-pythia6_AODSIM_PU_S13_START53_LV6-v1_010000_file_index.txt"
       }
     ],
-    "generator": {
-      "global_tag": "START53_LV6",
-      "names": [
-        "powheg15",
-        "pythia6"
-      ]
-    },
     "license": {
       "attribution": "CC0"
     },
@@ -18802,6 +18450,10 @@
               "recid": "3306",
               "title": "Configuration file for SIM step HIG-Summer11Leg-00049_1_cfg.py"
             }
+          ],
+          "generators": [
+            "powheg15",
+            "pythia6"
           ],
           "global_tag": "START53_LV4::All",
           "output_dataset": "/GluGluToHToZZTo2L2Nu_M-300_7TeV-powheg15-pythia6/Summer11Leg-START53_LV4-v2/GEN-SIM",
@@ -18935,13 +18587,6 @@
         "uri": "root://eospublic.cern.ch//eos/opendata/cms/MonteCarlo2011/Summer11LegDR/GluGluToHToZZTo2L2Nu_M-350_7TeV-powheg15-pythia6/AODSIM/PU_S13_START53_LV6-v1/file-indexes/CMS_MonteCarlo2011_Summer11LegDR_GluGluToHToZZTo2L2Nu_M-350_7TeV-powheg15-pythia6_AODSIM_PU_S13_START53_LV6-v1_010000_file_index.txt"
       }
     ],
-    "generator": {
-      "global_tag": "START53_LV6",
-      "names": [
-        "powheg15",
-        "pythia6"
-      ]
-    },
     "license": {
       "attribution": "CC0"
     },
@@ -18969,6 +18614,10 @@
               "recid": "3306",
               "title": "Configuration file for SIM step HIG-Summer11Leg-00049_1_cfg.py"
             }
+          ],
+          "generators": [
+            "powheg15",
+            "pythia6"
           ],
           "global_tag": "START53_LV4::All",
           "output_dataset": "/GluGluToHToZZTo2L2Nu_M-350_7TeV-powheg15-pythia6/Summer11Leg-START53_LV4-v2/GEN-SIM",
@@ -19102,13 +18751,6 @@
         "uri": "root://eospublic.cern.ch//eos/opendata/cms/MonteCarlo2011/Summer11LegDR/GluGluToHToZZTo2L2Nu_M-400_7TeV-powheg15-pythia6/AODSIM/PU_S13_START53_LV6-v1/file-indexes/CMS_MonteCarlo2011_Summer11LegDR_GluGluToHToZZTo2L2Nu_M-400_7TeV-powheg15-pythia6_AODSIM_PU_S13_START53_LV6-v1_010000_file_index.txt"
       }
     ],
-    "generator": {
-      "global_tag": "START53_LV6",
-      "names": [
-        "powheg15",
-        "pythia6"
-      ]
-    },
     "license": {
       "attribution": "CC0"
     },
@@ -19136,6 +18778,10 @@
               "recid": "3306",
               "title": "Configuration file for SIM step HIG-Summer11Leg-00049_1_cfg.py"
             }
+          ],
+          "generators": [
+            "powheg15",
+            "pythia6"
           ],
           "global_tag": "START53_LV4::All",
           "output_dataset": "/GluGluToHToZZTo2L2Nu_M-400_7TeV-powheg15-pythia6/Summer11Leg-START53_LV4-v2/GEN-SIM",
@@ -19269,13 +18915,6 @@
         "uri": "root://eospublic.cern.ch//eos/opendata/cms/MonteCarlo2011/Summer11LegDR/GluGluToHToZZTo2L2Nu_M-450_7TeV-powheg15-pythia6/AODSIM/PU_S13_START53_LV6-v1/file-indexes/CMS_MonteCarlo2011_Summer11LegDR_GluGluToHToZZTo2L2Nu_M-450_7TeV-powheg15-pythia6_AODSIM_PU_S13_START53_LV6-v1_010000_file_index.txt"
       }
     ],
-    "generator": {
-      "global_tag": "START53_LV6",
-      "names": [
-        "powheg15",
-        "pythia6"
-      ]
-    },
     "license": {
       "attribution": "CC0"
     },
@@ -19303,6 +18942,10 @@
               "recid": "3306",
               "title": "Configuration file for SIM step HIG-Summer11Leg-00049_1_cfg.py"
             }
+          ],
+          "generators": [
+            "powheg15",
+            "pythia6"
           ],
           "global_tag": "START53_LV4::All",
           "output_dataset": "/GluGluToHToZZTo2L2Nu_M-450_7TeV-powheg15-pythia6/Summer11Leg-START53_LV4-v2/GEN-SIM",
@@ -19424,13 +19067,6 @@
         "uri": "root://eospublic.cern.ch//eos/opendata/cms/MonteCarlo2011/Summer11LegDR/GluGluToHToZZTo2L2Nu_M-500_7TeV-powheg15-pythia6/AODSIM/PU_S13_START53_LV6-v1/file-indexes/CMS_MonteCarlo2011_Summer11LegDR_GluGluToHToZZTo2L2Nu_M-500_7TeV-powheg15-pythia6_AODSIM_PU_S13_START53_LV6-v1_00000_file_index.txt"
       }
     ],
-    "generator": {
-      "global_tag": "START53_LV6",
-      "names": [
-        "powheg15",
-        "pythia6"
-      ]
-    },
     "license": {
       "attribution": "CC0"
     },
@@ -19458,6 +19094,10 @@
               "recid": "3118",
               "title": "Configuration file for SIM step HIG-Summer11Leg-00057_1_cfg.py"
             }
+          ],
+          "generators": [
+            "powheg15",
+            "pythia6"
           ],
           "global_tag": "START53_LV4::All",
           "output_dataset": "/GluGluToHToZZTo2L2Nu_M-500_7TeV-powheg15-pythia6/Summer11Leg-START53_LV4-v3/GEN-SIM",
@@ -19591,13 +19231,6 @@
         "uri": "root://eospublic.cern.ch//eos/opendata/cms/MonteCarlo2011/Summer11LegDR/GluGluToHToZZTo2L2Nu_M-550_7TeV-powheg15-pythia6/AODSIM/PU_S13_START53_LV6-v1/file-indexes/CMS_MonteCarlo2011_Summer11LegDR_GluGluToHToZZTo2L2Nu_M-550_7TeV-powheg15-pythia6_AODSIM_PU_S13_START53_LV6-v1_010000_file_index.txt"
       }
     ],
-    "generator": {
-      "global_tag": "START53_LV6",
-      "names": [
-        "powheg15",
-        "pythia6"
-      ]
-    },
     "license": {
       "attribution": "CC0"
     },
@@ -19625,6 +19258,10 @@
               "recid": "3118",
               "title": "Configuration file for SIM step HIG-Summer11Leg-00057_1_cfg.py"
             }
+          ],
+          "generators": [
+            "powheg15",
+            "pythia6"
           ],
           "global_tag": "START53_LV4::All",
           "output_dataset": "/GluGluToHToZZTo2L2Nu_M-550_7TeV-powheg15-pythia6/Summer11Leg-START53_LV4-v2/GEN-SIM",
@@ -19758,13 +19395,6 @@
         "uri": "root://eospublic.cern.ch//eos/opendata/cms/MonteCarlo2011/Summer11LegDR/GluGluToHToZZTo2L2Nu_M-600_7TeV-powheg15-pythia6/AODSIM/PU_S13_START53_LV6-v1/file-indexes/CMS_MonteCarlo2011_Summer11LegDR_GluGluToHToZZTo2L2Nu_M-600_7TeV-powheg15-pythia6_AODSIM_PU_S13_START53_LV6-v1_010000_file_index.txt"
       }
     ],
-    "generator": {
-      "global_tag": "START53_LV6",
-      "names": [
-        "powheg15",
-        "pythia6"
-      ]
-    },
     "license": {
       "attribution": "CC0"
     },
@@ -19792,6 +19422,10 @@
               "recid": "3118",
               "title": "Configuration file for SIM step HIG-Summer11Leg-00057_1_cfg.py"
             }
+          ],
+          "generators": [
+            "powheg15",
+            "pythia6"
           ],
           "global_tag": "START53_LV4::All",
           "output_dataset": "/GluGluToHToZZTo2L2Nu_M-600_7TeV-powheg15-pythia6/Summer11Leg-START53_LV4-v3/GEN-SIM",
@@ -19925,13 +19559,6 @@
         "uri": "root://eospublic.cern.ch//eos/opendata/cms/MonteCarlo2011/Summer11LegDR/GluGluToHToZZTo2L2Nu_M-650_7TeV-powheg15-pythia6/AODSIM/PU_S13_START53_LV6-v1/file-indexes/CMS_MonteCarlo2011_Summer11LegDR_GluGluToHToZZTo2L2Nu_M-650_7TeV-powheg15-pythia6_AODSIM_PU_S13_START53_LV6-v1_010000_file_index.txt"
       }
     ],
-    "generator": {
-      "global_tag": "START53_LV6",
-      "names": [
-        "powheg15",
-        "pythia6"
-      ]
-    },
     "license": {
       "attribution": "CC0"
     },
@@ -19959,6 +19586,10 @@
               "recid": "3306",
               "title": "Configuration file for SIM step HIG-Summer11Leg-00049_1_cfg.py"
             }
+          ],
+          "generators": [
+            "powheg15",
+            "pythia6"
           ],
           "global_tag": "START53_LV4::All",
           "output_dataset": "/GluGluToHToZZTo2L2Nu_M-650_7TeV-powheg15-pythia6/Summer11Leg-START53_LV4-v2/GEN-SIM",
@@ -20092,13 +19723,6 @@
         "uri": "root://eospublic.cern.ch//eos/opendata/cms/MonteCarlo2011/Summer11LegDR/GluGluToHToZZTo2L2Nu_M-700_7TeV-powheg15-pythia6/AODSIM/PU_S13_START53_LV6-v1/file-indexes/CMS_MonteCarlo2011_Summer11LegDR_GluGluToHToZZTo2L2Nu_M-700_7TeV-powheg15-pythia6_AODSIM_PU_S13_START53_LV6-v1_010000_file_index.txt"
       }
     ],
-    "generator": {
-      "global_tag": "START53_LV6",
-      "names": [
-        "powheg15",
-        "pythia6"
-      ]
-    },
     "license": {
       "attribution": "CC0"
     },
@@ -20126,6 +19750,10 @@
               "recid": "3306",
               "title": "Configuration file for SIM step HIG-Summer11Leg-00049_1_cfg.py"
             }
+          ],
+          "generators": [
+            "powheg15",
+            "pythia6"
           ],
           "global_tag": "START53_LV4::All",
           "output_dataset": "/GluGluToHToZZTo2L2Nu_M-700_7TeV-powheg15-pythia6/Summer11Leg-START53_LV4-v2/GEN-SIM",
@@ -20259,13 +19887,6 @@
         "uri": "root://eospublic.cern.ch//eos/opendata/cms/MonteCarlo2011/Summer11LegDR/GluGluToHToZZTo2L2Nu_M-800_7TeV-powheg15-pythia6/AODSIM/PU_S13_START53_LV6-v1/file-indexes/CMS_MonteCarlo2011_Summer11LegDR_GluGluToHToZZTo2L2Nu_M-800_7TeV-powheg15-pythia6_AODSIM_PU_S13_START53_LV6-v1_010000_file_index.txt"
       }
     ],
-    "generator": {
-      "global_tag": "START53_LV6",
-      "names": [
-        "powheg15",
-        "pythia6"
-      ]
-    },
     "license": {
       "attribution": "CC0"
     },
@@ -20293,6 +19914,10 @@
               "recid": "3306",
               "title": "Configuration file for SIM step HIG-Summer11Leg-00049_1_cfg.py"
             }
+          ],
+          "generators": [
+            "powheg15",
+            "pythia6"
           ],
           "global_tag": "START53_LV4::All",
           "output_dataset": "/GluGluToHToZZTo2L2Nu_M-800_7TeV-powheg15-pythia6/Summer11Leg-START53_LV4-v2/GEN-SIM",
@@ -20426,13 +20051,6 @@
         "uri": "root://eospublic.cern.ch//eos/opendata/cms/MonteCarlo2011/Summer11LegDR/GluGluToHToZZTo2L2Nu_M-900_7TeV-powheg15-pythia6/AODSIM/PU_S13_START53_LV6-v1/file-indexes/CMS_MonteCarlo2011_Summer11LegDR_GluGluToHToZZTo2L2Nu_M-900_7TeV-powheg15-pythia6_AODSIM_PU_S13_START53_LV6-v1_010000_file_index.txt"
       }
     ],
-    "generator": {
-      "global_tag": "START53_LV6",
-      "names": [
-        "powheg15",
-        "pythia6"
-      ]
-    },
     "license": {
       "attribution": "CC0"
     },
@@ -20460,6 +20078,10 @@
               "recid": "3306",
               "title": "Configuration file for SIM step HIG-Summer11Leg-00049_1_cfg.py"
             }
+          ],
+          "generators": [
+            "powheg15",
+            "pythia6"
           ],
           "global_tag": "START53_LV4::All",
           "output_dataset": "/GluGluToHToZZTo2L2Nu_M-900_7TeV-powheg15-pythia6/Summer11Leg-START53_LV4-v2/GEN-SIM",
@@ -20581,13 +20203,6 @@
         "uri": "root://eospublic.cern.ch//eos/opendata/cms/MonteCarlo2011/Summer11LegDR/GluGluToHToZZTo2L2Q_M-1000_7TeV-powheg15-pythia6/AODSIM/PU_S13_START53_LV6-v1/file-indexes/CMS_MonteCarlo2011_Summer11LegDR_GluGluToHToZZTo2L2Q_M-1000_7TeV-powheg15-pythia6_AODSIM_PU_S13_START53_LV6-v1_00000_file_index.txt"
       }
     ],
-    "generator": {
-      "global_tag": "START53_LV6",
-      "names": [
-        "powheg15",
-        "pythia6"
-      ]
-    },
     "license": {
       "attribution": "CC0"
     },
@@ -20615,6 +20230,10 @@
               "recid": "3196",
               "title": "Configuration file for SIM step HIG-Summer11Leg-00017_1_cfg.py"
             }
+          ],
+          "generators": [
+            "powheg15",
+            "pythia6"
           ],
           "global_tag": "START53_LV4::All",
           "output_dataset": "/GluGluToHToZZTo2L2Q_M-1000_7TeV-powheg15-pythia6/Summer11Leg-START53_LV4-v1/GEN-SIM",
@@ -20736,13 +20355,6 @@
         "uri": "root://eospublic.cern.ch//eos/opendata/cms/MonteCarlo2011/Summer11LegDR/GluGluToHToZZTo2L2Q_M-200_7TeV-powheg15-pythia6/AODSIM/PU_S13_START53_LV6-v1/file-indexes/CMS_MonteCarlo2011_Summer11LegDR_GluGluToHToZZTo2L2Q_M-200_7TeV-powheg15-pythia6_AODSIM_PU_S13_START53_LV6-v1_00000_file_index.txt"
       }
     ],
-    "generator": {
-      "global_tag": "START53_LV6",
-      "names": [
-        "powheg15",
-        "pythia6"
-      ]
-    },
     "license": {
       "attribution": "CC0"
     },
@@ -20770,6 +20382,10 @@
               "recid": "3196",
               "title": "Configuration file for SIM step HIG-Summer11Leg-00017_1_cfg.py"
             }
+          ],
+          "generators": [
+            "powheg15",
+            "pythia6"
           ],
           "global_tag": "START53_LV4::All",
           "output_dataset": "/GluGluToHToZZTo2L2Q_M-200_7TeV-powheg15-pythia6/Summer11Leg-START53_LV4-v1/GEN-SIM",
@@ -20891,13 +20507,6 @@
         "uri": "root://eospublic.cern.ch//eos/opendata/cms/MonteCarlo2011/Summer11LegDR/GluGluToHToZZTo2L2Q_M-225_7TeV-powheg15-pythia6/AODSIM/PU_S13_START53_LV6-v1/file-indexes/CMS_MonteCarlo2011_Summer11LegDR_GluGluToHToZZTo2L2Q_M-225_7TeV-powheg15-pythia6_AODSIM_PU_S13_START53_LV6-v1_00000_file_index.txt"
       }
     ],
-    "generator": {
-      "global_tag": "START53_LV6",
-      "names": [
-        "powheg15",
-        "pythia6"
-      ]
-    },
     "license": {
       "attribution": "CC0"
     },
@@ -20925,6 +20534,10 @@
               "recid": "3196",
               "title": "Configuration file for SIM step HIG-Summer11Leg-00017_1_cfg.py"
             }
+          ],
+          "generators": [
+            "powheg15",
+            "pythia6"
           ],
           "global_tag": "START53_LV4::All",
           "output_dataset": "/GluGluToHToZZTo2L2Q_M-225_7TeV-powheg15-pythia6/Summer11Leg-START53_LV4-v1/GEN-SIM",
@@ -21046,13 +20659,6 @@
         "uri": "root://eospublic.cern.ch//eos/opendata/cms/MonteCarlo2011/Summer11LegDR/GluGluToHToZZTo2L2Q_M-250_7TeV-powheg15-pythia6/AODSIM/PU_S13_START53_LV6-v1/file-indexes/CMS_MonteCarlo2011_Summer11LegDR_GluGluToHToZZTo2L2Q_M-250_7TeV-powheg15-pythia6_AODSIM_PU_S13_START53_LV6-v1_00000_file_index.txt"
       }
     ],
-    "generator": {
-      "global_tag": "START53_LV6",
-      "names": [
-        "powheg15",
-        "pythia6"
-      ]
-    },
     "license": {
       "attribution": "CC0"
     },
@@ -21080,6 +20686,10 @@
               "recid": "3196",
               "title": "Configuration file for SIM step HIG-Summer11Leg-00017_1_cfg.py"
             }
+          ],
+          "generators": [
+            "powheg15",
+            "pythia6"
           ],
           "global_tag": "START53_LV4::All",
           "output_dataset": "/GluGluToHToZZTo2L2Q_M-250_7TeV-powheg15-pythia6/Summer11Leg-START53_LV4-v1/GEN-SIM",
@@ -21201,13 +20811,6 @@
         "uri": "root://eospublic.cern.ch//eos/opendata/cms/MonteCarlo2011/Summer11LegDR/GluGluToHToZZTo2L2Q_M-275_7TeV-powheg15-pythia6/AODSIM/PU_S13_START53_LV6-v1/file-indexes/CMS_MonteCarlo2011_Summer11LegDR_GluGluToHToZZTo2L2Q_M-275_7TeV-powheg15-pythia6_AODSIM_PU_S13_START53_LV6-v1_00000_file_index.txt"
       }
     ],
-    "generator": {
-      "global_tag": "START53_LV6",
-      "names": [
-        "powheg15",
-        "pythia6"
-      ]
-    },
     "license": {
       "attribution": "CC0"
     },
@@ -21235,6 +20838,10 @@
               "recid": "3196",
               "title": "Configuration file for SIM step HIG-Summer11Leg-00017_1_cfg.py"
             }
+          ],
+          "generators": [
+            "powheg15",
+            "pythia6"
           ],
           "global_tag": "START53_LV4::All",
           "output_dataset": "/GluGluToHToZZTo2L2Q_M-275_7TeV-powheg15-pythia6/Summer11Leg-START53_LV4-v1/GEN-SIM",
@@ -21356,13 +20963,6 @@
         "uri": "root://eospublic.cern.ch//eos/opendata/cms/MonteCarlo2011/Summer11LegDR/GluGluToHToZZTo2L2Q_M-300_7TeV-powheg15-pythia6/AODSIM/PU_S13_START53_LV6-v1/file-indexes/CMS_MonteCarlo2011_Summer11LegDR_GluGluToHToZZTo2L2Q_M-300_7TeV-powheg15-pythia6_AODSIM_PU_S13_START53_LV6-v1_00000_file_index.txt"
       }
     ],
-    "generator": {
-      "global_tag": "START53_LV6",
-      "names": [
-        "powheg15",
-        "pythia6"
-      ]
-    },
     "license": {
       "attribution": "CC0"
     },
@@ -21390,6 +20990,10 @@
               "recid": "3196",
               "title": "Configuration file for SIM step HIG-Summer11Leg-00017_1_cfg.py"
             }
+          ],
+          "generators": [
+            "powheg15",
+            "pythia6"
           ],
           "global_tag": "START53_LV4::All",
           "output_dataset": "/GluGluToHToZZTo2L2Q_M-300_7TeV-powheg15-pythia6/Summer11Leg-START53_LV4-v1/GEN-SIM",
@@ -21511,13 +21115,6 @@
         "uri": "root://eospublic.cern.ch//eos/opendata/cms/MonteCarlo2011/Summer11LegDR/GluGluToHToZZTo2L2Q_M-350_7TeV-powheg15-pythia6/AODSIM/PU_S13_START53_LV6-v1/file-indexes/CMS_MonteCarlo2011_Summer11LegDR_GluGluToHToZZTo2L2Q_M-350_7TeV-powheg15-pythia6_AODSIM_PU_S13_START53_LV6-v1_00000_file_index.txt"
       }
     ],
-    "generator": {
-      "global_tag": "START53_LV6",
-      "names": [
-        "powheg15",
-        "pythia6"
-      ]
-    },
     "license": {
       "attribution": "CC0"
     },
@@ -21545,6 +21142,10 @@
               "recid": "3196",
               "title": "Configuration file for SIM step HIG-Summer11Leg-00017_1_cfg.py"
             }
+          ],
+          "generators": [
+            "powheg15",
+            "pythia6"
           ],
           "global_tag": "START53_LV4::All",
           "output_dataset": "/GluGluToHToZZTo2L2Q_M-350_7TeV-powheg15-pythia6/Summer11Leg-START53_LV4-v1/GEN-SIM",
@@ -21666,13 +21267,6 @@
         "uri": "root://eospublic.cern.ch//eos/opendata/cms/MonteCarlo2011/Summer11LegDR/GluGluToHToZZTo2L2Q_M-400_7TeV-powheg15-pythia6/AODSIM/PU_S13_START53_LV6-v1/file-indexes/CMS_MonteCarlo2011_Summer11LegDR_GluGluToHToZZTo2L2Q_M-400_7TeV-powheg15-pythia6_AODSIM_PU_S13_START53_LV6-v1_00000_file_index.txt"
       }
     ],
-    "generator": {
-      "global_tag": "START53_LV6",
-      "names": [
-        "powheg15",
-        "pythia6"
-      ]
-    },
     "license": {
       "attribution": "CC0"
     },
@@ -21700,6 +21294,10 @@
               "recid": "3196",
               "title": "Configuration file for SIM step HIG-Summer11Leg-00017_1_cfg.py"
             }
+          ],
+          "generators": [
+            "powheg15",
+            "pythia6"
           ],
           "global_tag": "START53_LV4::All",
           "output_dataset": "/GluGluToHToZZTo2L2Q_M-400_7TeV-powheg15-pythia6/Summer11Leg-START53_LV4-v1/GEN-SIM",
@@ -21821,13 +21419,6 @@
         "uri": "root://eospublic.cern.ch//eos/opendata/cms/MonteCarlo2011/Summer11LegDR/GluGluToHToZZTo2L2Q_M-450_7TeV-powheg15-pythia6/AODSIM/PU_S13_START53_LV6-v1/file-indexes/CMS_MonteCarlo2011_Summer11LegDR_GluGluToHToZZTo2L2Q_M-450_7TeV-powheg15-pythia6_AODSIM_PU_S13_START53_LV6-v1_00000_file_index.txt"
       }
     ],
-    "generator": {
-      "global_tag": "START53_LV6",
-      "names": [
-        "powheg15",
-        "pythia6"
-      ]
-    },
     "license": {
       "attribution": "CC0"
     },
@@ -21855,6 +21446,10 @@
               "recid": "3196",
               "title": "Configuration file for SIM step HIG-Summer11Leg-00017_1_cfg.py"
             }
+          ],
+          "generators": [
+            "powheg15",
+            "pythia6"
           ],
           "global_tag": "START53_LV4::All",
           "output_dataset": "/GluGluToHToZZTo2L2Q_M-450_7TeV-powheg15-pythia6/Summer11Leg-START53_LV4-v1/GEN-SIM",
@@ -21976,13 +21571,6 @@
         "uri": "root://eospublic.cern.ch//eos/opendata/cms/MonteCarlo2011/Summer11LegDR/GluGluToHToZZTo2L2Q_M-500_7TeV-powheg15-pythia6/AODSIM/PU_S13_START53_LV6-v1/file-indexes/CMS_MonteCarlo2011_Summer11LegDR_GluGluToHToZZTo2L2Q_M-500_7TeV-powheg15-pythia6_AODSIM_PU_S13_START53_LV6-v1_00000_file_index.txt"
       }
     ],
-    "generator": {
-      "global_tag": "START53_LV6",
-      "names": [
-        "powheg15",
-        "pythia6"
-      ]
-    },
     "license": {
       "attribution": "CC0"
     },
@@ -22010,6 +21598,10 @@
               "recid": "3196",
               "title": "Configuration file for SIM step HIG-Summer11Leg-00017_1_cfg.py"
             }
+          ],
+          "generators": [
+            "powheg15",
+            "pythia6"
           ],
           "global_tag": "START53_LV4::All",
           "output_dataset": "/GluGluToHToZZTo2L2Q_M-500_7TeV-powheg15-pythia6/Summer11Leg-START53_LV4-v1/GEN-SIM",
@@ -22131,13 +21723,6 @@
         "uri": "root://eospublic.cern.ch//eos/opendata/cms/MonteCarlo2011/Summer11LegDR/GluGluToHToZZTo2L2Q_M-550_7TeV-powheg15-pythia6/AODSIM/PU_S13_START53_LV6-v1/file-indexes/CMS_MonteCarlo2011_Summer11LegDR_GluGluToHToZZTo2L2Q_M-550_7TeV-powheg15-pythia6_AODSIM_PU_S13_START53_LV6-v1_00000_file_index.txt"
       }
     ],
-    "generator": {
-      "global_tag": "START53_LV6",
-      "names": [
-        "powheg15",
-        "pythia6"
-      ]
-    },
     "license": {
       "attribution": "CC0"
     },
@@ -22165,6 +21750,10 @@
               "recid": "3196",
               "title": "Configuration file for SIM step HIG-Summer11Leg-00017_1_cfg.py"
             }
+          ],
+          "generators": [
+            "powheg15",
+            "pythia6"
           ],
           "global_tag": "START53_LV4::All",
           "output_dataset": "/GluGluToHToZZTo2L2Q_M-550_7TeV-powheg15-pythia6/Summer11Leg-START53_LV4-v1/GEN-SIM",
@@ -22286,13 +21875,6 @@
         "uri": "root://eospublic.cern.ch//eos/opendata/cms/MonteCarlo2011/Summer11LegDR/GluGluToHToZZTo2L2Q_M-600_7TeV-powheg15-pythia6/AODSIM/PU_S13_START53_LV6-v1/file-indexes/CMS_MonteCarlo2011_Summer11LegDR_GluGluToHToZZTo2L2Q_M-600_7TeV-powheg15-pythia6_AODSIM_PU_S13_START53_LV6-v1_00000_file_index.txt"
       }
     ],
-    "generator": {
-      "global_tag": "START53_LV6",
-      "names": [
-        "powheg15",
-        "pythia6"
-      ]
-    },
     "license": {
       "attribution": "CC0"
     },
@@ -22320,6 +21902,10 @@
               "recid": "3196",
               "title": "Configuration file for SIM step HIG-Summer11Leg-00017_1_cfg.py"
             }
+          ],
+          "generators": [
+            "powheg15",
+            "pythia6"
           ],
           "global_tag": "START53_LV4::All",
           "output_dataset": "/GluGluToHToZZTo2L2Q_M-600_7TeV-powheg15-pythia6/Summer11Leg-START53_LV4-v1/GEN-SIM",
@@ -22441,13 +22027,6 @@
         "uri": "root://eospublic.cern.ch//eos/opendata/cms/MonteCarlo2011/Summer11LegDR/GluGluToHToZZTo2L2Q_M-650_7TeV-powheg15-pythia6/AODSIM/PU_S13_START53_LV6-v1/file-indexes/CMS_MonteCarlo2011_Summer11LegDR_GluGluToHToZZTo2L2Q_M-650_7TeV-powheg15-pythia6_AODSIM_PU_S13_START53_LV6-v1_00000_file_index.txt"
       }
     ],
-    "generator": {
-      "global_tag": "START53_LV6",
-      "names": [
-        "powheg15",
-        "pythia6"
-      ]
-    },
     "license": {
       "attribution": "CC0"
     },
@@ -22475,6 +22054,10 @@
               "recid": "3196",
               "title": "Configuration file for SIM step HIG-Summer11Leg-00017_1_cfg.py"
             }
+          ],
+          "generators": [
+            "powheg15",
+            "pythia6"
           ],
           "global_tag": "START53_LV4::All",
           "output_dataset": "/GluGluToHToZZTo2L2Q_M-650_7TeV-powheg15-pythia6/Summer11Leg-START53_LV4-v1/GEN-SIM",
@@ -22596,13 +22179,6 @@
         "uri": "root://eospublic.cern.ch//eos/opendata/cms/MonteCarlo2011/Summer11LegDR/GluGluToHToZZTo2L2Q_M-700_7TeV-powheg15-pythia6/AODSIM/PU_S13_START53_LV6-v1/file-indexes/CMS_MonteCarlo2011_Summer11LegDR_GluGluToHToZZTo2L2Q_M-700_7TeV-powheg15-pythia6_AODSIM_PU_S13_START53_LV6-v1_00000_file_index.txt"
       }
     ],
-    "generator": {
-      "global_tag": "START53_LV6",
-      "names": [
-        "powheg15",
-        "pythia6"
-      ]
-    },
     "license": {
       "attribution": "CC0"
     },
@@ -22630,6 +22206,10 @@
               "recid": "3196",
               "title": "Configuration file for SIM step HIG-Summer11Leg-00017_1_cfg.py"
             }
+          ],
+          "generators": [
+            "powheg15",
+            "pythia6"
           ],
           "global_tag": "START53_LV4::All",
           "output_dataset": "/GluGluToHToZZTo2L2Q_M-700_7TeV-powheg15-pythia6/Summer11Leg-START53_LV4-v1/GEN-SIM",
@@ -22751,13 +22331,6 @@
         "uri": "root://eospublic.cern.ch//eos/opendata/cms/MonteCarlo2011/Summer11LegDR/GluGluToHToZZTo2L2Q_M-800_7TeV-powheg15-pythia6/AODSIM/PU_S13_START53_LV6-v1/file-indexes/CMS_MonteCarlo2011_Summer11LegDR_GluGluToHToZZTo2L2Q_M-800_7TeV-powheg15-pythia6_AODSIM_PU_S13_START53_LV6-v1_00000_file_index.txt"
       }
     ],
-    "generator": {
-      "global_tag": "START53_LV6",
-      "names": [
-        "powheg15",
-        "pythia6"
-      ]
-    },
     "license": {
       "attribution": "CC0"
     },
@@ -22785,6 +22358,10 @@
               "recid": "3196",
               "title": "Configuration file for SIM step HIG-Summer11Leg-00017_1_cfg.py"
             }
+          ],
+          "generators": [
+            "powheg15",
+            "pythia6"
           ],
           "global_tag": "START53_LV4::All",
           "output_dataset": "/GluGluToHToZZTo2L2Q_M-800_7TeV-powheg15-pythia6/Summer11Leg-START53_LV4-v1/GEN-SIM",
@@ -22906,13 +22483,6 @@
         "uri": "root://eospublic.cern.ch//eos/opendata/cms/MonteCarlo2011/Summer11LegDR/GluGluToHToZZTo2L2Q_M-900_7TeV-powheg15-pythia6/AODSIM/PU_S13_START53_LV6-v1/file-indexes/CMS_MonteCarlo2011_Summer11LegDR_GluGluToHToZZTo2L2Q_M-900_7TeV-powheg15-pythia6_AODSIM_PU_S13_START53_LV6-v1_00000_file_index.txt"
       }
     ],
-    "generator": {
-      "global_tag": "START53_LV6",
-      "names": [
-        "powheg15",
-        "pythia6"
-      ]
-    },
     "license": {
       "attribution": "CC0"
     },
@@ -22940,6 +22510,10 @@
               "recid": "3196",
               "title": "Configuration file for SIM step HIG-Summer11Leg-00017_1_cfg.py"
             }
+          ],
+          "generators": [
+            "powheg15",
+            "pythia6"
           ],
           "global_tag": "START53_LV4::All",
           "output_dataset": "/GluGluToHToZZTo2L2Q_M-900_7TeV-powheg15-pythia6/Summer11Leg-START53_LV4-v1/GEN-SIM",
@@ -23073,13 +22647,6 @@
         "uri": "root://eospublic.cern.ch//eos/opendata/cms/MonteCarlo2011/Summer11LegDR/GluGluToHToZZTo4L_M-1000_7TeV-powheg15-pythia6/AODSIM/PU_S13_START53_LV6-v1/file-indexes/CMS_MonteCarlo2011_Summer11LegDR_GluGluToHToZZTo4L_M-1000_7TeV-powheg15-pythia6_AODSIM_PU_S13_START53_LV6-v1_30000_file_index.txt"
       }
     ],
-    "generator": {
-      "global_tag": "START53_LV6",
-      "names": [
-        "powheg15",
-        "pythia6"
-      ]
-    },
     "license": {
       "attribution": "CC0"
     },
@@ -23107,6 +22674,10 @@
               "recid": "3229",
               "title": "Configuration file for SIM step HIG-Summer11Leg-00328_1_cfg.py"
             }
+          ],
+          "generators": [
+            "powheg15",
+            "pythia6"
           ],
           "global_tag": "START53_LV4::All",
           "output_dataset": "/GluGluToHToZZTo4L_M-1000_7TeV-powheg15-pythia6/Summer11Leg-START53_LV4-v1/GEN-SIM",
@@ -23228,13 +22799,6 @@
         "uri": "root://eospublic.cern.ch//eos/opendata/cms/MonteCarlo2011/Summer11LegDR/GluGluToHToZZTo4L_M-125_7TeV-minloHJJ-pythia6-tauola/AODSIM/PU_S13_START53_LV6-v1/file-indexes/CMS_MonteCarlo2011_Summer11LegDR_GluGluToHToZZTo4L_M-125_7TeV-minloHJJ-pythia6-tauola_AODSIM_PU_S13_START53_LV6-v1_10000_file_index.txt"
       }
     ],
-    "generator": {
-      "global_tag": "START53_LV6",
-      "names": [
-        "pythia6",
-        "powheg-minlo"
-      ]
-    },
     "license": {
       "attribution": "CC0"
     },
@@ -23262,6 +22826,10 @@
               "recid": "3051",
               "title": "Configuration file for SIM step HIG-Summer11Leg-00197_1_cfg.py"
             }
+          ],
+          "generators": [
+            "pythia6",
+            "powheg-minlo"
           ],
           "global_tag": "START53_LV4::All",
           "output_dataset": "/GluGluToHToZZTo4L_M-125_7TeV-minloHJJ-pythia6-tauola/Summer11Leg-START53_LV4-v2/GEN-SIM",
@@ -23383,13 +22951,6 @@
         "uri": "root://eospublic.cern.ch//eos/opendata/cms/MonteCarlo2011/Summer11LegDR/GluGluToHToZZTo4L_M-125_7TeV-powheg15-pythia6/AODSIM/PU_S13_START53_LV6-v1/file-indexes/CMS_MonteCarlo2011_Summer11LegDR_GluGluToHToZZTo4L_M-125_7TeV-powheg15-pythia6_AODSIM_PU_S13_START53_LV6-v1_00000_file_index.txt"
       }
     ],
-    "generator": {
-      "global_tag": "START53_LV6",
-      "names": [
-        "powheg15",
-        "pythia6"
-      ]
-    },
     "license": {
       "attribution": "CC0"
     },
@@ -23417,6 +22978,10 @@
               "recid": "3229",
               "title": "Configuration file for SIM step HIG-Summer11Leg-00328_1_cfg.py"
             }
+          ],
+          "generators": [
+            "powheg15",
+            "pythia6"
           ],
           "global_tag": "START53_LV4::All",
           "output_dataset": "/GluGluToHToZZTo4L_M-125_7TeV-powheg15-pythia6/Summer11Leg-START53_LV4-v1/GEN-SIM",
@@ -23538,13 +23103,6 @@
         "uri": "root://eospublic.cern.ch//eos/opendata/cms/MonteCarlo2011/Summer11LegDR/GluGluToHToZZTo4L_M-126_7TeV-minloHJJ-pythia6-tauola/AODSIM/PU_S13_START53_LV6-v2/file-indexes/CMS_MonteCarlo2011_Summer11LegDR_GluGluToHToZZTo4L_M-126_7TeV-minloHJJ-pythia6-tauola_AODSIM_PU_S13_START53_LV6-v2_40000_file_index.txt"
       }
     ],
-    "generator": {
-      "global_tag": "START53_LV6",
-      "names": [
-        "pythia6",
-        "powheg-minlo"
-      ]
-    },
     "license": {
       "attribution": "CC0"
     },
@@ -23572,6 +23130,10 @@
               "recid": "3051",
               "title": "Configuration file for SIM step HIG-Summer11Leg-00197_1_cfg.py"
             }
+          ],
+          "generators": [
+            "pythia6",
+            "powheg-minlo"
           ],
           "global_tag": "START53_LV4::All",
           "output_dataset": "/GluGluToHToZZTo4L_M-126_7TeV-minloHJJ-pythia6-tauola/Summer11Leg-START53_LV4-v1/GEN-SIM",
@@ -23705,13 +23267,6 @@
         "uri": "root://eospublic.cern.ch//eos/opendata/cms/MonteCarlo2011/Summer11LegDR/GluGluToHToZZTo4L_M-126_7TeV-powheg15-pythia6/AODSIM/PU_S13_START53_LV6-v1/file-indexes/CMS_MonteCarlo2011_Summer11LegDR_GluGluToHToZZTo4L_M-126_7TeV-powheg15-pythia6_AODSIM_PU_S13_START53_LV6-v1_30000_file_index.txt"
       }
     ],
-    "generator": {
-      "global_tag": "START53_LV6",
-      "names": [
-        "powheg15",
-        "pythia6"
-      ]
-    },
     "license": {
       "attribution": "CC0"
     },
@@ -23739,6 +23294,10 @@
               "recid": "3229",
               "title": "Configuration file for SIM step HIG-Summer11Leg-00328_1_cfg.py"
             }
+          ],
+          "generators": [
+            "powheg15",
+            "pythia6"
           ],
           "global_tag": "START53_LV4::All",
           "output_dataset": "/GluGluToHToZZTo4L_M-126_7TeV-powheg15-pythia6/Summer11Leg-START53_LV4-v1/GEN-SIM",
@@ -23872,13 +23431,6 @@
         "uri": "root://eospublic.cern.ch//eos/opendata/cms/MonteCarlo2011/Summer11LegDR/GluGluToHToZZTo4L_M-190_7TeV-minloHJJ-pythia6-tauola/AODSIM/PU_S13_START53_LV6-v1/file-indexes/CMS_MonteCarlo2011_Summer11LegDR_GluGluToHToZZTo4L_M-190_7TeV-minloHJJ-pythia6-tauola_AODSIM_PU_S13_START53_LV6-v1_40000_file_index.txt"
       }
     ],
-    "generator": {
-      "global_tag": "START53_LV6",
-      "names": [
-        "pythia6",
-        "powheg-minlo"
-      ]
-    },
     "license": {
       "attribution": "CC0"
     },
@@ -23906,6 +23458,10 @@
               "recid": "3051",
               "title": "Configuration file for SIM step HIG-Summer11Leg-00197_1_cfg.py"
             }
+          ],
+          "generators": [
+            "pythia6",
+            "powheg-minlo"
           ],
           "global_tag": "START53_LV4::All",
           "output_dataset": "/GluGluToHToZZTo4L_M-190_7TeV-minloHJJ-pythia6-tauola/Summer11Leg-START53_LV4-v2/GEN-SIM",
@@ -24051,13 +23607,6 @@
         "uri": "root://eospublic.cern.ch//eos/opendata/cms/MonteCarlo2011/Summer11LegDR/GluGluToHToZZTo4L_M-200_7TeV-minloHJJ-pythia6-tauola/AODSIM/PU_S13_START53_LV6-v1/file-indexes/CMS_MonteCarlo2011_Summer11LegDR_GluGluToHToZZTo4L_M-200_7TeV-minloHJJ-pythia6-tauola_AODSIM_PU_S13_START53_LV6-v1_40000_file_index.txt"
       }
     ],
-    "generator": {
-      "global_tag": "START53_LV6",
-      "names": [
-        "pythia6",
-        "powheg-minlo"
-      ]
-    },
     "license": {
       "attribution": "CC0"
     },
@@ -24085,6 +23634,10 @@
               "recid": "3051",
               "title": "Configuration file for SIM step HIG-Summer11Leg-00197_1_cfg.py"
             }
+          ],
+          "generators": [
+            "pythia6",
+            "powheg-minlo"
           ],
           "global_tag": "START53_LV4::All",
           "output_dataset": "/GluGluToHToZZTo4L_M-200_7TeV-minloHJJ-pythia6-tauola/Summer11Leg-START53_LV4-v1/GEN-SIM",
@@ -24218,13 +23771,6 @@
         "uri": "root://eospublic.cern.ch//eos/opendata/cms/MonteCarlo2011/Summer11LegDR/GluGluToHToZZTo4L_M-225_7TeV-powheg15-pythia6/AODSIM/PU_S13_START53_LV6-v1/file-indexes/CMS_MonteCarlo2011_Summer11LegDR_GluGluToHToZZTo4L_M-225_7TeV-powheg15-pythia6_AODSIM_PU_S13_START53_LV6-v1_30000_file_index.txt"
       }
     ],
-    "generator": {
-      "global_tag": "START53_LV6",
-      "names": [
-        "powheg15",
-        "pythia6"
-      ]
-    },
     "license": {
       "attribution": "CC0"
     },
@@ -24252,6 +23798,10 @@
               "recid": "3229",
               "title": "Configuration file for SIM step HIG-Summer11Leg-00328_1_cfg.py"
             }
+          ],
+          "generators": [
+            "powheg15",
+            "pythia6"
           ],
           "global_tag": "START53_LV4::All",
           "output_dataset": "/GluGluToHToZZTo4L_M-225_7TeV-powheg15-pythia6/Summer11Leg-START53_LV4-v1/GEN-SIM",
@@ -24373,13 +23923,6 @@
         "uri": "root://eospublic.cern.ch//eos/opendata/cms/MonteCarlo2011/Summer11LegDR/GluGluToHToZZTo4L_M-250_7TeV-minloHJJ-pythia6-tauola/AODSIM/PU_S13_START53_LV6-v1/file-indexes/CMS_MonteCarlo2011_Summer11LegDR_GluGluToHToZZTo4L_M-250_7TeV-minloHJJ-pythia6-tauola_AODSIM_PU_S13_START53_LV6-v1_410000_file_index.txt"
       }
     ],
-    "generator": {
-      "global_tag": "START53_LV6",
-      "names": [
-        "pythia6",
-        "powheg-minlo"
-      ]
-    },
     "license": {
       "attribution": "CC0"
     },
@@ -24407,6 +23950,10 @@
               "recid": "3051",
               "title": "Configuration file for SIM step HIG-Summer11Leg-00197_1_cfg.py"
             }
+          ],
+          "generators": [
+            "pythia6",
+            "powheg-minlo"
           ],
           "global_tag": "START53_LV4::All",
           "output_dataset": "/GluGluToHToZZTo4L_M-250_7TeV-minloHJJ-pythia6-tauola/Summer11Leg-START53_LV4-v2/GEN-SIM",
@@ -24528,13 +24075,6 @@
         "uri": "root://eospublic.cern.ch//eos/opendata/cms/MonteCarlo2011/Summer11LegDR/GluGluToHToZZTo4L_M-250_7TeV-powheg15-pythia6/AODSIM/PU_S13_START53_LV6-v1/file-indexes/CMS_MonteCarlo2011_Summer11LegDR_GluGluToHToZZTo4L_M-250_7TeV-powheg15-pythia6_AODSIM_PU_S13_START53_LV6-v1_20000_file_index.txt"
       }
     ],
-    "generator": {
-      "global_tag": "START53_LV6",
-      "names": [
-        "powheg15",
-        "pythia6"
-      ]
-    },
     "license": {
       "attribution": "CC0"
     },
@@ -24562,6 +24102,10 @@
               "recid": "3229",
               "title": "Configuration file for SIM step HIG-Summer11Leg-00328_1_cfg.py"
             }
+          ],
+          "generators": [
+            "powheg15",
+            "pythia6"
           ],
           "global_tag": "START53_LV4::All",
           "output_dataset": "/GluGluToHToZZTo4L_M-250_7TeV-powheg15-pythia6/Summer11Leg-START53_LV4-v1/GEN-SIM",
@@ -24695,13 +24239,6 @@
         "uri": "root://eospublic.cern.ch//eos/opendata/cms/MonteCarlo2011/Summer11LegDR/GluGluToHToZZTo4L_M-275_7TeV-powheg15-pythia6/AODSIM/PU_S13_START53_LV6-v1/file-indexes/CMS_MonteCarlo2011_Summer11LegDR_GluGluToHToZZTo4L_M-275_7TeV-powheg15-pythia6_AODSIM_PU_S13_START53_LV6-v1_20000_file_index.txt"
       }
     ],
-    "generator": {
-      "global_tag": "START53_LV6",
-      "names": [
-        "powheg15",
-        "pythia6"
-      ]
-    },
     "license": {
       "attribution": "CC0"
     },
@@ -24729,6 +24266,10 @@
               "recid": "3229",
               "title": "Configuration file for SIM step HIG-Summer11Leg-00328_1_cfg.py"
             }
+          ],
+          "generators": [
+            "powheg15",
+            "pythia6"
           ],
           "global_tag": "START53_LV4::All",
           "output_dataset": "/GluGluToHToZZTo4L_M-275_7TeV-powheg15-pythia6/Summer11Leg-START53_LV4-v1/GEN-SIM",
@@ -24850,13 +24391,6 @@
         "uri": "root://eospublic.cern.ch//eos/opendata/cms/MonteCarlo2011/Summer11LegDR/GluGluToHToZZTo4L_M-300_7TeV-minloHJJ-pythia6-tauola/AODSIM/PU_S13_START53_LV6-v1/file-indexes/CMS_MonteCarlo2011_Summer11LegDR_GluGluToHToZZTo4L_M-300_7TeV-minloHJJ-pythia6-tauola_AODSIM_PU_S13_START53_LV6-v1_00000_file_index.txt"
       }
     ],
-    "generator": {
-      "global_tag": "START53_LV6",
-      "names": [
-        "pythia6",
-        "powheg-minlo"
-      ]
-    },
     "license": {
       "attribution": "CC0"
     },
@@ -24884,6 +24418,10 @@
               "recid": "3051",
               "title": "Configuration file for SIM step HIG-Summer11Leg-00197_1_cfg.py"
             }
+          ],
+          "generators": [
+            "pythia6",
+            "powheg-minlo"
           ],
           "global_tag": "START53_LV4::All",
           "output_dataset": "/GluGluToHToZZTo4L_M-300_7TeV-minloHJJ-pythia6-tauola/Summer11Leg-START53_LV4-v1/GEN-SIM",
@@ -25017,13 +24555,6 @@
         "uri": "root://eospublic.cern.ch//eos/opendata/cms/MonteCarlo2011/Summer11LegDR/GluGluToHToZZTo4L_M-300_7TeV-powheg15-pythia6/AODSIM/PU_S13_START53_LV6-v1/file-indexes/CMS_MonteCarlo2011_Summer11LegDR_GluGluToHToZZTo4L_M-300_7TeV-powheg15-pythia6_AODSIM_PU_S13_START53_LV6-v1_20000_file_index.txt"
       }
     ],
-    "generator": {
-      "global_tag": "START53_LV6",
-      "names": [
-        "powheg15",
-        "pythia6"
-      ]
-    },
     "license": {
       "attribution": "CC0"
     },
@@ -25051,6 +24582,10 @@
               "recid": "3229",
               "title": "Configuration file for SIM step HIG-Summer11Leg-00328_1_cfg.py"
             }
+          ],
+          "generators": [
+            "powheg15",
+            "pythia6"
           ],
           "global_tag": "START53_LV4::All",
           "output_dataset": "/GluGluToHToZZTo4L_M-300_7TeV-powheg15-pythia6/Summer11Leg-START53_LV4-v1/GEN-SIM",
@@ -25172,13 +24707,6 @@
         "uri": "root://eospublic.cern.ch//eos/opendata/cms/MonteCarlo2011/Summer11LegDR/GluGluToHToZZTo4L_M-350_7TeV-minloHJJ-pythia6-tauola/AODSIM/PU_S13_START53_LV6-v2/file-indexes/CMS_MonteCarlo2011_Summer11LegDR_GluGluToHToZZTo4L_M-350_7TeV-minloHJJ-pythia6-tauola_AODSIM_PU_S13_START53_LV6-v2_40000_file_index.txt"
       }
     ],
-    "generator": {
-      "global_tag": "START53_LV6",
-      "names": [
-        "pythia6",
-        "powheg-minlo"
-      ]
-    },
     "license": {
       "attribution": "CC0"
     },
@@ -25206,6 +24734,10 @@
               "recid": "3051",
               "title": "Configuration file for SIM step HIG-Summer11Leg-00197_1_cfg.py"
             }
+          ],
+          "generators": [
+            "pythia6",
+            "powheg-minlo"
           ],
           "global_tag": "START53_LV4::All",
           "output_dataset": "/GluGluToHToZZTo4L_M-350_7TeV-minloHJJ-pythia6-tauola/Summer11Leg-START53_LV4-v1/GEN-SIM",
@@ -25327,13 +24859,6 @@
         "uri": "root://eospublic.cern.ch//eos/opendata/cms/MonteCarlo2011/Summer11LegDR/GluGluToHToZZTo4L_M-350_7TeV-powheg15-pythia6/AODSIM/PU_S13_START53_LV6-v1/file-indexes/CMS_MonteCarlo2011_Summer11LegDR_GluGluToHToZZTo4L_M-350_7TeV-powheg15-pythia6_AODSIM_PU_S13_START53_LV6-v1_20000_file_index.txt"
       }
     ],
-    "generator": {
-      "global_tag": "START53_LV6",
-      "names": [
-        "powheg15",
-        "pythia6"
-      ]
-    },
     "license": {
       "attribution": "CC0"
     },
@@ -25361,6 +24886,10 @@
               "recid": "3229",
               "title": "Configuration file for SIM step HIG-Summer11Leg-00328_1_cfg.py"
             }
+          ],
+          "generators": [
+            "powheg15",
+            "pythia6"
           ],
           "global_tag": "START53_LV4::All",
           "output_dataset": "/GluGluToHToZZTo4L_M-350_7TeV-powheg15-pythia6/Summer11Leg-START53_LV4-v1/GEN-SIM",
@@ -25482,13 +25011,6 @@
         "uri": "root://eospublic.cern.ch//eos/opendata/cms/MonteCarlo2011/Summer11LegDR/GluGluToHToZZTo4L_M-400_7TeV-minloHJJ-pythia6-tauola/AODSIM/PU_S13_START53_LV6-v2/file-indexes/CMS_MonteCarlo2011_Summer11LegDR_GluGluToHToZZTo4L_M-400_7TeV-minloHJJ-pythia6-tauola_AODSIM_PU_S13_START53_LV6-v2_40000_file_index.txt"
       }
     ],
-    "generator": {
-      "global_tag": "START53_LV6",
-      "names": [
-        "pythia6",
-        "powheg-minlo"
-      ]
-    },
     "license": {
       "attribution": "CC0"
     },
@@ -25516,6 +25038,10 @@
               "recid": "3051",
               "title": "Configuration file for SIM step HIG-Summer11Leg-00197_1_cfg.py"
             }
+          ],
+          "generators": [
+            "pythia6",
+            "powheg-minlo"
           ],
           "global_tag": "START53_LV4::All",
           "output_dataset": "/GluGluToHToZZTo4L_M-400_7TeV-minloHJJ-pythia6-tauola/Summer11Leg-START53_LV4-v2/GEN-SIM",
@@ -25637,13 +25163,6 @@
         "uri": "root://eospublic.cern.ch//eos/opendata/cms/MonteCarlo2011/Summer11LegDR/GluGluToHToZZTo4L_M-400_7TeV-powheg15-pythia6/AODSIM/PU_S13_START53_LV6-v1/file-indexes/CMS_MonteCarlo2011_Summer11LegDR_GluGluToHToZZTo4L_M-400_7TeV-powheg15-pythia6_AODSIM_PU_S13_START53_LV6-v1_00000_file_index.txt"
       }
     ],
-    "generator": {
-      "global_tag": "START53_LV6",
-      "names": [
-        "powheg15",
-        "pythia6"
-      ]
-    },
     "license": {
       "attribution": "CC0"
     },
@@ -25671,6 +25190,10 @@
               "recid": "3229",
               "title": "Configuration file for SIM step HIG-Summer11Leg-00328_1_cfg.py"
             }
+          ],
+          "generators": [
+            "powheg15",
+            "pythia6"
           ],
           "global_tag": "START53_LV4::All",
           "output_dataset": "/GluGluToHToZZTo4L_M-400_7TeV-powheg15-pythia6/Summer11Leg-START53_LV4-v1/GEN-SIM",
@@ -25804,13 +25327,6 @@
         "uri": "root://eospublic.cern.ch//eos/opendata/cms/MonteCarlo2011/Summer11LegDR/GluGluToHToZZTo4L_M-450_7TeV-minloHJJ-pythia6-tauola/AODSIM/PU_S13_START53_LV6-v1/file-indexes/CMS_MonteCarlo2011_Summer11LegDR_GluGluToHToZZTo4L_M-450_7TeV-minloHJJ-pythia6-tauola_AODSIM_PU_S13_START53_LV6-v1_10000_file_index.txt"
       }
     ],
-    "generator": {
-      "global_tag": "START53_LV6",
-      "names": [
-        "pythia6",
-        "powheg-minlo"
-      ]
-    },
     "license": {
       "attribution": "CC0"
     },
@@ -25838,6 +25354,10 @@
               "recid": "3051",
               "title": "Configuration file for SIM step HIG-Summer11Leg-00197_1_cfg.py"
             }
+          ],
+          "generators": [
+            "pythia6",
+            "powheg-minlo"
           ],
           "global_tag": "START53_LV4::All",
           "output_dataset": "/GluGluToHToZZTo4L_M-450_7TeV-minloHJJ-pythia6-tauola/Summer11Leg-START53_LV4-v1/GEN-SIM",
@@ -25983,13 +25503,6 @@
         "uri": "root://eospublic.cern.ch//eos/opendata/cms/MonteCarlo2011/Summer11LegDR/GluGluToHToZZTo4L_M-450_7TeV-powheg15-pythia6/AODSIM/PU_S13_START53_LV6-v1/file-indexes/CMS_MonteCarlo2011_Summer11LegDR_GluGluToHToZZTo4L_M-450_7TeV-powheg15-pythia6_AODSIM_PU_S13_START53_LV6-v1_40000_file_index.txt"
       }
     ],
-    "generator": {
-      "global_tag": "START53_LV6",
-      "names": [
-        "powheg15",
-        "pythia6"
-      ]
-    },
     "license": {
       "attribution": "CC0"
     },
@@ -26017,6 +25530,10 @@
               "recid": "3229",
               "title": "Configuration file for SIM step HIG-Summer11Leg-00328_1_cfg.py"
             }
+          ],
+          "generators": [
+            "powheg15",
+            "pythia6"
           ],
           "global_tag": "START53_LV4::All",
           "output_dataset": "/GluGluToHToZZTo4L_M-450_7TeV-powheg15-pythia6/Summer11Leg-START53_LV4-v1/GEN-SIM",
@@ -26150,13 +25667,6 @@
         "uri": "root://eospublic.cern.ch//eos/opendata/cms/MonteCarlo2011/Summer11LegDR/GluGluToHToZZTo4L_M-500_7TeV-minloHJJ-pythia6-tauola/AODSIM/PU_S13_START53_LV6-v1/file-indexes/CMS_MonteCarlo2011_Summer11LegDR_GluGluToHToZZTo4L_M-500_7TeV-minloHJJ-pythia6-tauola_AODSIM_PU_S13_START53_LV6-v1_30000_file_index.txt"
       }
     ],
-    "generator": {
-      "global_tag": "START53_LV6",
-      "names": [
-        "pythia6",
-        "powheg-minlo"
-      ]
-    },
     "license": {
       "attribution": "CC0"
     },
@@ -26184,6 +25694,10 @@
               "recid": "3051",
               "title": "Configuration file for SIM step HIG-Summer11Leg-00197_1_cfg.py"
             }
+          ],
+          "generators": [
+            "pythia6",
+            "powheg-minlo"
           ],
           "global_tag": "START53_LV4::All",
           "output_dataset": "/GluGluToHToZZTo4L_M-500_7TeV-minloHJJ-pythia6-tauola/Summer11Leg-START53_LV4-v2/GEN-SIM",
@@ -26305,12 +25819,6 @@
         "uri": "root://eospublic.cern.ch//eos/opendata/cms/MonteCarlo2011/Summer11LegDR/TTbarH_HToZZTo4L_M-180_7TeV-pythia6/AODSIM/PU_S13_START53_LV6-v1/file-indexes/CMS_MonteCarlo2011_Summer11LegDR_TTbarH_HToZZTo4L_M-180_7TeV-pythia6_AODSIM_PU_S13_START53_LV6-v1_10000_file_index.txt"
       }
     ],
-    "generator": {
-      "global_tag": "START53_LV6",
-      "names": [
-        "pythia6"
-      ]
-    },
     "license": {
       "attribution": "CC0"
     },
@@ -26324,6 +25832,9 @@
               "recid": "3368",
               "title": "Configuration file for SIM step HIG-Summer11Leg-00239_1_cfg.py"
             }
+          ],
+          "generators": [
+            "pythia6"
           ],
           "global_tag": "START53_LV4::All",
           "output_dataset": "/TTbarH_HToZZTo4L_M-180_7TeV-pythia6/Summer11Leg-START53_LV4-v1/GEN-SIM",
@@ -26445,12 +25956,6 @@
         "uri": "root://eospublic.cern.ch//eos/opendata/cms/MonteCarlo2011/Summer11LegDR/TTbarH_HToZZTo4L_M-160_7TeV-pythia6/AODSIM/PU_S13_START53_LV6-v1/file-indexes/CMS_MonteCarlo2011_Summer11LegDR_TTbarH_HToZZTo4L_M-160_7TeV-pythia6_AODSIM_PU_S13_START53_LV6-v1_00000_file_index.txt"
       }
     ],
-    "generator": {
-      "global_tag": "START53_LV6",
-      "names": [
-        "pythia6"
-      ]
-    },
     "license": {
       "attribution": "CC0"
     },
@@ -26464,6 +25969,9 @@
               "recid": "3165",
               "title": "Configuration file for SIM step HIG-Summer11Leg-00238_1_cfg.py"
             }
+          ],
+          "generators": [
+            "pythia6"
           ],
           "global_tag": "START53_LV4::All",
           "output_dataset": "/TTbarH_HToZZTo4L_M-160_7TeV-pythia6/Summer11Leg-START53_LV4-v1/GEN-SIM",
@@ -26585,12 +26093,6 @@
         "uri": "root://eospublic.cern.ch//eos/opendata/cms/MonteCarlo2011/Summer11LegDR/TTbarH_HToZZTo4L_M-115_7TeV-pythia6/AODSIM/PU_S13_START53_LV6-v1/file-indexes/CMS_MonteCarlo2011_Summer11LegDR_TTbarH_HToZZTo4L_M-115_7TeV-pythia6_AODSIM_PU_S13_START53_LV6-v1_40000_file_index.txt"
       }
     ],
-    "generator": {
-      "global_tag": "START53_LV6",
-      "names": [
-        "pythia6"
-      ]
-    },
     "license": {
       "attribution": "CC0"
     },
@@ -26604,6 +26106,9 @@
               "recid": "3143",
               "title": "Configuration file for SIM step HIG-Summer11Leg-00231_1_cfg.py"
             }
+          ],
+          "generators": [
+            "pythia6"
           ],
           "global_tag": "START53_LV4::All",
           "output_dataset": "/TTbarH_HToZZTo4L_M-115_7TeV-pythia6/Summer11Leg-START53_LV4-v1/GEN-SIM",
@@ -26725,12 +26230,6 @@
         "uri": "root://eospublic.cern.ch//eos/opendata/cms/MonteCarlo2011/Summer11LegDR/TTbarH_HToZZTo4L_M-120_7TeV-pythia6/AODSIM/PU_S13_START53_LV6-v2/file-indexes/CMS_MonteCarlo2011_Summer11LegDR_TTbarH_HToZZTo4L_M-120_7TeV-pythia6_AODSIM_PU_S13_START53_LV6-v2_40000_file_index.txt"
       }
     ],
-    "generator": {
-      "global_tag": "START53_LV6",
-      "names": [
-        "pythia6"
-      ]
-    },
     "license": {
       "attribution": "CC0"
     },
@@ -26744,6 +26243,9 @@
               "recid": "3114",
               "title": "Configuration file for SIM step HIG-Summer11Leg-00232_1_cfg.py"
             }
+          ],
+          "generators": [
+            "pythia6"
           ],
           "global_tag": "START53_LV4::All",
           "output_dataset": "/TTbarH_HToZZTo4L_M-120_7TeV-pythia6/Summer11Leg-START53_LV4-v1/GEN-SIM",
@@ -26865,12 +26367,6 @@
         "uri": "root://eospublic.cern.ch//eos/opendata/cms/MonteCarlo2011/Summer11LegDR/TTbarH_HToZZTo4L_M-125_7TeV-pythia6/AODSIM/PU_S13_START53_LV6-v1/file-indexes/CMS_MonteCarlo2011_Summer11LegDR_TTbarH_HToZZTo4L_M-125_7TeV-pythia6_AODSIM_PU_S13_START53_LV6-v1_00000_file_index.txt"
       }
     ],
-    "generator": {
-      "global_tag": "START53_LV6",
-      "names": [
-        "pythia6"
-      ]
-    },
     "license": {
       "attribution": "CC0"
     },
@@ -26884,6 +26380,9 @@
               "recid": "3068",
               "title": "Configuration file for SIM step HIG-Summer11Leg-00233_1_cfg.py"
             }
+          ],
+          "generators": [
+            "pythia6"
           ],
           "global_tag": "START53_LV4::All",
           "output_dataset": "/TTbarH_HToZZTo4L_M-125_7TeV-pythia6/Summer11Leg-START53_LV4-v1/GEN-SIM",
@@ -27005,13 +26504,6 @@
         "uri": "root://eospublic.cern.ch//eos/opendata/cms/MonteCarlo2011/Summer11LegDR/VBFToHToZZTo2L2Q_M-200_7TeV-powheg15-pythia6/AODSIM/PU_S13_START53_LV6-v1/file-indexes/CMS_MonteCarlo2011_Summer11LegDR_VBFToHToZZTo2L2Q_M-200_7TeV-powheg15-pythia6_AODSIM_PU_S13_START53_LV6-v1_00000_file_index.txt"
       }
     ],
-    "generator": {
-      "global_tag": "START53_LV6",
-      "names": [
-        "powheg15",
-        "pythia6"
-      ]
-    },
     "license": {
       "attribution": "CC0"
     },
@@ -27039,6 +26531,10 @@
               "recid": "3196",
               "title": "Configuration file for SIM step HIG-Summer11Leg-00017_1_cfg.py"
             }
+          ],
+          "generators": [
+            "powheg15",
+            "pythia6"
           ],
           "global_tag": "START53_LV4::All",
           "output_dataset": "/VBFToHToZZTo2L2Q_M-200_7TeV-powheg15-pythia6/Summer11Leg-START53_LV4-v1/GEN-SIM",
@@ -27160,13 +26656,6 @@
         "uri": "root://eospublic.cern.ch//eos/opendata/cms/MonteCarlo2011/Summer11LegDR/VBFHiggs0PToZZTo4L_M-125p6_7TeV-JHUGenV4/AODSIM/PU_S13_START53_LV6-v2/file-indexes/CMS_MonteCarlo2011_Summer11LegDR_VBFHiggs0PToZZTo4L_M-125p6_7TeV-JHUGenV4_AODSIM_PU_S13_START53_LV6-v2_40000_file_index.txt"
       }
     ],
-    "generator": {
-      "global_tag": "START53_LV6",
-      "names": [
-        "powheg15",
-        "pythia6"
-      ]
-    },
     "license": {
       "attribution": "CC0"
     },
@@ -27194,6 +26683,10 @@
               "recid": "3041",
               "title": "Configuration file for SIM step HIG-Summer11Leg-00317_1_cfg.py"
             }
+          ],
+          "generators": [
+            "powheg15",
+            "pythia6"
           ],
           "global_tag": "START53_LV4::All",
           "output_dataset": "/VBFHiggs0PToZZTo4L_M-125p6_7TeV-JHUGenV4/Summer11Leg-START53_LV4-v1/GEN-SIM",
@@ -27315,12 +26808,6 @@
         "uri": "root://eospublic.cern.ch//eos/opendata/cms/MonteCarlo2011/Summer11LegDR/QCD_Pt-300to470_TuneZ2_7TeV_pythia6/AODSIM/PU_S13_START53_LV6-v1/file-indexes/CMS_MonteCarlo2011_Summer11LegDR_QCD_Pt-300to470_TuneZ2_7TeV_pythia6_AODSIM_PU_S13_START53_LV6-v1_00000_file_index.txt"
       }
     ],
-    "generator": {
-      "global_tag": "START53_LV6",
-      "names": [
-        "pythia6"
-      ]
-    },
     "license": {
       "attribution": "CC0"
     },
@@ -27334,6 +26821,9 @@
               "recid": "3141",
               "title": "Configuration file for SIM step JME-Summer11Leg-00009_1_cfg.py"
             }
+          ],
+          "generators": [
+            "pythia6"
           ],
           "global_tag": "START53_LV4::All",
           "output_dataset": "/QCD_Pt-300to470_TuneZ2_7TeV_pythia6/Summer11Leg-START53_LV4-v1/GEN-SIM",
@@ -27455,13 +26945,6 @@
         "uri": "root://eospublic.cern.ch//eos/opendata/cms/MonteCarlo2011/Summer11LegDR/VBFToHToZZTo2L2Q_M-225_7TeV-powheg15-pythia6/AODSIM/PU_S13_START53_LV6-v1/file-indexes/CMS_MonteCarlo2011_Summer11LegDR_VBFToHToZZTo2L2Q_M-225_7TeV-powheg15-pythia6_AODSIM_PU_S13_START53_LV6-v1_00000_file_index.txt"
       }
     ],
-    "generator": {
-      "global_tag": "START53_LV6",
-      "names": [
-        "powheg15",
-        "pythia6"
-      ]
-    },
     "license": {
       "attribution": "CC0"
     },
@@ -27489,6 +26972,10 @@
               "recid": "3196",
               "title": "Configuration file for SIM step HIG-Summer11Leg-00017_1_cfg.py"
             }
+          ],
+          "generators": [
+            "powheg15",
+            "pythia6"
           ],
           "global_tag": "START53_LV4::All",
           "output_dataset": "/VBFToHToZZTo2L2Q_M-225_7TeV-powheg15-pythia6/Summer11Leg-START53_LV4-v1/GEN-SIM",
@@ -27610,13 +27097,6 @@
         "uri": "root://eospublic.cern.ch//eos/opendata/cms/MonteCarlo2011/Summer11LegDR/VBFHiggs0PHToZZTo4L_M-125p6_7TeV-JHUGenV4/AODSIM/PU_S13_START53_LV6-v1/file-indexes/CMS_MonteCarlo2011_Summer11LegDR_VBFHiggs0PHToZZTo4L_M-125p6_7TeV-JHUGenV4_AODSIM_PU_S13_START53_LV6-v1_10000_file_index.txt"
       }
     ],
-    "generator": {
-      "global_tag": "START53_LV6",
-      "names": [
-        "powheg15",
-        "pythia6"
-      ]
-    },
     "license": {
       "attribution": "CC0"
     },
@@ -27644,6 +27124,10 @@
               "recid": "3132",
               "title": "Configuration file for SIM step HIG-Summer11Leg-00151_1_cfg.py"
             }
+          ],
+          "generators": [
+            "powheg15",
+            "pythia6"
           ],
           "global_tag": "START53_LV4::All",
           "output_dataset": "/VBFHiggs0PHToZZTo4L_M-125p6_7TeV-JHUGenV4/Summer11Leg-START53_LV4-v1/GEN-SIM",
@@ -27765,13 +27249,6 @@
         "uri": "root://eospublic.cern.ch//eos/opendata/cms/MonteCarlo2011/Summer11LegDR/VBFToHToZZTo2L2Q_M-250_7TeV-powheg15-pythia6/AODSIM/PU_S13_START53_LV6-v1/file-indexes/CMS_MonteCarlo2011_Summer11LegDR_VBFToHToZZTo2L2Q_M-250_7TeV-powheg15-pythia6_AODSIM_PU_S13_START53_LV6-v1_00000_file_index.txt"
       }
     ],
-    "generator": {
-      "global_tag": "START53_LV6",
-      "names": [
-        "powheg15",
-        "pythia6"
-      ]
-    },
     "license": {
       "attribution": "CC0"
     },
@@ -27799,6 +27276,10 @@
               "recid": "3196",
               "title": "Configuration file for SIM step HIG-Summer11Leg-00017_1_cfg.py"
             }
+          ],
+          "generators": [
+            "powheg15",
+            "pythia6"
           ],
           "global_tag": "START53_LV4::All",
           "output_dataset": "/VBFToHToZZTo2L2Q_M-250_7TeV-powheg15-pythia6/Summer11Leg-START53_LV4-v1/GEN-SIM",
@@ -27920,12 +27401,6 @@
         "uri": "root://eospublic.cern.ch//eos/opendata/cms/MonteCarlo2011/Summer11LegDR/QCD_Pt-30to50_MuEnrichedPt5_TuneZ2_7TeV_pythia6/AODSIM/PU_S13_START53_LV6-v1/file-indexes/CMS_MonteCarlo2011_Summer11LegDR_QCD_Pt-30to50_MuEnrichedPt5_TuneZ2_7TeV_pythia6_AODSIM_PU_S13_START53_LV6-v1_00000_file_index.txt"
       }
     ],
-    "generator": {
-      "global_tag": "START53_LV6",
-      "names": [
-        "pythia6"
-      ]
-    },
     "license": {
       "attribution": "CC0"
     },
@@ -27939,6 +27414,9 @@
               "recid": "3081",
               "title": "Configuration file for SIM step BTV-Summer11Leg-00003_1_cfg.py"
             }
+          ],
+          "generators": [
+            "pythia6"
           ],
           "global_tag": "START53_LV4::All",
           "output_dataset": "/QCD_Pt-30to50_MuEnrichedPt5_TuneZ2_7TeV_pythia6/Summer11Leg-START53_LV4-v1/GEN-SIM",
@@ -28057,13 +27535,6 @@
         "uri": "root://eospublic.cern.ch//eos/opendata/cms/MonteCarlo2011/Summer11LegDR/Bd2JpsiKstar_EtaPtFilter_TuneZ2star_7TeV-pythia6-evtgen/AODSIM/PU_S13_START53_LV6-v2/file-indexes/CMS_MonteCarlo2011_Summer11LegDR_Bd2JpsiKstar_EtaPtFilter_TuneZ2star_7TeV-pythia6-evtgen_AODSIM_PU_S13_START53_LV6-v2_00000_file_index.txt"
       }
     ],
-    "generator": {
-      "global_tag": "START53_LV6",
-      "names": [
-        "PYTHIA6",
-        "EvtGen"
-      ]
-    },
     "license": {
       "attribution": "CC0"
     },
@@ -28077,6 +27548,10 @@
               "recid": "3104",
               "title": "Configuration file for SIM step BPH-Summer11Leg-00002_1_cfg.py"
             }
+          ],
+          "generators": [
+            "PYTHIA6",
+            "EvtGen"
           ],
           "global_tag": "START53_LV4::All",
           "output_dataset": "/Bd2JpsiKstar_EtaPtFilter_TuneZ2star_7TeV-pythia6-evtgen/Summer11Leg-START53_LV4-v1/GEN-SIM",
@@ -28195,13 +27670,6 @@
         "uri": "root://eospublic.cern.ch//eos/opendata/cms/MonteCarlo2011/Summer11LegDR/Bd2KstarMuMu_EtaPtFilter_TuneZ2star_7TeV-pythia6-evtgen/AODSIM/PU_S13_START53_LV6-v2/file-indexes/CMS_MonteCarlo2011_Summer11LegDR_Bd2KstarMuMu_EtaPtFilter_TuneZ2star_7TeV-pythia6-evtgen_AODSIM_PU_S13_START53_LV6-v2_00000_file_index.txt"
       }
     ],
-    "generator": {
-      "global_tag": "START53_LV6",
-      "names": [
-        "PYTHIA6",
-        "EvtGen"
-      ]
-    },
     "license": {
       "attribution": "CC0"
     },
@@ -28215,6 +27683,10 @@
               "recid": "3170",
               "title": "Configuration file for SIM step BPH-Summer11Leg-00001_1_cfg.py"
             }
+          ],
+          "generators": [
+            "PYTHIA6",
+            "EvtGen"
           ],
           "global_tag": "START53_LV4::All",
           "output_dataset": "/Bd2KstarMuMu_EtaPtFilter_TuneZ2star_7TeV-pythia6-evtgen/Summer11Leg-START53_LV4_ext1-v1/GEN-SIM",
@@ -28333,13 +27805,6 @@
         "uri": "root://eospublic.cern.ch//eos/opendata/cms/MonteCarlo2011/Summer11LegDR/Bd2Psi2SKstar_EtaPtFilter_TuneZ2star_7TeV-pythia6-evtgen/AODSIM/PU_S13_START53_LV6-v2/file-indexes/CMS_MonteCarlo2011_Summer11LegDR_Bd2Psi2SKstar_EtaPtFilter_TuneZ2star_7TeV-pythia6-evtgen_AODSIM_PU_S13_START53_LV6-v2_00000_file_index.txt"
       }
     ],
-    "generator": {
-      "global_tag": "START53_LV6",
-      "names": [
-        "Pythia6",
-        "EvtGen"
-      ]
-    },
     "license": {
       "attribution": "CC0"
     },
@@ -28353,6 +27818,10 @@
               "recid": "3054",
               "title": "Configuration file for SIM step BPH-Summer11Leg-00003_1_cfg.py"
             }
+          ],
+          "generators": [
+            "Pythia6",
+            "EvtGen"
           ],
           "global_tag": "START53_LV4::All",
           "output_dataset": "/Bd2Psi2SKstar_EtaPtFilter_TuneZ2star_7TeV-pythia6-evtgen/Summer11Leg-START53_LV4-v1/GEN-SIM",
@@ -28483,13 +27952,6 @@
         "uri": "root://eospublic.cern.ch//eos/opendata/cms/MonteCarlo2011/Summer11LegDR/BuToJPsiKV2_2MuPtEtaFilterKPtEtaFilter_7TeV-pythia6-evtgen/AODSIM/PU_S13_START53_LV6-v1/file-indexes/CMS_MonteCarlo2011_Summer11LegDR_BuToJPsiKV2_2MuPtEtaFilterKPtEtaFilter_7TeV-pythia6-evtgen_AODSIM_PU_S13_START53_LV6-v1_30000_file_index.txt"
       }
     ],
-    "generator": {
-      "global_tag": "START53_LV6",
-      "names": [
-        "Pythia6",
-        "EvtGen"
-      ]
-    },
     "license": {
       "attribution": "CC0"
     },
@@ -28503,6 +27965,10 @@
               "recid": "3249",
               "title": "Configuration file for SIM step BPH-Summer11Leg-00018_1_cfg.py"
             }
+          ],
+          "generators": [
+            "Pythia6",
+            "EvtGen"
           ],
           "global_tag": "START53_LV4::All",
           "output_dataset": "/BuToJPsiKV2_2MuPtEtaFilterKPtEtaFilter_7TeV-pythia6-evtgen/Summer11Leg-START53_LV4-v1/GEN-SIM",
@@ -28672,13 +28138,6 @@
         "uri": "root://eospublic.cern.ch//eos/opendata/cms/MonteCarlo2011/Summer11LegDR/GluGluTo2L2Lprime_HContinInterf_M-125p6_7TeV-gg2vv315-pythia6/AODSIM/PU_S13_START53_LV6-v1/file-indexes/CMS_MonteCarlo2011_Summer11LegDR_GluGluTo2L2Lprime_HContinInterf_M-125p6_7TeV-gg2vv315-pythia6_AODSIM_PU_S13_START53_LV6-v1_40000_file_index.txt"
       }
     ],
-    "generator": {
-      "global_tag": "START53_LV6",
-      "names": [
-        "gg2VV",
-        "pythia6"
-      ]
-    },
     "license": {
       "attribution": "CC0"
     },
@@ -28706,6 +28165,10 @@
               "recid": "3101",
               "title": "Configuration file for SIM step HIG-Summer11Leg-00156_1_cfg.py"
             }
+          ],
+          "generators": [
+            "gg2VV",
+            "pythia6"
           ],
           "global_tag": "START53_LV4::All",
           "output_dataset": "/GluGluTo2L2Lprime_HContinInterf_M-125p6_7TeV-gg2vv315-pythia6/Summer11Leg-START53_LV4-v1/GEN-SIM",
@@ -28875,13 +28338,6 @@
         "uri": "root://eospublic.cern.ch//eos/opendata/cms/MonteCarlo2011/Summer11LegDR/GluGluTo2e2mu_BSMHContinInterf_M-125p6_7TeV-MCFM67-pythia6/AODSIM/PU_S13_START53_LV6-v1/file-indexes/CMS_MonteCarlo2011_Summer11LegDR_GluGluTo2e2mu_BSMHContinInterf_M-125p6_7TeV-MCFM67-pythia6_AODSIM_PU_S13_START53_LV6-v1_40000_file_index.txt"
       }
     ],
-    "generator": {
-      "global_tag": "START53_LV6",
-      "names": [
-        "MCFM",
-        "pythia6"
-      ]
-    },
     "license": {
       "attribution": "CC0"
     },
@@ -28909,6 +28365,10 @@
               "recid": "3132",
               "title": "Configuration file for SIM step HIG-Summer11Leg-00151_1_cfg.py"
             }
+          ],
+          "generators": [
+            "MCFM",
+            "pythia6"
           ],
           "global_tag": "START53_LV4::All",
           "output_dataset": "/GluGluTo2e2mu_BSMHContinInterf_M-125p6_7TeV-MCFM67-pythia6/Summer11Leg-START53_LV4-v1/GEN-SIM",
@@ -29054,13 +28514,6 @@
         "uri": "root://eospublic.cern.ch//eos/opendata/cms/MonteCarlo2011/Summer11LegDR/GluGluTo2e2mu_SMHContinInterf_M-125p6_7TeV-MCFM67-pythia6/AODSIM/PU_S13_START53_LV6-v1/file-indexes/CMS_MonteCarlo2011_Summer11LegDR_GluGluTo2e2mu_SMHContinInterf_M-125p6_7TeV-MCFM67-pythia6_AODSIM_PU_S13_START53_LV6-v1_40000_file_index.txt"
       }
     ],
-    "generator": {
-      "global_tag": "START53_LV6",
-      "names": [
-        "MCFM",
-        "pythia6"
-      ]
-    },
     "license": {
       "attribution": "CC0"
     },
@@ -29088,6 +28541,10 @@
               "recid": "3132",
               "title": "Configuration file for SIM step HIG-Summer11Leg-00151_1_cfg.py"
             }
+          ],
+          "generators": [
+            "MCFM",
+            "pythia6"
           ],
           "global_tag": "START53_LV4::All",
           "output_dataset": "/GluGluTo2e2mu_SMHContinInterf_M-125p6_7TeV-MCFM67-pythia6/Summer11Leg-START53_LV4-v1/GEN-SIM",
@@ -29209,13 +28666,6 @@
         "uri": "root://eospublic.cern.ch//eos/opendata/cms/MonteCarlo2011/Summer11LegDR/GluGluTo4L_HContinInterf_M-125p6_7TeV-gg2vv315-pythia6/AODSIM/PU_S13_START53_LV6-v1/file-indexes/CMS_MonteCarlo2011_Summer11LegDR_GluGluTo4L_HContinInterf_M-125p6_7TeV-gg2vv315-pythia6_AODSIM_PU_S13_START53_LV6-v1_00000_file_index.txt"
       }
     ],
-    "generator": {
-      "global_tag": "START53_LV6",
-      "names": [
-        "gg2VV",
-        "pythia6"
-      ]
-    },
     "license": {
       "attribution": "CC0"
     },
@@ -29243,6 +28693,10 @@
               "recid": "3101",
               "title": "Configuration file for SIM step HIG-Summer11Leg-00156_1_cfg.py"
             }
+          ],
+          "generators": [
+            "gg2VV",
+            "pythia6"
           ],
           "global_tag": "START53_LV4::All",
           "output_dataset": "/GluGluTo4L_HContinInterf_M-125p6_7TeV-gg2vv315-pythia6/Summer11Leg-START53_LV4-v1/GEN-SIM",
@@ -29376,13 +28830,6 @@
         "uri": "root://eospublic.cern.ch//eos/opendata/cms/MonteCarlo2011/Summer11LegDR/GluGluTo4e_BSMHContinInterf_M-125p6_7TeV-MCFM67-pythia6/AODSIM/PU_S13_START53_LV6-v1/file-indexes/CMS_MonteCarlo2011_Summer11LegDR_GluGluTo4e_BSMHContinInterf_M-125p6_7TeV-MCFM67-pythia6_AODSIM_PU_S13_START53_LV6-v1_30000_file_index.txt"
       }
     ],
-    "generator": {
-      "global_tag": "START53_LV6",
-      "names": [
-        "MCFM",
-        "pythia6"
-      ]
-    },
     "license": {
       "attribution": "CC0"
     },
@@ -29410,6 +28857,10 @@
               "recid": "3132",
               "title": "Configuration file for SIM step HIG-Summer11Leg-00151_1_cfg.py"
             }
+          ],
+          "generators": [
+            "MCFM",
+            "pythia6"
           ],
           "global_tag": "START53_LV4::All",
           "output_dataset": "/GluGluTo4e_BSMHContinInterf_M-125p6_7TeV-MCFM67-pythia6/Summer11Leg-START53_LV4-v1/GEN-SIM",
@@ -29555,13 +29006,6 @@
         "uri": "root://eospublic.cern.ch//eos/opendata/cms/MonteCarlo2011/Summer11LegDR/GluGluTo4e_SMHContinInterf_M-125p6_7TeV-MCFM67-pythia6/AODSIM/PU_S13_START53_LV6-v1/file-indexes/CMS_MonteCarlo2011_Summer11LegDR_GluGluTo4e_SMHContinInterf_M-125p6_7TeV-MCFM67-pythia6_AODSIM_PU_S13_START53_LV6-v1_40000_file_index.txt"
       }
     ],
-    "generator": {
-      "global_tag": "START53_LV6",
-      "names": [
-        "MCFM",
-        "pythia6"
-      ]
-    },
     "license": {
       "attribution": "CC0"
     },
@@ -29589,6 +29033,10 @@
               "recid": "3132",
               "title": "Configuration file for SIM step HIG-Summer11Leg-00151_1_cfg.py"
             }
+          ],
+          "generators": [
+            "MCFM",
+            "pythia6"
           ],
           "global_tag": "START53_LV4::All",
           "output_dataset": "/GluGluTo4e_SMHContinInterf_M-125p6_7TeV-MCFM67-pythia6/Summer11Leg-START53_LV4-v1/GEN-SIM",
@@ -29710,13 +29158,6 @@
         "uri": "root://eospublic.cern.ch//eos/opendata/cms/MonteCarlo2011/Summer11LegDR/GluGluTo4mu_BSMHContinInterf_M-125p6_7TeV-MCFM67-pythia6/AODSIM/PU_S13_START53_LV6-v1/file-indexes/CMS_MonteCarlo2011_Summer11LegDR_GluGluTo4mu_BSMHContinInterf_M-125p6_7TeV-MCFM67-pythia6_AODSIM_PU_S13_START53_LV6-v1_00000_file_index.txt"
       }
     ],
-    "generator": {
-      "global_tag": "START53_LV6",
-      "names": [
-        "MCFM",
-        "pythia6"
-      ]
-    },
     "license": {
       "attribution": "CC0"
     },
@@ -29744,6 +29185,10 @@
               "recid": "3132",
               "title": "Configuration file for SIM step HIG-Summer11Leg-00151_1_cfg.py"
             }
+          ],
+          "generators": [
+            "MCFM",
+            "pythia6"
           ],
           "global_tag": "START53_LV4::All",
           "output_dataset": "/GluGluTo4mu_BSMHContinInterf_M-125p6_7TeV-MCFM67-pythia6/Summer11Leg-START53_LV4-v1/GEN-SIM",
@@ -29877,13 +29322,6 @@
         "uri": "root://eospublic.cern.ch//eos/opendata/cms/MonteCarlo2011/Summer11LegDR/GluGluTo4mu_SMHContinInterf_M-125p6_7TeV-MCFM67-pythia6/AODSIM/PU_S13_START53_LV6-v1/file-indexes/CMS_MonteCarlo2011_Summer11LegDR_GluGluTo4mu_SMHContinInterf_M-125p6_7TeV-MCFM67-pythia6_AODSIM_PU_S13_START53_LV6-v1_20000_file_index.txt"
       }
     ],
-    "generator": {
-      "global_tag": "START53_LV6",
-      "names": [
-        "MCFM",
-        "pythia6"
-      ]
-    },
     "license": {
       "attribution": "CC0"
     },
@@ -29911,6 +29349,10 @@
               "recid": "3132",
               "title": "Configuration file for SIM step HIG-Summer11Leg-00151_1_cfg.py"
             }
+          ],
+          "generators": [
+            "MCFM",
+            "pythia6"
           ],
           "global_tag": "START53_LV4::All",
           "output_dataset": "/GluGluTo4mu_SMHContinInterf_M-125p6_7TeV-MCFM67-pythia6/Summer11Leg-START53_LV4-v1/GEN-SIM",
@@ -30056,13 +29498,6 @@
         "uri": "root://eospublic.cern.ch//eos/opendata/cms/MonteCarlo2011/Summer11LegDR/GluGluToHToZZTo4L_M-1000_7TeV-minloHJJ-pythia6-tauola/AODSIM/PU_S13_START53_LV6-v1/file-indexes/CMS_MonteCarlo2011_Summer11LegDR_GluGluToHToZZTo4L_M-1000_7TeV-minloHJJ-pythia6-tauola_AODSIM_PU_S13_START53_LV6-v1_20000_file_index.txt"
       }
     ],
-    "generator": {
-      "global_tag": "START53_LV6",
-      "names": [
-        "pythia6",
-        "powheg-minlo"
-      ]
-    },
     "license": {
       "attribution": "CC0"
     },
@@ -30090,6 +29525,10 @@
               "recid": "3051",
               "title": "Configuration file for SIM step HIG-Summer11Leg-00197_1_cfg.py"
             }
+          ],
+          "generators": [
+            "pythia6",
+            "powheg-minlo"
           ],
           "global_tag": "START53_LV4::All",
           "output_dataset": "/GluGluToHToZZTo4L_M-1000_7TeV-minloHJJ-pythia6-tauola/Summer11Leg-START53_LV4-v1/GEN-SIM",
@@ -30211,13 +29650,6 @@
         "uri": "root://eospublic.cern.ch//eos/opendata/cms/MonteCarlo2011/Summer11LegDR/Graviton2BPqqbarToZZTo4L_M-125p6_7TeV-JHUGenV3-pythia6/AODSIM/PU_S13_START53_LV6-v1/file-indexes/CMS_MonteCarlo2011_Summer11LegDR_Graviton2BPqqbarToZZTo4L_M-125p6_7TeV-JHUGenV3-pythia6_AODSIM_PU_S13_START53_LV6-v1_80000_file_index.txt"
       }
     ],
-    "generator": {
-      "global_tag": "START53_LV6",
-      "names": [
-        "powheg15",
-        "pythia6"
-      ]
-    },
     "license": {
       "attribution": "CC0"
     },
@@ -30245,6 +29677,10 @@
               "recid": "3132",
               "title": "Configuration file for SIM step HIG-Summer11Leg-00151_1_cfg.py"
             }
+          ],
+          "generators": [
+            "powheg15",
+            "pythia6"
           ],
           "global_tag": "START53_LV4::All",
           "output_dataset": "/Graviton2BPqqbarToZZTo4L_M-125p6_7TeV-JHUGenV3-pythia6/Summer11Leg-START53_LV4-v1/GEN-SIM",
@@ -30390,13 +29826,6 @@
         "uri": "root://eospublic.cern.ch//eos/opendata/cms/MonteCarlo2011/Summer11LegDR/Graviton2HPqqbarToZZTo4L_M-125p6_7TeV-JHUGenV3-pythia6/AODSIM/PU_S13_START53_LV6-v1/file-indexes/CMS_MonteCarlo2011_Summer11LegDR_Graviton2HPqqbarToZZTo4L_M-125p6_7TeV-JHUGenV3-pythia6_AODSIM_PU_S13_START53_LV6-v1_30000_file_index.txt"
       }
     ],
-    "generator": {
-      "global_tag": "START53_LV6",
-      "names": [
-        "powheg15",
-        "pythia6"
-      ]
-    },
     "license": {
       "attribution": "CC0"
     },
@@ -30424,6 +29853,10 @@
               "recid": "3132",
               "title": "Configuration file for SIM step HIG-Summer11Leg-00151_1_cfg.py"
             }
+          ],
+          "generators": [
+            "powheg15",
+            "pythia6"
           ],
           "global_tag": "START53_LV4::All",
           "output_dataset": "/Graviton2HPqqbarToZZTo4L_M-125p6_7TeV-JHUGenV3-pythia6/Summer11Leg-START53_LV4-v2/GEN-SIM",
@@ -30557,13 +29990,6 @@
         "uri": "root://eospublic.cern.ch//eos/opendata/cms/MonteCarlo2011/Summer11LegDR/Graviton2MH10qqbarToZZTo4L_M-125p6_7TeV-JHUGenV3-pythia6/AODSIM/PU_S13_START53_LV6-v1/file-indexes/CMS_MonteCarlo2011_Summer11LegDR_Graviton2MH10qqbarToZZTo4L_M-125p6_7TeV-JHUGenV3-pythia6_AODSIM_PU_S13_START53_LV6-v1_40000_file_index.txt"
       }
     ],
-    "generator": {
-      "global_tag": "START53_LV6",
-      "names": [
-        "powheg15",
-        "pythia6"
-      ]
-    },
     "license": {
       "attribution": "CC0"
     },
@@ -30591,6 +30017,10 @@
               "recid": "3132",
               "title": "Configuration file for SIM step HIG-Summer11Leg-00151_1_cfg.py"
             }
+          ],
+          "generators": [
+            "powheg15",
+            "pythia6"
           ],
           "global_tag": "START53_LV4::All",
           "output_dataset": "/Graviton2MH10qqbarToZZTo4L_M-125p6_7TeV-JHUGenV3-pythia6/Summer11Leg-START53_LV4-v1/GEN-SIM",
@@ -30712,13 +30142,6 @@
         "uri": "root://eospublic.cern.ch//eos/opendata/cms/MonteCarlo2011/Summer11LegDR/Graviton2PH2qqbarToZZTo4L_M-125p6_7TeV-JHUGenV3-pythia6/AODSIM/PU_S13_START53_LV6-v1/file-indexes/CMS_MonteCarlo2011_Summer11LegDR_Graviton2PH2qqbarToZZTo4L_M-125p6_7TeV-JHUGenV3-pythia6_AODSIM_PU_S13_START53_LV6-v1_00000_file_index.txt"
       }
     ],
-    "generator": {
-      "global_tag": "START53_LV6",
-      "names": [
-        "powheg15",
-        "pythia6"
-      ]
-    },
     "license": {
       "attribution": "CC0"
     },
@@ -30746,6 +30169,10 @@
               "recid": "3132",
               "title": "Configuration file for SIM step HIG-Summer11Leg-00151_1_cfg.py"
             }
+          ],
+          "generators": [
+            "powheg15",
+            "pythia6"
           ],
           "global_tag": "START53_LV4::All",
           "output_dataset": "/Graviton2PH2qqbarToZZTo4L_M-125p6_7TeV-JHUGenV3-pythia6/Summer11Leg-START53_LV4-v1/GEN-SIM",
@@ -30867,13 +30294,6 @@
         "uri": "root://eospublic.cern.ch//eos/opendata/cms/MonteCarlo2011/Summer11LegDR/Graviton2PH3qqbarToZZTo4L_M-125p6_7TeV-JHUGenV3-pythia6/AODSIM/PU_S13_START53_LV6-v1/file-indexes/CMS_MonteCarlo2011_Summer11LegDR_Graviton2PH3qqbarToZZTo4L_M-125p6_7TeV-JHUGenV3-pythia6_AODSIM_PU_S13_START53_LV6-v1_50000_file_index.txt"
       }
     ],
-    "generator": {
-      "global_tag": "START53_LV6",
-      "names": [
-        "powheg15",
-        "pythia6"
-      ]
-    },
     "license": {
       "attribution": "CC0"
     },
@@ -30901,6 +30321,10 @@
               "recid": "3132",
               "title": "Configuration file for SIM step HIG-Summer11Leg-00151_1_cfg.py"
             }
+          ],
+          "generators": [
+            "powheg15",
+            "pythia6"
           ],
           "global_tag": "START53_LV4::All",
           "output_dataset": "/Graviton2PH3qqbarToZZTo4L_M-125p6_7TeV-JHUGenV3-pythia6/Summer11Leg-START53_LV4-v1/GEN-SIM",
@@ -31034,13 +30458,6 @@
         "uri": "root://eospublic.cern.ch//eos/opendata/cms/MonteCarlo2011/Summer11LegDR/Higgs0L1f01ph0ToZZTo4L_M-125p6_7TeV-powheg15-JHUgenV4/AODSIM/PU_S13_START53_LV6-v1/file-indexes/CMS_MonteCarlo2011_Summer11LegDR_Higgs0L1f01ph0ToZZTo4L_M-125p6_7TeV-powheg15-JHUgenV4_AODSIM_PU_S13_START53_LV6-v1_30000_file_index.txt"
       }
     ],
-    "generator": {
-      "global_tag": "START53_LV6",
-      "names": [
-        "powheg15",
-        "pythia6"
-      ]
-    },
     "license": {
       "attribution": "CC0"
     },
@@ -31068,6 +30485,10 @@
               "recid": "3245",
               "title": "Configuration file for SIM step HIG-Summer11Leg-00270_1_cfg.py"
             }
+          ],
+          "generators": [
+            "powheg15",
+            "pythia6"
           ],
           "global_tag": "START53_LV4::All",
           "output_dataset": "/Higgs0L1f01ph0ToZZTo4L_M-125p6_7TeV-powheg15-JHUgenV4/Summer11Leg-START53_LV4-v1/GEN-SIM",
@@ -31213,13 +30634,6 @@
         "uri": "root://eospublic.cern.ch//eos/opendata/cms/MonteCarlo2011/Summer11LegDR/Higgs0L1f05ph0ToZZTo4L_M-125p6_7TeV-powheg15-JHUgenV4/AODSIM/PU_S13_START53_LV6-v1/file-indexes/CMS_MonteCarlo2011_Summer11LegDR_Higgs0L1f05ph0ToZZTo4L_M-125p6_7TeV-powheg15-JHUgenV4_AODSIM_PU_S13_START53_LV6-v1_40000_file_index.txt"
       }
     ],
-    "generator": {
-      "global_tag": "START53_LV6",
-      "names": [
-        "powheg15",
-        "pythia6"
-      ]
-    },
     "license": {
       "attribution": "CC0"
     },
@@ -31247,6 +30661,10 @@
               "recid": "3245",
               "title": "Configuration file for SIM step HIG-Summer11Leg-00270_1_cfg.py"
             }
+          ],
+          "generators": [
+            "powheg15",
+            "pythia6"
           ],
           "global_tag": "START53_LV4::All",
           "output_dataset": "/Higgs0L1f05ph0ToZZTo4L_M-125p6_7TeV-powheg15-JHUgenV4/Summer11Leg-START53_LV4-v1/GEN-SIM",
@@ -31368,13 +30786,6 @@
         "uri": "root://eospublic.cern.ch//eos/opendata/cms/MonteCarlo2011/Summer11LegDR/Higgs0PHf01ph0ToZZTo4L_M-125p6_7TeV-powheg15-JHUgenV3/AODSIM/PU_S13_START53_LV6-v1/file-indexes/CMS_MonteCarlo2011_Summer11LegDR_Higgs0PHf01ph0ToZZTo4L_M-125p6_7TeV-powheg15-JHUgenV3_AODSIM_PU_S13_START53_LV6-v1_00000_file_index.txt"
       }
     ],
-    "generator": {
-      "global_tag": "START53_LV6",
-      "names": [
-        "powheg15",
-        "pythia6"
-      ]
-    },
     "license": {
       "attribution": "CC0"
     },
@@ -31402,6 +30813,10 @@
               "recid": "3245",
               "title": "Configuration file for SIM step HIG-Summer11Leg-00270_1_cfg.py"
             }
+          ],
+          "generators": [
+            "powheg15",
+            "pythia6"
           ],
           "global_tag": "START53_LV4::All",
           "output_dataset": "/Higgs0PHf01ph0ToZZTo4L_M-125p6_7TeV-powheg15-JHUgenV3/Summer11Leg-START53_LV4-v1/GEN-SIM",
@@ -31523,13 +30938,6 @@
         "uri": "root://eospublic.cern.ch//eos/opendata/cms/MonteCarlo2011/Summer11LegDR/Higgs0PHf01ph90ToZZTo4L_M-125p6_7TeV-powheg15-JHUgenV3/AODSIM/PU_S13_START53_LV6-v1/file-indexes/CMS_MonteCarlo2011_Summer11LegDR_Higgs0PHf01ph90ToZZTo4L_M-125p6_7TeV-powheg15-JHUgenV3_AODSIM_PU_S13_START53_LV6-v1_00000_file_index.txt"
       }
     ],
-    "generator": {
-      "global_tag": "START53_LV6",
-      "names": [
-        "powheg15",
-        "pythia6"
-      ]
-    },
     "license": {
       "attribution": "CC0"
     },
@@ -31557,6 +30965,10 @@
               "recid": "3245",
               "title": "Configuration file for SIM step HIG-Summer11Leg-00270_1_cfg.py"
             }
+          ],
+          "generators": [
+            "powheg15",
+            "pythia6"
           ],
           "global_tag": "START53_LV4::All",
           "output_dataset": "/Higgs0PHf01ph90ToZZTo4L_M-125p6_7TeV-powheg15-JHUgenV3/Summer11Leg-START53_LV4-v1/GEN-SIM",
@@ -31690,13 +31102,6 @@
         "uri": "root://eospublic.cern.ch//eos/opendata/cms/MonteCarlo2011/Summer11LegDR/Higgs0PHf033ph0Mf033ph0ToZZTo4L_M-125p6_7TeV-powheg15-JHUgenV3/AODSIM/PU_S13_START53_LV6-v1/file-indexes/CMS_MonteCarlo2011_Summer11LegDR_Higgs0PHf033ph0Mf033ph0ToZZTo4L_M-125p6_7TeV-powheg15-JHUgenV3_AODSIM_PU_S13_START53_LV6-v1_30000_file_index.txt"
       }
     ],
-    "generator": {
-      "global_tag": "START53_LV6",
-      "names": [
-        "powheg15",
-        "pythia6"
-      ]
-    },
     "license": {
       "attribution": "CC0"
     },
@@ -31724,6 +31129,10 @@
               "recid": "3245",
               "title": "Configuration file for SIM step HIG-Summer11Leg-00270_1_cfg.py"
             }
+          ],
+          "generators": [
+            "powheg15",
+            "pythia6"
           ],
           "global_tag": "START53_LV4::All",
           "output_dataset": "/Higgs0PHf033ph0Mf033ph0ToZZTo4L_M-125p6_7TeV-powheg15-JHUgenV3/Summer11Leg-START53_LV4-v1/GEN-SIM",
@@ -31869,13 +31278,6 @@
         "uri": "root://eospublic.cern.ch//eos/opendata/cms/MonteCarlo2011/Summer11LegDR/Higgs0PHf05ph0Mf05ph0ToZZTo4L_M-125p6_7TeV-powheg15-JHUgenV3/AODSIM/PU_S13_START53_LV6-v1/file-indexes/CMS_MonteCarlo2011_Summer11LegDR_Higgs0PHf05ph0Mf05ph0ToZZTo4L_M-125p6_7TeV-powheg15-JHUgenV3_AODSIM_PU_S13_START53_LV6-v1_30000_file_index.txt"
       }
     ],
-    "generator": {
-      "global_tag": "START53_LV6",
-      "names": [
-        "powheg15",
-        "pythia6"
-      ]
-    },
     "license": {
       "attribution": "CC0"
     },
@@ -31903,6 +31305,10 @@
               "recid": "3245",
               "title": "Configuration file for SIM step HIG-Summer11Leg-00270_1_cfg.py"
             }
+          ],
+          "generators": [
+            "powheg15",
+            "pythia6"
           ],
           "global_tag": "START53_LV4::All",
           "output_dataset": "/Higgs0PHf05ph0Mf05ph0ToZZTo4L_M-125p6_7TeV-powheg15-JHUgenV3/Summer11Leg-START53_LV4-v1/GEN-SIM",
@@ -32036,13 +31442,6 @@
         "uri": "root://eospublic.cern.ch//eos/opendata/cms/MonteCarlo2011/Summer11LegDR/Higgs0PHf05ph0ToZZTo4L_M-125p6_7TeV-powheg15-JHUgenV3/AODSIM/PU_S13_START53_LV6-v1/file-indexes/CMS_MonteCarlo2011_Summer11LegDR_Higgs0PHf05ph0ToZZTo4L_M-125p6_7TeV-powheg15-JHUgenV3_AODSIM_PU_S13_START53_LV6-v1_40000_file_index.txt"
       }
     ],
-    "generator": {
-      "global_tag": "START53_LV6",
-      "names": [
-        "powheg15",
-        "pythia6"
-      ]
-    },
     "license": {
       "attribution": "CC0"
     },
@@ -32070,6 +31469,10 @@
               "recid": "3245",
               "title": "Configuration file for SIM step HIG-Summer11Leg-00270_1_cfg.py"
             }
+          ],
+          "generators": [
+            "powheg15",
+            "pythia6"
           ],
           "global_tag": "START53_LV4::All",
           "output_dataset": "/Higgs0PHf05ph0ToZZTo4L_M-125p6_7TeV-powheg15-JHUgenV3/Summer11Leg-START53_LV4-v1/GEN-SIM",
@@ -32203,13 +31606,6 @@
         "uri": "root://eospublic.cern.ch//eos/opendata/cms/MonteCarlo2011/Summer11LegDR/Higgs0PHf05ph180ToZZTo4L_M-125p6_7TeV-powheg15-JHUgenV4/AODSIM/PU_S13_START53_LV6-v1/file-indexes/CMS_MonteCarlo2011_Summer11LegDR_Higgs0PHf05ph180ToZZTo4L_M-125p6_7TeV-powheg15-JHUgenV4_AODSIM_PU_S13_START53_LV6-v1_30000_file_index.txt"
       }
     ],
-    "generator": {
-      "global_tag": "START53_LV6",
-      "names": [
-        "powheg15",
-        "pythia6"
-      ]
-    },
     "license": {
       "attribution": "CC0"
     },
@@ -32237,6 +31633,10 @@
               "recid": "3245",
               "title": "Configuration file for SIM step HIG-Summer11Leg-00270_1_cfg.py"
             }
+          ],
+          "generators": [
+            "powheg15",
+            "pythia6"
           ],
           "global_tag": "START53_LV4::All",
           "output_dataset": "/Higgs0PHf05ph180ToZZTo4L_M-125p6_7TeV-powheg15-JHUgenV4/Summer11Leg-START53_LV4-v1/GEN-SIM",
@@ -32394,13 +31794,6 @@
         "uri": "root://eospublic.cern.ch//eos/opendata/cms/MonteCarlo2011/Summer11LegDR/Higgs0PMToZZf05GGf05To4L_M-125p6_7TeV-powheg15-JHUgenV4/AODSIM/PU_S13_START53_LV6-v1/file-indexes/CMS_MonteCarlo2011_Summer11LegDR_Higgs0PMToZZf05GGf05To4L_M-125p6_7TeV-powheg15-JHUgenV4_AODSIM_PU_S13_START53_LV6-v1_40000_file_index.txt"
       }
     ],
-    "generator": {
-      "global_tag": "START53_LV6",
-      "names": [
-        "powheg15",
-        "pythia6"
-      ]
-    },
     "license": {
       "attribution": "CC0"
     },
@@ -32428,6 +31821,10 @@
               "recid": "3245",
               "title": "Configuration file for SIM step HIG-Summer11Leg-00270_1_cfg.py"
             }
+          ],
+          "generators": [
+            "powheg15",
+            "pythia6"
           ],
           "global_tag": "START53_LV4::All",
           "output_dataset": "/Higgs0PMToZZf05GGf05To4L_M-125p6_7TeV-powheg15-JHUgenV4/Summer11Leg-START53_LV4-v1/GEN-SIM",
@@ -32549,13 +31946,6 @@
         "uri": "root://eospublic.cern.ch//eos/opendata/cms/MonteCarlo2011/Summer11LegDR/Higgs0PMToZZf05ZGf05To4L_M-125p6_7TeV-powheg15-JHUgenV4/AODSIM/PU_S13_START53_LV6-v1/file-indexes/CMS_MonteCarlo2011_Summer11LegDR_Higgs0PMToZZf05ZGf05To4L_M-125p6_7TeV-powheg15-JHUgenV4_AODSIM_PU_S13_START53_LV6-v1_40000_file_index.txt"
       }
     ],
-    "generator": {
-      "global_tag": "START53_LV6",
-      "names": [
-        "powheg15",
-        "pythia6"
-      ]
-    },
     "license": {
       "attribution": "CC0"
     },
@@ -32583,6 +31973,10 @@
               "recid": "3245",
               "title": "Configuration file for SIM step HIG-Summer11Leg-00270_1_cfg.py"
             }
+          ],
+          "generators": [
+            "powheg15",
+            "pythia6"
           ],
           "global_tag": "START53_LV4::All",
           "output_dataset": "/Higgs0PMToZZf05ZGf05To4L_M-125p6_7TeV-powheg15-JHUgenV4/Summer11Leg-START53_LV4-v2/GEN-SIM",
@@ -32704,13 +32098,6 @@
         "uri": "root://eospublic.cern.ch//eos/opendata/cms/MonteCarlo2011/Summer11LegDR/Higgs0PMToZZfZGfGGfTo4L_M-125p6_7TeV-powheg15-JHUgenV4/AODSIM/PU_S13_START53_LV6-v1/file-indexes/CMS_MonteCarlo2011_Summer11LegDR_Higgs0PMToZZfZGfGGfTo4L_M-125p6_7TeV-powheg15-JHUgenV4_AODSIM_PU_S13_START53_LV6-v1_10000_file_index.txt"
       }
     ],
-    "generator": {
-      "global_tag": "START53_LV6",
-      "names": [
-        "powheg15",
-        "pythia6"
-      ]
-    },
     "license": {
       "attribution": "CC0"
     },
@@ -32738,6 +32125,10 @@
               "recid": "3245",
               "title": "Configuration file for SIM step HIG-Summer11Leg-00270_1_cfg.py"
             }
+          ],
+          "generators": [
+            "powheg15",
+            "pythia6"
           ],
           "global_tag": "START53_LV4::All",
           "output_dataset": "/Higgs0PMToZZfZGfGGfTo4L_M-125p6_7TeV-powheg15-JHUgenV4/Summer11Leg-START53_LV4-v1/GEN-SIM",
@@ -32871,13 +32262,6 @@
         "uri": "root://eospublic.cern.ch//eos/opendata/cms/MonteCarlo2011/Summer11LegDR/JJHiggs0MToBB_M-125p6_7TeV-JHUGenV4-pythia6-tauola/AODSIM/PU_S13_START53_LV6-v1/file-indexes/CMS_MonteCarlo2011_Summer11LegDR_JJHiggs0MToBB_M-125p6_7TeV-JHUGenV4-pythia6-tauola_AODSIM_PU_S13_START53_LV6-v1_30000_file_index.txt"
       }
     ],
-    "generator": {
-      "global_tag": "START53_LV6",
-      "names": [
-        "JHUGen4",
-        "pythia6"
-      ]
-    },
     "license": {
       "attribution": "CC0"
     },
@@ -32905,6 +32289,10 @@
               "recid": "3030",
               "title": "Configuration file for SIM step HIG-Summer11Leg-00082_1_cfg.py"
             }
+          ],
+          "generators": [
+            "JHUGen4",
+            "pythia6"
           ],
           "global_tag": "START53_LV4::All",
           "output_dataset": "/JJHiggs0MToBB_M-125p6_7TeV-JHUGenV4-pythia6-tauola/Summer11Leg-START53_LV4-v1/GEN-SIM",
@@ -33023,13 +32411,6 @@
         "uri": "root://eospublic.cern.ch//eos/opendata/cms/MonteCarlo2011/Summer11LegDR/LambdaBToLambdaPsi_JpsiPiPiPPi_EtaPtFilter_7TeV-pythia6-evtgen/AODSIM/PU_S13_START53_LV6-v1/file-indexes/CMS_MonteCarlo2011_Summer11LegDR_LambdaBToLambdaPsi_JpsiPiPiPPi_EtaPtFilter_7TeV-pythia6-evtgen_AODSIM_PU_S13_START53_LV6-v1_00000_file_index.txt"
       }
     ],
-    "generator": {
-      "global_tag": "START53_LV6",
-      "names": [
-        "PYTHIA6",
-        "EvtGen"
-      ]
-    },
     "license": {
       "attribution": "CC0"
     },
@@ -33043,6 +32424,10 @@
               "recid": "3255",
               "title": "Configuration file for SIM step BPH-Summer11Leg-00008_1_cfg.py"
             }
+          ],
+          "generators": [
+            "PYTHIA6",
+            "EvtGen"
           ],
           "global_tag": "START53_LV4::All",
           "output_dataset": "/LambdaBToLambdaPsi_JpsiPiPiPPi_EtaPtFilter_7TeV-pythia6-evtgen/Summer11Leg-START53_LV4-v3/GEN-SIM",
@@ -33176,13 +32561,6 @@
         "uri": "root://eospublic.cern.ch//eos/opendata/cms/MonteCarlo2011/Summer11LegDR/SMHiggsToZZTo4L_M-115_7TeV-powheg15-JHUgenV3-pythia6/AODSIM/PU_S13_START53_LV6-v1/file-indexes/CMS_MonteCarlo2011_Summer11LegDR_SMHiggsToZZTo4L_M-115_7TeV-powheg15-JHUgenV3-pythia6_AODSIM_PU_S13_START53_LV6-v1_40000_file_index.txt"
       }
     ],
-    "generator": {
-      "global_tag": "START53_LV6",
-      "names": [
-        "powheg15",
-        "pythia6"
-      ]
-    },
     "license": {
       "attribution": "CC0"
     },
@@ -33210,6 +32588,10 @@
               "recid": "3031",
               "title": "Configuration file for SIM step HIG-Summer11Leg-00119_1_cfg.py"
             }
+          ],
+          "generators": [
+            "powheg15",
+            "pythia6"
           ],
           "global_tag": "START53_LV4::All",
           "output_dataset": "/SMHiggsToZZTo4L_M-115_7TeV-powheg15-JHUgenV3-pythia6/Summer11Leg-START53_LV4-v1/GEN-SIM",
@@ -33331,13 +32713,6 @@
         "uri": "root://eospublic.cern.ch//eos/opendata/cms/MonteCarlo2011/Summer11LegDR/SMHiggsToZZTo4L_M-122_7TeV-powheg15-JHUgenV3-pythia6/AODSIM/PU_S13_START53_LV6-v1/file-indexes/CMS_MonteCarlo2011_Summer11LegDR_SMHiggsToZZTo4L_M-122_7TeV-powheg15-JHUgenV3-pythia6_AODSIM_PU_S13_START53_LV6-v1_20000_file_index.txt"
       }
     ],
-    "generator": {
-      "global_tag": "START53_LV6",
-      "names": [
-        "powheg15",
-        "pythia6"
-      ]
-    },
     "license": {
       "attribution": "CC0"
     },
@@ -33365,6 +32740,10 @@
               "recid": "3031",
               "title": "Configuration file for SIM step HIG-Summer11Leg-00119_1_cfg.py"
             }
+          ],
+          "generators": [
+            "powheg15",
+            "pythia6"
           ],
           "global_tag": "START53_LV4::All",
           "output_dataset": "/SMHiggsToZZTo4L_M-122_7TeV-powheg15-JHUgenV3-pythia6/Summer11Leg-START53_LV4-v1/GEN-SIM",
@@ -33486,13 +32865,6 @@
         "uri": "root://eospublic.cern.ch//eos/opendata/cms/MonteCarlo2011/Summer11LegDR/SMHiggsToZZTo4L_M-125_7TeV-powheg15-JHUgenV3-pythia6/AODSIM/PU_S13_START53_LV6-v1/file-indexes/CMS_MonteCarlo2011_Summer11LegDR_SMHiggsToZZTo4L_M-125_7TeV-powheg15-JHUgenV3-pythia6_AODSIM_PU_S13_START53_LV6-v1_20000_file_index.txt"
       }
     ],
-    "generator": {
-      "global_tag": "START53_LV6",
-      "names": [
-        "powheg15",
-        "pythia6"
-      ]
-    },
     "license": {
       "attribution": "CC0"
     },
@@ -33520,6 +32892,10 @@
               "recid": "3031",
               "title": "Configuration file for SIM step HIG-Summer11Leg-00119_1_cfg.py"
             }
+          ],
+          "generators": [
+            "powheg15",
+            "pythia6"
           ],
           "global_tag": "START53_LV4::All",
           "output_dataset": "/SMHiggsToZZTo4L_M-125_7TeV-powheg15-JHUgenV3-pythia6/Summer11Leg-START53_LV4-v1/GEN-SIM",
@@ -33677,13 +33053,6 @@
         "uri": "root://eospublic.cern.ch//eos/opendata/cms/MonteCarlo2011/Summer11LegDR/SMHiggsToZZTo4L_M-126_7TeV-powheg15-JHUgenV3-pythia6/AODSIM/PU_S13_START53_LV6-v1/file-indexes/CMS_MonteCarlo2011_Summer11LegDR_SMHiggsToZZTo4L_M-126_7TeV-powheg15-JHUgenV3-pythia6_AODSIM_PU_S13_START53_LV6-v1_40000_file_index.txt"
       }
     ],
-    "generator": {
-      "global_tag": "START53_LV6",
-      "names": [
-        "powheg15",
-        "pythia6"
-      ]
-    },
     "license": {
       "attribution": "CC0"
     },
@@ -33711,6 +33080,10 @@
               "recid": "3031",
               "title": "Configuration file for SIM step HIG-Summer11Leg-00119_1_cfg.py"
             }
+          ],
+          "generators": [
+            "powheg15",
+            "pythia6"
           ],
           "global_tag": "START53_LV4::All",
           "output_dataset": "/SMHiggsToZZTo4L_M-126_7TeV-powheg15-JHUgenV3-pythia6/Summer11Leg-START53_LV4-v1/GEN-SIM",
@@ -33868,13 +33241,6 @@
         "uri": "root://eospublic.cern.ch//eos/opendata/cms/MonteCarlo2011/Summer11LegDR/SMHiggsToZZTo4L_M-130_7TeV-powheg15-JHUgenV3-pythia6/AODSIM/PU_S13_START53_LV6-v1/file-indexes/CMS_MonteCarlo2011_Summer11LegDR_SMHiggsToZZTo4L_M-130_7TeV-powheg15-JHUgenV3-pythia6_AODSIM_PU_S13_START53_LV6-v1_40000_file_index.txt"
       }
     ],
-    "generator": {
-      "global_tag": "START53_LV6",
-      "names": [
-        "powheg15",
-        "pythia6"
-      ]
-    },
     "license": {
       "attribution": "CC0"
     },
@@ -33902,6 +33268,10 @@
               "recid": "3031",
               "title": "Configuration file for SIM step HIG-Summer11Leg-00119_1_cfg.py"
             }
+          ],
+          "generators": [
+            "powheg15",
+            "pythia6"
           ],
           "global_tag": "START53_LV4::All",
           "output_dataset": "/SMHiggsToZZTo4L_M-130_7TeV-powheg15-JHUgenV3-pythia6/Summer11Leg-START53_LV4-v1/GEN-SIM",
@@ -34035,13 +33405,6 @@
         "uri": "root://eospublic.cern.ch//eos/opendata/cms/MonteCarlo2011/Summer11LegDR/SMHiggsToZZTo4L_M-185_7TeV-powheg15-JHUgenV3-pythia6/AODSIM/PU_S13_START53_LV6-v1/file-indexes/CMS_MonteCarlo2011_Summer11LegDR_SMHiggsToZZTo4L_M-185_7TeV-powheg15-JHUgenV3-pythia6_AODSIM_PU_S13_START53_LV6-v1_20000_file_index.txt"
       }
     ],
-    "generator": {
-      "global_tag": "START53_LV6",
-      "names": [
-        "powheg15",
-        "pythia6"
-      ]
-    },
     "license": {
       "attribution": "CC0"
     },
@@ -34069,6 +33432,10 @@
               "recid": "3031",
               "title": "Configuration file for SIM step HIG-Summer11Leg-00119_1_cfg.py"
             }
+          ],
+          "generators": [
+            "powheg15",
+            "pythia6"
           ],
           "global_tag": "START53_LV4::All",
           "output_dataset": "/SMHiggsToZZTo4L_M-185_7TeV-powheg15-JHUgenV3-pythia6/Summer11Leg-START53_LV4-v1/GEN-SIM",
@@ -34202,15 +33569,6 @@
         "uri": "root://eospublic.cern.ch//eos/opendata/cms/MonteCarlo2011/Summer11LegDR/TTJets_MSDecays_dileptonic_central_7TeV-madgraph-tauola/AODSIM/PU_S13_START53_LV6-v1/file-indexes/CMS_MonteCarlo2011_Summer11LegDR_TTJets_MSDecays_dileptonic_central_7TeV-madgraph-tauola_AODSIM_PU_S13_START53_LV6-v1_70000_file_index.txt"
       }
     ],
-    "generator": {
-      "global_tag": "START53_LV6",
-      "names": [
-        "madgraph",
-        "madspin",
-        "pythia6",
-        "tauola"
-      ]
-    },
     "license": {
       "attribution": "CC0"
     },
@@ -34238,6 +33596,12 @@
               "recid": "3384",
               "title": "Configuration file for SIM step TOP-Summer11Leg-00035_1_cfg.py"
             }
+          ],
+          "generators": [
+            "madgraph",
+            "madspin",
+            "pythia6",
+            "tauola"
           ],
           "global_tag": "START53_LV4::All",
           "output_dataset": "/TTJets_MSDecays_dileptonic_central_7TeV-madgraph-tauola/Summer11Leg-START53_LV4-v1/GEN-SIM",
@@ -34359,15 +33723,6 @@
         "uri": "root://eospublic.cern.ch//eos/opendata/cms/MonteCarlo2011/Summer11LegDR/TTJets_MSDecays_dileptonic_matchingdown_7TeV-madgraph-tauola/AODSIM/PU_S13_START53_LV6-v1/file-indexes/CMS_MonteCarlo2011_Summer11LegDR_TTJets_MSDecays_dileptonic_matchingdown_7TeV-madgraph-tauola_AODSIM_PU_S13_START53_LV6-v1_40000_file_index.txt"
       }
     ],
-    "generator": {
-      "global_tag": "START53_LV6",
-      "names": [
-        "madgraph",
-        "madspin",
-        "pythia6",
-        "tauola"
-      ]
-    },
     "license": {
       "attribution": "CC0"
     },
@@ -34395,6 +33750,12 @@
               "recid": "3014",
               "title": "Configuration file for SIM step TOP-Summer11Leg-00037_1_cfg.py"
             }
+          ],
+          "generators": [
+            "madgraph",
+            "madspin",
+            "pythia6",
+            "tauola"
           ],
           "global_tag": "START53_LV4::All",
           "output_dataset": "/TTJets_MSDecays_dileptonic_matchingdown_7TeV-madgraph-tauola/Summer11Leg-START53_LV4-v1/GEN-SIM",
@@ -34516,15 +33877,6 @@
         "uri": "root://eospublic.cern.ch//eos/opendata/cms/MonteCarlo2011/Summer11LegDR/TTJets_MSDecays_dileptonic_matchingdown_7TeV-madgraph-tauola/AODSIM/PU_S13_START53_LV6_ext1-v1/file-indexes/CMS_MonteCarlo2011_Summer11LegDR_TTJets_MSDecays_dileptonic_matchingdown_7TeV-madgraph-tauola_AODSIM_PU_S13_START53_LV6_ext1-v1_60000_file_index.txt"
       }
     ],
-    "generator": {
-      "global_tag": "START53_LV6",
-      "names": [
-        "madgraph",
-        "madspin",
-        "pythia6",
-        "tauola"
-      ]
-    },
     "license": {
       "attribution": "CC0"
     },
@@ -34552,6 +33904,12 @@
               "recid": "3266",
               "title": "Configuration file for SIM step TOP-Summer11Leg-00041_1_cfg.py"
             }
+          ],
+          "generators": [
+            "madgraph",
+            "madspin",
+            "pythia6",
+            "tauola"
           ],
           "global_tag": "START53_LV4::All",
           "output_dataset": "/TTJets_MSDecays_dileptonic_matchingdown_7TeV-madgraph-tauola/Summer11Leg-START53_LV4_ext1-v1/GEN-SIM",
@@ -34685,15 +34043,6 @@
         "uri": "root://eospublic.cern.ch//eos/opendata/cms/MonteCarlo2011/Summer11LegDR/TTJets_MSDecays_dileptonic_matchingup_7TeV-madgraph-tauola/AODSIM/PU_S13_START53_LV6-v1/file-indexes/CMS_MonteCarlo2011_Summer11LegDR_TTJets_MSDecays_dileptonic_matchingup_7TeV-madgraph-tauola_AODSIM_PU_S13_START53_LV6-v1_50000_file_index.txt"
       }
     ],
-    "generator": {
-      "global_tag": "START53_LV6",
-      "names": [
-        "madgraph",
-        "madspin",
-        "pythia6",
-        "tauola"
-      ]
-    },
     "license": {
       "attribution": "CC0"
     },
@@ -34721,6 +34070,12 @@
               "recid": "3028",
               "title": "Configuration file for SIM step TOP-Summer11Leg-00033_1_cfg.py"
             }
+          ],
+          "generators": [
+            "madgraph",
+            "madspin",
+            "pythia6",
+            "tauola"
           ],
           "global_tag": "START53_LV4::All",
           "output_dataset": "/TTJets_MSDecays_dileptonic_matchingup_7TeV-madgraph-tauola/Summer11Leg-START53_LV4-v1/GEN-SIM",
@@ -34842,15 +34197,6 @@
         "uri": "root://eospublic.cern.ch//eos/opendata/cms/MonteCarlo2011/Summer11LegDR/TTJets_MSDecays_dileptonic_mt166_5_7TeV-madgraph-tauola/AODSIM/PU_S13_START53_LV6-v2/file-indexes/CMS_MonteCarlo2011_Summer11LegDR_TTJets_MSDecays_dileptonic_mt166_5_7TeV-madgraph-tauola_AODSIM_PU_S13_START53_LV6-v2_80000_file_index.txt"
       }
     ],
-    "generator": {
-      "global_tag": "START53_LV6",
-      "names": [
-        "madgraph",
-        "madspin",
-        "pythia6",
-        "tauola"
-      ]
-    },
     "license": {
       "attribution": "CC0"
     },
@@ -34878,6 +34224,12 @@
               "recid": "3128",
               "title": "Configuration file for SIM step TOP-Summer11Leg-00031_1_cfg.py"
             }
+          ],
+          "generators": [
+            "madgraph",
+            "madspin",
+            "pythia6",
+            "tauola"
           ],
           "global_tag": "START53_LV4::All",
           "output_dataset": "/TTJets_MSDecays_dileptonic_mt166_5_7TeV-madgraph-tauola/Summer11Leg-START53_LV4-v1/GEN-SIM",
@@ -35023,15 +34375,6 @@
         "uri": "root://eospublic.cern.ch//eos/opendata/cms/MonteCarlo2011/Summer11LegDR/TTJets_MSDecays_dileptonic_mt178_5_7TeV-madgraph-tauola/AODSIM/PU_S13_START53_LV6-v2/file-indexes/CMS_MonteCarlo2011_Summer11LegDR_TTJets_MSDecays_dileptonic_mt178_5_7TeV-madgraph-tauola_AODSIM_PU_S13_START53_LV6-v2_80000_file_index.txt"
       }
     ],
-    "generator": {
-      "global_tag": "START53_LV6",
-      "names": [
-        "madgraph",
-        "madspin",
-        "pythia6",
-        "tauola"
-      ]
-    },
     "license": {
       "attribution": "CC0"
     },
@@ -35059,6 +34402,12 @@
               "recid": "3219",
               "title": "Configuration file for SIM step TOP-Summer11Leg-00038_1_cfg.py"
             }
+          ],
+          "generators": [
+            "madgraph",
+            "madspin",
+            "pythia6",
+            "tauola"
           ],
           "global_tag": "START53_LV4::All",
           "output_dataset": "/TTJets_MSDecays_dileptonic_mt178_5_7TeV-madgraph-tauola/Summer11Leg-START53_LV4-v1/GEN-SIM",
@@ -35180,15 +34529,6 @@
         "uri": "root://eospublic.cern.ch//eos/opendata/cms/MonteCarlo2011/Summer11LegDR/TTJets_MSDecays_dileptonic_scaledown_7TeV-madgraph-tauola/AODSIM/PU_S13_START53_LV6-v3/file-indexes/CMS_MonteCarlo2011_Summer11LegDR_TTJets_MSDecays_dileptonic_scaledown_7TeV-madgraph-tauola_AODSIM_PU_S13_START53_LV6-v3_60000_file_index.txt"
       }
     ],
-    "generator": {
-      "global_tag": "START53_LV6",
-      "names": [
-        "madgraph",
-        "madspin",
-        "pythia6",
-        "tauola"
-      ]
-    },
     "license": {
       "attribution": "CC0"
     },
@@ -35216,6 +34556,12 @@
               "recid": "3160",
               "title": "Configuration file for SIM step TOP-Summer11Leg-00030_1_cfg.py"
             }
+          ],
+          "generators": [
+            "madgraph",
+            "madspin",
+            "pythia6",
+            "tauola"
           ],
           "global_tag": "START53_LV4::All",
           "output_dataset": "/TTJets_MSDecays_dileptonic_scaledown_7TeV-madgraph-tauola/Summer11Leg-START53_LV4-v1/GEN-SIM",
@@ -35349,15 +34695,6 @@
         "uri": "root://eospublic.cern.ch//eos/opendata/cms/MonteCarlo2011/Summer11LegDR/TTJets_MSDecays_dileptonic_scaleup_7TeV-madgraph-tauola/AODSIM/PU_S13_START53_LV6-v1/file-indexes/CMS_MonteCarlo2011_Summer11LegDR_TTJets_MSDecays_dileptonic_scaleup_7TeV-madgraph-tauola_AODSIM_PU_S13_START53_LV6-v1_40000_file_index.txt"
       }
     ],
-    "generator": {
-      "global_tag": "START53_LV6",
-      "names": [
-        "madgraph",
-        "madspin",
-        "pythia6",
-        "tauola"
-      ]
-    },
     "license": {
       "attribution": "CC0"
     },
@@ -35385,6 +34722,12 @@
               "recid": "3265",
               "title": "Configuration file for SIM step TOP-Summer11Leg-00036_1_cfg.py"
             }
+          ],
+          "generators": [
+            "madgraph",
+            "madspin",
+            "pythia6",
+            "tauola"
           ],
           "global_tag": "START53_LV4::All",
           "output_dataset": "/TTJets_MSDecays_dileptonic_scaleup_7TeV-madgraph-tauola/Summer11Leg-START53_LV4-v1/GEN-SIM",
@@ -35542,15 +34885,6 @@
         "uri": "root://eospublic.cern.ch//eos/opendata/cms/MonteCarlo2011/Summer11LegDR/TTJets_MSDecays_scaledown_TuneZ2star_7TeV-madgraph-tauola/AODSIM/PU_S13_START53_LV6-v2/file-indexes/CMS_MonteCarlo2011_Summer11LegDR_TTJets_MSDecays_scaledown_TuneZ2star_7TeV-madgraph-tauola_AODSIM_PU_S13_START53_LV6-v2_010002_file_index.txt"
       }
     ],
-    "generator": {
-      "global_tag": "START53_LV6",
-      "names": [
-        "madgraph",
-        "madspin",
-        "pythia6",
-        "tauola"
-      ]
-    },
     "license": {
       "attribution": "CC0"
     },
@@ -35578,6 +34912,12 @@
               "recid": "3039",
               "title": "Configuration file for SIM step TOP-Summer11Leg-00017_1_cfg.py"
             }
+          ],
+          "generators": [
+            "madgraph",
+            "madspin",
+            "pythia6",
+            "tauola"
           ],
           "global_tag": "START53_LV4::All",
           "output_dataset": "/TTJets_MSDecays_scaledown_TuneZ2star_7TeV-madgraph-tauola/Summer11Leg-START53_LV4-v1/GEN-SIM",
@@ -35735,15 +35075,6 @@
         "uri": "root://eospublic.cern.ch//eos/opendata/cms/MonteCarlo2011/Summer11LegDR/TTJets_MSDecays_scaledown_mt172_5_7TeV-madgraph-tauola/AODSIM/PU_S13_START53_LV6-v1/file-indexes/CMS_MonteCarlo2011_Summer11LegDR_TTJets_MSDecays_scaledown_mt172_5_7TeV-madgraph-tauola_AODSIM_PU_S13_START53_LV6-v1_80000_file_index.txt"
       }
     ],
-    "generator": {
-      "global_tag": "START53_LV6",
-      "names": [
-        "madgraph",
-        "madspin",
-        "pythia6",
-        "tauola"
-      ]
-    },
     "license": {
       "attribution": "CC0"
     },
@@ -35771,6 +35102,12 @@
               "recid": "3160",
               "title": "Configuration file for SIM step TOP-Summer11Leg-00030_1_cfg.py"
             }
+          ],
+          "generators": [
+            "madgraph",
+            "madspin",
+            "pythia6",
+            "tauola"
           ],
           "global_tag": "START53_LV4::All",
           "output_dataset": "/TTJets_MSDecays_scaledown_mt172_5_7TeV-madgraph-tauola/Summer11Leg-START53_LV4-v1/GEN-SIM",
@@ -35928,15 +35265,6 @@
         "uri": "root://eospublic.cern.ch//eos/opendata/cms/MonteCarlo2011/Summer11LegDR/TTJets_MSDecays_scaleup_TuneZ2star_7TeV-madgraph-tauola/AODSIM/PU_S13_START53_LV6-v2/file-indexes/CMS_MonteCarlo2011_Summer11LegDR_TTJets_MSDecays_scaleup_TuneZ2star_7TeV-madgraph-tauola_AODSIM_PU_S13_START53_LV6-v2_010002_file_index.txt"
       }
     ],
-    "generator": {
-      "global_tag": "START53_LV6",
-      "names": [
-        "madgraph",
-        "madspin",
-        "pythia6",
-        "tauola"
-      ]
-    },
     "license": {
       "attribution": "CC0"
     },
@@ -35964,6 +35292,12 @@
               "recid": "3169",
               "title": "Configuration file for SIM step TOP-Summer11Leg-00016_1_cfg.py"
             }
+          ],
+          "generators": [
+            "madgraph",
+            "madspin",
+            "pythia6",
+            "tauola"
           ],
           "global_tag": "START53_LV4::All",
           "output_dataset": "/TTJets_MSDecays_scaleup_TuneZ2star_7TeV-madgraph-tauola/Summer11Leg-START53_LV4-v1/GEN-SIM",
@@ -36094,12 +35428,6 @@
         "uri": "root://eospublic.cern.ch//eos/opendata/cms/MonteCarlo2011/Summer11LegDR/Upsilon1SToMuMu_2MuEtaFilter_tuneD6T_7TeV-pythia6-evtgen/AODSIM/PU_S13_START53_LV6-v1/file-indexes/CMS_MonteCarlo2011_Summer11LegDR_Upsilon1SToMuMu_2MuEtaFilter_tuneD6T_7TeV-pythia6-evtgen_AODSIM_PU_S13_START53_LV6-v1_50000_file_index.txt"
       }
     ],
-    "generator": {
-      "global_tag": "START53_LV6",
-      "names": [
-        "pythia6"
-      ]
-    },
     "license": {
       "attribution": "CC0"
     },
@@ -36113,6 +35441,9 @@
               "recid": "3352",
               "title": "Configuration file for SIM step BPH-Summer11Leg-00019_1_cfg.py"
             }
+          ],
+          "generators": [
+            "pythia6"
           ],
           "global_tag": "START53_LV4::All",
           "output_dataset": "/Upsilon1SToMuMu_2MuEtaFilter_tuneD6T_7TeV-pythia6-evtgen/Summer11Leg-START53_LV4-v1/GEN-SIM",
@@ -36234,13 +35565,6 @@
         "uri": "root://eospublic.cern.ch//eos/opendata/cms/MonteCarlo2011/Summer11LegDR/VBFHiggs0Mf05ph0ToBB_M-125p6_7TeV-JHUGenV4-pythia6-tauola/AODSIM/PU_S13_START53_LV6-v1/file-indexes/CMS_MonteCarlo2011_Summer11LegDR_VBFHiggs0Mf05ph0ToBB_M-125p6_7TeV-JHUGenV4-pythia6-tauola_AODSIM_PU_S13_START53_LV6-v1_00000_file_index.txt"
       }
     ],
-    "generator": {
-      "global_tag": "START53_LV6",
-      "names": [
-        "JHUGen4",
-        "pythia6"
-      ]
-    },
     "license": {
       "attribution": "CC0"
     },
@@ -36268,6 +35592,10 @@
               "recid": "3030",
               "title": "Configuration file for SIM step HIG-Summer11Leg-00082_1_cfg.py"
             }
+          ],
+          "generators": [
+            "JHUGen4",
+            "pythia6"
           ],
           "global_tag": "START53_LV4::All",
           "output_dataset": "/VBFHiggs0Mf05ph0ToBB_M-125p6_7TeV-JHUGenV4-pythia6-tauola/Summer11Leg-START53_LV4-v1/GEN-SIM",
@@ -36401,13 +35729,6 @@
         "uri": "root://eospublic.cern.ch//eos/opendata/cms/MonteCarlo2011/Summer11LegDR/VBFHiggs0Mf05ph0ToGG_M-125p6_7TeV-JHUGenV4-pythia6-tauola/AODSIM/PU_S13_START53_LV6-v1/file-indexes/CMS_MonteCarlo2011_Summer11LegDR_VBFHiggs0Mf05ph0ToGG_M-125p6_7TeV-JHUGenV4-pythia6-tauola_AODSIM_PU_S13_START53_LV6-v1_20000_file_index.txt"
       }
     ],
-    "generator": {
-      "global_tag": "START53_LV6",
-      "names": [
-        "JHUGen4",
-        "pythia6"
-      ]
-    },
     "license": {
       "attribution": "CC0"
     },
@@ -36435,6 +35756,10 @@
               "recid": "3332",
               "title": "Configuration file for SIM step HIG-Summer11Leg-00096_1_cfg.py"
             }
+          ],
+          "generators": [
+            "JHUGen4",
+            "pythia6"
           ],
           "global_tag": "START53_LV4::All",
           "output_dataset": "/VBFHiggs0Mf05ph0ToGG_M-125p6_7TeV-JHUGenV4-pythia6-tauola/Summer11Leg-START53_LV4-v1/GEN-SIM",
@@ -36556,13 +35881,6 @@
         "uri": "root://eospublic.cern.ch//eos/opendata/cms/MonteCarlo2011/Summer11LegDR/VBFHiggs0PHToBB_M-125p6_7TeV-JHUGenV4-pythia6-tauola/AODSIM/PU_S13_START53_LV6-v1/file-indexes/CMS_MonteCarlo2011_Summer11LegDR_VBFHiggs0PHToBB_M-125p6_7TeV-JHUGenV4-pythia6-tauola_AODSIM_PU_S13_START53_LV6-v1_00000_file_index.txt"
       }
     ],
-    "generator": {
-      "global_tag": "START53_LV6",
-      "names": [
-        "JHUGen4",
-        "pythia6"
-      ]
-    },
     "license": {
       "attribution": "CC0"
     },
@@ -36590,6 +35908,10 @@
               "recid": "3030",
               "title": "Configuration file for SIM step HIG-Summer11Leg-00082_1_cfg.py"
             }
+          ],
+          "generators": [
+            "JHUGen4",
+            "pythia6"
           ],
           "global_tag": "START53_LV4::All",
           "output_dataset": "/VBFHiggs0PHToBB_M-125p6_7TeV-JHUGenV4-pythia6-tauola/Summer11Leg-START53_LV4-v1/GEN-SIM",
@@ -36711,13 +36033,6 @@
         "uri": "root://eospublic.cern.ch//eos/opendata/cms/MonteCarlo2011/Summer11LegDR/VBFHiggs0PHToGG_M-125p6_7TeV-JHUGenV4-pythia6-tauola/AODSIM/PU_S13_START53_LV6-v1/file-indexes/CMS_MonteCarlo2011_Summer11LegDR_VBFHiggs0PHToGG_M-125p6_7TeV-JHUGenV4-pythia6-tauola_AODSIM_PU_S13_START53_LV6-v1_00000_file_index.txt"
       }
     ],
-    "generator": {
-      "global_tag": "START53_LV6",
-      "names": [
-        "JHUGen4",
-        "pythia6"
-      ]
-    },
     "license": {
       "attribution": "CC0"
     },
@@ -36745,6 +36060,10 @@
               "recid": "3332",
               "title": "Configuration file for SIM step HIG-Summer11Leg-00096_1_cfg.py"
             }
+          ],
+          "generators": [
+            "JHUGen4",
+            "pythia6"
           ],
           "global_tag": "START53_LV4::All",
           "output_dataset": "/VBFHiggs0PHToGG_M-125p6_7TeV-JHUGenV4-pythia6-tauola/Summer11Leg-START53_LV4-v1/GEN-SIM",
@@ -36866,13 +36185,6 @@
         "uri": "root://eospublic.cern.ch//eos/opendata/cms/MonteCarlo2011/Summer11LegDR/WHiggs0Mf05ph0ToBB_M-125p6_7TeV-JHUGenV4-pythia6-tauola/AODSIM/PU_S13_START53_LV6-v1/file-indexes/CMS_MonteCarlo2011_Summer11LegDR_WHiggs0Mf05ph0ToBB_M-125p6_7TeV-JHUGenV4-pythia6-tauola_AODSIM_PU_S13_START53_LV6-v1_00000_file_index.txt"
       }
     ],
-    "generator": {
-      "global_tag": "START53_LV6",
-      "names": [
-        "JHUGen4",
-        "pythia6"
-      ]
-    },
     "license": {
       "attribution": "CC0"
     },
@@ -36900,6 +36212,10 @@
               "recid": "3030",
               "title": "Configuration file for SIM step HIG-Summer11Leg-00082_1_cfg.py"
             }
+          ],
+          "generators": [
+            "JHUGen4",
+            "pythia6"
           ],
           "global_tag": "START53_LV4::All",
           "output_dataset": "/WHiggs0Mf05ph0ToBB_M-125p6_7TeV-JHUGenV4-pythia6-tauola/Summer11Leg-START53_LV4-v1/GEN-SIM",
@@ -37033,13 +36349,6 @@
         "uri": "root://eospublic.cern.ch//eos/opendata/cms/MonteCarlo2011/Summer11LegDR/ZHiggs0Mf05ph0ToBB_M-125p6_7TeV-JHUGenV4-pythia6-tauola/AODSIM/PU_S13_START53_LV6-v2/file-indexes/CMS_MonteCarlo2011_Summer11LegDR_ZHiggs0Mf05ph0ToBB_M-125p6_7TeV-JHUGenV4-pythia6-tauola_AODSIM_PU_S13_START53_LV6-v2_30000_file_index.txt"
       }
     ],
-    "generator": {
-      "global_tag": "START53_LV6",
-      "names": [
-        "JHUGen4",
-        "pythia6"
-      ]
-    },
     "license": {
       "attribution": "CC0"
     },
@@ -37067,6 +36376,10 @@
               "recid": "3030",
               "title": "Configuration file for SIM step HIG-Summer11Leg-00082_1_cfg.py"
             }
+          ],
+          "generators": [
+            "JHUGen4",
+            "pythia6"
           ],
           "global_tag": "START53_LV4::All",
           "output_dataset": "/ZHiggs0Mf05ph0ToBB_M-125p6_7TeV-JHUGenV4-pythia6-tauola/Summer11Leg-START53_LV4-v3/GEN-SIM",
@@ -37236,13 +36549,6 @@
         "uri": "root://eospublic.cern.ch//eos/opendata/cms/MonteCarlo2011/Summer11LegDR/ZZTo2e2muJJ_BSM10HContinInterf_M-125p6_7TeV-phantom-pythia6/AODSIM/PU_S13_START53_LV6-v1/file-indexes/CMS_MonteCarlo2011_Summer11LegDR_ZZTo2e2muJJ_BSM10HContinInterf_M-125p6_7TeV-phantom-pythia6_AODSIM_PU_S13_START53_LV6-v1_40000_file_index.txt"
       }
     ],
-    "generator": {
-      "global_tag": "START53_LV6",
-      "names": [
-        "pythia6",
-        "phantom"
-      ]
-    },
     "license": {
       "attribution": "CC0"
     },
@@ -37270,6 +36576,10 @@
               "recid": "3132",
               "title": "Configuration file for SIM step HIG-Summer11Leg-00151_1_cfg.py"
             }
+          ],
+          "generators": [
+            "pythia6",
+            "phantom"
           ],
           "global_tag": "START53_LV4::All",
           "output_dataset": "/ZZTo2e2muJJ_BSM10HContinInterf_M-125p6_7TeV-phantom-pythia6/Summer11Leg-START53_LV4-v1/GEN-SIM",
@@ -37415,13 +36725,6 @@
         "uri": "root://eospublic.cern.ch//eos/opendata/cms/MonteCarlo2011/Summer11LegDR/ZZTo2e2muJJ_BSM25HContinInterf_M-125p6_7TeV-phantom-pythia6/AODSIM/PU_S13_START53_LV6-v1/file-indexes/CMS_MonteCarlo2011_Summer11LegDR_ZZTo2e2muJJ_BSM25HContinInterf_M-125p6_7TeV-phantom-pythia6_AODSIM_PU_S13_START53_LV6-v1_20000_file_index.txt"
       }
     ],
-    "generator": {
-      "global_tag": "START53_LV6",
-      "names": [
-        "pythia6",
-        "phantom"
-      ]
-    },
     "license": {
       "attribution": "CC0"
     },
@@ -37449,6 +36752,10 @@
               "recid": "3132",
               "title": "Configuration file for SIM step HIG-Summer11Leg-00151_1_cfg.py"
             }
+          ],
+          "generators": [
+            "pythia6",
+            "phantom"
           ],
           "global_tag": "START53_LV4::All",
           "output_dataset": "/ZZTo2e2muJJ_BSM25HContinInterf_M-125p6_7TeV-phantom-pythia6/Summer11Leg-START53_LV4-v1/GEN-SIM",
@@ -37594,13 +36901,6 @@
         "uri": "root://eospublic.cern.ch//eos/opendata/cms/MonteCarlo2011/Summer11LegDR/ZZTo2e2muJJ_SMHContinInterf_M-125p6_7TeV-phantom-pythia6/AODSIM/PU_S13_START53_LV6-v1/file-indexes/CMS_MonteCarlo2011_Summer11LegDR_ZZTo2e2muJJ_SMHContinInterf_M-125p6_7TeV-phantom-pythia6_AODSIM_PU_S13_START53_LV6-v1_40000_file_index.txt"
       }
     ],
-    "generator": {
-      "global_tag": "START53_LV6",
-      "names": [
-        "pythia6",
-        "phantom"
-      ]
-    },
     "license": {
       "attribution": "CC0"
     },
@@ -37628,6 +36928,10 @@
               "recid": "3132",
               "title": "Configuration file for SIM step HIG-Summer11Leg-00151_1_cfg.py"
             }
+          ],
+          "generators": [
+            "pythia6",
+            "phantom"
           ],
           "global_tag": "START53_LV4::All",
           "output_dataset": "/ZZTo2e2muJJ_SMHContinInterf_M-125p6_7TeV-phantom-pythia6/Summer11Leg-START53_LV4-v1/GEN-SIM",
@@ -37749,13 +37053,6 @@
         "uri": "root://eospublic.cern.ch//eos/opendata/cms/MonteCarlo2011/Summer11LegDR/ZZTo4eJJ_BSM10HContinInterf_M-125p6_7TeV-phantom-pythia6/AODSIM/PU_S13_START53_LV6-v1/file-indexes/CMS_MonteCarlo2011_Summer11LegDR_ZZTo4eJJ_BSM10HContinInterf_M-125p6_7TeV-phantom-pythia6_AODSIM_PU_S13_START53_LV6-v1_00000_file_index.txt"
       }
     ],
-    "generator": {
-      "global_tag": "START53_LV6",
-      "names": [
-        "pythia6",
-        "phantom"
-      ]
-    },
     "license": {
       "attribution": "CC0"
     },
@@ -37783,6 +37080,10 @@
               "recid": "3132",
               "title": "Configuration file for SIM step HIG-Summer11Leg-00151_1_cfg.py"
             }
+          ],
+          "generators": [
+            "pythia6",
+            "phantom"
           ],
           "global_tag": "START53_LV4::All",
           "output_dataset": "/ZZTo4eJJ_BSM10HContinInterf_M-125p6_7TeV-phantom-pythia6/Summer11Leg-START53_LV4-v2/GEN-SIM",
@@ -37916,13 +37217,6 @@
         "uri": "root://eospublic.cern.ch//eos/opendata/cms/MonteCarlo2011/Summer11LegDR/ZZTo4eJJ_BSM25HContinInterf_M-125p6_7TeV-phantom-pythia6/AODSIM/PU_S13_START53_LV6-v1/file-indexes/CMS_MonteCarlo2011_Summer11LegDR_ZZTo4eJJ_BSM25HContinInterf_M-125p6_7TeV-phantom-pythia6_AODSIM_PU_S13_START53_LV6-v1_40000_file_index.txt"
       }
     ],
-    "generator": {
-      "global_tag": "START53_LV6",
-      "names": [
-        "pythia6",
-        "phantom"
-      ]
-    },
     "license": {
       "attribution": "CC0"
     },
@@ -37950,6 +37244,10 @@
               "recid": "3132",
               "title": "Configuration file for SIM step HIG-Summer11Leg-00151_1_cfg.py"
             }
+          ],
+          "generators": [
+            "pythia6",
+            "phantom"
           ],
           "global_tag": "START53_LV4::All",
           "output_dataset": "/ZZTo4eJJ_BSM25HContinInterf_M-125p6_7TeV-phantom-pythia6/Summer11Leg-START53_LV4-v1/GEN-SIM",
@@ -38107,13 +37405,6 @@
         "uri": "root://eospublic.cern.ch//eos/opendata/cms/MonteCarlo2011/Summer11LegDR/ZZTo4eJJ_SMHContinInterf_M-125p6_7TeV-phantom-pythia6/AODSIM/PU_S13_START53_LV6-v1/file-indexes/CMS_MonteCarlo2011_Summer11LegDR_ZZTo4eJJ_SMHContinInterf_M-125p6_7TeV-phantom-pythia6_AODSIM_PU_S13_START53_LV6-v1_40000_file_index.txt"
       }
     ],
-    "generator": {
-      "global_tag": "START53_LV6",
-      "names": [
-        "pythia6",
-        "phantom"
-      ]
-    },
     "license": {
       "attribution": "CC0"
     },
@@ -38141,6 +37432,10 @@
               "recid": "3132",
               "title": "Configuration file for SIM step HIG-Summer11Leg-00151_1_cfg.py"
             }
+          ],
+          "generators": [
+            "pythia6",
+            "phantom"
           ],
           "global_tag": "START53_LV4::All",
           "output_dataset": "/ZZTo4eJJ_SMHContinInterf_M-125p6_7TeV-phantom-pythia6/Summer11Leg-START53_LV4-v1/GEN-SIM",
@@ -38286,13 +37581,6 @@
         "uri": "root://eospublic.cern.ch//eos/opendata/cms/MonteCarlo2011/Summer11LegDR/ZZTo4muJJ_BSM10HContinInterf_M-125p6_7TeV-phantom-pythia6/AODSIM/PU_S13_START53_LV6-v1/file-indexes/CMS_MonteCarlo2011_Summer11LegDR_ZZTo4muJJ_BSM10HContinInterf_M-125p6_7TeV-phantom-pythia6_AODSIM_PU_S13_START53_LV6-v1_20000_file_index.txt"
       }
     ],
-    "generator": {
-      "global_tag": "START53_LV6",
-      "names": [
-        "pythia6",
-        "phantom"
-      ]
-    },
     "license": {
       "attribution": "CC0"
     },
@@ -38320,6 +37608,10 @@
               "recid": "3132",
               "title": "Configuration file for SIM step HIG-Summer11Leg-00151_1_cfg.py"
             }
+          ],
+          "generators": [
+            "pythia6",
+            "phantom"
           ],
           "global_tag": "START53_LV4::All",
           "output_dataset": "/ZZTo4muJJ_BSM10HContinInterf_M-125p6_7TeV-phantom-pythia6/Summer11Leg-START53_LV4-v1/GEN-SIM",
@@ -38453,13 +37745,6 @@
         "uri": "root://eospublic.cern.ch//eos/opendata/cms/MonteCarlo2011/Summer11LegDR/ZZTo4muJJ_BSM25HContinInterf_M-125p6_7TeV-phantom-pythia6/AODSIM/PU_S13_START53_LV6-v1/file-indexes/CMS_MonteCarlo2011_Summer11LegDR_ZZTo4muJJ_BSM25HContinInterf_M-125p6_7TeV-phantom-pythia6_AODSIM_PU_S13_START53_LV6-v1_410000_file_index.txt"
       }
     ],
-    "generator": {
-      "global_tag": "START53_LV6",
-      "names": [
-        "pythia6",
-        "phantom"
-      ]
-    },
     "license": {
       "attribution": "CC0"
     },
@@ -38487,6 +37772,10 @@
               "recid": "3132",
               "title": "Configuration file for SIM step HIG-Summer11Leg-00151_1_cfg.py"
             }
+          ],
+          "generators": [
+            "pythia6",
+            "phantom"
           ],
           "global_tag": "START53_LV4::All",
           "output_dataset": "/ZZTo4muJJ_BSM25HContinInterf_M-125p6_7TeV-phantom-pythia6/Summer11Leg-START53_LV4-v2/GEN-SIM",
@@ -38632,13 +37921,6 @@
         "uri": "root://eospublic.cern.ch//eos/opendata/cms/MonteCarlo2011/Summer11LegDR/ZZTo4muJJ_SMHContinInterf_M-125p6_7TeV-phantom-pythia6/AODSIM/PU_S13_START53_LV6-v2/file-indexes/CMS_MonteCarlo2011_Summer11LegDR_ZZTo4muJJ_SMHContinInterf_M-125p6_7TeV-phantom-pythia6_AODSIM_PU_S13_START53_LV6-v2_40000_file_index.txt"
       }
     ],
-    "generator": {
-      "global_tag": "START53_LV6",
-      "names": [
-        "pythia6",
-        "phantom"
-      ]
-    },
     "license": {
       "attribution": "CC0"
     },
@@ -38666,6 +37948,10 @@
               "recid": "3132",
               "title": "Configuration file for SIM step HIG-Summer11Leg-00151_1_cfg.py"
             }
+          ],
+          "generators": [
+            "pythia6",
+            "phantom"
           ],
           "global_tag": "START53_LV4::All",
           "output_dataset": "/ZZTo4muJJ_SMHContinInterf_M-125p6_7TeV-phantom-pythia6/Summer11Leg-START53_LV4-v2/GEN-SIM",
@@ -38799,13 +38085,6 @@
         "uri": "root://eospublic.cern.ch//eos/opendata/cms/MonteCarlo2011/Summer11LegDR/VBFToHToZZTo2L2Q_M-275_7TeV-powheg15-pythia6/AODSIM/PU_S13_START53_LV6-v1/file-indexes/CMS_MonteCarlo2011_Summer11LegDR_VBFToHToZZTo2L2Q_M-275_7TeV-powheg15-pythia6_AODSIM_PU_S13_START53_LV6-v1_010000_file_index.txt"
       }
     ],
-    "generator": {
-      "global_tag": "START53_LV6",
-      "names": [
-        "powheg15",
-        "pythia6"
-      ]
-    },
     "license": {
       "attribution": "CC0"
     },
@@ -38833,6 +38112,10 @@
               "recid": "3196",
               "title": "Configuration file for SIM step HIG-Summer11Leg-00017_1_cfg.py"
             }
+          ],
+          "generators": [
+            "powheg15",
+            "pythia6"
           ],
           "global_tag": "START53_LV4::All",
           "output_dataset": "/VBFToHToZZTo2L2Q_M-275_7TeV-powheg15-pythia6/Summer11Leg-START53_LV4-v1/GEN-SIM",
@@ -38954,12 +38237,6 @@
         "uri": "root://eospublic.cern.ch//eos/opendata/cms/MonteCarlo2011/Summer11LegDR/QCD_Pt-30to50_TuneZ2_7TeV_pythia6/AODSIM/PU_S13_START53_LV6-v1/file-indexes/CMS_MonteCarlo2011_Summer11LegDR_QCD_Pt-30to50_TuneZ2_7TeV_pythia6_AODSIM_PU_S13_START53_LV6-v1_00000_file_index.txt"
       }
     ],
-    "generator": {
-      "global_tag": "START53_LV6",
-      "names": [
-        "pythia6"
-      ]
-    },
     "license": {
       "attribution": "CC0"
     },
@@ -38973,6 +38250,9 @@
               "recid": "3093",
               "title": "Configuration file for SIM step JME-Summer11Leg-00004_1_cfg.py"
             }
+          ],
+          "generators": [
+            "pythia6"
           ],
           "global_tag": "START53_LV4::All",
           "output_dataset": "/QCD_Pt-30to50_TuneZ2_7TeV_pythia6/Summer11Leg-START53_LV4-v1/GEN-SIM",
@@ -39094,12 +38374,6 @@
         "uri": "root://eospublic.cern.ch//eos/opendata/cms/MonteCarlo2011/Summer11LegDR/QCD_Pt-30to80_BCtoE_TuneZ2_7TeV-pythia6/AODSIM/PU_S13_START53_LV6-v1/file-indexes/CMS_MonteCarlo2011_Summer11LegDR_QCD_Pt-30to80_BCtoE_TuneZ2_7TeV-pythia6_AODSIM_PU_S13_START53_LV6-v1_00000_file_index.txt"
       }
     ],
-    "generator": {
-      "global_tag": "START53_LV6",
-      "names": [
-        "pythia6"
-      ]
-    },
     "license": {
       "attribution": "CC0"
     },
@@ -39113,6 +38387,9 @@
               "recid": "3083",
               "title": "Configuration file for SIM step EWK-Summer11Leg-00003_1_cfg.py"
             }
+          ],
+          "generators": [
+            "pythia6"
           ],
           "global_tag": "START53_LV4::All",
           "output_dataset": "/QCD_Pt-30to80_BCtoE_TuneZ2_7TeV-pythia6/Summer11Leg-START53_LV4-v1/GEN-SIM",
@@ -39246,12 +38523,6 @@
         "uri": "root://eospublic.cern.ch//eos/opendata/cms/MonteCarlo2011/Summer11LegDR/QCD_Pt-30to80_EMEnriched_TuneZ2_7TeV-pythia/AODSIM/PU_S13_START53_LV6-v1/file-indexes/CMS_MonteCarlo2011_Summer11LegDR_QCD_Pt-30to80_EMEnriched_TuneZ2_7TeV-pythia_AODSIM_PU_S13_START53_LV6-v1_00001_file_index.txt"
       }
     ],
-    "generator": {
-      "global_tag": "START53_LV6",
-      "names": [
-        "pythia6"
-      ]
-    },
     "license": {
       "attribution": "CC0"
     },
@@ -39265,6 +38536,9 @@
               "recid": "3055",
               "title": "Configuration file for SIM step EWK-Summer11Leg-00004_1_cfg.py"
             }
+          ],
+          "generators": [
+            "pythia6"
           ],
           "global_tag": "START53_LV4::All",
           "output_dataset": "/QCD_Pt-30to80_EMEnriched_TuneZ2_7TeV-pythia/Summer11Leg-START53_LV4-v1/GEN-SIM",
@@ -39386,13 +38660,6 @@
         "uri": "root://eospublic.cern.ch//eos/opendata/cms/MonteCarlo2011/Summer11LegDR/ZHiggs0PToBB_M-125p6_7TeV-JHUGenV4-pythia6-tauola/AODSIM/PU_S13_START53_LV6-v1/file-indexes/CMS_MonteCarlo2011_Summer11LegDR_ZHiggs0PToBB_M-125p6_7TeV-JHUGenV4-pythia6-tauola_AODSIM_PU_S13_START53_LV6-v1_00000_file_index.txt"
       }
     ],
-    "generator": {
-      "global_tag": "START53_LV6",
-      "names": [
-        "JHUGen4",
-        "pythia6"
-      ]
-    },
     "license": {
       "attribution": "CC0"
     },
@@ -39420,6 +38687,10 @@
               "recid": "3030",
               "title": "Configuration file for SIM step HIG-Summer11Leg-00082_1_cfg.py"
             }
+          ],
+          "generators": [
+            "JHUGen4",
+            "pythia6"
           ],
           "global_tag": "START53_LV4::All",
           "output_dataset": "/ZHiggs0PToBB_M-125p6_7TeV-JHUGenV4-pythia6-tauola/Summer11Leg-START53_LV4-v3/GEN-SIM",
@@ -39541,13 +38812,6 @@
         "uri": "root://eospublic.cern.ch//eos/opendata/cms/MonteCarlo2011/Summer11LegDR/ZHiggs0PHToBB_M-125p6_7TeV-JHUGenV4-pythia6-tauola/AODSIM/PU_S13_START53_LV6-v1/file-indexes/CMS_MonteCarlo2011_Summer11LegDR_ZHiggs0PHToBB_M-125p6_7TeV-JHUGenV4-pythia6-tauola_AODSIM_PU_S13_START53_LV6-v1_00000_file_index.txt"
       }
     ],
-    "generator": {
-      "global_tag": "START53_LV6",
-      "names": [
-        "JHUGen4",
-        "pythia6"
-      ]
-    },
     "license": {
       "attribution": "CC0"
     },
@@ -39575,6 +38839,10 @@
               "recid": "3030",
               "title": "Configuration file for SIM step HIG-Summer11Leg-00082_1_cfg.py"
             }
+          ],
+          "generators": [
+            "JHUGen4",
+            "pythia6"
           ],
           "global_tag": "START53_LV4::All",
           "output_dataset": "/ZHiggs0PHToBB_M-125p6_7TeV-JHUGenV4-pythia6-tauola/Summer11Leg-START53_LV4-v1/GEN-SIM",
@@ -39756,13 +39024,6 @@
         "uri": "root://eospublic.cern.ch//eos/opendata/cms/MonteCarlo2011/Summer11LegDR/TTJets_TuneZ2_7TeV-madgraph-tauola/AODSIM/PU_S13_START53_LV6-v1/file-indexes/CMS_MonteCarlo2011_Summer11LegDR_TTJets_TuneZ2_7TeV-madgraph-tauola_AODSIM_PU_S13_START53_LV6-v1_010003_file_index.txt"
       }
     ],
-    "generator": {
-      "global_tag": "START53_LV6",
-      "names": [
-        "madgraph",
-        "pythia6"
-      ]
-    },
     "license": {
       "attribution": "CC0"
     },
@@ -39790,6 +39051,10 @@
               "recid": "3317",
               "title": "Configuration file for SIM step TOP-Summer11Leg-00013_1_cfg.py"
             }
+          ],
+          "generators": [
+            "madgraph",
+            "pythia6"
           ],
           "global_tag": "START53_LV4::All",
           "output_dataset": "/TTJets_TuneZ2_7TeV-madgraph-tauola/Summer11Leg-START53_LV4-v1/GEN-SIM",
@@ -39911,13 +39176,6 @@
         "uri": "root://eospublic.cern.ch//eos/opendata/cms/MonteCarlo2011/Summer11LegDR/GluGluToHToZZTo4L_M-500_7TeV-powheg15-pythia6/AODSIM/PU_S13_START53_LV6-v1/file-indexes/CMS_MonteCarlo2011_Summer11LegDR_GluGluToHToZZTo4L_M-500_7TeV-powheg15-pythia6_AODSIM_PU_S13_START53_LV6-v1_10000_file_index.txt"
       }
     ],
-    "generator": {
-      "global_tag": "START53_LV6",
-      "names": [
-        "powheg15",
-        "pythia6"
-      ]
-    },
     "license": {
       "attribution": "CC0"
     },
@@ -39945,6 +39203,10 @@
               "recid": "3229",
               "title": "Configuration file for SIM step HIG-Summer11Leg-00328_1_cfg.py"
             }
+          ],
+          "generators": [
+            "powheg15",
+            "pythia6"
           ],
           "global_tag": "START53_LV4::All",
           "output_dataset": "/GluGluToHToZZTo4L_M-500_7TeV-powheg15-pythia6/Summer11Leg-START53_LV4-v1/GEN-SIM",
@@ -40078,13 +39340,6 @@
         "uri": "root://eospublic.cern.ch//eos/opendata/cms/MonteCarlo2011/Summer11LegDR/VBFToHToZZTo2L2Nu_M-275_7TeV-powheg15-pythia6/AODSIM/PU_S13_START53_LV6-v1/file-indexes/CMS_MonteCarlo2011_Summer11LegDR_VBFToHToZZTo2L2Nu_M-275_7TeV-powheg15-pythia6_AODSIM_PU_S13_START53_LV6-v1_010000_file_index.txt"
       }
     ],
-    "generator": {
-      "global_tag": "START53_LV6",
-      "names": [
-        "powheg15",
-        "pythia6"
-      ]
-    },
     "license": {
       "attribution": "CC0"
     },
@@ -40112,6 +39367,10 @@
               "recid": "3118",
               "title": "Configuration file for SIM step HIG-Summer11Leg-00057_1_cfg.py"
             }
+          ],
+          "generators": [
+            "powheg15",
+            "pythia6"
           ],
           "global_tag": "START53_LV4::All",
           "output_dataset": "/VBFToHToZZTo2L2Nu_M-275_7TeV-powheg15-pythia6/Summer11Leg-START53_LV4-v2/GEN-SIM",
@@ -40233,13 +39492,6 @@
         "uri": "root://eospublic.cern.ch//eos/opendata/cms/MonteCarlo2011/Summer11LegDR/VBFToHToZZTo2L2Q_M-300_7TeV-powheg15-pythia6/AODSIM/PU_S13_START53_LV6-v1/file-indexes/CMS_MonteCarlo2011_Summer11LegDR_VBFToHToZZTo2L2Q_M-300_7TeV-powheg15-pythia6_AODSIM_PU_S13_START53_LV6-v1_00000_file_index.txt"
       }
     ],
-    "generator": {
-      "global_tag": "START53_LV6",
-      "names": [
-        "powheg15",
-        "pythia6"
-      ]
-    },
     "license": {
       "attribution": "CC0"
     },
@@ -40267,6 +39519,10 @@
               "recid": "3196",
               "title": "Configuration file for SIM step HIG-Summer11Leg-00017_1_cfg.py"
             }
+          ],
+          "generators": [
+            "powheg15",
+            "pythia6"
           ],
           "global_tag": "START53_LV4::All",
           "output_dataset": "/VBFToHToZZTo2L2Q_M-300_7TeV-powheg15-pythia6/Summer11Leg-START53_LV4-v1/GEN-SIM",
@@ -40388,12 +39644,6 @@
         "uri": "root://eospublic.cern.ch//eos/opendata/cms/MonteCarlo2011/Summer11LegDR/QCD_Pt-350_EMEnriched_TuneZ2_7TeV-pythia6/AODSIM/PU_S13_START53_LV6-v1/file-indexes/CMS_MonteCarlo2011_Summer11LegDR_QCD_Pt-350_EMEnriched_TuneZ2_7TeV-pythia6_AODSIM_PU_S13_START53_LV6-v1_00000_file_index.txt"
       }
     ],
-    "generator": {
-      "global_tag": "START53_LV6",
-      "names": [
-        "pythia6"
-      ]
-    },
     "license": {
       "attribution": "CC0"
     },
@@ -40407,6 +39657,9 @@
               "recid": "3328",
               "title": "Configuration file for SIM step EWK-Summer11Leg-00011_1_cfg.py"
             }
+          ],
+          "generators": [
+            "pythia6"
           ],
           "global_tag": "START53_LV4::All",
           "output_dataset": "/QCD_Pt-350_EMEnriched_TuneZ2_7TeV-pythia6/Summer11Leg-START53_LV4-v1/GEN-SIM",
@@ -40528,13 +39781,6 @@
         "uri": "root://eospublic.cern.ch//eos/opendata/cms/MonteCarlo2011/Summer11LegDR/VBFToHToZZTo2L2Q_M-350_7TeV-powheg15-pythia6/AODSIM/PU_S13_START53_LV6-v1/file-indexes/CMS_MonteCarlo2011_Summer11LegDR_VBFToHToZZTo2L2Q_M-350_7TeV-powheg15-pythia6_AODSIM_PU_S13_START53_LV6-v1_00000_file_index.txt"
       }
     ],
-    "generator": {
-      "global_tag": "START53_LV6",
-      "names": [
-        "powheg15",
-        "pythia6"
-      ]
-    },
     "license": {
       "attribution": "CC0"
     },
@@ -40562,6 +39808,10 @@
               "recid": "3196",
               "title": "Configuration file for SIM step HIG-Summer11Leg-00017_1_cfg.py"
             }
+          ],
+          "generators": [
+            "powheg15",
+            "pythia6"
           ],
           "global_tag": "START53_LV4::All",
           "output_dataset": "/VBFToHToZZTo2L2Q_M-350_7TeV-powheg15-pythia6/Summer11Leg-START53_LV4-v1/GEN-SIM",
@@ -40683,12 +39933,6 @@
         "uri": "root://eospublic.cern.ch//eos/opendata/cms/MonteCarlo2011/Summer11LegDR/QCD_Pt-470to600_MuEnrichedPt5_TuneZ2_7TeV_pythia6/AODSIM/PU_S13_START53_LV6-v1/file-indexes/CMS_MonteCarlo2011_Summer11LegDR_QCD_Pt-470to600_MuEnrichedPt5_TuneZ2_7TeV_pythia6_AODSIM_PU_S13_START53_LV6-v1_00000_file_index.txt"
       }
     ],
-    "generator": {
-      "global_tag": "START53_LV6",
-      "names": [
-        "pythia6"
-      ]
-    },
     "license": {
       "attribution": "CC0"
     },
@@ -40702,6 +39946,9 @@
               "recid": "3267",
               "title": "Configuration file for SIM step BTV-Summer11Leg-00009_1_cfg.py"
             }
+          ],
+          "generators": [
+            "pythia6"
           ],
           "global_tag": "START53_LV4::All",
           "output_dataset": "/QCD_Pt-470to600_MuEnrichedPt5_TuneZ2_7TeV_pythia6/Summer11Leg-START53_LV4-v1/GEN-SIM",
@@ -40835,13 +40082,6 @@
         "uri": "root://eospublic.cern.ch//eos/opendata/cms/MonteCarlo2011/Summer11LegDR/ZZTo2e2tau_7TeV_mll8_mZZ95-160-powheg15-pythia6/AODSIM/PU_S13_START53_LV6-v1/file-indexes/CMS_MonteCarlo2011_Summer11LegDR_ZZTo2e2tau_7TeV_mll8_mZZ95-160-powheg15-pythia6_AODSIM_PU_S13_START53_LV6-v1_40000_file_index.txt"
       }
     ],
-    "generator": {
-      "global_tag": "START53_LV6",
-      "names": [
-        "powheg15",
-        "pythia6"
-      ]
-    },
     "license": {
       "attribution": "CC0"
     },
@@ -40869,6 +40109,10 @@
               "recid": "3176",
               "title": "Configuration file for SIM step HIG-Summer11Leg-00107_1_cfg.py"
             }
+          ],
+          "generators": [
+            "powheg15",
+            "pythia6"
           ],
           "global_tag": "START53_LV4::All",
           "output_dataset": "/ZZTo2e2tau_7TeV_mll8_mZZ95-160-powheg15-pythia6/Summer11Leg-START53_LV4-v1/GEN-SIM",
@@ -41002,13 +40246,6 @@
         "uri": "root://eospublic.cern.ch//eos/opendata/cms/MonteCarlo2011/Summer11LegDR/ZZTo2e2tau_mll4_7TeV-powheg-pythia6/AODSIM/PU_S13_START53_LV6-v1/file-indexes/CMS_MonteCarlo2011_Summer11LegDR_ZZTo2e2tau_mll4_7TeV-powheg-pythia6_AODSIM_PU_S13_START53_LV6-v1_20000_file_index.txt"
       }
     ],
-    "generator": {
-      "global_tag": "START53_LV6",
-      "names": [
-        "powheg15",
-        "pythia6"
-      ]
-    },
     "license": {
       "attribution": "CC0"
     },
@@ -41036,6 +40273,10 @@
               "recid": "3310",
               "title": "Configuration file for SIM step HIG-Summer11Leg-00113_1_cfg.py"
             }
+          ],
+          "generators": [
+            "powheg15",
+            "pythia6"
           ],
           "global_tag": "START53_LV4::All",
           "output_dataset": "/ZZTo2e2tau_mll4_7TeV-powheg-pythia6/Summer11Leg-START53_LV4-v1/GEN-SIM",
@@ -41157,12 +40398,6 @@
         "uri": "root://eospublic.cern.ch//eos/opendata/cms/MonteCarlo2011/Summer11LegDR/QCD_Pt-470to600_TuneZ2_7TeV_pythia6/AODSIM/PU_S13_START53_LV6-v1/file-indexes/CMS_MonteCarlo2011_Summer11LegDR_QCD_Pt-470to600_TuneZ2_7TeV_pythia6_AODSIM_PU_S13_START53_LV6-v1_00000_file_index.txt"
       }
     ],
-    "generator": {
-      "global_tag": "START53_LV6",
-      "names": [
-        "pythia6"
-      ]
-    },
     "license": {
       "attribution": "CC0"
     },
@@ -41176,6 +40411,9 @@
               "recid": "3109",
               "title": "Configuration file for SIM step JME-Summer11Leg-00010_1_cfg.py"
             }
+          ],
+          "generators": [
+            "pythia6"
           ],
           "global_tag": "START53_LV4::All",
           "output_dataset": "/QCD_Pt-470to600_TuneZ2_7TeV_pythia6/Summer11Leg-START53_LV4-v2/GEN-SIM",
@@ -41297,12 +40535,6 @@
         "uri": "root://eospublic.cern.ch//eos/opendata/cms/MonteCarlo2011/Summer11LegDR/QCD_Pt-50to80_MuEnrichedPt5_TuneZ2_7TeV_pythia6/AODSIM/PU_S13_START53_LV6-v1/file-indexes/CMS_MonteCarlo2011_Summer11LegDR_QCD_Pt-50to80_MuEnrichedPt5_TuneZ2_7TeV_pythia6_AODSIM_PU_S13_START53_LV6-v1_00000_file_index.txt"
       }
     ],
-    "generator": {
-      "global_tag": "START53_LV6",
-      "names": [
-        "pythia6"
-      ]
-    },
     "license": {
       "attribution": "CC0"
     },
@@ -41316,6 +40548,9 @@
               "recid": "3231",
               "title": "Configuration file for SIM step BTV-Summer11Leg-00004_1_cfg.py"
             }
+          ],
+          "generators": [
+            "pythia6"
           ],
           "global_tag": "START53_LV4::All",
           "output_dataset": "/QCD_Pt-50to80_MuEnrichedPt5_TuneZ2_7TeV_pythia6/Summer11Leg-START53_LV4-v2/GEN-SIM",
@@ -41437,12 +40672,6 @@
         "uri": "root://eospublic.cern.ch//eos/opendata/cms/MonteCarlo2011/Summer11LegDR/QCD_Pt-50to80_TuneZ2_7TeV_pythia6/AODSIM/PU_S13_START53_LV6-v1/file-indexes/CMS_MonteCarlo2011_Summer11LegDR_QCD_Pt-50to80_TuneZ2_7TeV_pythia6_AODSIM_PU_S13_START53_LV6-v1_00000_file_index.txt"
       }
     ],
-    "generator": {
-      "global_tag": "START53_LV6",
-      "names": [
-        "pythia6"
-      ]
-    },
     "license": {
       "attribution": "CC0"
     },
@@ -41456,6 +40685,9 @@
               "recid": "3155",
               "title": "Configuration file for SIM step JME-Summer11Leg-00005_1_cfg.py"
             }
+          ],
+          "generators": [
+            "pythia6"
           ],
           "global_tag": "START53_LV4::All",
           "output_dataset": "/QCD_Pt-50to80_TuneZ2_7TeV_pythia6/Summer11Leg-START53_LV4-v1/GEN-SIM",
@@ -41577,12 +40809,6 @@
         "uri": "root://eospublic.cern.ch//eos/opendata/cms/MonteCarlo2011/Summer11LegDR/QCD_Pt-5to15_TuneZ2_7TeV_pythia6/AODSIM/PU_S13_START53_LV6-v1/file-indexes/CMS_MonteCarlo2011_Summer11LegDR_QCD_Pt-5to15_TuneZ2_7TeV_pythia6_AODSIM_PU_S13_START53_LV6-v1_00000_file_index.txt"
       }
     ],
-    "generator": {
-      "global_tag": "START53_LV6",
-      "names": [
-        "pythia6"
-      ]
-    },
     "license": {
       "attribution": "CC0"
     },
@@ -41596,6 +40822,9 @@
               "recid": "3066",
               "title": "Configuration file for SIM step JME-Summer11Leg-00002_1_cfg.py"
             }
+          ],
+          "generators": [
+            "pythia6"
           ],
           "global_tag": "START53_LV4::All",
           "output_dataset": "/QCD_Pt-5to15_TuneZ2_7TeV_pythia6/Summer11Leg-START53_LV4-v1/GEN-SIM",
@@ -41717,12 +40946,6 @@
         "uri": "root://eospublic.cern.ch//eos/opendata/cms/MonteCarlo2011/Summer11LegDR/QCD_Pt-600to800_MuEnrichedPt5_TuneZ2_7TeV_pythia6/AODSIM/PU_S13_START53_LV6-v1/file-indexes/CMS_MonteCarlo2011_Summer11LegDR_QCD_Pt-600to800_MuEnrichedPt5_TuneZ2_7TeV_pythia6_AODSIM_PU_S13_START53_LV6-v1_00000_file_index.txt"
       }
     ],
-    "generator": {
-      "global_tag": "START53_LV6",
-      "names": [
-        "pythia6"
-      ]
-    },
     "license": {
       "attribution": "CC0"
     },
@@ -41736,6 +40959,9 @@
               "recid": "3063",
               "title": "Configuration file for SIM step BTV-Summer11Leg-00010_1_cfg.py"
             }
+          ],
+          "generators": [
+            "pythia6"
           ],
           "global_tag": "START53_LV4::All",
           "output_dataset": "/QCD_Pt-600to800_MuEnrichedPt5_TuneZ2_7TeV_pythia6/Summer11Leg-START53_LV4-v1/GEN-SIM",
@@ -41857,12 +41083,6 @@
         "uri": "root://eospublic.cern.ch//eos/opendata/cms/MonteCarlo2011/Summer11LegDR/QCD_Pt-600to800_TuneZ2_7TeV_pythia6/AODSIM/PU_S13_START53_LV6-v1/file-indexes/CMS_MonteCarlo2011_Summer11LegDR_QCD_Pt-600to800_TuneZ2_7TeV_pythia6_AODSIM_PU_S13_START53_LV6-v1_00000_file_index.txt"
       }
     ],
-    "generator": {
-      "global_tag": "START53_LV6",
-      "names": [
-        "pythia6"
-      ]
-    },
     "license": {
       "attribution": "CC0"
     },
@@ -41876,6 +41096,9 @@
               "recid": "3015",
               "title": "Configuration file for SIM step JME-Summer11Leg-00011_1_cfg.py"
             }
+          ],
+          "generators": [
+            "pythia6"
           ],
           "global_tag": "START53_LV4::All",
           "output_dataset": "/QCD_Pt-600to800_TuneZ2_7TeV_pythia6/Summer11Leg-START53_LV4-v1/GEN-SIM",
@@ -41997,12 +41220,6 @@
         "uri": "root://eospublic.cern.ch//eos/opendata/cms/MonteCarlo2011/Summer11LegDR/QCD_Pt-800to1000_MuEnrichedPt5_TuneZ2_7TeV_pythia6/AODSIM/PU_S13_START53_LV6-v1/file-indexes/CMS_MonteCarlo2011_Summer11LegDR_QCD_Pt-800to1000_MuEnrichedPt5_TuneZ2_7TeV_pythia6_AODSIM_PU_S13_START53_LV6-v1_00000_file_index.txt"
       }
     ],
-    "generator": {
-      "global_tag": "START53_LV6",
-      "names": [
-        "pythia6"
-      ]
-    },
     "license": {
       "attribution": "CC0"
     },
@@ -42016,6 +41233,9 @@
               "recid": "3137",
               "title": "Configuration file for SIM step BTV-Summer11Leg-00011_1_cfg.py"
             }
+          ],
+          "generators": [
+            "pythia6"
           ],
           "global_tag": "START53_LV4::All",
           "output_dataset": "/QCD_Pt-800to1000_MuEnrichedPt5_TuneZ2_7TeV_pythia6/Summer11Leg-START53_LV4-v2/GEN-SIM",
@@ -42137,12 +41357,6 @@
         "uri": "root://eospublic.cern.ch//eos/opendata/cms/MonteCarlo2011/Summer11LegDR/QCD_Pt-800to1000_TuneZ2_7TeV_pythia6/AODSIM/PU_S13_START53_LV6-v1/file-indexes/CMS_MonteCarlo2011_Summer11LegDR_QCD_Pt-800to1000_TuneZ2_7TeV_pythia6_AODSIM_PU_S13_START53_LV6-v1_00000_file_index.txt"
       }
     ],
-    "generator": {
-      "global_tag": "START53_LV6",
-      "names": [
-        "pythia6"
-      ]
-    },
     "license": {
       "attribution": "CC0"
     },
@@ -42156,6 +41370,9 @@
               "recid": "3019",
               "title": "Configuration file for SIM step JME-Summer11Leg-00012_1_cfg.py"
             }
+          ],
+          "generators": [
+            "pythia6"
           ],
           "global_tag": "START53_LV4::All",
           "output_dataset": "/QCD_Pt-800to1000_TuneZ2_7TeV_pythia6/Summer11Leg-START53_LV4-v1/GEN-SIM",
@@ -42277,12 +41494,6 @@
         "uri": "root://eospublic.cern.ch//eos/opendata/cms/MonteCarlo2011/Summer11LegDR/QCD_Pt-80to120_MuEnrichedPt5_TuneZ2_7TeV_pythia6/AODSIM/PU_S13_START53_LV6-v1/file-indexes/CMS_MonteCarlo2011_Summer11LegDR_QCD_Pt-80to120_MuEnrichedPt5_TuneZ2_7TeV_pythia6_AODSIM_PU_S13_START53_LV6-v1_00000_file_index.txt"
       }
     ],
-    "generator": {
-      "global_tag": "START53_LV6",
-      "names": [
-        "pythia6"
-      ]
-    },
     "license": {
       "attribution": "CC0"
     },
@@ -42296,6 +41507,9 @@
               "recid": "3285",
               "title": "Configuration file for SIM step BTV-Summer11Leg-00005_1_cfg.py"
             }
+          ],
+          "generators": [
+            "pythia6"
           ],
           "global_tag": "START53_LV4::All",
           "output_dataset": "/QCD_Pt-80to120_MuEnrichedPt5_TuneZ2_7TeV_pythia6/Summer11Leg-START53_LV4-v1/GEN-SIM",
@@ -42417,12 +41631,6 @@
         "uri": "root://eospublic.cern.ch//eos/opendata/cms/MonteCarlo2011/Summer11LegDR/QCD_Pt-80to120_TuneZ2_7TeV_pythia6/AODSIM/PU_S13_START53_LV6-v1/file-indexes/CMS_MonteCarlo2011_Summer11LegDR_QCD_Pt-80to120_TuneZ2_7TeV_pythia6_AODSIM_PU_S13_START53_LV6-v1_00000_file_index.txt"
       }
     ],
-    "generator": {
-      "global_tag": "START53_LV6",
-      "names": [
-        "pythia6"
-      ]
-    },
     "license": {
       "attribution": "CC0"
     },
@@ -42436,6 +41644,9 @@
               "recid": "3211",
               "title": "Configuration file for SIM step JME-Summer11Leg-00006_1_cfg.py"
             }
+          ],
+          "generators": [
+            "pythia6"
           ],
           "global_tag": "START53_LV4::All",
           "output_dataset": "/QCD_Pt-80to120_TuneZ2_7TeV_pythia6/Summer11Leg-START53_LV4-v1/GEN-SIM",
@@ -42557,12 +41768,6 @@
         "uri": "root://eospublic.cern.ch//eos/opendata/cms/MonteCarlo2011/Summer11LegDR/QCD_Pt-80to170_BCtoE_TuneZ2_7TeV-pythia/AODSIM/PU_S13_START53_LV6-v1/file-indexes/CMS_MonteCarlo2011_Summer11LegDR_QCD_Pt-80to170_BCtoE_TuneZ2_7TeV-pythia_AODSIM_PU_S13_START53_LV6-v1_00000_file_index.txt"
       }
     ],
-    "generator": {
-      "global_tag": "START53_LV6",
-      "names": [
-        "pythia6"
-      ]
-    },
     "license": {
       "attribution": "CC0"
     },
@@ -42576,6 +41781,9 @@
               "recid": "3362",
               "title": "Configuration file for SIM step EWK-Summer11Leg-00005_1_cfg.py"
             }
+          ],
+          "generators": [
+            "pythia6"
           ],
           "global_tag": "START53_LV4::All",
           "output_dataset": "/QCD_Pt-80to170_BCtoE_TuneZ2_7TeV-pythia/Summer11Leg-START53_LV4-v1/GEN-SIM",
@@ -42697,12 +41905,6 @@
         "uri": "root://eospublic.cern.ch//eos/opendata/cms/MonteCarlo2011/Summer11LegDR/QCD_Pt-80to170_EMEnriched_TuneZ2_7TeV-pythia6/AODSIM/PU_S13_START53_LV6-v1/file-indexes/CMS_MonteCarlo2011_Summer11LegDR_QCD_Pt-80to170_EMEnriched_TuneZ2_7TeV-pythia6_AODSIM_PU_S13_START53_LV6-v1_00000_file_index.txt"
       }
     ],
-    "generator": {
-      "global_tag": "START53_LV6",
-      "names": [
-        "pythia6"
-      ]
-    },
     "license": {
       "attribution": "CC0"
     },
@@ -42716,6 +41918,9 @@
               "recid": "3294",
               "title": "Configuration file for SIM step EWK-Summer11Leg-00006_1_cfg.py"
             }
+          ],
+          "generators": [
+            "pythia6"
           ],
           "global_tag": "START53_LV4::All",
           "output_dataset": "/QCD_Pt-80to170_EMEnriched_TuneZ2_7TeV-pythia6/Summer11Leg-START53_LV4-v1/GEN-SIM",
@@ -42837,13 +42042,6 @@
         "uri": "root://eospublic.cern.ch//eos/opendata/cms/MonteCarlo2011/Summer11LegDR/SMHiggsToZZTo4L_M-120_7TeV-powheg15-JHUgenV3-pythia6/AODSIM/PU_S13_START53_LV6-v1/file-indexes/CMS_MonteCarlo2011_Summer11LegDR_SMHiggsToZZTo4L_M-120_7TeV-powheg15-JHUgenV3-pythia6_AODSIM_PU_S13_START53_LV6-v1_00000_file_index.txt"
       }
     ],
-    "generator": {
-      "global_tag": "START53_LV6",
-      "names": [
-        "powheg15",
-        "pythia6"
-      ]
-    },
     "license": {
       "attribution": "CC0"
     },
@@ -42871,6 +42069,10 @@
               "recid": "3031",
               "title": "Configuration file for SIM step HIG-Summer11Leg-00119_1_cfg.py"
             }
+          ],
+          "generators": [
+            "powheg15",
+            "pythia6"
           ],
           "global_tag": "START53_LV4::All",
           "output_dataset": "/SMHiggsToZZTo4L_M-120_7TeV-powheg15-JHUgenV3-pythia6/Summer11Leg-START53_LV4-v1/GEN-SIM",
@@ -42992,13 +42194,6 @@
         "uri": "root://eospublic.cern.ch//eos/opendata/cms/MonteCarlo2011/Summer11LegDR/SMHiggsToZZTo4L_M-124_7TeV-powheg15-JHUgenV3-pythia6/AODSIM/PU_S13_START53_LV6-v1/file-indexes/CMS_MonteCarlo2011_Summer11LegDR_SMHiggsToZZTo4L_M-124_7TeV-powheg15-JHUgenV3-pythia6_AODSIM_PU_S13_START53_LV6-v1_40000_file_index.txt"
       }
     ],
-    "generator": {
-      "global_tag": "START53_LV6",
-      "names": [
-        "powheg15",
-        "pythia6"
-      ]
-    },
     "license": {
       "attribution": "CC0"
     },
@@ -43026,6 +42221,10 @@
               "recid": "3031",
               "title": "Configuration file for SIM step HIG-Summer11Leg-00119_1_cfg.py"
             }
+          ],
+          "generators": [
+            "powheg15",
+            "pythia6"
           ],
           "global_tag": "START53_LV4::All",
           "output_dataset": "/SMHiggsToZZTo4L_M-124_7TeV-powheg15-JHUgenV3-pythia6/Summer11Leg-START53_LV4-v1/GEN-SIM",
@@ -43147,13 +42346,6 @@
         "uri": "root://eospublic.cern.ch//eos/opendata/cms/MonteCarlo2011/Summer11LegDR/SMHiggsToZZTo4L_M-128_7TeV-powheg15-JHUgenV3-pythia6/AODSIM/PU_S13_START53_LV6-v1/file-indexes/CMS_MonteCarlo2011_Summer11LegDR_SMHiggsToZZTo4L_M-128_7TeV-powheg15-JHUgenV3-pythia6_AODSIM_PU_S13_START53_LV6-v1_00000_file_index.txt"
       }
     ],
-    "generator": {
-      "global_tag": "START53_LV6",
-      "names": [
-        "powheg15",
-        "pythia6"
-      ]
-    },
     "license": {
       "attribution": "CC0"
     },
@@ -43181,6 +42373,10 @@
               "recid": "3031",
               "title": "Configuration file for SIM step HIG-Summer11Leg-00119_1_cfg.py"
             }
+          ],
+          "generators": [
+            "powheg15",
+            "pythia6"
           ],
           "global_tag": "START53_LV4::All",
           "output_dataset": "/SMHiggsToZZTo4L_M-128_7TeV-powheg15-JHUgenV3-pythia6/Summer11Leg-START53_LV4-v1/GEN-SIM",
@@ -43302,13 +42498,6 @@
         "uri": "root://eospublic.cern.ch//eos/opendata/cms/MonteCarlo2011/Summer11LegDR/SMHiggsToZZTo4L_M-135_7TeV-powheg15-JHUgenV3-pythia6/AODSIM/PU_S13_START53_LV6-v1/file-indexes/CMS_MonteCarlo2011_Summer11LegDR_SMHiggsToZZTo4L_M-135_7TeV-powheg15-JHUgenV3-pythia6_AODSIM_PU_S13_START53_LV6-v1_10000_file_index.txt"
       }
     ],
-    "generator": {
-      "global_tag": "START53_LV6",
-      "names": [
-        "powheg15",
-        "pythia6"
-      ]
-    },
     "license": {
       "attribution": "CC0"
     },
@@ -43336,6 +42525,10 @@
               "recid": "3031",
               "title": "Configuration file for SIM step HIG-Summer11Leg-00119_1_cfg.py"
             }
+          ],
+          "generators": [
+            "powheg15",
+            "pythia6"
           ],
           "global_tag": "START53_LV4::All",
           "output_dataset": "/SMHiggsToZZTo4L_M-135_7TeV-powheg15-JHUgenV3-pythia6/Summer11Leg-START53_LV4-v1/GEN-SIM",
@@ -43469,13 +42662,6 @@
         "uri": "root://eospublic.cern.ch//eos/opendata/cms/MonteCarlo2011/Summer11LegDR/SMHiggsToZZTo4L_M-140_7TeV-powheg15-JHUgenV3-pythia6/AODSIM/PU_S13_START53_LV6-v1/file-indexes/CMS_MonteCarlo2011_Summer11LegDR_SMHiggsToZZTo4L_M-140_7TeV-powheg15-JHUgenV3-pythia6_AODSIM_PU_S13_START53_LV6-v1_30000_file_index.txt"
       }
     ],
-    "generator": {
-      "global_tag": "START53_LV6",
-      "names": [
-        "powheg15",
-        "pythia6"
-      ]
-    },
     "license": {
       "attribution": "CC0"
     },
@@ -43503,6 +42689,10 @@
               "recid": "3031",
               "title": "Configuration file for SIM step HIG-Summer11Leg-00119_1_cfg.py"
             }
+          ],
+          "generators": [
+            "powheg15",
+            "pythia6"
           ],
           "global_tag": "START53_LV4::All",
           "output_dataset": "/SMHiggsToZZTo4L_M-140_7TeV-powheg15-JHUgenV3-pythia6/Summer11Leg-START53_LV4-v1/GEN-SIM",
@@ -43624,13 +42814,6 @@
         "uri": "root://eospublic.cern.ch//eos/opendata/cms/MonteCarlo2011/Summer11LegDR/SMHiggsToZZTo4L_M-145_7TeV-powheg15-JHUgenV3-pythia6/AODSIM/PU_S13_START53_LV6-v1/file-indexes/CMS_MonteCarlo2011_Summer11LegDR_SMHiggsToZZTo4L_M-145_7TeV-powheg15-JHUgenV3-pythia6_AODSIM_PU_S13_START53_LV6-v1_30000_file_index.txt"
       }
     ],
-    "generator": {
-      "global_tag": "START53_LV6",
-      "names": [
-        "powheg15",
-        "pythia6"
-      ]
-    },
     "license": {
       "attribution": "CC0"
     },
@@ -43658,6 +42841,10 @@
               "recid": "3031",
               "title": "Configuration file for SIM step HIG-Summer11Leg-00119_1_cfg.py"
             }
+          ],
+          "generators": [
+            "powheg15",
+            "pythia6"
           ],
           "global_tag": "START53_LV4::All",
           "output_dataset": "/SMHiggsToZZTo4L_M-145_7TeV-powheg15-JHUgenV3-pythia6/Summer11Leg-START53_LV4-v1/GEN-SIM",
@@ -43803,13 +42990,6 @@
         "uri": "root://eospublic.cern.ch//eos/opendata/cms/MonteCarlo2011/Summer11LegDR/SMHiggsToZZTo4L_M-150_7TeV-powheg15-JHUgenV3-pythia6/AODSIM/PU_S13_START53_LV6-v1/file-indexes/CMS_MonteCarlo2011_Summer11LegDR_SMHiggsToZZTo4L_M-150_7TeV-powheg15-JHUgenV3-pythia6_AODSIM_PU_S13_START53_LV6-v1_40000_file_index.txt"
       }
     ],
-    "generator": {
-      "global_tag": "START53_LV6",
-      "names": [
-        "powheg15",
-        "pythia6"
-      ]
-    },
     "license": {
       "attribution": "CC0"
     },
@@ -43837,6 +43017,10 @@
               "recid": "3031",
               "title": "Configuration file for SIM step HIG-Summer11Leg-00119_1_cfg.py"
             }
+          ],
+          "generators": [
+            "powheg15",
+            "pythia6"
           ],
           "global_tag": "START53_LV4::All",
           "output_dataset": "/SMHiggsToZZTo4L_M-150_7TeV-powheg15-JHUgenV3-pythia6/Summer11Leg-START53_LV4-v1/GEN-SIM",
@@ -43994,13 +43178,6 @@
         "uri": "root://eospublic.cern.ch//eos/opendata/cms/MonteCarlo2011/Summer11LegDR/SMHiggsToZZTo4L_M-160_7TeV-powheg15-JHUgenV3-pythia6/AODSIM/PU_S13_START53_LV6-v1/file-indexes/CMS_MonteCarlo2011_Summer11LegDR_SMHiggsToZZTo4L_M-160_7TeV-powheg15-JHUgenV3-pythia6_AODSIM_PU_S13_START53_LV6-v1_40000_file_index.txt"
       }
     ],
-    "generator": {
-      "global_tag": "START53_LV6",
-      "names": [
-        "powheg15",
-        "pythia6"
-      ]
-    },
     "license": {
       "attribution": "CC0"
     },
@@ -44028,6 +43205,10 @@
               "recid": "3031",
               "title": "Configuration file for SIM step HIG-Summer11Leg-00119_1_cfg.py"
             }
+          ],
+          "generators": [
+            "powheg15",
+            "pythia6"
           ],
           "global_tag": "START53_LV4::All",
           "output_dataset": "/SMHiggsToZZTo4L_M-160_7TeV-powheg15-JHUgenV3-pythia6/Summer11Leg-START53_LV4-v1/GEN-SIM",
@@ -44149,13 +43330,6 @@
         "uri": "root://eospublic.cern.ch//eos/opendata/cms/MonteCarlo2011/Summer11LegDR/VBFToHToZZTo2L2Q_M-400_7TeV-powheg15-pythia6/AODSIM/PU_S13_START53_LV6-v1/file-indexes/CMS_MonteCarlo2011_Summer11LegDR_VBFToHToZZTo2L2Q_M-400_7TeV-powheg15-pythia6_AODSIM_PU_S13_START53_LV6-v1_00000_file_index.txt"
       }
     ],
-    "generator": {
-      "global_tag": "START53_LV6",
-      "names": [
-        "powheg15",
-        "pythia6"
-      ]
-    },
     "license": {
       "attribution": "CC0"
     },
@@ -44183,6 +43357,10 @@
               "recid": "3196",
               "title": "Configuration file for SIM step HIG-Summer11Leg-00017_1_cfg.py"
             }
+          ],
+          "generators": [
+            "powheg15",
+            "pythia6"
           ],
           "global_tag": "START53_LV4::All",
           "output_dataset": "/VBFToHToZZTo2L2Q_M-400_7TeV-powheg15-pythia6/Summer11Leg-START53_LV4-v1/GEN-SIM",
@@ -44316,13 +43494,6 @@
         "uri": "root://eospublic.cern.ch//eos/opendata/cms/MonteCarlo2011/Summer11LegDR/VBFToHToZZTo2L2Q_M-450_7TeV-powheg15-pythia6/AODSIM/PU_S13_START53_LV6-v1/file-indexes/CMS_MonteCarlo2011_Summer11LegDR_VBFToHToZZTo2L2Q_M-450_7TeV-powheg15-pythia6_AODSIM_PU_S13_START53_LV6-v1_010000_file_index.txt"
       }
     ],
-    "generator": {
-      "global_tag": "START53_LV6",
-      "names": [
-        "powheg15",
-        "pythia6"
-      ]
-    },
     "license": {
       "attribution": "CC0"
     },
@@ -44350,6 +43521,10 @@
               "recid": "3196",
               "title": "Configuration file for SIM step HIG-Summer11Leg-00017_1_cfg.py"
             }
+          ],
+          "generators": [
+            "powheg15",
+            "pythia6"
           ],
           "global_tag": "START53_LV4::All",
           "output_dataset": "/VBFToHToZZTo2L2Q_M-450_7TeV-powheg15-pythia6/Summer11Leg-START53_LV4-v1/GEN-SIM",
@@ -44471,13 +43646,6 @@
         "uri": "root://eospublic.cern.ch//eos/opendata/cms/MonteCarlo2011/Summer11LegDR/SMHiggsToZZTo4L_M-170_7TeV-powheg15-JHUgenV3-pythia6/AODSIM/PU_S13_START53_LV6-v1/file-indexes/CMS_MonteCarlo2011_Summer11LegDR_SMHiggsToZZTo4L_M-170_7TeV-powheg15-JHUgenV3-pythia6_AODSIM_PU_S13_START53_LV6-v1_10000_file_index.txt"
       }
     ],
-    "generator": {
-      "global_tag": "START53_LV6",
-      "names": [
-        "powheg15",
-        "pythia6"
-      ]
-    },
     "license": {
       "attribution": "CC0"
     },
@@ -44505,6 +43673,10 @@
               "recid": "3031",
               "title": "Configuration file for SIM step HIG-Summer11Leg-00119_1_cfg.py"
             }
+          ],
+          "generators": [
+            "powheg15",
+            "pythia6"
           ],
           "global_tag": "START53_LV4::All",
           "output_dataset": "/SMHiggsToZZTo4L_M-170_7TeV-powheg15-JHUgenV3-pythia6/Summer11Leg-START53_LV4-v1/GEN-SIM",
@@ -44626,13 +43798,6 @@
         "uri": "root://eospublic.cern.ch//eos/opendata/cms/MonteCarlo2011/Summer11LegDR/ZZTo2mu2tau_7TeV_mll8_mZZ95-160-powheg15-pythia6/AODSIM/PU_S13_START53_LV6-v1/file-indexes/CMS_MonteCarlo2011_Summer11LegDR_ZZTo2mu2tau_7TeV_mll8_mZZ95-160-powheg15-pythia6_AODSIM_PU_S13_START53_LV6-v1_10000_file_index.txt"
       }
     ],
-    "generator": {
-      "global_tag": "START53_LV6",
-      "names": [
-        "powheg15",
-        "pythia6"
-      ]
-    },
     "license": {
       "attribution": "CC0"
     },
@@ -44660,6 +43825,10 @@
               "recid": "3176",
               "title": "Configuration file for SIM step HIG-Summer11Leg-00107_1_cfg.py"
             }
+          ],
+          "generators": [
+            "powheg15",
+            "pythia6"
           ],
           "global_tag": "START53_LV4::All",
           "output_dataset": "/ZZTo2mu2tau_7TeV_mll8_mZZ95-160-powheg15-pythia6/Summer11Leg-START53_LV4-v1/GEN-SIM",
@@ -44793,13 +43962,6 @@
         "uri": "root://eospublic.cern.ch//eos/opendata/cms/MonteCarlo2011/Summer11LegDR/ZZTo2mu2tau_mll4_7TeV-powheg-pythia6/AODSIM/PU_S13_START53_LV6-v1/file-indexes/CMS_MonteCarlo2011_Summer11LegDR_ZZTo2mu2tau_mll4_7TeV-powheg-pythia6_AODSIM_PU_S13_START53_LV6-v1_40000_file_index.txt"
       }
     ],
-    "generator": {
-      "global_tag": "START53_LV6",
-      "names": [
-        "powheg15",
-        "pythia6"
-      ]
-    },
     "license": {
       "attribution": "CC0"
     },
@@ -44827,6 +43989,10 @@
               "recid": "3310",
               "title": "Configuration file for SIM step HIG-Summer11Leg-00113_1_cfg.py"
             }
+          ],
+          "generators": [
+            "powheg15",
+            "pythia6"
           ],
           "global_tag": "START53_LV4::All",
           "output_dataset": "/ZZTo2mu2tau_mll4_7TeV-powheg-pythia6/Summer11Leg-START53_LV4-v1/GEN-SIM",
@@ -44948,13 +44114,6 @@
         "uri": "root://eospublic.cern.ch//eos/opendata/cms/MonteCarlo2011/Summer11LegDR/VBFToHToZZTo2L2Q_M-500_7TeV-powheg15-pythia6/AODSIM/PU_S13_START53_LV6-v1/file-indexes/CMS_MonteCarlo2011_Summer11LegDR_VBFToHToZZTo2L2Q_M-500_7TeV-powheg15-pythia6_AODSIM_PU_S13_START53_LV6-v1_00000_file_index.txt"
       }
     ],
-    "generator": {
-      "global_tag": "START53_LV6",
-      "names": [
-        "powheg15",
-        "pythia6"
-      ]
-    },
     "license": {
       "attribution": "CC0"
     },
@@ -44982,6 +44141,10 @@
               "recid": "3196",
               "title": "Configuration file for SIM step HIG-Summer11Leg-00017_1_cfg.py"
             }
+          ],
+          "generators": [
+            "powheg15",
+            "pythia6"
           ],
           "global_tag": "START53_LV4::All",
           "output_dataset": "/VBFToHToZZTo2L2Q_M-500_7TeV-powheg15-pythia6/Summer11Leg-START53_LV4-v1/GEN-SIM",
@@ -45103,13 +44266,6 @@
         "uri": "root://eospublic.cern.ch//eos/opendata/cms/MonteCarlo2011/Summer11LegDR/VBFToHToZZTo2L2Q_M-550_7TeV-powheg15-pythia6/AODSIM/PU_S13_START53_LV6-v1/file-indexes/CMS_MonteCarlo2011_Summer11LegDR_VBFToHToZZTo2L2Q_M-550_7TeV-powheg15-pythia6_AODSIM_PU_S13_START53_LV6-v1_00000_file_index.txt"
       }
     ],
-    "generator": {
-      "global_tag": "START53_LV6",
-      "names": [
-        "powheg15",
-        "pythia6"
-      ]
-    },
     "license": {
       "attribution": "CC0"
     },
@@ -45137,6 +44293,10 @@
               "recid": "3196",
               "title": "Configuration file for SIM step HIG-Summer11Leg-00017_1_cfg.py"
             }
+          ],
+          "generators": [
+            "powheg15",
+            "pythia6"
           ],
           "global_tag": "START53_LV4::All",
           "output_dataset": "/VBFToHToZZTo2L2Q_M-550_7TeV-powheg15-pythia6/Summer11Leg-START53_LV4-v1/GEN-SIM",
@@ -45258,13 +44418,6 @@
         "uri": "root://eospublic.cern.ch//eos/opendata/cms/MonteCarlo2011/Summer11LegDR/VBFToHToZZTo2L2Q_M-600_7TeV-powheg15-pythia6/AODSIM/PU_S13_START53_LV6-v1/file-indexes/CMS_MonteCarlo2011_Summer11LegDR_VBFToHToZZTo2L2Q_M-600_7TeV-powheg15-pythia6_AODSIM_PU_S13_START53_LV6-v1_00000_file_index.txt"
       }
     ],
-    "generator": {
-      "global_tag": "START53_LV6",
-      "names": [
-        "powheg15",
-        "pythia6"
-      ]
-    },
     "license": {
       "attribution": "CC0"
     },
@@ -45292,6 +44445,10 @@
               "recid": "3196",
               "title": "Configuration file for SIM step HIG-Summer11Leg-00017_1_cfg.py"
             }
+          ],
+          "generators": [
+            "powheg15",
+            "pythia6"
           ],
           "global_tag": "START53_LV4::All",
           "output_dataset": "/VBFToHToZZTo2L2Q_M-600_7TeV-powheg15-pythia6/Summer11Leg-START53_LV4-v1/GEN-SIM",
@@ -45413,13 +44570,6 @@
         "uri": "root://eospublic.cern.ch//eos/opendata/cms/MonteCarlo2011/Summer11LegDR/VBFToHToZZTo2L2Q_M-650_7TeV-powheg15-pythia6/AODSIM/PU_S13_START53_LV6-v1/file-indexes/CMS_MonteCarlo2011_Summer11LegDR_VBFToHToZZTo2L2Q_M-650_7TeV-powheg15-pythia6_AODSIM_PU_S13_START53_LV6-v1_00000_file_index.txt"
       }
     ],
-    "generator": {
-      "global_tag": "START53_LV6",
-      "names": [
-        "powheg15",
-        "pythia6"
-      ]
-    },
     "license": {
       "attribution": "CC0"
     },
@@ -45447,6 +44597,10 @@
               "recid": "3196",
               "title": "Configuration file for SIM step HIG-Summer11Leg-00017_1_cfg.py"
             }
+          ],
+          "generators": [
+            "powheg15",
+            "pythia6"
           ],
           "global_tag": "START53_LV4::All",
           "output_dataset": "/VBFToHToZZTo2L2Q_M-650_7TeV-powheg15-pythia6/Summer11Leg-START53_LV4-v1/GEN-SIM",
@@ -45592,13 +44746,6 @@
         "uri": "root://eospublic.cern.ch//eos/opendata/cms/MonteCarlo2011/Summer11LegDR/ZHiggs0PToZZTo4L_M-125p6_7TeV-JHUGenV4/AODSIM/PU_S13_START53_LV6-v1/file-indexes/CMS_MonteCarlo2011_Summer11LegDR_ZHiggs0PToZZTo4L_M-125p6_7TeV-JHUGenV4_AODSIM_PU_S13_START53_LV6-v1_40000_file_index.txt"
       }
     ],
-    "generator": {
-      "global_tag": "START53_LV6",
-      "names": [
-        "powheg15",
-        "pythia6"
-      ]
-    },
     "license": {
       "attribution": "CC0"
     },
@@ -45626,6 +44773,10 @@
               "recid": "3041",
               "title": "Configuration file for SIM step HIG-Summer11Leg-00317_1_cfg.py"
             }
+          ],
+          "generators": [
+            "powheg15",
+            "pythia6"
           ],
           "global_tag": "START53_LV4::All",
           "output_dataset": "/ZHiggs0PToZZTo4L_M-125p6_7TeV-JHUGenV4/Summer11Leg-START53_LV4-v1/GEN-SIM",
@@ -45747,13 +44898,6 @@
         "uri": "root://eospublic.cern.ch//eos/opendata/cms/MonteCarlo2011/Summer11LegDR/VBFToHToZZTo2L2Q_M-700_7TeV-powheg15-pythia6/AODSIM/PU_S13_START53_LV6-v1/file-indexes/CMS_MonteCarlo2011_Summer11LegDR_VBFToHToZZTo2L2Q_M-700_7TeV-powheg15-pythia6_AODSIM_PU_S13_START53_LV6-v1_00000_file_index.txt"
       }
     ],
-    "generator": {
-      "global_tag": "START53_LV6",
-      "names": [
-        "powheg15",
-        "pythia6"
-      ]
-    },
     "license": {
       "attribution": "CC0"
     },
@@ -45781,6 +44925,10 @@
               "recid": "3196",
               "title": "Configuration file for SIM step HIG-Summer11Leg-00017_1_cfg.py"
             }
+          ],
+          "generators": [
+            "powheg15",
+            "pythia6"
           ],
           "global_tag": "START53_LV4::All",
           "output_dataset": "/VBFToHToZZTo2L2Q_M-700_7TeV-powheg15-pythia6/Summer11Leg-START53_LV4-v1/GEN-SIM",
@@ -45914,13 +45062,6 @@
         "uri": "root://eospublic.cern.ch//eos/opendata/cms/MonteCarlo2011/Summer11LegDR/VBFToHToZZTo2L2Q_M-800_7TeV-powheg15-pythia6/AODSIM/PU_S13_START53_LV6-v1/file-indexes/CMS_MonteCarlo2011_Summer11LegDR_VBFToHToZZTo2L2Q_M-800_7TeV-powheg15-pythia6_AODSIM_PU_S13_START53_LV6-v1_010000_file_index.txt"
       }
     ],
-    "generator": {
-      "global_tag": "START53_LV6",
-      "names": [
-        "powheg15",
-        "pythia6"
-      ]
-    },
     "license": {
       "attribution": "CC0"
     },
@@ -45948,6 +45089,10 @@
               "recid": "3196",
               "title": "Configuration file for SIM step HIG-Summer11Leg-00017_1_cfg.py"
             }
+          ],
+          "generators": [
+            "powheg15",
+            "pythia6"
           ],
           "global_tag": "START53_LV4::All",
           "output_dataset": "/VBFToHToZZTo2L2Q_M-800_7TeV-powheg15-pythia6/Summer11Leg-START53_LV4-v1/GEN-SIM",
@@ -46069,13 +45214,6 @@
         "uri": "root://eospublic.cern.ch//eos/opendata/cms/MonteCarlo2011/Summer11LegDR/VBFToHToZZTo2L2Q_M-900_7TeV-powheg15-pythia6/AODSIM/PU_S13_START53_LV6-v1/file-indexes/CMS_MonteCarlo2011_Summer11LegDR_VBFToHToZZTo2L2Q_M-900_7TeV-powheg15-pythia6_AODSIM_PU_S13_START53_LV6-v1_00000_file_index.txt"
       }
     ],
-    "generator": {
-      "global_tag": "START53_LV6",
-      "names": [
-        "powheg15",
-        "pythia6"
-      ]
-    },
     "license": {
       "attribution": "CC0"
     },
@@ -46103,6 +45241,10 @@
               "recid": "3196",
               "title": "Configuration file for SIM step HIG-Summer11Leg-00017_1_cfg.py"
             }
+          ],
+          "generators": [
+            "powheg15",
+            "pythia6"
           ],
           "global_tag": "START53_LV4::All",
           "output_dataset": "/VBFToHToZZTo2L2Q_M-900_7TeV-powheg15-pythia6/Summer11Leg-START53_LV4-v1/GEN-SIM",
@@ -46224,13 +45366,6 @@
         "uri": "root://eospublic.cern.ch//eos/opendata/cms/MonteCarlo2011/Summer11LegDR/VBFToHToZZTo4L_M-250_7TeV-powheg15-pythia6/AODSIM/PU_S13_START53_LV6-v1/file-indexes/CMS_MonteCarlo2011_Summer11LegDR_VBFToHToZZTo4L_M-250_7TeV-powheg15-pythia6_AODSIM_PU_S13_START53_LV6-v1_20000_file_index.txt"
       }
     ],
-    "generator": {
-      "global_tag": "START53_LV6",
-      "names": [
-        "pythia6",
-        "powheg15"
-      ]
-    },
     "license": {
       "attribution": "CC0"
     },
@@ -46258,6 +45393,10 @@
               "recid": "3051",
               "title": "Configuration file for SIM step HIG-Summer11Leg-00197_1_cfg.py"
             }
+          ],
+          "generators": [
+            "pythia6",
+            "powheg15"
           ],
           "global_tag": "START53_LV4::All",
           "output_dataset": "/VBFToHToZZTo4L_M-250_7TeV-powheg15-pythia6/Summer11Leg-START53_LV4-v1/GEN-SIM",
@@ -46379,13 +45518,6 @@
         "uri": "root://eospublic.cern.ch//eos/opendata/cms/MonteCarlo2011/Summer11LegDR/SMHiggsToZZTo4L_M-175_7TeV-powheg15-JHUgenV3-pythia6/AODSIM/PU_S13_START53_LV6-v1/file-indexes/CMS_MonteCarlo2011_Summer11LegDR_SMHiggsToZZTo4L_M-175_7TeV-powheg15-JHUgenV3-pythia6_AODSIM_PU_S13_START53_LV6-v1_00000_file_index.txt"
       }
     ],
-    "generator": {
-      "global_tag": "START53_LV6",
-      "names": [
-        "powheg15",
-        "pythia6"
-      ]
-    },
     "license": {
       "attribution": "CC0"
     },
@@ -46413,6 +45545,10 @@
               "recid": "3031",
               "title": "Configuration file for SIM step HIG-Summer11Leg-00119_1_cfg.py"
             }
+          ],
+          "generators": [
+            "powheg15",
+            "pythia6"
           ],
           "global_tag": "START53_LV4::All",
           "output_dataset": "/SMHiggsToZZTo4L_M-175_7TeV-powheg15-JHUgenV3-pythia6/Summer11Leg-START53_LV4-v1/GEN-SIM",
@@ -46558,13 +45694,6 @@
         "uri": "root://eospublic.cern.ch//eos/opendata/cms/MonteCarlo2011/Summer11LegDR/ZZTo4eJJ_Contin_7TeV-phantom-pythia6/AODSIM/PU_S13_START53_LV6-v1/file-indexes/CMS_MonteCarlo2011_Summer11LegDR_ZZTo4eJJ_Contin_7TeV-phantom-pythia6_AODSIM_PU_S13_START53_LV6-v1_40000_file_index.txt"
       }
     ],
-    "generator": {
-      "global_tag": "START53_LV6",
-      "names": [
-        "pythia6",
-        "phantom"
-      ]
-    },
     "license": {
       "attribution": "CC0"
     },
@@ -46592,6 +45721,10 @@
               "recid": "3132",
               "title": "Configuration file for SIM step HIG-Summer11Leg-00151_1_cfg.py"
             }
+          ],
+          "generators": [
+            "pythia6",
+            "phantom"
           ],
           "global_tag": "START53_LV4::All",
           "output_dataset": "/ZZTo4eJJ_Contin_7TeV-phantom-pythia6/Summer11Leg-START53_LV4-v2/GEN-SIM",
@@ -46725,12 +45858,6 @@
         "uri": "root://eospublic.cern.ch//eos/opendata/cms/MonteCarlo2011/Summer11LegDR/TTbarH_HToZZTo4L_M-200_7TeV-pythia6/AODSIM/PU_S13_START53_LV6-v1/file-indexes/CMS_MonteCarlo2011_Summer11LegDR_TTbarH_HToZZTo4L_M-200_7TeV-pythia6_AODSIM_PU_S13_START53_LV6-v1_40000_file_index.txt"
       }
     ],
-    "generator": {
-      "global_tag": "START53_LV6",
-      "names": [
-        "pythia6"
-      ]
-    },
     "license": {
       "attribution": "CC0"
     },
@@ -46744,6 +45871,9 @@
               "recid": "3377",
               "title": "Configuration file for SIM step HIG-Summer11Leg-00240_1_cfg.py"
             }
+          ],
+          "generators": [
+            "pythia6"
           ],
           "global_tag": "START53_LV4::All",
           "output_dataset": "/TTbarH_HToZZTo4L_M-200_7TeV-pythia6/Summer11Leg-START53_LV4-v1/GEN-SIM",
@@ -46865,12 +45995,6 @@
         "uri": "root://eospublic.cern.ch//eos/opendata/cms/MonteCarlo2011/Summer11LegDR/TTbarH_HToZZTo4L_M-140_7TeV-pythia6/AODSIM/PU_S13_START53_LV6-v1/file-indexes/CMS_MonteCarlo2011_Summer11LegDR_TTbarH_HToZZTo4L_M-140_7TeV-pythia6_AODSIM_PU_S13_START53_LV6-v1_30000_file_index.txt"
       }
     ],
-    "generator": {
-      "global_tag": "START53_LV6",
-      "names": [
-        "pythia6"
-      ]
-    },
     "license": {
       "attribution": "CC0"
     },
@@ -46884,6 +46008,9 @@
               "recid": "3269",
               "title": "Configuration file for SIM step HIG-Summer11Leg-00236_1_cfg.py"
             }
+          ],
+          "generators": [
+            "pythia6"
           ],
           "global_tag": "START53_LV4::All",
           "output_dataset": "/TTbarH_HToZZTo4L_M-140_7TeV-pythia6/Summer11Leg-START53_LV4-v1/GEN-SIM",
@@ -47029,13 +46156,6 @@
         "uri": "root://eospublic.cern.ch//eos/opendata/cms/MonteCarlo2011/Summer11LegDR/TT_weights_CT10_AUET2_7TeV-powheg-herwig/AODSIM/PU_S13_START53_LV6-v2/file-indexes/CMS_MonteCarlo2011_Summer11LegDR_TT_weights_CT10_AUET2_7TeV-powheg-herwig_AODSIM_PU_S13_START53_LV6-v2_40000_file_index.txt"
       }
     ],
-    "generator": {
-      "global_tag": "START53_LV6",
-      "names": [
-        "powheg",
-        "herwig"
-      ]
-    },
     "license": {
       "attribution": "CC0"
     },
@@ -47063,6 +46183,10 @@
               "recid": "3283",
               "title": "Configuration file for SIM step TOP-Summer11Leg-00028_1_cfg.py"
             }
+          ],
+          "generators": [
+            "powheg",
+            "herwig"
           ],
           "global_tag": "START53_LV4::All",
           "output_dataset": "/TT_weights_CT10_AUET2_7TeV-powheg-herwig/Summer11Leg-START53_LV4-v1/GEN-SIM",
@@ -47196,13 +46320,6 @@
         "uri": "root://eospublic.cern.ch//eos/opendata/cms/MonteCarlo2011/Summer11LegDR/T_TuneZ2_s-channel_7TeV-powheg-tauola/AODSIM/PU_S13_START53_LV6-v1/file-indexes/CMS_MonteCarlo2011_Summer11LegDR_T_TuneZ2_s-channel_7TeV-powheg-tauola_AODSIM_PU_S13_START53_LV6-v1_010000_file_index.txt"
       }
     ],
-    "generator": {
-      "global_tag": "START53_LV6",
-      "names": [
-        "powheg",
-        "pythia6"
-      ]
-    },
     "license": {
       "attribution": "CC0"
     },
@@ -47230,6 +46347,10 @@
               "recid": "3273",
               "title": "Configuration file for SIM step TOP-Summer11Leg-00002_1_cfg.py"
             }
+          ],
+          "generators": [
+            "powheg",
+            "pythia6"
           ],
           "global_tag": "START53_LV4::All",
           "output_dataset": "/T_TuneZ2_s-channel_7TeV-powheg-tauola/Summer11Leg-START53_LV4-v1/GEN-SIM",
@@ -47351,13 +46472,6 @@
         "uri": "root://eospublic.cern.ch//eos/opendata/cms/MonteCarlo2011/Summer11LegDR/VBFToHToZZTo4L_M-275_7TeV-powheg15-pythia6/AODSIM/PU_S13_START53_LV6-v1/file-indexes/CMS_MonteCarlo2011_Summer11LegDR_VBFToHToZZTo4L_M-275_7TeV-powheg15-pythia6_AODSIM_PU_S13_START53_LV6-v1_20000_file_index.txt"
       }
     ],
-    "generator": {
-      "global_tag": "START53_LV6",
-      "names": [
-        "pythia6",
-        "powheg15"
-      ]
-    },
     "license": {
       "attribution": "CC0"
     },
@@ -47385,6 +46499,10 @@
               "recid": "3051",
               "title": "Configuration file for SIM step HIG-Summer11Leg-00197_1_cfg.py"
             }
+          ],
+          "generators": [
+            "pythia6",
+            "powheg15"
           ],
           "global_tag": "START53_LV4::All",
           "output_dataset": "/VBFToHToZZTo4L_M-275_7TeV-powheg15-pythia6/Summer11Leg-START53_LV4-v1/GEN-SIM",
@@ -47518,13 +46636,6 @@
         "uri": "root://eospublic.cern.ch//eos/opendata/cms/MonteCarlo2011/Summer11LegDR/VBFToHToZZTo4L_M-300_7TeV-powheg15-pythia6/AODSIM/PU_S13_START53_LV6-v1/file-indexes/CMS_MonteCarlo2011_Summer11LegDR_VBFToHToZZTo4L_M-300_7TeV-powheg15-pythia6_AODSIM_PU_S13_START53_LV6-v1_40000_file_index.txt"
       }
     ],
-    "generator": {
-      "global_tag": "START53_LV6",
-      "names": [
-        "pythia6",
-        "powheg15"
-      ]
-    },
     "license": {
       "attribution": "CC0"
     },
@@ -47552,6 +46663,10 @@
               "recid": "3051",
               "title": "Configuration file for SIM step HIG-Summer11Leg-00197_1_cfg.py"
             }
+          ],
+          "generators": [
+            "pythia6",
+            "powheg15"
           ],
           "global_tag": "START53_LV4::All",
           "output_dataset": "/VBFToHToZZTo4L_M-300_7TeV-powheg15-pythia6/Summer11Leg-START53_LV4-v1/GEN-SIM",
@@ -47685,13 +46800,6 @@
         "uri": "root://eospublic.cern.ch//eos/opendata/cms/MonteCarlo2011/Summer11LegDR/VBFToHToZZTo4L_M-350_7TeV-powheg15-pythia6/AODSIM/PU_S13_START53_LV6-v1/file-indexes/CMS_MonteCarlo2011_Summer11LegDR_VBFToHToZZTo4L_M-350_7TeV-powheg15-pythia6_AODSIM_PU_S13_START53_LV6-v1_40000_file_index.txt"
       }
     ],
-    "generator": {
-      "global_tag": "START53_LV6",
-      "names": [
-        "pythia6",
-        "powheg15"
-      ]
-    },
     "license": {
       "attribution": "CC0"
     },
@@ -47719,6 +46827,10 @@
               "recid": "3051",
               "title": "Configuration file for SIM step HIG-Summer11Leg-00197_1_cfg.py"
             }
+          ],
+          "generators": [
+            "pythia6",
+            "powheg15"
           ],
           "global_tag": "START53_LV4::All",
           "output_dataset": "/VBFToHToZZTo4L_M-350_7TeV-powheg15-pythia6/Summer11Leg-START53_LV4-v1/GEN-SIM",
@@ -47852,13 +46964,6 @@
         "uri": "root://eospublic.cern.ch//eos/opendata/cms/MonteCarlo2011/Summer11LegDR/VBFToHToZZTo4L_M-450_7TeV-powheg15-pythia6/AODSIM/PU_S13_START53_LV6-v1/file-indexes/CMS_MonteCarlo2011_Summer11LegDR_VBFToHToZZTo4L_M-450_7TeV-powheg15-pythia6_AODSIM_PU_S13_START53_LV6-v1_40000_file_index.txt"
       }
     ],
-    "generator": {
-      "global_tag": "START53_LV6",
-      "names": [
-        "pythia6",
-        "powheg15"
-      ]
-    },
     "license": {
       "attribution": "CC0"
     },
@@ -47886,6 +46991,10 @@
               "recid": "3051",
               "title": "Configuration file for SIM step HIG-Summer11Leg-00197_1_cfg.py"
             }
+          ],
+          "generators": [
+            "pythia6",
+            "powheg15"
           ],
           "global_tag": "START53_LV4::All",
           "output_dataset": "/VBFToHToZZTo4L_M-450_7TeV-powheg15-pythia6/Summer11Leg-START53_LV4-v1/GEN-SIM",
@@ -48007,13 +47116,6 @@
         "uri": "root://eospublic.cern.ch//eos/opendata/cms/MonteCarlo2011/Summer11LegDR/VBFToHToZZTo4L_M-550_7TeV-powheg15-pythia6/AODSIM/PU_S13_START53_LV6-v1/file-indexes/CMS_MonteCarlo2011_Summer11LegDR_VBFToHToZZTo4L_M-550_7TeV-powheg15-pythia6_AODSIM_PU_S13_START53_LV6-v1_30000_file_index.txt"
       }
     ],
-    "generator": {
-      "global_tag": "START53_LV6",
-      "names": [
-        "pythia6",
-        "powheg15"
-      ]
-    },
     "license": {
       "attribution": "CC0"
     },
@@ -48041,6 +47143,10 @@
               "recid": "3051",
               "title": "Configuration file for SIM step HIG-Summer11Leg-00197_1_cfg.py"
             }
+          ],
+          "generators": [
+            "pythia6",
+            "powheg15"
           ],
           "global_tag": "START53_LV4::All",
           "output_dataset": "/VBFToHToZZTo4L_M-550_7TeV-powheg15-pythia6/Summer11Leg-START53_LV4-v1/GEN-SIM",
@@ -48162,13 +47268,6 @@
         "uri": "root://eospublic.cern.ch//eos/opendata/cms/MonteCarlo2011/Summer11LegDR/VBFToHToZZTo4L_M-600_7TeV-powheg15-pythia6/AODSIM/PU_S13_START53_LV6-v1/file-indexes/CMS_MonteCarlo2011_Summer11LegDR_VBFToHToZZTo4L_M-600_7TeV-powheg15-pythia6_AODSIM_PU_S13_START53_LV6-v1_40000_file_index.txt"
       }
     ],
-    "generator": {
-      "global_tag": "START53_LV6",
-      "names": [
-        "pythia6",
-        "powheg15"
-      ]
-    },
     "license": {
       "attribution": "CC0"
     },
@@ -48196,6 +47295,10 @@
               "recid": "3051",
               "title": "Configuration file for SIM step HIG-Summer11Leg-00197_1_cfg.py"
             }
+          ],
+          "generators": [
+            "pythia6",
+            "powheg15"
           ],
           "global_tag": "START53_LV4::All",
           "output_dataset": "/VBFToHToZZTo4L_M-600_7TeV-powheg15-pythia6/Summer11Leg-START53_LV4-v1/GEN-SIM",
@@ -48329,13 +47432,6 @@
         "uri": "root://eospublic.cern.ch//eos/opendata/cms/MonteCarlo2011/Summer11LegDR/VBFToHToZZTo4L_M-900_7TeV-powheg15-pythia6/AODSIM/PU_S13_START53_LV6-v1/file-indexes/CMS_MonteCarlo2011_Summer11LegDR_VBFToHToZZTo4L_M-900_7TeV-powheg15-pythia6_AODSIM_PU_S13_START53_LV6-v1_40000_file_index.txt"
       }
     ],
-    "generator": {
-      "global_tag": "START53_LV6",
-      "names": [
-        "pythia6",
-        "powheg15"
-      ]
-    },
     "license": {
       "attribution": "CC0"
     },
@@ -48363,6 +47459,10 @@
               "recid": "3051",
               "title": "Configuration file for SIM step HIG-Summer11Leg-00197_1_cfg.py"
             }
+          ],
+          "generators": [
+            "pythia6",
+            "powheg15"
           ],
           "global_tag": "START53_LV4::All",
           "output_dataset": "/VBFToHToZZTo4L_M-900_7TeV-powheg15-pythia6/Summer11Leg-START53_LV4-v1/GEN-SIM",
@@ -48484,13 +47584,6 @@
         "uri": "root://eospublic.cern.ch//eos/opendata/cms/MonteCarlo2011/Summer11LegDR/VBF_ToHToZZTo4L_M-115_7TeV-powheg-pythia6/AODSIM/PU_S13_START53_LV6-v1/file-indexes/CMS_MonteCarlo2011_Summer11LegDR_VBF_ToHToZZTo4L_M-115_7TeV-powheg-pythia6_AODSIM_PU_S13_START53_LV6-v1_10000_file_index.txt"
       }
     ],
-    "generator": {
-      "global_tag": "START53_LV6",
-      "names": [
-        "powheg",
-        "pythia6"
-      ]
-    },
     "license": {
       "attribution": "CC0"
     },
@@ -48518,6 +47611,10 @@
               "recid": "3295",
               "title": "Configuration file for SIM step HIG-Summer11Leg-00172_1_cfg.py"
             }
+          ],
+          "generators": [
+            "powheg",
+            "pythia6"
           ],
           "global_tag": "START53_LV4::All",
           "output_dataset": "/VBF_ToHToZZTo4L_M-115_7TeV-powheg-pythia6/Summer11Leg-START53_LV4-v1/GEN-SIM",
@@ -48639,13 +47736,6 @@
         "uri": "root://eospublic.cern.ch//eos/opendata/cms/MonteCarlo2011/Summer11LegDR/VBF_ToHToZZTo4L_M-120_7TeV-powheg-pythia6/AODSIM/PU_S13_START53_LV6-v1/file-indexes/CMS_MonteCarlo2011_Summer11LegDR_VBF_ToHToZZTo4L_M-120_7TeV-powheg-pythia6_AODSIM_PU_S13_START53_LV6-v1_00000_file_index.txt"
       }
     ],
-    "generator": {
-      "global_tag": "START53_LV6",
-      "names": [
-        "powheg",
-        "pythia6"
-      ]
-    },
     "license": {
       "attribution": "CC0"
     },
@@ -48673,6 +47763,10 @@
               "recid": "3295",
               "title": "Configuration file for SIM step HIG-Summer11Leg-00172_1_cfg.py"
             }
+          ],
+          "generators": [
+            "powheg",
+            "pythia6"
           ],
           "global_tag": "START53_LV4::All",
           "output_dataset": "/VBF_ToHToZZTo4L_M-120_7TeV-powheg-pythia6/Summer11Leg-START53_LV4-v1/GEN-SIM",
@@ -48794,13 +47888,6 @@
         "uri": "root://eospublic.cern.ch//eos/opendata/cms/MonteCarlo2011/Summer11LegDR/VBF_ToHToZZTo4L_M-125_7TeV-powheg-pythia6/AODSIM/PU_S13_START53_LV6-v1/file-indexes/CMS_MonteCarlo2011_Summer11LegDR_VBF_ToHToZZTo4L_M-125_7TeV-powheg-pythia6_AODSIM_PU_S13_START53_LV6-v1_00000_file_index.txt"
       }
     ],
-    "generator": {
-      "global_tag": "START53_LV6",
-      "names": [
-        "powheg",
-        "pythia6"
-      ]
-    },
     "license": {
       "attribution": "CC0"
     },
@@ -48821,6 +47908,10 @@
               "recid": "3031",
               "title": "Configuration file for SIM step HIG-Summer11Leg-00119_1_cfg.py"
             }
+          ],
+          "generators": [
+            "powheg",
+            "pythia6"
           ],
           "global_tag": "START53_LV4::All",
           "output_dataset": "/VBF_ToHToZZTo4L_M-125_7TeV-powheg-pythia6/Summer11Leg-START53_LV4-v1/GEN-SIM",
@@ -48942,13 +48033,6 @@
         "uri": "root://eospublic.cern.ch//eos/opendata/cms/MonteCarlo2011/Summer11LegDR/VBF_ToHToZZTo4L_M-130_7TeV-powheg-pythia6/AODSIM/PU_S13_START53_LV6-v1/file-indexes/CMS_MonteCarlo2011_Summer11LegDR_VBF_ToHToZZTo4L_M-130_7TeV-powheg-pythia6_AODSIM_PU_S13_START53_LV6-v1_20000_file_index.txt"
       }
     ],
-    "generator": {
-      "global_tag": "START53_LV6",
-      "names": [
-        "powheg",
-        "pythia6"
-      ]
-    },
     "license": {
       "attribution": "CC0"
     },
@@ -48976,6 +48060,10 @@
               "recid": "3295",
               "title": "Configuration file for SIM step HIG-Summer11Leg-00172_1_cfg.py"
             }
+          ],
+          "generators": [
+            "powheg",
+            "pythia6"
           ],
           "global_tag": "START53_LV4::All",
           "output_dataset": "/VBF_ToHToZZTo4L_M-130_7TeV-powheg-pythia6/Summer11Leg-START53_LV4-v2/GEN-SIM",
@@ -49097,13 +48185,6 @@
         "uri": "root://eospublic.cern.ch//eos/opendata/cms/MonteCarlo2011/Summer11LegDR/VBF_ToHToZZTo4L_M-140_7TeV-powheg-pythia6/AODSIM/PU_S13_START53_LV6-v1/file-indexes/CMS_MonteCarlo2011_Summer11LegDR_VBF_ToHToZZTo4L_M-140_7TeV-powheg-pythia6_AODSIM_PU_S13_START53_LV6-v1_40000_file_index.txt"
       }
     ],
-    "generator": {
-      "global_tag": "START53_LV6",
-      "names": [
-        "powheg",
-        "pythia6"
-      ]
-    },
     "license": {
       "attribution": "CC0"
     },
@@ -49131,6 +48212,10 @@
               "recid": "3295",
               "title": "Configuration file for SIM step HIG-Summer11Leg-00172_1_cfg.py"
             }
+          ],
+          "generators": [
+            "powheg",
+            "pythia6"
           ],
           "global_tag": "START53_LV4::All",
           "output_dataset": "/VBF_ToHToZZTo4L_M-140_7TeV-powheg-pythia6/Summer11Leg-START53_LV4-v1/GEN-SIM",
@@ -49252,13 +48337,6 @@
         "uri": "root://eospublic.cern.ch//eos/opendata/cms/MonteCarlo2011/Summer11LegDR/VBF_ToHToZZTo4L_M-150_7TeV-powheg-pythia6/AODSIM/PU_S13_START53_LV6-v1/file-indexes/CMS_MonteCarlo2011_Summer11LegDR_VBF_ToHToZZTo4L_M-150_7TeV-powheg-pythia6_AODSIM_PU_S13_START53_LV6-v1_020000_file_index.txt"
       }
     ],
-    "generator": {
-      "global_tag": "START53_LV6",
-      "names": [
-        "powheg",
-        "pythia6"
-      ]
-    },
     "license": {
       "attribution": "CC0"
     },
@@ -49286,6 +48364,10 @@
               "recid": "3295",
               "title": "Configuration file for SIM step HIG-Summer11Leg-00172_1_cfg.py"
             }
+          ],
+          "generators": [
+            "powheg",
+            "pythia6"
           ],
           "global_tag": "START53_LV4::All",
           "output_dataset": "/VBF_ToHToZZTo4L_M-150_7TeV-powheg-pythia6/Summer11Leg-START53_LV4-v1/GEN-SIM",
@@ -49407,13 +48489,6 @@
         "uri": "root://eospublic.cern.ch//eos/opendata/cms/MonteCarlo2011/Summer11LegDR/VBF_ToHToZZTo4L_M-160_7TeV-powheg-pythia6/AODSIM/PU_S13_START53_LV6-v1/file-indexes/CMS_MonteCarlo2011_Summer11LegDR_VBF_ToHToZZTo4L_M-160_7TeV-powheg-pythia6_AODSIM_PU_S13_START53_LV6-v1_20000_file_index.txt"
       }
     ],
-    "generator": {
-      "global_tag": "START53_LV6",
-      "names": [
-        "powheg",
-        "pythia6"
-      ]
-    },
     "license": {
       "attribution": "CC0"
     },
@@ -49441,6 +48516,10 @@
               "recid": "3295",
               "title": "Configuration file for SIM step HIG-Summer11Leg-00172_1_cfg.py"
             }
+          ],
+          "generators": [
+            "powheg",
+            "pythia6"
           ],
           "global_tag": "START53_LV4::All",
           "output_dataset": "/VBF_ToHToZZTo4L_M-160_7TeV-powheg-pythia6/Summer11Leg-START53_LV4-v1/GEN-SIM",
@@ -49562,13 +48641,6 @@
         "uri": "root://eospublic.cern.ch//eos/opendata/cms/MonteCarlo2011/Summer11LegDR/VBF_ToHToZZTo4L_M-170_7TeV-powheg-pythia6/AODSIM/PU_S13_START53_LV6-v1/file-indexes/CMS_MonteCarlo2011_Summer11LegDR_VBF_ToHToZZTo4L_M-170_7TeV-powheg-pythia6_AODSIM_PU_S13_START53_LV6-v1_10000_file_index.txt"
       }
     ],
-    "generator": {
-      "global_tag": "START53_LV6",
-      "names": [
-        "powheg",
-        "pythia6"
-      ]
-    },
     "license": {
       "attribution": "CC0"
     },
@@ -49596,6 +48668,10 @@
               "recid": "3295",
               "title": "Configuration file for SIM step HIG-Summer11Leg-00172_1_cfg.py"
             }
+          ],
+          "generators": [
+            "powheg",
+            "pythia6"
           ],
           "global_tag": "START53_LV4::All",
           "output_dataset": "/VBF_ToHToZZTo4L_M-170_7TeV-powheg-pythia6/Summer11Leg-START53_LV4-v2/GEN-SIM",
@@ -49717,13 +48793,6 @@
         "uri": "root://eospublic.cern.ch//eos/opendata/cms/MonteCarlo2011/Summer11LegDR/VBF_ToHToZZTo4L_M-180_7TeV-powheg-pythia6/AODSIM/PU_S13_START53_LV6-v1/file-indexes/CMS_MonteCarlo2011_Summer11LegDR_VBF_ToHToZZTo4L_M-180_7TeV-powheg-pythia6_AODSIM_PU_S13_START53_LV6-v1_00000_file_index.txt"
       }
     ],
-    "generator": {
-      "global_tag": "START53_LV6",
-      "names": [
-        "powheg",
-        "pythia6"
-      ]
-    },
     "license": {
       "attribution": "CC0"
     },
@@ -49751,6 +48820,10 @@
               "recid": "3295",
               "title": "Configuration file for SIM step HIG-Summer11Leg-00172_1_cfg.py"
             }
+          ],
+          "generators": [
+            "powheg",
+            "pythia6"
           ],
           "global_tag": "START53_LV4::All",
           "output_dataset": "/VBF_ToHToZZTo4L_M-180_7TeV-powheg-pythia6/Summer11Leg-START53_LV4-v1/GEN-SIM",
@@ -49872,13 +48945,6 @@
         "uri": "root://eospublic.cern.ch//eos/opendata/cms/MonteCarlo2011/Summer11LegDR/VBF_ToHToZZTo4L_M-190_7TeV-powheg-pythia6/AODSIM/PU_S13_START53_LV6-v1/file-indexes/CMS_MonteCarlo2011_Summer11LegDR_VBF_ToHToZZTo4L_M-190_7TeV-powheg-pythia6_AODSIM_PU_S13_START53_LV6-v1_00000_file_index.txt"
       }
     ],
-    "generator": {
-      "global_tag": "START53_LV6",
-      "names": [
-        "powheg",
-        "pythia6"
-      ]
-    },
     "license": {
       "attribution": "CC0"
     },
@@ -49906,6 +48972,10 @@
               "recid": "3295",
               "title": "Configuration file for SIM step HIG-Summer11Leg-00172_1_cfg.py"
             }
+          ],
+          "generators": [
+            "powheg",
+            "pythia6"
           ],
           "global_tag": "START53_LV4::All",
           "output_dataset": "/VBF_ToHToZZTo4L_M-190_7TeV-powheg-pythia6/Summer11Leg-START53_LV4-v1/GEN-SIM",
@@ -50027,13 +49097,6 @@
         "uri": "root://eospublic.cern.ch//eos/opendata/cms/MonteCarlo2011/Summer11LegDR/VBF_ToHToZZTo4L_M-200_7TeV-powheg-pythia6/AODSIM/PU_S13_START53_LV6-v1/file-indexes/CMS_MonteCarlo2011_Summer11LegDR_VBF_ToHToZZTo4L_M-200_7TeV-powheg-pythia6_AODSIM_PU_S13_START53_LV6-v1_00000_file_index.txt"
       }
     ],
-    "generator": {
-      "global_tag": "START53_LV6",
-      "names": [
-        "powheg",
-        "pythia6"
-      ]
-    },
     "license": {
       "attribution": "CC0"
     },
@@ -50061,6 +49124,10 @@
               "recid": "3295",
               "title": "Configuration file for SIM step HIG-Summer11Leg-00172_1_cfg.py"
             }
+          ],
+          "generators": [
+            "powheg",
+            "pythia6"
           ],
           "global_tag": "START53_LV4::All",
           "output_dataset": "/VBF_ToHToZZTo4L_M-200_7TeV-powheg-pythia6/Summer11Leg-START53_LV4-v2/GEN-SIM",
@@ -50194,12 +49261,6 @@
         "uri": "root://eospublic.cern.ch//eos/opendata/cms/MonteCarlo2011/Summer11LegDR/W1Jet_TuneZ2_7TeV-madgraph-tauola/AODSIM/PU_S13_START53_LV6-v1/file-indexes/CMS_MonteCarlo2011_Summer11LegDR_W1Jet_TuneZ2_7TeV-madgraph-tauola_AODSIM_PU_S13_START53_LV6-v1_30000_file_index.txt"
       }
     ],
-    "generator": {
-      "global_tag": "START53_LV6",
-      "names": [
-        "madgraph"
-      ]
-    },
     "license": {
       "attribution": "CC0"
     },
@@ -50227,6 +49288,9 @@
               "recid": "3290",
               "title": "Configuration file for SIM step TOP-Summer11Leg-00010_1_cfg.py"
             }
+          ],
+          "generators": [
+            "madgraph"
           ],
           "global_tag": "START53_LV4::All",
           "output_dataset": "/W1Jet_TuneZ2_7TeV-madgraph-tauola/Summer11Leg-START53_LV4-v1/GEN-SIM",
@@ -50348,12 +49412,6 @@
         "uri": "root://eospublic.cern.ch//eos/opendata/cms/MonteCarlo2011/Summer11LegDR/W2Jets_TuneZ2_7TeV-madgraph-tauola/AODSIM/PU_S13_START53_LV6-v1/file-indexes/CMS_MonteCarlo2011_Summer11LegDR_W2Jets_TuneZ2_7TeV-madgraph-tauola_AODSIM_PU_S13_START53_LV6-v1_00000_file_index.txt"
       }
     ],
-    "generator": {
-      "global_tag": "START53_LV6",
-      "names": [
-        "madgraph"
-      ]
-    },
     "license": {
       "attribution": "CC0"
     },
@@ -50381,6 +49439,9 @@
               "recid": "3208",
               "title": "Configuration file for SIM step TOP-Summer11Leg-00009_1_cfg.py"
             }
+          ],
+          "generators": [
+            "madgraph"
           ],
           "global_tag": "START53_LV4::All",
           "output_dataset": "/W2Jets_TuneZ2_7TeV-madgraph-tauola/Summer11Leg-START53_LV4-v1/GEN-SIM",
@@ -50514,12 +49575,6 @@
         "uri": "root://eospublic.cern.ch//eos/opendata/cms/MonteCarlo2011/Summer11LegDR/W3Jets_TuneZ2_7TeV-madgraph-tauola/AODSIM/PU_S13_START53_LV6-v1/file-indexes/CMS_MonteCarlo2011_Summer11LegDR_W3Jets_TuneZ2_7TeV-madgraph-tauola_AODSIM_PU_S13_START53_LV6-v1_30000_file_index.txt"
       }
     ],
-    "generator": {
-      "global_tag": "START53_LV6",
-      "names": [
-        "madgraph"
-      ]
-    },
     "license": {
       "attribution": "CC0"
     },
@@ -50547,6 +49602,9 @@
               "recid": "3329",
               "title": "Configuration file for SIM step TOP-Summer11Leg-00008_1_cfg.py"
             }
+          ],
+          "generators": [
+            "madgraph"
           ],
           "global_tag": "START53_LV4::All",
           "output_dataset": "/W3Jets_TuneZ2_7TeV-madgraph-tauola/Summer11Leg-START53_LV4-v4/GEN-SIM",
@@ -50668,12 +49726,6 @@
         "uri": "root://eospublic.cern.ch//eos/opendata/cms/MonteCarlo2011/Summer11LegDR/W4Jets_TuneZ2_7TeV-madgraph-tauola/AODSIM/PU_S13_START53_LV6-v1/file-indexes/CMS_MonteCarlo2011_Summer11LegDR_W4Jets_TuneZ2_7TeV-madgraph-tauola_AODSIM_PU_S13_START53_LV6-v1_00000_file_index.txt"
       }
     ],
-    "generator": {
-      "global_tag": "START53_LV6",
-      "names": [
-        "madgraph"
-      ]
-    },
     "license": {
       "attribution": "CC0"
     },
@@ -50701,6 +49753,9 @@
               "recid": "3208",
               "title": "Configuration file for SIM step TOP-Summer11Leg-00009_1_cfg.py"
             }
+          ],
+          "generators": [
+            "madgraph"
           ],
           "global_tag": "START53_LV4::All",
           "output_dataset": "/W4Jets_TuneZ2_7TeV-madgraph-tauola/Summer11Leg-START53_LV4-v1/GEN-SIM",
@@ -50822,12 +49877,6 @@
         "uri": "root://eospublic.cern.ch//eos/opendata/cms/MonteCarlo2011/Summer11LegDR/WH_HToZZTo4L_M-110_7TeV-pythia6/AODSIM/PU_S13_START53_LV6-v1/file-indexes/CMS_MonteCarlo2011_Summer11LegDR_WH_HToZZTo4L_M-110_7TeV-pythia6_AODSIM_PU_S13_START53_LV6-v1_00000_file_index.txt"
       }
     ],
-    "generator": {
-      "global_tag": "START53_LV6",
-      "names": [
-        "pythia6"
-      ]
-    },
     "license": {
       "attribution": "CC0"
     },
@@ -50841,6 +49890,9 @@
               "recid": "3320",
               "title": "Configuration file for SIM step HIG-Summer11Leg-00241_1_cfg.py"
             }
+          ],
+          "generators": [
+            "pythia6"
           ],
           "global_tag": "START53_LV4::All",
           "output_dataset": "/WH_HToZZTo4L_M-110_7TeV-pythia6/Summer11Leg-START53_LV4-v1/GEN-SIM",
@@ -50974,12 +50026,6 @@
         "uri": "root://eospublic.cern.ch//eos/opendata/cms/MonteCarlo2011/Summer11LegDR/WH_HToZZTo4L_M-115_7TeV-pythia6/AODSIM/PU_S13_START53_LV6-v1/file-indexes/CMS_MonteCarlo2011_Summer11LegDR_WH_HToZZTo4L_M-115_7TeV-pythia6_AODSIM_PU_S13_START53_LV6-v1_10000_file_index.txt"
       }
     ],
-    "generator": {
-      "global_tag": "START53_LV6",
-      "names": [
-        "pythia6"
-      ]
-    },
     "license": {
       "attribution": "CC0"
     },
@@ -50993,6 +50039,9 @@
               "recid": "3163",
               "title": "Configuration file for SIM step HIG-Summer11Leg-00242_1_cfg.py"
             }
+          ],
+          "generators": [
+            "pythia6"
           ],
           "global_tag": "START53_LV4::All",
           "output_dataset": "/WH_HToZZTo4L_M-115_7TeV-pythia6/Summer11Leg-START53_LV4-v1/GEN-SIM",
@@ -51126,12 +50175,6 @@
         "uri": "root://eospublic.cern.ch//eos/opendata/cms/MonteCarlo2011/Summer11LegDR/WH_HToZZTo4L_M-120_7TeV-pythia6/AODSIM/PU_S13_START53_LV6-v1/file-indexes/CMS_MonteCarlo2011_Summer11LegDR_WH_HToZZTo4L_M-120_7TeV-pythia6_AODSIM_PU_S13_START53_LV6-v1_40000_file_index.txt"
       }
     ],
-    "generator": {
-      "global_tag": "START53_LV6",
-      "names": [
-        "pythia6"
-      ]
-    },
     "license": {
       "attribution": "CC0"
     },
@@ -51145,6 +50188,9 @@
               "recid": "3154",
               "title": "Configuration file for SIM step HIG-Summer11Leg-00243_1_cfg.py"
             }
+          ],
+          "generators": [
+            "pythia6"
           ],
           "global_tag": "START53_LV4::All",
           "output_dataset": "/WH_HToZZTo4L_M-120_7TeV-pythia6/Summer11Leg-START53_LV4-v1/GEN-SIM",
@@ -51266,12 +50312,6 @@
         "uri": "root://eospublic.cern.ch//eos/opendata/cms/MonteCarlo2011/Summer11LegDR/WH_HToZZTo4L_M-125_7TeV-pythia6/AODSIM/PU_S13_START53_LV6-v1/file-indexes/CMS_MonteCarlo2011_Summer11LegDR_WH_HToZZTo4L_M-125_7TeV-pythia6_AODSIM_PU_S13_START53_LV6-v1_00000_file_index.txt"
       }
     ],
-    "generator": {
-      "global_tag": "START53_LV6",
-      "names": [
-        "pythia6"
-      ]
-    },
     "license": {
       "attribution": "CC0"
     },
@@ -51285,6 +50325,9 @@
               "recid": "3052",
               "title": "Configuration file for SIM step HIG-Summer11Leg-00244_1_cfg.py"
             }
+          ],
+          "generators": [
+            "pythia6"
           ],
           "global_tag": "START53_LV4::All",
           "output_dataset": "/WH_HToZZTo4L_M-125_7TeV-pythia6/Summer11Leg-START53_LV4-v1/GEN-SIM",
@@ -51406,12 +50449,6 @@
         "uri": "root://eospublic.cern.ch//eos/opendata/cms/MonteCarlo2011/Summer11LegDR/WH_HToZZTo4L_M-126_7TeV-pythia6/AODSIM/PU_S13_START53_LV6-v1/file-indexes/CMS_MonteCarlo2011_Summer11LegDR_WH_HToZZTo4L_M-126_7TeV-pythia6_AODSIM_PU_S13_START53_LV6-v1_00000_file_index.txt"
       }
     ],
-    "generator": {
-      "global_tag": "START53_LV6",
-      "names": [
-        "pythia6"
-      ]
-    },
     "license": {
       "attribution": "CC0"
     },
@@ -51425,6 +50462,9 @@
               "recid": "3259",
               "title": "Configuration file for SIM step HIG-Summer11Leg-00245_1_cfg.py"
             }
+          ],
+          "generators": [
+            "pythia6"
           ],
           "global_tag": "START53_LV4::All",
           "output_dataset": "/WH_HToZZTo4L_M-126_7TeV-pythia6/Summer11Leg-START53_LV4-v1/GEN-SIM",
@@ -51546,12 +50586,6 @@
         "uri": "root://eospublic.cern.ch//eos/opendata/cms/MonteCarlo2011/Summer11LegDR/WH_HToZZTo4L_M-130_7TeV-pythia6/AODSIM/PU_S13_START53_LV6-v1/file-indexes/CMS_MonteCarlo2011_Summer11LegDR_WH_HToZZTo4L_M-130_7TeV-pythia6_AODSIM_PU_S13_START53_LV6-v1_10000_file_index.txt"
       }
     ],
-    "generator": {
-      "global_tag": "START53_LV6",
-      "names": [
-        "pythia6"
-      ]
-    },
     "license": {
       "attribution": "CC0"
     },
@@ -51565,6 +50599,9 @@
               "recid": "3096",
               "title": "Configuration file for SIM step HIG-Summer11Leg-00246_1_cfg.py"
             }
+          ],
+          "generators": [
+            "pythia6"
           ],
           "global_tag": "START53_LV4::All",
           "output_dataset": "/WH_HToZZTo4L_M-130_7TeV-pythia6/Summer11Leg-START53_LV4-v1/GEN-SIM",
@@ -51686,12 +50723,6 @@
         "uri": "root://eospublic.cern.ch//eos/opendata/cms/MonteCarlo2011/Summer11LegDR/WH_HToZZTo4L_M-140_7TeV-pythia6/AODSIM/PU_S13_START53_LV6-v1/file-indexes/CMS_MonteCarlo2011_Summer11LegDR_WH_HToZZTo4L_M-140_7TeV-pythia6_AODSIM_PU_S13_START53_LV6-v1_110000_file_index.txt"
       }
     ],
-    "generator": {
-      "global_tag": "START53_LV6",
-      "names": [
-        "pythia6"
-      ]
-    },
     "license": {
       "attribution": "CC0"
     },
@@ -51705,6 +50736,9 @@
               "recid": "3113",
               "title": "Configuration file for SIM step HIG-Summer11Leg-00247_1_cfg.py"
             }
+          ],
+          "generators": [
+            "pythia6"
           ],
           "global_tag": "START53_LV4::All",
           "output_dataset": "/WH_HToZZTo4L_M-140_7TeV-pythia6/Summer11Leg-START53_LV4-v1/GEN-SIM",
@@ -51838,12 +50872,6 @@
         "uri": "root://eospublic.cern.ch//eos/opendata/cms/MonteCarlo2011/Summer11LegDR/WH_HToZZTo4L_M-150_7TeV-pythia6/AODSIM/PU_S13_START53_LV6-v1/file-indexes/CMS_MonteCarlo2011_Summer11LegDR_WH_HToZZTo4L_M-150_7TeV-pythia6_AODSIM_PU_S13_START53_LV6-v1_40000_file_index.txt"
       }
     ],
-    "generator": {
-      "global_tag": "START53_LV6",
-      "names": [
-        "pythia6"
-      ]
-    },
     "license": {
       "attribution": "CC0"
     },
@@ -51857,6 +50885,9 @@
               "recid": "3009",
               "title": "Configuration file for SIM step HIG-Summer11Leg-00248_1_cfg.py"
             }
+          ],
+          "generators": [
+            "pythia6"
           ],
           "global_tag": "START53_LV4::All",
           "output_dataset": "/WH_HToZZTo4L_M-150_7TeV-pythia6/Summer11Leg-START53_LV4-v1/GEN-SIM",
@@ -51990,12 +51021,6 @@
         "uri": "root://eospublic.cern.ch//eos/opendata/cms/MonteCarlo2011/Summer11LegDR/WH_HToZZTo4L_M-160_7TeV-pythia6/AODSIM/PU_S13_START53_LV6-v1/file-indexes/CMS_MonteCarlo2011_Summer11LegDR_WH_HToZZTo4L_M-160_7TeV-pythia6_AODSIM_PU_S13_START53_LV6-v1_20000_file_index.txt"
       }
     ],
-    "generator": {
-      "global_tag": "START53_LV6",
-      "names": [
-        "pythia6"
-      ]
-    },
     "license": {
       "attribution": "CC0"
     },
@@ -52009,6 +51034,9 @@
               "recid": "3378",
               "title": "Configuration file for SIM step HIG-Summer11Leg-00249_1_cfg.py"
             }
+          ],
+          "generators": [
+            "pythia6"
           ],
           "global_tag": "START53_LV4::All",
           "output_dataset": "/WH_HToZZTo4L_M-160_7TeV-pythia6/Summer11Leg-START53_LV4-v1/GEN-SIM",
@@ -52130,12 +51158,6 @@
         "uri": "root://eospublic.cern.ch//eos/opendata/cms/MonteCarlo2011/Summer11LegDR/WH_HToZZTo4L_M-180_7TeV-pythia6/AODSIM/PU_S13_START53_LV6-v2/file-indexes/CMS_MonteCarlo2011_Summer11LegDR_WH_HToZZTo4L_M-180_7TeV-pythia6_AODSIM_PU_S13_START53_LV6-v2_40000_file_index.txt"
       }
     ],
-    "generator": {
-      "global_tag": "START53_LV6",
-      "names": [
-        "pythia6"
-      ]
-    },
     "license": {
       "attribution": "CC0"
     },
@@ -52149,6 +51171,9 @@
               "recid": "3060",
               "title": "Configuration file for SIM step HIG-Summer11Leg-00250_1_cfg.py"
             }
+          ],
+          "generators": [
+            "pythia6"
           ],
           "global_tag": "START53_LV4::All",
           "output_dataset": "/WH_HToZZTo4L_M-180_7TeV-pythia6/Summer11Leg-START53_LV4-v1/GEN-SIM",
@@ -52270,12 +51295,6 @@
         "uri": "root://eospublic.cern.ch//eos/opendata/cms/MonteCarlo2011/Summer11LegDR/WH_HToZZTo4L_M-200_7TeV-pythia6/AODSIM/PU_S13_START53_LV6-v1/file-indexes/CMS_MonteCarlo2011_Summer11LegDR_WH_HToZZTo4L_M-200_7TeV-pythia6_AODSIM_PU_S13_START53_LV6-v1_10000_file_index.txt"
       }
     ],
-    "generator": {
-      "global_tag": "START53_LV6",
-      "names": [
-        "pythia6"
-      ]
-    },
     "license": {
       "attribution": "CC0"
     },
@@ -52289,6 +51308,9 @@
               "recid": "3228",
               "title": "Configuration file for SIM step HIG-Summer11Leg-00251_1_cfg.py"
             }
+          ],
+          "generators": [
+            "pythia6"
           ],
           "global_tag": "START53_LV4::All",
           "output_dataset": "/WH_HToZZTo4L_M-200_7TeV-pythia6/Summer11Leg-START53_LV4-v1/GEN-SIM",
@@ -52410,13 +51432,6 @@
         "uri": "root://eospublic.cern.ch//eos/opendata/cms/MonteCarlo2011/Summer11LegDR/WHiggs0MToBB_M-125p6_7TeV-JHUGenV4-pythia6-tauola/AODSIM/PU_S13_START53_LV6-v1/file-indexes/CMS_MonteCarlo2011_Summer11LegDR_WHiggs0MToBB_M-125p6_7TeV-JHUGenV4-pythia6-tauola_AODSIM_PU_S13_START53_LV6-v1_00000_file_index.txt"
       }
     ],
-    "generator": {
-      "global_tag": "START53_LV6",
-      "names": [
-        "JHUGen4",
-        "pythia6"
-      ]
-    },
     "license": {
       "attribution": "CC0"
     },
@@ -52444,6 +51459,10 @@
               "recid": "3030",
               "title": "Configuration file for SIM step HIG-Summer11Leg-00082_1_cfg.py"
             }
+          ],
+          "generators": [
+            "JHUGen4",
+            "pythia6"
           ],
           "global_tag": "START53_LV4::All",
           "output_dataset": "/WHiggs0MToBB_M-125p6_7TeV-JHUGenV4-pythia6-tauola/Summer11Leg-START53_LV4-v1/GEN-SIM",
@@ -52577,13 +51596,6 @@
         "uri": "root://eospublic.cern.ch//eos/opendata/cms/MonteCarlo2011/Summer11LegDR/WHiggs0MToZZTo4L_M-125p6_7TeV-JHUGenV4/AODSIM/PU_S13_START53_LV6-v1/file-indexes/CMS_MonteCarlo2011_Summer11LegDR_WHiggs0MToZZTo4L_M-125p6_7TeV-JHUGenV4_AODSIM_PU_S13_START53_LV6-v1_40000_file_index.txt"
       }
     ],
-    "generator": {
-      "global_tag": "START53_LV6",
-      "names": [
-        "powheg15",
-        "pythia6"
-      ]
-    },
     "license": {
       "attribution": "CC0"
     },
@@ -52611,6 +51623,10 @@
               "recid": "3132",
               "title": "Configuration file for SIM step HIG-Summer11Leg-00151_1_cfg.py"
             }
+          ],
+          "generators": [
+            "powheg15",
+            "pythia6"
           ],
           "global_tag": "START53_LV4::All",
           "output_dataset": "/WHiggs0MToZZTo4L_M-125p6_7TeV-JHUGenV4/Summer11Leg-START53_LV4-v1/GEN-SIM",
@@ -52744,13 +51760,6 @@
         "uri": "root://eospublic.cern.ch//eos/opendata/cms/MonteCarlo2011/Summer11LegDR/WHiggs0Mf05ph0ToZZTo4L_M-125p6_7TeV-JHUGenV4/AODSIM/PU_S13_START53_LV6-v1/file-indexes/CMS_MonteCarlo2011_Summer11LegDR_WHiggs0Mf05ph0ToZZTo4L_M-125p6_7TeV-JHUGenV4_AODSIM_PU_S13_START53_LV6-v1_20000_file_index.txt"
       }
     ],
-    "generator": {
-      "global_tag": "START53_LV6",
-      "names": [
-        "powheg15",
-        "pythia6"
-      ]
-    },
     "license": {
       "attribution": "CC0"
     },
@@ -52778,6 +51787,10 @@
               "recid": "3132",
               "title": "Configuration file for SIM step HIG-Summer11Leg-00151_1_cfg.py"
             }
+          ],
+          "generators": [
+            "powheg15",
+            "pythia6"
           ],
           "global_tag": "START53_LV4::All",
           "output_dataset": "/WHiggs0Mf05ph0ToZZTo4L_M-125p6_7TeV-JHUGenV4/Summer11Leg-START53_LV4-v1/GEN-SIM",
@@ -52899,13 +51912,6 @@
         "uri": "root://eospublic.cern.ch//eos/opendata/cms/MonteCarlo2011/Summer11LegDR/WHiggs0PHToBB_M-125p6_7TeV-JHUGenV4-pythia6-tauola/AODSIM/PU_S13_START53_LV6-v1/file-indexes/CMS_MonteCarlo2011_Summer11LegDR_WHiggs0PHToBB_M-125p6_7TeV-JHUGenV4-pythia6-tauola_AODSIM_PU_S13_START53_LV6-v1_00000_file_index.txt"
       }
     ],
-    "generator": {
-      "global_tag": "START53_LV6",
-      "names": [
-        "JHUGen4",
-        "pythia6"
-      ]
-    },
     "license": {
       "attribution": "CC0"
     },
@@ -52933,6 +51939,10 @@
               "recid": "3030",
               "title": "Configuration file for SIM step HIG-Summer11Leg-00082_1_cfg.py"
             }
+          ],
+          "generators": [
+            "JHUGen4",
+            "pythia6"
           ],
           "global_tag": "START53_LV4::All",
           "output_dataset": "/WHiggs0PHToBB_M-125p6_7TeV-JHUGenV4-pythia6-tauola/Summer11Leg-START53_LV4-v1/GEN-SIM",
@@ -53066,13 +52076,6 @@
         "uri": "root://eospublic.cern.ch//eos/opendata/cms/MonteCarlo2011/Summer11LegDR/WHiggs0PHToZZTo4L_M-125p6_7TeV-JHUGenV4/AODSIM/PU_S13_START53_LV6-v1/file-indexes/CMS_MonteCarlo2011_Summer11LegDR_WHiggs0PHToZZTo4L_M-125p6_7TeV-JHUGenV4_AODSIM_PU_S13_START53_LV6-v1_30000_file_index.txt"
       }
     ],
-    "generator": {
-      "global_tag": "START53_LV6",
-      "names": [
-        "powheg15",
-        "pythia6"
-      ]
-    },
     "license": {
       "attribution": "CC0"
     },
@@ -53100,6 +52103,10 @@
               "recid": "3132",
               "title": "Configuration file for SIM step HIG-Summer11Leg-00151_1_cfg.py"
             }
+          ],
+          "generators": [
+            "powheg15",
+            "pythia6"
           ],
           "global_tag": "START53_LV4::All",
           "output_dataset": "/WHiggs0PHToZZTo4L_M-125p6_7TeV-JHUGenV4/Summer11Leg-START53_LV4-v1/GEN-SIM",
@@ -53221,13 +52228,6 @@
         "uri": "root://eospublic.cern.ch//eos/opendata/cms/MonteCarlo2011/Summer11LegDR/WHiggs0PToBB_M-125p6_7TeV-JHUGenV4-pythia6-tauola/AODSIM/PU_S13_START53_LV6-v1/file-indexes/CMS_MonteCarlo2011_Summer11LegDR_WHiggs0PToBB_M-125p6_7TeV-JHUGenV4-pythia6-tauola_AODSIM_PU_S13_START53_LV6-v1_00000_file_index.txt"
       }
     ],
-    "generator": {
-      "global_tag": "START53_LV6",
-      "names": [
-        "JHUGen4",
-        "pythia6"
-      ]
-    },
     "license": {
       "attribution": "CC0"
     },
@@ -53255,6 +52255,10 @@
               "recid": "3030",
               "title": "Configuration file for SIM step HIG-Summer11Leg-00082_1_cfg.py"
             }
+          ],
+          "generators": [
+            "JHUGen4",
+            "pythia6"
           ],
           "global_tag": "START53_LV4::All",
           "output_dataset": "/WHiggs0PToBB_M-125p6_7TeV-JHUGenV4-pythia6-tauola/Summer11Leg-START53_LV4-v1/GEN-SIM",
@@ -53388,13 +52392,6 @@
         "uri": "root://eospublic.cern.ch//eos/opendata/cms/MonteCarlo2011/Summer11LegDR/WHiggs0PToZZTo4L_M-125p6_7TeV-JHUGenV4/AODSIM/PU_S13_START53_LV6-v1/file-indexes/CMS_MonteCarlo2011_Summer11LegDR_WHiggs0PToZZTo4L_M-125p6_7TeV-JHUGenV4_AODSIM_PU_S13_START53_LV6-v1_40000_file_index.txt"
       }
     ],
-    "generator": {
-      "global_tag": "START53_LV6",
-      "names": [
-        "powheg15",
-        "pythia6"
-      ]
-    },
     "license": {
       "attribution": "CC0"
     },
@@ -53422,6 +52419,10 @@
               "recid": "3041",
               "title": "Configuration file for SIM step HIG-Summer11Leg-00317_1_cfg.py"
             }
+          ],
+          "generators": [
+            "powheg15",
+            "pythia6"
           ],
           "global_tag": "START53_LV4::All",
           "output_dataset": "/WHiggs0PToZZTo4L_M-125p6_7TeV-JHUGenV4/Summer11Leg-START53_LV4-v1/GEN-SIM",
@@ -53579,12 +52580,6 @@
         "uri": "root://eospublic.cern.ch//eos/opendata/cms/MonteCarlo2011/Summer11LegDR/WJetsToLNu_TuneZ2_7TeV-madgraph-tauola/AODSIM/PU_S13_START53_LV6-v1/file-indexes/CMS_MonteCarlo2011_Summer11LegDR_WJetsToLNu_TuneZ2_7TeV-madgraph-tauola_AODSIM_PU_S13_START53_LV6-v1_00003_file_index.txt"
       }
     ],
-    "generator": {
-      "global_tag": "START53_LV6",
-      "names": [
-        "madgraph"
-      ]
-    },
     "license": {
       "attribution": "CC0"
     },
@@ -53612,6 +52607,9 @@
               "recid": "3038",
               "title": "Configuration file for SIM step SUS-Summer11Leg-00001_1_cfg.py"
             }
+          ],
+          "generators": [
+            "madgraph"
           ],
           "global_tag": "START53_LV4::All",
           "output_dataset": "/WJetsToLNu_TuneZ2_7TeV-madgraph-tauola/Summer11Leg-START53_LV4-v1/GEN-SIM",
@@ -53733,12 +52731,6 @@
         "uri": "root://eospublic.cern.ch//eos/opendata/cms/MonteCarlo2011/Summer11LegDR/WWJetsTo2L2Nu_TuneZ2_7TeV-madgraph-tauola/AODSIM/PU_S13_START53_LV6-v2/file-indexes/CMS_MonteCarlo2011_Summer11LegDR_WWJetsTo2L2Nu_TuneZ2_7TeV-madgraph-tauola_AODSIM_PU_S13_START53_LV6-v2_00000_file_index.txt"
       }
     ],
-    "generator": {
-      "global_tag": "START53_LV6",
-      "names": [
-        "madgraph"
-      ]
-    },
     "license": {
       "attribution": "CC0"
     },
@@ -53766,6 +52758,9 @@
               "recid": "3164",
               "title": "Configuration file for SIM step HIG-Summer11Leg-00011_1_cfg.py"
             }
+          ],
+          "generators": [
+            "madgraph"
           ],
           "global_tag": "START53_LV4::All",
           "output_dataset": "/WWJetsTo2L2Nu_TuneZ2_7TeV-madgraph-tauola/Summer11Leg-START53_LV4-v2/GEN-SIM",
@@ -53887,13 +52882,6 @@
         "uri": "root://eospublic.cern.ch//eos/opendata/cms/MonteCarlo2011/Summer11LegDR/WW_TuneZ2_7TeV_pythia6_tauola/AODSIM/PU_S13_START53_LV6-v1/file-indexes/CMS_MonteCarlo2011_Summer11LegDR_WW_TuneZ2_7TeV_pythia6_tauola_AODSIM_PU_S13_START53_LV6-v1_00000_file_index.txt"
       }
     ],
-    "generator": {
-      "global_tag": "START53_LV6",
-      "names": [
-        "pythia6",
-        "tauola"
-      ]
-    },
     "license": {
       "attribution": "CC0"
     },
@@ -53907,6 +52895,10 @@
               "recid": "3217",
               "title": "Configuration file for SIM step HIG-Summer11Leg-00015_1_cfg.py"
             }
+          ],
+          "generators": [
+            "pythia6",
+            "tauola"
           ],
           "global_tag": "START53_LV4::All",
           "output_dataset": "/WW_TuneZ2_7TeV_pythia6_tauola/Summer11Leg-START53_LV4-v1/GEN-SIM",
@@ -54040,12 +53032,6 @@
         "uri": "root://eospublic.cern.ch//eos/opendata/cms/MonteCarlo2011/Summer11LegDR/WZJetsTo2L2Q_TuneZ2_7TeV-madgraph-tauola/AODSIM/PU_S13_START53_LV6-v1/file-indexes/CMS_MonteCarlo2011_Summer11LegDR_WZJetsTo2L2Q_TuneZ2_7TeV-madgraph-tauola_AODSIM_PU_S13_START53_LV6-v1_010000_file_index.txt"
       }
     ],
-    "generator": {
-      "global_tag": "START53_LV6",
-      "names": [
-        "madgraph"
-      ]
-    },
     "license": {
       "attribution": "CC0"
     },
@@ -54073,6 +53059,9 @@
               "recid": "3164",
               "title": "Configuration file for SIM step HIG-Summer11Leg-00011_1_cfg.py"
             }
+          ],
+          "generators": [
+            "madgraph"
           ],
           "global_tag": "START53_LV4::All",
           "output_dataset": "/WZJetsTo2L2Q_TuneZ2_7TeV-madgraph-tauola/Summer11Leg-START53_LV4-v2/GEN-SIM",
@@ -54194,13 +53183,6 @@
         "uri": "root://eospublic.cern.ch//eos/opendata/cms/MonteCarlo2011/Summer11LegDR/ZHiggs0PHToZZTo4L_M-125p6_7TeV-JHUGenV4/AODSIM/PU_S13_START53_LV6-v2/file-indexes/CMS_MonteCarlo2011_Summer11LegDR_ZHiggs0PHToZZTo4L_M-125p6_7TeV-JHUGenV4_AODSIM_PU_S13_START53_LV6-v2_40000_file_index.txt"
       }
     ],
-    "generator": {
-      "global_tag": "START53_LV6",
-      "names": [
-        "powheg15",
-        "pythia6"
-      ]
-    },
     "license": {
       "attribution": "CC0"
     },
@@ -54228,6 +53210,10 @@
               "recid": "3132",
               "title": "Configuration file for SIM step HIG-Summer11Leg-00151_1_cfg.py"
             }
+          ],
+          "generators": [
+            "powheg15",
+            "pythia6"
           ],
           "global_tag": "START53_LV4::All",
           "output_dataset": "/ZHiggs0PHToZZTo4L_M-125p6_7TeV-JHUGenV4/Summer11Leg-START53_LV4-v1/GEN-SIM",
@@ -54361,13 +53347,6 @@
         "uri": "root://eospublic.cern.ch//eos/opendata/cms/MonteCarlo2011/Summer11LegDR/T_TuneZ2_tW-channel-DR_7TeV-powheg-tauola/AODSIM/PU_S13_START53_LV6-v1/file-indexes/CMS_MonteCarlo2011_Summer11LegDR_T_TuneZ2_tW-channel-DR_7TeV-powheg-tauola_AODSIM_PU_S13_START53_LV6-v1_010000_file_index.txt"
       }
     ],
-    "generator": {
-      "global_tag": "START53_LV6",
-      "names": [
-        "pythia6",
-        "powheg"
-      ]
-    },
     "license": {
       "attribution": "CC0"
     },
@@ -54395,6 +53374,10 @@
               "recid": "3146",
               "title": "Configuration file for SIM step TOP-Summer11Leg-00014_1_cfg.py"
             }
+          ],
+          "generators": [
+            "pythia6",
+            "powheg"
           ],
           "global_tag": "START53_LV4::All",
           "output_dataset": "/T_TuneZ2_tW-channel-DR_7TeV-powheg-tauola/Summer11Leg-START53_LV4-v1/GEN-SIM",
@@ -54552,15 +53535,6 @@
         "uri": "root://eospublic.cern.ch//eos/opendata/cms/MonteCarlo2011/Summer11LegDR/TTJets_MSDecays_matchingdown_7TeV-madgraph-tauola/AODSIM/PU_S13_START53_LV6-v1/file-indexes/CMS_MonteCarlo2011_Summer11LegDR_TTJets_MSDecays_matchingdown_7TeV-madgraph-tauola_AODSIM_PU_S13_START53_LV6-v1_30000_file_index.txt"
       }
     ],
-    "generator": {
-      "global_tag": "START53_LV6",
-      "names": [
-        "madgraph",
-        "madspin",
-        "pythia6",
-        "tauola"
-      ]
-    },
     "license": {
       "attribution": "CC0"
     },
@@ -54588,6 +53562,12 @@
               "recid": "3354",
               "title": "Configuration file for SIM step TOP-Summer11Leg-00021_1_cfg.py"
             }
+          ],
+          "generators": [
+            "madgraph",
+            "madspin",
+            "pythia6",
+            "tauola"
           ],
           "global_tag": "START53_LV4::All",
           "output_dataset": "/TTJets_MSDecays_matchingdown_7TeV-madgraph-tauola/Summer11Leg-START53_LV4-v1/GEN-SIM",
@@ -54709,12 +53689,6 @@
         "uri": "root://eospublic.cern.ch//eos/opendata/cms/MonteCarlo2011/Summer11LegDR/WZJetsTo3LNu_TuneZ2_7TeV-madgraph-tauola/AODSIM/PU_S13_START53_LV6-v1/file-indexes/CMS_MonteCarlo2011_Summer11LegDR_WZJetsTo3LNu_TuneZ2_7TeV-madgraph-tauola_AODSIM_PU_S13_START53_LV6-v1_00000_file_index.txt"
       }
     ],
-    "generator": {
-      "global_tag": "START53_LV6",
-      "names": [
-        "madgraph"
-      ]
-    },
     "license": {
       "attribution": "CC0"
     },
@@ -54742,6 +53716,9 @@
               "recid": "3164",
               "title": "Configuration file for SIM step HIG-Summer11Leg-00011_1_cfg.py"
             }
+          ],
+          "generators": [
+            "madgraph"
           ],
           "global_tag": "START53_LV4::All",
           "output_dataset": "/WZJetsTo3LNu_TuneZ2_7TeV-madgraph-tauola/Summer11Leg-START53_LV4-v2/GEN-SIM",
@@ -54863,13 +53840,6 @@
         "uri": "root://eospublic.cern.ch//eos/opendata/cms/MonteCarlo2011/Summer11LegDR/WZ_TuneZ2_7TeV_pythia6_tauola/AODSIM/PU_S13_START53_LV6-v1/file-indexes/CMS_MonteCarlo2011_Summer11LegDR_WZ_TuneZ2_7TeV_pythia6_tauola_AODSIM_PU_S13_START53_LV6-v1_00000_file_index.txt"
       }
     ],
-    "generator": {
-      "global_tag": "START53_LV6",
-      "names": [
-        "pythia6",
-        "tauola"
-      ]
-    },
     "license": {
       "attribution": "CC0"
     },
@@ -54883,6 +53853,10 @@
               "recid": "3017",
               "title": "Configuration file for SIM step HIG-Summer11Leg-00014_1_cfg.py"
             }
+          ],
+          "generators": [
+            "pythia6",
+            "tauola"
           ],
           "global_tag": "START53_LV4::All",
           "output_dataset": "/WZ_TuneZ2_7TeV_pythia6_tauola/Summer11Leg-START53_LV4-v1/GEN-SIM",
@@ -55004,12 +53978,6 @@
         "uri": "root://eospublic.cern.ch//eos/opendata/cms/MonteCarlo2011/Summer11LegDR/ZGToNuNuG_TuneZ2_7TeV-madgraph/AODSIM/PU_S13_START53_LV6-v1/file-indexes/CMS_MonteCarlo2011_Summer11LegDR_ZGToNuNuG_TuneZ2_7TeV-madgraph_AODSIM_PU_S13_START53_LV6-v1_00000_file_index.txt"
       }
     ],
-    "generator": {
-      "global_tag": "START53_LV6",
-      "names": [
-        "madgraph"
-      ]
-    },
     "license": {
       "attribution": "CC0"
     },
@@ -55037,6 +54005,9 @@
               "recid": "3177",
               "title": "Configuration file for SIM step HIG-Summer11Leg-00081_1_cfg.py"
             }
+          ],
+          "generators": [
+            "madgraph"
           ],
           "global_tag": "START53_LV4::All",
           "output_dataset": "/ZGToNuNuG_TuneZ2_7TeV-madgraph/Summer11Leg-START53_LV4-v1/GEN-SIM",
@@ -55158,12 +54129,6 @@
         "uri": "root://eospublic.cern.ch//eos/opendata/cms/MonteCarlo2011/Summer11LegDR/ZH_HToZZTo4L_M-110_7TeV-pythia6/AODSIM/PU_S13_START53_LV6-v1/file-indexes/CMS_MonteCarlo2011_Summer11LegDR_ZH_HToZZTo4L_M-110_7TeV-pythia6_AODSIM_PU_S13_START53_LV6-v1_00000_file_index.txt"
       }
     ],
-    "generator": {
-      "global_tag": "START53_LV6",
-      "names": [
-        "pythia6"
-      ]
-    },
     "license": {
       "attribution": "CC0"
     },
@@ -55177,6 +54142,9 @@
               "recid": "3321",
               "title": "Configuration file for SIM step HIG-Summer11Leg-00252_1_cfg.py"
             }
+          ],
+          "generators": [
+            "pythia6"
           ],
           "global_tag": "START53_LV4::All",
           "output_dataset": "/ZH_HToZZTo4L_M-110_7TeV-pythia6/Summer11Leg-START53_LV4-v1/GEN-SIM",
@@ -55298,13 +54266,6 @@
         "uri": "root://eospublic.cern.ch//eos/opendata/cms/MonteCarlo2011/Summer11LegDR/VBFHiggs0PToBB_M-125p6_7TeV-JHUGenV4-pythia6-tauola/AODSIM/PU_S13_START53_LV6-v1/file-indexes/CMS_MonteCarlo2011_Summer11LegDR_VBFHiggs0PToBB_M-125p6_7TeV-JHUGenV4-pythia6-tauola_AODSIM_PU_S13_START53_LV6-v1_00000_file_index.txt"
       }
     ],
-    "generator": {
-      "global_tag": "START53_LV6",
-      "names": [
-        "JHUGen4",
-        "pythia6"
-      ]
-    },
     "license": {
       "attribution": "CC0"
     },
@@ -55332,6 +54293,10 @@
               "recid": "3030",
               "title": "Configuration file for SIM step HIG-Summer11Leg-00082_1_cfg.py"
             }
+          ],
+          "generators": [
+            "JHUGen4",
+            "pythia6"
           ],
           "global_tag": "START53_LV4::All",
           "output_dataset": "/VBFHiggs0PToBB_M-125p6_7TeV-JHUGenV4-pythia6-tauola/Summer11Leg-START53_LV4-v1/GEN-SIM",
@@ -55465,12 +54430,6 @@
         "uri": "root://eospublic.cern.ch//eos/opendata/cms/MonteCarlo2011/Summer11LegDR/ZH_HToZZTo4L_M-115_7TeV-pythia6/AODSIM/PU_S13_START53_LV6-v1/file-indexes/CMS_MonteCarlo2011_Summer11LegDR_ZH_HToZZTo4L_M-115_7TeV-pythia6_AODSIM_PU_S13_START53_LV6-v1_10000_file_index.txt"
       }
     ],
-    "generator": {
-      "global_tag": "START53_LV6",
-      "names": [
-        "pythia6"
-      ]
-    },
     "license": {
       "attribution": "CC0"
     },
@@ -55484,6 +54443,9 @@
               "recid": "3004",
               "title": "Configuration file for SIM step HIG-Summer11Leg-00253_1_cfg.py"
             }
+          ],
+          "generators": [
+            "pythia6"
           ],
           "global_tag": "START53_LV4::All",
           "output_dataset": "/ZH_HToZZTo4L_M-115_7TeV-pythia6/Summer11Leg-START53_LV4-v1/GEN-SIM",
@@ -55617,12 +54579,6 @@
         "uri": "root://eospublic.cern.ch//eos/opendata/cms/MonteCarlo2011/Summer11LegDR/ZH_HToZZTo4L_M-120_7TeV-pythia6/AODSIM/PU_S13_START53_LV6-v1/file-indexes/CMS_MonteCarlo2011_Summer11LegDR_ZH_HToZZTo4L_M-120_7TeV-pythia6_AODSIM_PU_S13_START53_LV6-v1_40000_file_index.txt"
       }
     ],
-    "generator": {
-      "global_tag": "START53_LV6",
-      "names": [
-        "pythia6"
-      ]
-    },
     "license": {
       "attribution": "CC0"
     },
@@ -55636,6 +54592,9 @@
               "recid": "3035",
               "title": "Configuration file for SIM step HIG-Summer11Leg-00254_1_cfg.py"
             }
+          ],
+          "generators": [
+            "pythia6"
           ],
           "global_tag": "START53_LV4::All",
           "output_dataset": "/ZH_HToZZTo4L_M-120_7TeV-pythia6/Summer11Leg-START53_LV4-v1/GEN-SIM",
@@ -55757,13 +54716,6 @@
         "uri": "root://eospublic.cern.ch//eos/opendata/cms/MonteCarlo2011/Summer11LegDR/ZZTo4e_7TeV_mll8_mZZ95-160-powheg15-pythia6/AODSIM/PU_S13_START53_LV6-v1/file-indexes/CMS_MonteCarlo2011_Summer11LegDR_ZZTo4e_7TeV_mll8_mZZ95-160-powheg15-pythia6_AODSIM_PU_S13_START53_LV6-v1_00000_file_index.txt"
       }
     ],
-    "generator": {
-      "global_tag": "START53_LV6",
-      "names": [
-        "powheg15",
-        "pythia6"
-      ]
-    },
     "license": {
       "attribution": "CC0"
     },
@@ -55791,6 +54743,10 @@
               "recid": "3176",
               "title": "Configuration file for SIM step HIG-Summer11Leg-00107_1_cfg.py"
             }
+          ],
+          "generators": [
+            "powheg15",
+            "pythia6"
           ],
           "global_tag": "START53_LV4::All",
           "output_dataset": "/ZZTo4e_7TeV_mll8_mZZ95-160-powheg15-pythia6/Summer11Leg-START53_LV4-v1/GEN-SIM",
@@ -55972,13 +54928,6 @@
         "uri": "root://eospublic.cern.ch//eos/opendata/cms/MonteCarlo2011/Summer11LegDR/ZZTo4e_mll4_7TeV-powheg-pythia6/AODSIM/PU_S13_START53_LV6-v1/file-indexes/CMS_MonteCarlo2011_Summer11LegDR_ZZTo4e_mll4_7TeV-powheg-pythia6_AODSIM_PU_S13_START53_LV6-v1_420000_file_index.txt"
       }
     ],
-    "generator": {
-      "global_tag": "START53_LV6",
-      "names": [
-        "powheg15",
-        "pythia6"
-      ]
-    },
     "license": {
       "attribution": "CC0"
     },
@@ -56006,6 +54955,10 @@
               "recid": "3310",
               "title": "Configuration file for SIM step HIG-Summer11Leg-00113_1_cfg.py"
             }
+          ],
+          "generators": [
+            "powheg15",
+            "pythia6"
           ],
           "global_tag": "START53_LV4::All",
           "output_dataset": "/ZZTo4e_mll4_7TeV-powheg-pythia6/Summer11Leg-START53_LV4-v1/GEN-SIM",
@@ -56127,13 +55080,6 @@
         "uri": "root://eospublic.cern.ch//eos/opendata/cms/MonteCarlo2011/Summer11LegDR/ZZTo4muJJ_Contin_7TeV-phantom-pythia6/AODSIM/PU_S13_START53_LV6-v1/file-indexes/CMS_MonteCarlo2011_Summer11LegDR_ZZTo4muJJ_Contin_7TeV-phantom-pythia6_AODSIM_PU_S13_START53_LV6-v1_40000_file_index.txt"
       }
     ],
-    "generator": {
-      "global_tag": "START53_LV6",
-      "names": [
-        "pythia6",
-        "phantom"
-      ]
-    },
     "license": {
       "attribution": "CC0"
     },
@@ -56161,6 +55107,10 @@
               "recid": "3132",
               "title": "Configuration file for SIM step HIG-Summer11Leg-00151_1_cfg.py"
             }
+          ],
+          "generators": [
+            "pythia6",
+            "phantom"
           ],
           "global_tag": "START53_LV4::All",
           "output_dataset": "/ZZTo4muJJ_Contin_7TeV-phantom-pythia6/Summer11Leg-START53_LV4-v1/GEN-SIM",
@@ -56282,13 +55232,6 @@
         "uri": "root://eospublic.cern.ch//eos/opendata/cms/MonteCarlo2011/Summer11LegDR/ZZTo4mu_7TeV_mll8_mZZ95-160-powheg15-pythia6/AODSIM/PU_S13_START53_LV6-v1/file-indexes/CMS_MonteCarlo2011_Summer11LegDR_ZZTo4mu_7TeV_mll8_mZZ95-160-powheg15-pythia6_AODSIM_PU_S13_START53_LV6-v1_10000_file_index.txt"
       }
     ],
-    "generator": {
-      "global_tag": "START53_LV6",
-      "names": [
-        "powheg15",
-        "pythia6"
-      ]
-    },
     "license": {
       "attribution": "CC0"
     },
@@ -56316,6 +55259,10 @@
               "recid": "3176",
               "title": "Configuration file for SIM step HIG-Summer11Leg-00107_1_cfg.py"
             }
+          ],
+          "generators": [
+            "powheg15",
+            "pythia6"
           ],
           "global_tag": "START53_LV4::All",
           "output_dataset": "/ZZTo4mu_7TeV_mll8_mZZ95-160-powheg15-pythia6/Summer11Leg-START53_LV4-v1/GEN-SIM",
@@ -56449,13 +55396,6 @@
         "uri": "root://eospublic.cern.ch//eos/opendata/cms/MonteCarlo2011/Summer11LegDR/ZZTo4mu_mll4_7TeV-powheg-pythia6/AODSIM/PU_S13_START53_LV6-v1/file-indexes/CMS_MonteCarlo2011_Summer11LegDR_ZZTo4mu_mll4_7TeV-powheg-pythia6_AODSIM_PU_S13_START53_LV6-v1_40000_file_index.txt"
       }
     ],
-    "generator": {
-      "global_tag": "START53_LV6",
-      "names": [
-        "powheg15",
-        "pythia6"
-      ]
-    },
     "license": {
       "attribution": "CC0"
     },
@@ -56483,6 +55423,10 @@
               "recid": "3310",
               "title": "Configuration file for SIM step HIG-Summer11Leg-00113_1_cfg.py"
             }
+          ],
+          "generators": [
+            "powheg15",
+            "pythia6"
           ],
           "global_tag": "START53_LV4::All",
           "output_dataset": "/ZZTo4mu_mll4_7TeV-powheg-pythia6/Summer11Leg-START53_LV4-v1/GEN-SIM",
@@ -56640,13 +55584,6 @@
         "uri": "root://eospublic.cern.ch//eos/opendata/cms/MonteCarlo2011/Summer11LegDR/ZZTo4tau_7TeV_mll8_mZZ95-160-powheg15-pythia6/AODSIM/PU_S13_START53_LV6-v1/file-indexes/CMS_MonteCarlo2011_Summer11LegDR_ZZTo4tau_7TeV_mll8_mZZ95-160-powheg15-pythia6_AODSIM_PU_S13_START53_LV6-v1_40000_file_index.txt"
       }
     ],
-    "generator": {
-      "global_tag": "START53_LV6",
-      "names": [
-        "powheg15",
-        "pythia6"
-      ]
-    },
     "license": {
       "attribution": "CC0"
     },
@@ -56674,6 +55611,10 @@
               "recid": "3176",
               "title": "Configuration file for SIM step HIG-Summer11Leg-00107_1_cfg.py"
             }
+          ],
+          "generators": [
+            "powheg15",
+            "pythia6"
           ],
           "global_tag": "START53_LV4::All",
           "output_dataset": "/ZZTo4tau_7TeV_mll8_mZZ95-160-powheg15-pythia6/Summer11Leg-START53_LV4-v1/GEN-SIM",
@@ -56807,13 +55748,6 @@
         "uri": "root://eospublic.cern.ch//eos/opendata/cms/MonteCarlo2011/Summer11LegDR/ZZTo4tau_mll4_7TeV-powheg-pythia6/AODSIM/PU_S13_START53_LV6-v1/file-indexes/CMS_MonteCarlo2011_Summer11LegDR_ZZTo4tau_mll4_7TeV-powheg-pythia6_AODSIM_PU_S13_START53_LV6-v1_30000_file_index.txt"
       }
     ],
-    "generator": {
-      "global_tag": "START53_LV6",
-      "names": [
-        "powheg15",
-        "pythia6"
-      ]
-    },
     "license": {
       "attribution": "CC0"
     },
@@ -56841,6 +55775,10 @@
               "recid": "3310",
               "title": "Configuration file for SIM step HIG-Summer11Leg-00113_1_cfg.py"
             }
+          ],
+          "generators": [
+            "powheg15",
+            "pythia6"
           ],
           "global_tag": "START53_LV4::All",
           "output_dataset": "/ZZTo4tau_mll4_7TeV-powheg-pythia6/Summer11Leg-START53_LV4-v1/GEN-SIM",
@@ -56962,13 +55900,6 @@
         "uri": "root://eospublic.cern.ch//eos/opendata/cms/MonteCarlo2011/Summer11LegDR/ZZ_TuneZ2_7TeV_pythia6_tauola/AODSIM/PU_S13_START53_LV6-v1/file-indexes/CMS_MonteCarlo2011_Summer11LegDR_ZZ_TuneZ2_7TeV_pythia6_tauola_AODSIM_PU_S13_START53_LV6-v1_00000_file_index.txt"
       }
     ],
-    "generator": {
-      "global_tag": "START53_LV6",
-      "names": [
-        "pythia6",
-        "tauola"
-      ]
-    },
     "license": {
       "attribution": "CC0"
     },
@@ -56982,6 +55913,10 @@
               "recid": "3319",
               "title": "Configuration file for SIM step HIG-Summer11Leg-00013_1_cfg.py"
             }
+          ],
+          "generators": [
+            "pythia6",
+            "tauola"
           ],
           "global_tag": "START53_LV4::All",
           "output_dataset": "/ZZ_TuneZ2_7TeV_pythia6_tauola/Summer11Leg-START53_LV4-v1/GEN-SIM",
@@ -57103,12 +56038,6 @@
         "uri": "root://eospublic.cern.ch//eos/opendata/cms/MonteCarlo2011/Summer11LegDR/TTbarH_HToZZTo4L_M-150_7TeV-pythia6/AODSIM/PU_S13_START53_LV6-v1/file-indexes/CMS_MonteCarlo2011_Summer11LegDR_TTbarH_HToZZTo4L_M-150_7TeV-pythia6_AODSIM_PU_S13_START53_LV6-v1_20000_file_index.txt"
       }
     ],
-    "generator": {
-      "global_tag": "START53_LV6",
-      "names": [
-        "pythia6"
-      ]
-    },
     "license": {
       "attribution": "CC0"
     },
@@ -57122,6 +56051,9 @@
               "recid": "3033",
               "title": "Configuration file for SIM step HIG-Summer11Leg-00237_1_cfg.py"
             }
+          ],
+          "generators": [
+            "pythia6"
           ],
           "global_tag": "START53_LV4::All",
           "output_dataset": "/TTbarH_HToZZTo4L_M-150_7TeV-pythia6/Summer11Leg-START53_LV4-v1/GEN-SIM",
@@ -57243,13 +56175,6 @@
         "uri": "root://eospublic.cern.ch//eos/opendata/cms/MonteCarlo2011/Summer11LegDR/SMHiggsToZZTo4L_M-180_7TeV-powheg15-JHUgenV3-pythia6/AODSIM/PU_S13_START53_LV6-v1/file-indexes/CMS_MonteCarlo2011_Summer11LegDR_SMHiggsToZZTo4L_M-180_7TeV-powheg15-JHUgenV3-pythia6_AODSIM_PU_S13_START53_LV6-v1_00000_file_index.txt"
       }
     ],
-    "generator": {
-      "global_tag": "START53_LV6",
-      "names": [
-        "powheg15",
-        "pythia6"
-      ]
-    },
     "license": {
       "attribution": "CC0"
     },
@@ -57277,6 +56202,10 @@
               "recid": "3031",
               "title": "Configuration file for SIM step HIG-Summer11Leg-00119_1_cfg.py"
             }
+          ],
+          "generators": [
+            "powheg15",
+            "pythia6"
           ],
           "global_tag": "START53_LV4::All",
           "output_dataset": "/SMHiggsToZZTo4L_M-180_7TeV-powheg15-JHUgenV3-pythia6/Summer11Leg-START53_LV4-v1/GEN-SIM",
@@ -57398,13 +56327,6 @@
         "uri": "root://eospublic.cern.ch//eos/opendata/cms/MonteCarlo2011/Summer11LegDR/VBFToHToZZTo2L2Nu_M-250_7TeV-powheg15-pythia6/AODSIM/PU_S13_START53_LV6-v1/file-indexes/CMS_MonteCarlo2011_Summer11LegDR_VBFToHToZZTo2L2Nu_M-250_7TeV-powheg15-pythia6_AODSIM_PU_S13_START53_LV6-v1_00000_file_index.txt"
       }
     ],
-    "generator": {
-      "global_tag": "START53_LV6",
-      "names": [
-        "powheg15",
-        "pythia6"
-      ]
-    },
     "license": {
       "attribution": "CC0"
     },
@@ -57432,6 +56354,10 @@
               "recid": "3118",
               "title": "Configuration file for SIM step HIG-Summer11Leg-00057_1_cfg.py"
             }
+          ],
+          "generators": [
+            "powheg15",
+            "pythia6"
           ],
           "global_tag": "START53_LV4::All",
           "output_dataset": "/VBFToHToZZTo2L2Nu_M-250_7TeV-powheg15-pythia6/Summer11Leg-START53_LV4-v3/GEN-SIM",
@@ -57553,12 +56479,6 @@
         "uri": "root://eospublic.cern.ch//eos/opendata/cms/MonteCarlo2011/Summer11LegDR/ZH_HToZZTo4L_M-125_7TeV-pythia6/AODSIM/PU_S13_START53_LV6-v1/file-indexes/CMS_MonteCarlo2011_Summer11LegDR_ZH_HToZZTo4L_M-125_7TeV-pythia6_AODSIM_PU_S13_START53_LV6-v1_30000_file_index.txt"
       }
     ],
-    "generator": {
-      "global_tag": "START53_LV6",
-      "names": [
-        "pythia6"
-      ]
-    },
     "license": {
       "attribution": "CC0"
     },
@@ -57572,6 +56492,9 @@
               "recid": "3223",
               "title": "Configuration file for SIM step HIG-Summer11Leg-00255_1_cfg.py"
             }
+          ],
+          "generators": [
+            "pythia6"
           ],
           "global_tag": "START53_LV4::All",
           "output_dataset": "/ZH_HToZZTo4L_M-125_7TeV-pythia6/Summer11Leg-START53_LV4-v1/GEN-SIM",
@@ -57705,13 +56628,6 @@
         "uri": "root://eospublic.cern.ch//eos/opendata/cms/MonteCarlo2011/Summer11LegDR/SMHiggsToZZTo4L_M-200_7TeV-powheg15-JHUgenV3-pythia6/AODSIM/PU_S13_START53_LV6-v1/file-indexes/CMS_MonteCarlo2011_Summer11LegDR_SMHiggsToZZTo4L_M-200_7TeV-powheg15-JHUgenV3-pythia6_AODSIM_PU_S13_START53_LV6-v1_30000_file_index.txt"
       }
     ],
-    "generator": {
-      "global_tag": "START53_LV6",
-      "names": [
-        "powheg15",
-        "pythia6"
-      ]
-    },
     "license": {
       "attribution": "CC0"
     },
@@ -57739,6 +56655,10 @@
               "recid": "3031",
               "title": "Configuration file for SIM step HIG-Summer11Leg-00119_1_cfg.py"
             }
+          ],
+          "generators": [
+            "powheg15",
+            "pythia6"
           ],
           "global_tag": "START53_LV4::All",
           "output_dataset": "/SMHiggsToZZTo4L_M-200_7TeV-powheg15-JHUgenV3-pythia6/Summer11Leg-START53_LV4-v1/GEN-SIM",
@@ -57872,13 +56792,6 @@
         "uri": "root://eospublic.cern.ch//eos/opendata/cms/MonteCarlo2011/Summer11LegDR/VBFToHToZZTo2L2Nu_M-1000_7TeV-powheg15-pythia6/AODSIM/PU_S13_START53_LV6-v1/file-indexes/CMS_MonteCarlo2011_Summer11LegDR_VBFToHToZZTo2L2Nu_M-1000_7TeV-powheg15-pythia6_AODSIM_PU_S13_START53_LV6-v1_010000_file_index.txt"
       }
     ],
-    "generator": {
-      "global_tag": "START53_LV6",
-      "names": [
-        "powheg15",
-        "pythia6"
-      ]
-    },
     "license": {
       "attribution": "CC0"
     },
@@ -57906,6 +56819,10 @@
               "recid": "3118",
               "title": "Configuration file for SIM step HIG-Summer11Leg-00057_1_cfg.py"
             }
+          ],
+          "generators": [
+            "powheg15",
+            "pythia6"
           ],
           "global_tag": "START53_LV4::All",
           "output_dataset": "/VBFToHToZZTo2L2Nu_M-1000_7TeV-powheg15-pythia6/Summer11Leg-START53_LV4-v2/GEN-SIM",
@@ -58027,12 +56944,6 @@
         "uri": "root://eospublic.cern.ch//eos/opendata/cms/MonteCarlo2011/Summer11LegDR/ZH_HToZZTo4L_M-126_7TeV-pythia6/AODSIM/PU_S13_START53_LV6-v1/file-indexes/CMS_MonteCarlo2011_Summer11LegDR_ZH_HToZZTo4L_M-126_7TeV-pythia6_AODSIM_PU_S13_START53_LV6-v1_00000_file_index.txt"
       }
     ],
-    "generator": {
-      "global_tag": "START53_LV6",
-      "names": [
-        "pythia6"
-      ]
-    },
     "license": {
       "attribution": "CC0"
     },
@@ -58046,6 +56957,9 @@
               "recid": "3090",
               "title": "Configuration file for SIM step HIG-Summer11Leg-00256_1_cfg.py"
             }
+          ],
+          "generators": [
+            "pythia6"
           ],
           "global_tag": "START53_LV4::All",
           "output_dataset": "/ZH_HToZZTo4L_M-126_7TeV-pythia6/Summer11Leg-START53_LV4-v1/GEN-SIM",
@@ -58167,15 +57081,6 @@
         "uri": "root://eospublic.cern.ch//eos/opendata/cms/MonteCarlo2011/Summer11LegDR/TTJets_MSDecays_central_TuneZ2_7TeV-madgraph-tauola/AODSIM/PU_S13_START53_LV6-v1/file-indexes/CMS_MonteCarlo2011_Summer11LegDR_TTJets_MSDecays_central_TuneZ2_7TeV-madgraph-tauola_AODSIM_PU_S13_START53_LV6-v1_00000_file_index.txt"
       }
     ],
-    "generator": {
-      "global_tag": "START53_LV6",
-      "names": [
-        "madgraph",
-        "madspin",
-        "pythia6",
-        "tauola"
-      ]
-    },
     "license": {
       "attribution": "CC0"
     },
@@ -58203,6 +57108,12 @@
               "recid": "3188",
               "title": "Configuration file for SIM step TOP-Summer11Leg-00015_1_cfg.py"
             }
+          ],
+          "generators": [
+            "madgraph",
+            "madspin",
+            "pythia6",
+            "tauola"
           ],
           "global_tag": "START53_LV4::All",
           "output_dataset": "/TTJets_MSDecays_central_TuneZ2_7TeV-madgraph-tauola/Summer11Leg-START53_LV4-v2/GEN-SIM",
@@ -58360,15 +57271,6 @@
         "uri": "root://eospublic.cern.ch//eos/opendata/cms/MonteCarlo2011/Summer11LegDR/TTJets_MSDecays_mass169_5_7TeV-madgraph-tauola/AODSIM/PU_S13_START53_LV6-v1/file-indexes/CMS_MonteCarlo2011_Summer11LegDR_TTJets_MSDecays_mass169_5_7TeV-madgraph-tauola_AODSIM_PU_S13_START53_LV6-v1_30000_file_index.txt"
       }
     ],
-    "generator": {
-      "global_tag": "START53_LV6",
-      "names": [
-        "madgraph",
-        "madspin",
-        "pythia6",
-        "tauola"
-      ]
-    },
     "license": {
       "attribution": "CC0"
     },
@@ -58396,6 +57298,12 @@
               "recid": "3253",
               "title": "Configuration file for SIM step TOP-Summer11Leg-00023_1_cfg.py"
             }
+          ],
+          "generators": [
+            "madgraph",
+            "madspin",
+            "pythia6",
+            "tauola"
           ],
           "global_tag": "START53_LV4::All",
           "output_dataset": "/TTJets_MSDecays_mass169_5_7TeV-madgraph-tauola/Summer11Leg-START53_LV4-v1/GEN-SIM",
@@ -58517,12 +57425,6 @@
         "uri": "root://eospublic.cern.ch//eos/opendata/cms/MonteCarlo2011/Summer11LegDR/ZH_HToZZTo4L_M-130_7TeV-pythia6/AODSIM/PU_S13_START53_LV6-v1/file-indexes/CMS_MonteCarlo2011_Summer11LegDR_ZH_HToZZTo4L_M-130_7TeV-pythia6_AODSIM_PU_S13_START53_LV6-v1_00000_file_index.txt"
       }
     ],
-    "generator": {
-      "global_tag": "START53_LV6",
-      "names": [
-        "pythia6"
-      ]
-    },
     "license": {
       "attribution": "CC0"
     },
@@ -58536,6 +57438,9 @@
               "recid": "3400",
               "title": "Configuration file for SIM step HIG-Summer11Leg-00257_1_cfg.py"
             }
+          ],
+          "generators": [
+            "pythia6"
           ],
           "global_tag": "START53_LV4::All",
           "output_dataset": "/ZH_HToZZTo4L_M-130_7TeV-pythia6/Summer11Leg-START53_LV4-v1/GEN-SIM",
@@ -58657,12 +57562,6 @@
         "uri": "root://eospublic.cern.ch//eos/opendata/cms/MonteCarlo2011/Summer11LegDR/ZH_HToZZTo4L_M-140_7TeV-pythia6/AODSIM/PU_S13_START53_LV6-v1/file-indexes/CMS_MonteCarlo2011_Summer11LegDR_ZH_HToZZTo4L_M-140_7TeV-pythia6_AODSIM_PU_S13_START53_LV6-v1_410000_file_index.txt"
       }
     ],
-    "generator": {
-      "global_tag": "START53_LV6",
-      "names": [
-        "pythia6"
-      ]
-    },
     "license": {
       "attribution": "CC0"
     },
@@ -58676,6 +57575,9 @@
               "recid": "3134",
               "title": "Configuration file for SIM step HIG-Summer11Leg-00258_1_cfg.py"
             }
+          ],
+          "generators": [
+            "pythia6"
           ],
           "global_tag": "START53_LV4::All",
           "output_dataset": "/ZH_HToZZTo4L_M-140_7TeV-pythia6/Summer11Leg-START53_LV4-v2/GEN-SIM",
@@ -58821,15 +57723,6 @@
         "uri": "root://eospublic.cern.ch//eos/opendata/cms/MonteCarlo2011/Summer11LegDR/TTJets_MSDecays_mass171_5_7TeV-madgraph-tauola/AODSIM/PU_S13_START53_LV6-v1/file-indexes/CMS_MonteCarlo2011_Summer11LegDR_TTJets_MSDecays_mass171_5_7TeV-madgraph-tauola_AODSIM_PU_S13_START53_LV6-v1_20000_file_index.txt"
       }
     ],
-    "generator": {
-      "global_tag": "START53_LV6",
-      "names": [
-        "madgraph",
-        "madspin",
-        "pythia6",
-        "tauola"
-      ]
-    },
     "license": {
       "attribution": "CC0"
     },
@@ -58857,6 +57750,12 @@
               "recid": "3203",
               "title": "Configuration file for SIM step TOP-Summer11Leg-00019_1_cfg.py"
             }
+          ],
+          "generators": [
+            "madgraph",
+            "madspin",
+            "pythia6",
+            "tauola"
           ],
           "global_tag": "START53_LV4::All",
           "output_dataset": "/TTJets_MSDecays_mass171_5_7TeV-madgraph-tauola/Summer11Leg-START53_LV4-v1/GEN-SIM",
@@ -58978,12 +57877,6 @@
         "uri": "root://eospublic.cern.ch//eos/opendata/cms/MonteCarlo2011/Summer11LegDR/ZH_HToZZTo4L_M-150_7TeV-pythia6/AODSIM/PU_S13_START53_LV6-v1/file-indexes/CMS_MonteCarlo2011_Summer11LegDR_ZH_HToZZTo4L_M-150_7TeV-pythia6_AODSIM_PU_S13_START53_LV6-v1_10000_file_index.txt"
       }
     ],
-    "generator": {
-      "global_tag": "START53_LV6",
-      "names": [
-        "pythia6"
-      ]
-    },
     "license": {
       "attribution": "CC0"
     },
@@ -58997,6 +57890,9 @@
               "recid": "3207",
               "title": "Configuration file for SIM step HIG-Summer11Leg-00259_1_cfg.py"
             }
+          ],
+          "generators": [
+            "pythia6"
           ],
           "global_tag": "START53_LV4::All",
           "output_dataset": "/ZH_HToZZTo4L_M-150_7TeV-pythia6/Summer11Leg-START53_LV4-v1/GEN-SIM",
@@ -59130,12 +58026,6 @@
         "uri": "root://eospublic.cern.ch//eos/opendata/cms/MonteCarlo2011/Summer11LegDR/ZH_HToZZTo4L_M-160_7TeV-pythia6/AODSIM/PU_S13_START53_LV6-v1/file-indexes/CMS_MonteCarlo2011_Summer11LegDR_ZH_HToZZTo4L_M-160_7TeV-pythia6_AODSIM_PU_S13_START53_LV6-v1_40000_file_index.txt"
       }
     ],
-    "generator": {
-      "global_tag": "START53_LV6",
-      "names": [
-        "pythia6"
-      ]
-    },
     "license": {
       "attribution": "CC0"
     },
@@ -59149,6 +58039,9 @@
               "recid": "3278",
               "title": "Configuration file for SIM step HIG-Summer11Leg-00260_1_cfg.py"
             }
+          ],
+          "generators": [
+            "pythia6"
           ],
           "global_tag": "START53_LV4::All",
           "output_dataset": "/ZH_HToZZTo4L_M-160_7TeV-pythia6/Summer11Leg-START53_LV4-v1/GEN-SIM",
@@ -59270,12 +58163,6 @@
         "uri": "root://eospublic.cern.ch//eos/opendata/cms/MonteCarlo2011/Summer11LegDR/ZH_HToZZTo4L_M-180_7TeV-pythia6/AODSIM/PU_S13_START53_LV6-v1/file-indexes/CMS_MonteCarlo2011_Summer11LegDR_ZH_HToZZTo4L_M-180_7TeV-pythia6_AODSIM_PU_S13_START53_LV6-v1_00000_file_index.txt"
       }
     ],
-    "generator": {
-      "global_tag": "START53_LV6",
-      "names": [
-        "pythia6"
-      ]
-    },
     "license": {
       "attribution": "CC0"
     },
@@ -59289,6 +58176,9 @@
               "recid": "3000",
               "title": "Configuration file for SIM step HIG-Summer11Leg-00261_1_cfg.py"
             }
+          ],
+          "generators": [
+            "pythia6"
           ],
           "global_tag": "START53_LV4::All",
           "output_dataset": "/ZH_HToZZTo4L_M-180_7TeV-pythia6/Summer11Leg-START53_LV4-v1/GEN-SIM",
@@ -59422,12 +58312,6 @@
         "uri": "root://eospublic.cern.ch//eos/opendata/cms/MonteCarlo2011/Summer11LegDR/ZH_HToZZTo4L_M-200_7TeV-pythia6/AODSIM/PU_S13_START53_LV6-v1/file-indexes/CMS_MonteCarlo2011_Summer11LegDR_ZH_HToZZTo4L_M-200_7TeV-pythia6_AODSIM_PU_S13_START53_LV6-v1_40000_file_index.txt"
       }
     ],
-    "generator": {
-      "global_tag": "START53_LV6",
-      "names": [
-        "pythia6"
-      ]
-    },
     "license": {
       "attribution": "CC0"
     },
@@ -59441,6 +58325,9 @@
               "recid": "3018",
               "title": "Configuration file for SIM step HIG-Summer11Leg-00262_1_cfg.py"
             }
+          ],
+          "generators": [
+            "pythia6"
           ],
           "global_tag": "START53_LV4::All",
           "output_dataset": "/ZH_HToZZTo4L_M-200_7TeV-pythia6/Summer11Leg-START53_LV4-v1/GEN-SIM",
@@ -59562,13 +58449,6 @@
         "uri": "root://eospublic.cern.ch//eos/opendata/cms/MonteCarlo2011/Summer11LegDR/ZHiggs0MToBB_M-125p6_7TeV-JHUGenV4-pythia6-tauola/AODSIM/PU_S13_START53_LV6-v1/file-indexes/CMS_MonteCarlo2011_Summer11LegDR_ZHiggs0MToBB_M-125p6_7TeV-JHUGenV4-pythia6-tauola_AODSIM_PU_S13_START53_LV6-v1_00000_file_index.txt"
       }
     ],
-    "generator": {
-      "global_tag": "START53_LV6",
-      "names": [
-        "JHUGen4",
-        "pythia6"
-      ]
-    },
     "license": {
       "attribution": "CC0"
     },
@@ -59596,6 +58476,10 @@
               "recid": "3030",
               "title": "Configuration file for SIM step HIG-Summer11Leg-00082_1_cfg.py"
             }
+          ],
+          "generators": [
+            "JHUGen4",
+            "pythia6"
           ],
           "global_tag": "START53_LV4::All",
           "output_dataset": "/ZHiggs0MToBB_M-125p6_7TeV-JHUGenV4-pythia6-tauola/Summer11Leg-START53_LV4-v1/GEN-SIM",
@@ -59717,13 +58601,6 @@
         "uri": "root://eospublic.cern.ch//eos/opendata/cms/MonteCarlo2011/Summer11LegDR/ZHiggs0MToZZTo4L_M-125p6_7TeV-JHUGenV4/AODSIM/PU_S13_START53_LV6-v1/file-indexes/CMS_MonteCarlo2011_Summer11LegDR_ZHiggs0MToZZTo4L_M-125p6_7TeV-JHUGenV4_AODSIM_PU_S13_START53_LV6-v1_310000_file_index.txt"
       }
     ],
-    "generator": {
-      "global_tag": "START53_LV6",
-      "names": [
-        "powheg15",
-        "pythia6"
-      ]
-    },
     "license": {
       "attribution": "CC0"
     },
@@ -59751,6 +58628,10 @@
               "recid": "3132",
               "title": "Configuration file for SIM step HIG-Summer11Leg-00151_1_cfg.py"
             }
+          ],
+          "generators": [
+            "powheg15",
+            "pythia6"
           ],
           "global_tag": "START53_LV4::All",
           "output_dataset": "/ZHiggs0MToZZTo4L_M-125p6_7TeV-JHUGenV4/Summer11Leg-START53_LV4-v1/GEN-SIM",
@@ -59872,13 +58753,6 @@
         "uri": "root://eospublic.cern.ch//eos/opendata/cms/MonteCarlo2011/Summer11LegDR/ZHiggs0Mf05ph0ToZZTo4L_M-125p6_7TeV-JHUGenV4/AODSIM/PU_S13_START53_LV6-v1/file-indexes/CMS_MonteCarlo2011_Summer11LegDR_ZHiggs0Mf05ph0ToZZTo4L_M-125p6_7TeV-JHUGenV4_AODSIM_PU_S13_START53_LV6-v1_10000_file_index.txt"
       }
     ],
-    "generator": {
-      "global_tag": "START53_LV6",
-      "names": [
-        "powheg15",
-        "pythia6"
-      ]
-    },
     "license": {
       "attribution": "CC0"
     },
@@ -59906,6 +58780,10 @@
               "recid": "3132",
               "title": "Configuration file for SIM step HIG-Summer11Leg-00151_1_cfg.py"
             }
+          ],
+          "generators": [
+            "powheg15",
+            "pythia6"
           ],
           "global_tag": "START53_LV4::All",
           "output_dataset": "/ZHiggs0Mf05ph0ToZZTo4L_M-125p6_7TeV-JHUGenV4/Summer11Leg-START53_LV4-v1/GEN-SIM",
@@ -60039,13 +58917,6 @@
         "uri": "root://eospublic.cern.ch//eos/opendata/cms/MonteCarlo2011/Summer11LegDR/Tbar_TuneZ2_s-channel_7TeV-powheg-tauola/AODSIM/PU_S13_START53_LV6-v1/file-indexes/CMS_MonteCarlo2011_Summer11LegDR_Tbar_TuneZ2_s-channel_7TeV-powheg-tauola_AODSIM_PU_S13_START53_LV6-v1_010000_file_index.txt"
       }
     ],
-    "generator": {
-      "global_tag": "START53_LV6",
-      "names": [
-        "powheg",
-        "pythia6"
-      ]
-    },
     "license": {
       "attribution": "CC0"
     },
@@ -60073,6 +58944,10 @@
               "recid": "3107",
               "title": "Configuration file for SIM step TOP-Summer11Leg-00003_1_cfg.py"
             }
+          ],
+          "generators": [
+            "powheg",
+            "pythia6"
           ],
           "global_tag": "START53_LV4::All",
           "output_dataset": "/Tbar_TuneZ2_s-channel_7TeV-powheg-tauola/Summer11Leg-START53_LV4-v1/GEN-SIM",
@@ -60230,15 +59105,6 @@
         "uri": "root://eospublic.cern.ch//eos/opendata/cms/MonteCarlo2011/Summer11LegDR/TTJets_MSDecays_mass173_5_7TeV-madgraph-tauola/AODSIM/PU_S13_START53_LV6-v1/file-indexes/CMS_MonteCarlo2011_Summer11LegDR_TTJets_MSDecays_mass173_5_7TeV-madgraph-tauola_AODSIM_PU_S13_START53_LV6-v1_30000_file_index.txt"
       }
     ],
-    "generator": {
-      "global_tag": "START53_LV6",
-      "names": [
-        "madgraph",
-        "madspin",
-        "pythia6",
-        "tauola"
-      ]
-    },
     "license": {
       "attribution": "CC0"
     },
@@ -60266,6 +59132,12 @@
               "recid": "3214",
               "title": "Configuration file for SIM step TOP-Summer11Leg-00018_1_cfg.py"
             }
+          ],
+          "generators": [
+            "madgraph",
+            "madspin",
+            "pythia6",
+            "tauola"
           ],
           "global_tag": "START53_LV4::All",
           "output_dataset": "/TTJets_MSDecays_mass173_5_7TeV-madgraph-tauola/Summer11Leg-START53_LV4-v1/GEN-SIM",
@@ -60411,12 +59283,6 @@
         "uri": "root://eospublic.cern.ch//eos/opendata/cms/MonteCarlo2011/Summer11LegDR/TTbarH_HToZZTo4L_M-126_7TeV-pythia6/AODSIM/PU_S13_START53_LV6-v1/file-indexes/CMS_MonteCarlo2011_Summer11LegDR_TTbarH_HToZZTo4L_M-126_7TeV-pythia6_AODSIM_PU_S13_START53_LV6-v1_30000_file_index.txt"
       }
     ],
-    "generator": {
-      "global_tag": "START53_LV6",
-      "names": [
-        "pythia6"
-      ]
-    },
     "license": {
       "attribution": "CC0"
     },
@@ -60430,6 +59296,9 @@
               "recid": "3309",
               "title": "Configuration file for SIM step HIG-Summer11Leg-00234_1_cfg.py"
             }
+          ],
+          "generators": [
+            "pythia6"
           ],
           "global_tag": "START53_LV4::All",
           "output_dataset": "/TTbarH_HToZZTo4L_M-126_7TeV-pythia6/Summer11Leg-START53_LV4-v1/GEN-SIM",
@@ -60599,15 +59468,6 @@
         "uri": "root://eospublic.cern.ch//eos/opendata/cms/MonteCarlo2011/Summer11LegDR/TTJets_MSDecays_mass175_5_7TeV-madgraph-tauola/AODSIM/PU_S13_START53_LV6-v1/file-indexes/CMS_MonteCarlo2011_Summer11LegDR_TTJets_MSDecays_mass175_5_7TeV-madgraph-tauola_AODSIM_PU_S13_START53_LV6-v1_40000_file_index.txt"
       }
     ],
-    "generator": {
-      "global_tag": "START53_LV6",
-      "names": [
-        "madgraph",
-        "madspin",
-        "pythia6",
-        "tauola"
-      ]
-    },
     "license": {
       "attribution": "CC0"
     },
@@ -60635,6 +59495,12 @@
               "recid": "3076",
               "title": "Configuration file for SIM step TOP-Summer11Leg-00022_1_cfg.py"
             }
+          ],
+          "generators": [
+            "madgraph",
+            "madspin",
+            "pythia6",
+            "tauola"
           ],
           "global_tag": "START53_LV4::All",
           "output_dataset": "/TTJets_MSDecays_mass175_5_7TeV-madgraph-tauola/Summer11Leg-START53_LV4-v1/GEN-SIM",
@@ -60756,13 +59622,6 @@
         "uri": "root://eospublic.cern.ch//eos/opendata/cms/MonteCarlo2011/Summer11LegDR/VBFHiggs0PToGG_M-125p6_7TeV-JHUGenV4-pythia6-tauola/AODSIM/PU_S13_START53_LV6-v1/file-indexes/CMS_MonteCarlo2011_Summer11LegDR_VBFHiggs0PToGG_M-125p6_7TeV-JHUGenV4-pythia6-tauola_AODSIM_PU_S13_START53_LV6-v1_00000_file_index.txt"
       }
     ],
-    "generator": {
-      "global_tag": "START53_LV6",
-      "names": [
-        "JHUGen4",
-        "pythia6"
-      ]
-    },
     "license": {
       "attribution": "CC0"
     },
@@ -60790,6 +59649,10 @@
               "recid": "3332",
               "title": "Configuration file for SIM step HIG-Summer11Leg-00096_1_cfg.py"
             }
+          ],
+          "generators": [
+            "JHUGen4",
+            "pythia6"
           ],
           "global_tag": "START53_LV4::All",
           "output_dataset": "/VBFHiggs0PToGG_M-125p6_7TeV-JHUGenV4-pythia6-tauola/Summer11Leg-START53_LV4-v1/GEN-SIM",
@@ -60911,14 +59774,6 @@
         "uri": "root://eospublic.cern.ch//eos/opendata/cms/MonteCarlo2011/Summer11LegDR/Vector1MToZZTo4L_M-125p6_7TeV-JHUGenV3-pythia6/AODSIM/PU_S13_START53_LV6-v1/file-indexes/CMS_MonteCarlo2011_Summer11LegDR_Vector1MToZZTo4L_M-125p6_7TeV-JHUGenV3-pythia6_AODSIM_PU_S13_START53_LV6-v1_20000_file_index.txt"
       }
     ],
-    "generator": {
-      "global_tag": "START53_LV6",
-      "names": [
-        "pythia6",
-        "JHUgen",
-        "powheg15"
-      ]
-    },
     "license": {
       "attribution": "CC0"
     },
@@ -60946,6 +59801,11 @@
               "recid": "3132",
               "title": "Configuration file for SIM step HIG-Summer11Leg-00151_1_cfg.py"
             }
+          ],
+          "generators": [
+            "pythia6",
+            "JHUgen",
+            "powheg15"
           ],
           "global_tag": "START53_LV4::All",
           "output_dataset": "/Vector1MToZZTo4L_M-125p6_7TeV-JHUGenV3-pythia6/Summer11Leg-START53_LV4-v1/GEN-SIM",
@@ -61079,15 +59939,6 @@
         "uri": "root://eospublic.cern.ch//eos/opendata/cms/MonteCarlo2011/Summer11LegDR/TTJets_MSDecays_scaleup_mt172_5_7TeV-madgraph-tauola/AODSIM/PU_S13_START53_LV6-v1/file-indexes/CMS_MonteCarlo2011_Summer11LegDR_TTJets_MSDecays_scaleup_mt172_5_7TeV-madgraph-tauola_AODSIM_PU_S13_START53_LV6-v1_80000_file_index.txt"
       }
     ],
-    "generator": {
-      "global_tag": "START53_LV6",
-      "names": [
-        "madgraph",
-        "madspin",
-        "pythia6",
-        "tauola"
-      ]
-    },
     "license": {
       "attribution": "CC0"
     },
@@ -61115,6 +59966,12 @@
               "recid": "3265",
               "title": "Configuration file for SIM step TOP-Summer11Leg-00036_1_cfg.py"
             }
+          ],
+          "generators": [
+            "madgraph",
+            "madspin",
+            "pythia6",
+            "tauola"
           ],
           "global_tag": "START53_LV4::All",
           "output_dataset": "/TTJets_MSDecays_scaleup_mt172_5_7TeV-madgraph-tauola/Summer11Leg-START53_LV4-v1/GEN-SIM",


### PR DESCRIPTION
* Updates CMS 2011 MC records generator information by moving it to the SIM
  step as for 2010 2012 etc records. (closes #2700)

* Amends data model to remove the ``generator`` field now that it is no longer
  used by any record.

Signed-off-by: Tibor Simko <tibor.simko@cern.ch>
