### PR TITLE
records: add file indexes to Run2010A

### DIFF
--- a/cernopendata/modules/fixtures/data/records/cms-primary-datasets.json
+++ b/cernopendata/modules/fixtures/data/records/cms-primary-datasets.json
@@ -2499,6 +2499,92 @@
       "size": 2193478806310
     },
     "experiment": "CMS",
+    "files": [
+      {
+        "checksum": "adler32:f6e5aee6",
+        "size": 221538,
+        "type": "index.json",
+        "uri": "root://eospublic.cern.ch//eos/opendata/cms/Run2010A/BTau/AOD/Apr21ReReco-v1/file-indexes/CMS_Run2010A_BTau_AOD_Apr21ReReco-v1_0000_file_index.json"
+      },
+      {
+        "checksum": "adler32:f24bc934",
+        "size": 102582,
+        "type": "index.txt",
+        "uri": "root://eospublic.cern.ch//eos/opendata/cms/Run2010A/BTau/AOD/Apr21ReReco-v1/file-indexes/CMS_Run2010A_BTau_AOD_Apr21ReReco-v1_0000_file_index.txt"
+      },
+      {
+        "checksum": "adler32:a93091ae",
+        "size": 47204,
+        "type": "index.json",
+        "uri": "root://eospublic.cern.ch//eos/opendata/cms/Run2010A/BTau/AOD/Apr21ReReco-v1/file-indexes/CMS_Run2010A_BTau_AOD_Apr21ReReco-v1_0001_file_index.json"
+      },
+      {
+        "checksum": "adler32:7e3925b0",
+        "size": 21894,
+        "type": "index.txt",
+        "uri": "root://eospublic.cern.ch//eos/opendata/cms/Run2010A/BTau/AOD/Apr21ReReco-v1/file-indexes/CMS_Run2010A_BTau_AOD_Apr21ReReco-v1_0001_file_index.txt"
+      },
+      {
+        "checksum": "adler32:768db5b7",
+        "size": 49308,
+        "type": "index.json",
+        "uri": "root://eospublic.cern.ch//eos/opendata/cms/Run2010A/BTau/AOD/Apr21ReReco-v1/file-indexes/CMS_Run2010A_BTau_AOD_Apr21ReReco-v1_0002_file_index.json"
+      },
+      {
+        "checksum": "adler32:f2614349",
+        "size": 22878,
+        "type": "index.txt",
+        "uri": "root://eospublic.cern.ch//eos/opendata/cms/Run2010A/BTau/AOD/Apr21ReReco-v1/file-indexes/CMS_Run2010A_BTau_AOD_Apr21ReReco-v1_0002_file_index.txt"
+      },
+      {
+        "checksum": "adler32:afd57902",
+        "size": 52019,
+        "type": "index.json",
+        "uri": "root://eospublic.cern.ch//eos/opendata/cms/Run2010A/BTau/AOD/Apr21ReReco-v1/file-indexes/CMS_Run2010A_BTau_AOD_Apr21ReReco-v1_0003_file_index.json"
+      },
+      {
+        "checksum": "adler32:f115ae1d",
+        "size": 24108,
+        "type": "index.txt",
+        "uri": "root://eospublic.cern.ch//eos/opendata/cms/Run2010A/BTau/AOD/Apr21ReReco-v1/file-indexes/CMS_Run2010A_BTau_AOD_Apr21ReReco-v1_0003_file_index.txt"
+      },
+      {
+        "checksum": "adler32:4df34203",
+        "size": 76062,
+        "type": "index.json",
+        "uri": "root://eospublic.cern.ch//eos/opendata/cms/Run2010A/BTau/AOD/Apr21ReReco-v1/file-indexes/CMS_Run2010A_BTau_AOD_Apr21ReReco-v1_0004_file_index.json"
+      },
+      {
+        "checksum": "adler32:ced98cd4",
+        "size": 35301,
+        "type": "index.txt",
+        "uri": "root://eospublic.cern.ch//eos/opendata/cms/Run2010A/BTau/AOD/Apr21ReReco-v1/file-indexes/CMS_Run2010A_BTau_AOD_Apr21ReReco-v1_0004_file_index.txt"
+      },
+      {
+        "checksum": "adler32:5e579e64",
+        "size": 100789,
+        "type": "index.json",
+        "uri": "root://eospublic.cern.ch//eos/opendata/cms/Run2010A/BTau/AOD/Apr21ReReco-v1/file-indexes/CMS_Run2010A_BTau_AOD_Apr21ReReco-v1_0005_file_index.json"
+      },
+      {
+        "checksum": "adler32:9a0eadf6",
+        "size": 46740,
+        "type": "index.txt",
+        "uri": "root://eospublic.cern.ch//eos/opendata/cms/Run2010A/BTau/AOD/Apr21ReReco-v1/file-indexes/CMS_Run2010A_BTau_AOD_Apr21ReReco-v1_0005_file_index.txt"
+      },
+      {
+        "checksum": "adler32:490ea290",
+        "size": 1593,
+        "type": "index.json",
+        "uri": "root://eospublic.cern.ch//eos/opendata/cms/Run2010A/BTau/AOD/Apr21ReReco-v1/file-indexes/CMS_Run2010A_BTau_AOD_Apr21ReReco-v1_0006_file_index.json"
+      },
+      {
+        "checksum": "adler32:a785d8ec",
+        "size": 738,
+        "type": "index.txt",
+        "uri": "root://eospublic.cern.ch//eos/opendata/cms/Run2010A/BTau/AOD/Apr21ReReco-v1/file-indexes/CMS_Run2010A_BTau_AOD_Apr21ReReco-v1_0006_file_index.txt"
+      }
+    ],
     "license": {
       "attribution": "CC0"
     },
@@ -2559,7 +2645,7 @@
       ]
     }
   },
-{
+  {
     "abstract": {
       "description": "<p>ZeroBias primary dataset in AOD format from RunA of 2010</p> <p>This dataset contains all runs from 2010 RunA. The list of validated runs, which must be applied to all analyses, can be found in</p>",
       "links": [
@@ -2595,6 +2681,56 @@
       "size": 979720468256
     },
     "experiment": "CMS",
+    "files": [
+      {
+        "checksum": "adler32:2614b043",
+        "size": 200773,
+        "type": "index.json",
+        "uri": "root://eospublic.cern.ch//eos/opendata/cms/Run2010A/ZeroBias/AOD/Apr21ReReco-v1/file-indexes/CMS_Run2010A_ZeroBias_AOD_Apr21ReReco-v1_0000_file_index.json"
+      },
+      {
+        "checksum": "adler32:1be9c4f2",
+        "size": 94488,
+        "type": "index.txt",
+        "uri": "root://eospublic.cern.ch//eos/opendata/cms/Run2010A/ZeroBias/AOD/Apr21ReReco-v1/file-indexes/CMS_Run2010A_ZeroBias_AOD_Apr21ReReco-v1_0000_file_index.txt"
+      },
+      {
+        "checksum": "adler32:a7f48ee9",
+        "size": 541,
+        "type": "index.json",
+        "uri": "root://eospublic.cern.ch//eos/opendata/cms/Run2010A/ZeroBias/AOD/Apr21ReReco-v1/file-indexes/CMS_Run2010A_ZeroBias_AOD_Apr21ReReco-v1_0002_file_index.json"
+      },
+      {
+        "checksum": "adler32:86524b80",
+        "size": 254,
+        "type": "index.txt",
+        "uri": "root://eospublic.cern.ch//eos/opendata/cms/Run2010A/ZeroBias/AOD/Apr21ReReco-v1/file-indexes/CMS_Run2010A_ZeroBias_AOD_Apr21ReReco-v1_0002_file_index.txt"
+      },
+      {
+        "checksum": "adler32:e457f935",
+        "size": 1893,
+        "type": "index.json",
+        "uri": "root://eospublic.cern.ch//eos/opendata/cms/Run2010A/ZeroBias/AOD/Apr21ReReco-v1/file-indexes/CMS_Run2010A_ZeroBias_AOD_Apr21ReReco-v1_0003_file_index.json"
+      },
+      {
+        "checksum": "adler32:b79009a5",
+        "size": 889,
+        "type": "index.txt",
+        "uri": "root://eospublic.cern.ch//eos/opendata/cms/Run2010A/ZeroBias/AOD/Apr21ReReco-v1/file-indexes/CMS_Run2010A_ZeroBias_AOD_Apr21ReReco-v1_0003_file_index.txt"
+      },
+      {
+        "checksum": "adler32:f0b48f59",
+        "size": 541,
+        "type": "index.json",
+        "uri": "root://eospublic.cern.ch//eos/opendata/cms/Run2010A/ZeroBias/AOD/Apr21ReReco-v1/file-indexes/CMS_Run2010A_ZeroBias_AOD_Apr21ReReco-v1_0024_file_index.json"
+      },
+      {
+        "checksum": "adler32:bdde4bcf",
+        "size": 254,
+        "type": "index.txt",
+        "uri": "root://eospublic.cern.ch//eos/opendata/cms/Run2010A/ZeroBias/AOD/Apr21ReReco-v1/file-indexes/CMS_Run2010A_ZeroBias_AOD_Apr21ReReco-v1_0024_file_index.txt"
+      }
+    ],
     "license": {
       "attribution": "CC0"
     },
@@ -2691,6 +2827,104 @@
       "size": 2603503059480
     },
     "experiment": "CMS",
+    "files": [
+      {
+        "checksum": "adler32:2559273f",
+        "size": 180155,
+        "type": "index.json",
+        "uri": "root://eospublic.cern.ch//eos/opendata/cms/Run2010A/MuOnia/AOD/Apr21ReReco-v1/file-indexes/CMS_Run2010A_MuOnia_AOD_Apr21ReReco-v1_0000_file_index.json"
+      },
+      {
+        "checksum": "adler32:34aee2bc",
+        "size": 84125,
+        "type": "index.txt",
+        "uri": "root://eospublic.cern.ch//eos/opendata/cms/Run2010A/MuOnia/AOD/Apr21ReReco-v1/file-indexes/CMS_Run2010A_MuOnia_AOD_Apr21ReReco-v1_0000_file_index.txt"
+      },
+      {
+        "checksum": "adler32:e90725e1",
+        "size": 92392,
+        "type": "index.json",
+        "uri": "root://eospublic.cern.ch//eos/opendata/cms/Run2010A/MuOnia/AOD/Apr21ReReco-v1/file-indexes/CMS_Run2010A_MuOnia_AOD_Apr21ReReco-v1_0001_file_index.json"
+      },
+      {
+        "checksum": "adler32:11ca5b9b",
+        "size": 43250,
+        "type": "index.txt",
+        "uri": "root://eospublic.cern.ch//eos/opendata/cms/Run2010A/MuOnia/AOD/Apr21ReReco-v1/file-indexes/CMS_Run2010A_MuOnia_AOD_Apr21ReReco-v1_0001_file_index.txt"
+      },
+      {
+        "checksum": "adler32:6e03c90a",
+        "size": 75848,
+        "type": "index.json",
+        "uri": "root://eospublic.cern.ch//eos/opendata/cms/Run2010A/MuOnia/AOD/Apr21ReReco-v1/file-indexes/CMS_Run2010A_MuOnia_AOD_Apr21ReReco-v1_0002_file_index.json"
+      },
+      {
+        "checksum": "adler32:21fc45b3",
+        "size": 35500,
+        "type": "index.txt",
+        "uri": "root://eospublic.cern.ch//eos/opendata/cms/Run2010A/MuOnia/AOD/Apr21ReReco-v1/file-indexes/CMS_Run2010A_MuOnia_AOD_Apr21ReReco-v1_0002_file_index.txt"
+      },
+      {
+        "checksum": "adler32:ab916296",
+        "size": 10950,
+        "type": "index.json",
+        "uri": "root://eospublic.cern.ch//eos/opendata/cms/Run2010A/MuOnia/AOD/Apr21ReReco-v1/file-indexes/CMS_Run2010A_MuOnia_AOD_Apr21ReReco-v1_0003_file_index.json"
+      },
+      {
+        "checksum": "adler32:d8f0f6a1",
+        "size": 5125,
+        "type": "index.txt",
+        "uri": "root://eospublic.cern.ch//eos/opendata/cms/Run2010A/MuOnia/AOD/Apr21ReReco-v1/file-indexes/CMS_Run2010A_MuOnia_AOD_Apr21ReReco-v1_0003_file_index.txt"
+      },
+      {
+        "checksum": "adler32:8d357ffd",
+        "size": 91871,
+        "type": "index.json",
+        "uri": "root://eospublic.cern.ch//eos/opendata/cms/Run2010A/MuOnia/AOD/Apr21ReReco-v1/file-indexes/CMS_Run2010A_MuOnia_AOD_Apr21ReReco-v1_0004_file_index.json"
+      },
+      {
+        "checksum": "adler32:78ae0b16",
+        "size": 43000,
+        "type": "index.txt",
+        "uri": "root://eospublic.cern.ch//eos/opendata/cms/Run2010A/MuOnia/AOD/Apr21ReReco-v1/file-indexes/CMS_Run2010A_MuOnia_AOD_Apr21ReReco-v1_0004_file_index.txt"
+      },
+      {
+        "checksum": "adler32:0f8f54c6",
+        "size": 138876,
+        "type": "index.json",
+        "uri": "root://eospublic.cern.ch//eos/opendata/cms/Run2010A/MuOnia/AOD/Apr21ReReco-v1/file-indexes/CMS_Run2010A_MuOnia_AOD_Apr21ReReco-v1_0005_file_index.json"
+      },
+      {
+        "checksum": "adler32:018da102",
+        "size": 65000,
+        "type": "index.txt",
+        "uri": "root://eospublic.cern.ch//eos/opendata/cms/Run2010A/MuOnia/AOD/Apr21ReReco-v1/file-indexes/CMS_Run2010A_MuOnia_AOD_Apr21ReReco-v1_0005_file_index.txt"
+      },
+      {
+        "checksum": "adler32:77673639",
+        "size": 61696,
+        "type": "index.json",
+        "uri": "root://eospublic.cern.ch//eos/opendata/cms/Run2010A/MuOnia/AOD/Apr21ReReco-v1/file-indexes/CMS_Run2010A_MuOnia_AOD_Apr21ReReco-v1_0006_file_index.json"
+      },
+      {
+        "checksum": "adler32:b964a401",
+        "size": 28875,
+        "type": "index.txt",
+        "uri": "root://eospublic.cern.ch//eos/opendata/cms/Run2010A/MuOnia/AOD/Apr21ReReco-v1/file-indexes/CMS_Run2010A_MuOnia_AOD_Apr21ReReco-v1_0006_file_index.txt"
+      },
+      {
+        "checksum": "adler32:1d57d92d",
+        "size": 39290,
+        "type": "index.json",
+        "uri": "root://eospublic.cern.ch//eos/opendata/cms/Run2010A/MuOnia/AOD/Apr21ReReco-v1/file-indexes/CMS_Run2010A_MuOnia_AOD_Apr21ReReco-v1_0007_file_index.json"
+      },
+      {
+        "checksum": "adler32:f16965f3",
+        "size": 18375,
+        "type": "index.txt",
+        "uri": "root://eospublic.cern.ch//eos/opendata/cms/Run2010A/MuOnia/AOD/Apr21ReReco-v1/file-indexes/CMS_Run2010A_MuOnia_AOD_Apr21ReReco-v1_0007_file_index.txt"
+      }
+    ],
     "license": {
       "attribution": "CC0"
     },
@@ -2787,6 +3021,164 @@
       "size": 1898409317210
     },
     "experiment": "CMS",
+    "files": [
+      {
+        "checksum": "adler32:06e441a8",
+        "size": 270785,
+        "type": "index.json",
+        "uri": "root://eospublic.cern.ch//eos/opendata/cms/Run2010A/MuMonitor/AOD/Apr21ReReco-v1/file-indexes/CMS_Run2010A_MuMonitor_AOD_Apr21ReReco-v1_0000_file_index.json"
+      },
+      {
+        "checksum": "adler32:e55bae6c",
+        "size": 128000,
+        "type": "index.txt",
+        "uri": "root://eospublic.cern.ch//eos/opendata/cms/Run2010A/MuMonitor/AOD/Apr21ReReco-v1/file-indexes/CMS_Run2010A_MuMonitor_AOD_Apr21ReReco-v1_0000_file_index.txt"
+      },
+      {
+        "checksum": "adler32:1b173616",
+        "size": 26001,
+        "type": "index.json",
+        "uri": "root://eospublic.cern.ch//eos/opendata/cms/Run2010A/MuMonitor/AOD/Apr21ReReco-v1/file-indexes/CMS_Run2010A_MuMonitor_AOD_Apr21ReReco-v1_0001_file_index.json"
+      },
+      {
+        "checksum": "adler32:b3cc792b",
+        "size": 12288,
+        "type": "index.txt",
+        "uri": "root://eospublic.cern.ch//eos/opendata/cms/Run2010A/MuMonitor/AOD/Apr21ReReco-v1/file-indexes/CMS_Run2010A_MuMonitor_AOD_Apr21ReReco-v1_0001_file_index.txt"
+      },
+      {
+        "checksum": "adler32:99aa492d",
+        "size": 273,
+        "type": "index.json",
+        "uri": "root://eospublic.cern.ch//eos/opendata/cms/Run2010A/MuMonitor/AOD/Apr21ReReco-v1/file-indexes/CMS_Run2010A_MuMonitor_AOD_Apr21ReReco-v1_0002_file_index.json"
+      },
+      {
+        "checksum": "adler32:aa6926af",
+        "size": 128,
+        "type": "index.txt",
+        "uri": "root://eospublic.cern.ch//eos/opendata/cms/Run2010A/MuMonitor/AOD/Apr21ReReco-v1/file-indexes/CMS_Run2010A_MuMonitor_AOD_Apr21ReReco-v1_0002_file_index.txt"
+      },
+      {
+        "checksum": "adler32:6140a44e",
+        "size": 17823,
+        "type": "index.json",
+        "uri": "root://eospublic.cern.ch//eos/opendata/cms/Run2010A/MuMonitor/AOD/Apr21ReReco-v1/file-indexes/CMS_Run2010A_MuMonitor_AOD_Apr21ReReco-v1_0005_file_index.json"
+      },
+      {
+        "checksum": "adler32:3370ef8b",
+        "size": 8448,
+        "type": "index.txt",
+        "uri": "root://eospublic.cern.ch//eos/opendata/cms/Run2010A/MuMonitor/AOD/Apr21ReReco-v1/file-indexes/CMS_Run2010A_MuMonitor_AOD_Apr21ReReco-v1_0005_file_index.txt"
+      },
+      {
+        "checksum": "adler32:8cd148e7",
+        "size": 274,
+        "type": "index.json",
+        "uri": "root://eospublic.cern.ch//eos/opendata/cms/Run2010A/MuMonitor/AOD/Apr21ReReco-v1/file-indexes/CMS_Run2010A_MuMonitor_AOD_Apr21ReReco-v1_0006_file_index.json"
+      },
+      {
+        "checksum": "adler32:a83e268a",
+        "size": 128,
+        "type": "index.txt",
+        "uri": "root://eospublic.cern.ch//eos/opendata/cms/Run2010A/MuMonitor/AOD/Apr21ReReco-v1/file-indexes/CMS_Run2010A_MuMonitor_AOD_Apr21ReReco-v1_0006_file_index.txt"
+      },
+      {
+        "checksum": "adler32:5377b2b1",
+        "size": 1623,
+        "type": "index.json",
+        "uri": "root://eospublic.cern.ch//eos/opendata/cms/Run2010A/MuMonitor/AOD/Apr21ReReco-v1/file-indexes/CMS_Run2010A_MuMonitor_AOD_Apr21ReReco-v1_0007_file_index.json"
+      },
+      {
+        "checksum": "adler32:0155e775",
+        "size": 768,
+        "type": "index.txt",
+        "uri": "root://eospublic.cern.ch//eos/opendata/cms/Run2010A/MuMonitor/AOD/Apr21ReReco-v1/file-indexes/CMS_Run2010A_MuMonitor_AOD_Apr21ReReco-v1_0007_file_index.txt"
+      },
+      {
+        "checksum": "adler32:c8141d48",
+        "size": 2973,
+        "type": "index.json",
+        "uri": "root://eospublic.cern.ch//eos/opendata/cms/Run2010A/MuMonitor/AOD/Apr21ReReco-v1/file-indexes/CMS_Run2010A_MuMonitor_AOD_Apr21ReReco-v1_0008_file_index.json"
+      },
+      {
+        "checksum": "adler32:e547a903",
+        "size": 1408,
+        "type": "index.txt",
+        "uri": "root://eospublic.cern.ch//eos/opendata/cms/Run2010A/MuMonitor/AOD/Apr21ReReco-v1/file-indexes/CMS_Run2010A_MuMonitor_AOD_Apr21ReReco-v1_0008_file_index.txt"
+      },
+      {
+        "checksum": "adler32:18fc413e",
+        "size": 48063,
+        "type": "index.json",
+        "uri": "root://eospublic.cern.ch//eos/opendata/cms/Run2010A/MuMonitor/AOD/Apr21ReReco-v1/file-indexes/CMS_Run2010A_MuMonitor_AOD_Apr21ReReco-v1_0010_file_index.json"
+      },
+      {
+        "checksum": "adler32:5bc1cc38",
+        "size": 22784,
+        "type": "index.txt",
+        "uri": "root://eospublic.cern.ch//eos/opendata/cms/Run2010A/MuMonitor/AOD/Apr21ReReco-v1/file-indexes/CMS_Run2010A_MuMonitor_AOD_Apr21ReReco-v1_0010_file_index.txt"
+      },
+      {
+        "checksum": "adler32:529a1c69",
+        "size": 2973,
+        "type": "index.json",
+        "uri": "root://eospublic.cern.ch//eos/opendata/cms/Run2010A/MuMonitor/AOD/Apr21ReReco-v1/file-indexes/CMS_Run2010A_MuMonitor_AOD_Apr21ReReco-v1_0011_file_index.json"
+      },
+      {
+        "checksum": "adler32:39d4a8cd",
+        "size": 1408,
+        "type": "index.txt",
+        "uri": "root://eospublic.cern.ch//eos/opendata/cms/Run2010A/MuMonitor/AOD/Apr21ReReco-v1/file-indexes/CMS_Run2010A_MuMonitor_AOD_Apr21ReReco-v1_0011_file_index.txt"
+      },
+      {
+        "checksum": "adler32:822c6bc0",
+        "size": 1353,
+        "type": "index.json",
+        "uri": "root://eospublic.cern.ch//eos/opendata/cms/Run2010A/MuMonitor/AOD/Apr21ReReco-v1/file-indexes/CMS_Run2010A_MuMonitor_AOD_Apr21ReReco-v1_0012_file_index.json"
+      },
+      {
+        "checksum": "adler32:6dc9c12e",
+        "size": 640,
+        "type": "index.txt",
+        "uri": "root://eospublic.cern.ch//eos/opendata/cms/Run2010A/MuMonitor/AOD/Apr21ReReco-v1/file-indexes/CMS_Run2010A_MuMonitor_AOD_Apr21ReReco-v1_0012_file_index.txt"
+      },
+      {
+        "checksum": "adler32:fd02d68e",
+        "size": 2703,
+        "type": "index.json",
+        "uri": "root://eospublic.cern.ch//eos/opendata/cms/Run2010A/MuMonitor/AOD/Apr21ReReco-v1/file-indexes/CMS_Run2010A_MuMonitor_AOD_Apr21ReReco-v1_0013_file_index.json"
+      },
+      {
+        "checksum": "adler32:235f8264",
+        "size": 1280,
+        "type": "index.txt",
+        "uri": "root://eospublic.cern.ch//eos/opendata/cms/Run2010A/MuMonitor/AOD/Apr21ReReco-v1/file-indexes/CMS_Run2010A_MuMonitor_AOD_Apr21ReReco-v1_0013_file_index.txt"
+      },
+      {
+        "checksum": "adler32:0ff5f310",
+        "size": 5676,
+        "type": "index.json",
+        "uri": "root://eospublic.cern.ch//eos/opendata/cms/Run2010A/MuMonitor/AOD/Apr21ReReco-v1/file-indexes/CMS_Run2010A_MuMonitor_AOD_Apr21ReReco-v1_0015_file_index.json"
+      },
+      {
+        "checksum": "adler32:85672b09",
+        "size": 2688,
+        "type": "index.txt",
+        "uri": "root://eospublic.cern.ch//eos/opendata/cms/Run2010A/MuMonitor/AOD/Apr21ReReco-v1/file-indexes/CMS_Run2010A_MuMonitor_AOD_Apr21ReReco-v1_0015_file_index.txt"
+      },
+      {
+        "checksum": "adler32:8a38d957",
+        "size": 813,
+        "type": "index.json",
+        "uri": "root://eospublic.cern.ch//eos/opendata/cms/Run2010A/MuMonitor/AOD/Apr21ReReco-v1/file-indexes/CMS_Run2010A_MuMonitor_AOD_Apr21ReReco-v1_0017_file_index.json"
+      },
+      {
+        "checksum": "adler32:b5937367",
+        "size": 384,
+        "type": "index.txt",
+        "uri": "root://eospublic.cern.ch//eos/opendata/cms/Run2010A/MuMonitor/AOD/Apr21ReReco-v1/file-indexes/CMS_Run2010A_MuMonitor_AOD_Apr21ReReco-v1_0017_file_index.txt"
+      }
+    ],
     "license": {
       "attribution": "CC0"
     },
@@ -2883,6 +3275,200 @@
       "size": 2429704559456
     },
     "experiment": "CMS",
+    "files": [
+      {
+        "checksum": "adler32:c98f0082",
+        "size": 289130,
+        "type": "index.json",
+        "uri": "root://eospublic.cern.ch//eos/opendata/cms/Run2010A/Mu/AOD/Apr21ReReco-v1/file-indexes/CMS_Run2010A_Mu_AOD_Apr21ReReco-v1_0000_file_index.json"
+      },
+      {
+        "checksum": "adler32:bf143359",
+        "size": 132616,
+        "type": "index.txt",
+        "uri": "root://eospublic.cern.ch//eos/opendata/cms/Run2010A/Mu/AOD/Apr21ReReco-v1/file-indexes/CMS_Run2010A_Mu_AOD_Apr21ReReco-v1_0000_file_index.txt"
+      },
+      {
+        "checksum": "adler32:417c95e3",
+        "size": 13195,
+        "type": "index.json",
+        "uri": "root://eospublic.cern.ch//eos/opendata/cms/Run2010A/Mu/AOD/Apr21ReReco-v1/file-indexes/CMS_Run2010A_Mu_AOD_Apr21ReReco-v1_0001_file_index.json"
+      },
+      {
+        "checksum": "adler32:12ccf5ad",
+        "size": 6050,
+        "type": "index.txt",
+        "uri": "root://eospublic.cern.ch//eos/opendata/cms/Run2010A/Mu/AOD/Apr21ReReco-v1/file-indexes/CMS_Run2010A_Mu_AOD_Apr21ReReco-v1_0001_file_index.txt"
+      },
+      {
+        "checksum": "adler32:de29dd33",
+        "size": 17361,
+        "type": "index.json",
+        "uri": "root://eospublic.cern.ch//eos/opendata/cms/Run2010A/Mu/AOD/Apr21ReReco-v1/file-indexes/CMS_Run2010A_Mu_AOD_Apr21ReReco-v1_0002_file_index.json"
+      },
+      {
+        "checksum": "adler32:2ad72cf6",
+        "size": 7986,
+        "type": "index.txt",
+        "uri": "root://eospublic.cern.ch//eos/opendata/cms/Run2010A/Mu/AOD/Apr21ReReco-v1/file-indexes/CMS_Run2010A_Mu_AOD_Apr21ReReco-v1_0002_file_index.txt"
+      },
+      {
+        "checksum": "adler32:bc230a62",
+        "size": 6841,
+        "type": "index.json",
+        "uri": "root://eospublic.cern.ch//eos/opendata/cms/Run2010A/Mu/AOD/Apr21ReReco-v1/file-indexes/CMS_Run2010A_Mu_AOD_Apr21ReReco-v1_0003_file_index.json"
+      },
+      {
+        "checksum": "adler32:8b279d60",
+        "size": 3146,
+        "type": "index.txt",
+        "uri": "root://eospublic.cern.ch//eos/opendata/cms/Run2010A/Mu/AOD/Apr21ReReco-v1/file-indexes/CMS_Run2010A_Mu_AOD_Apr21ReReco-v1_0003_file_index.txt"
+      },
+      {
+        "checksum": "adler32:06695b4a",
+        "size": 13942,
+        "type": "index.json",
+        "uri": "root://eospublic.cern.ch//eos/opendata/cms/Run2010A/Mu/AOD/Apr21ReReco-v1/file-indexes/CMS_Run2010A_Mu_AOD_Apr21ReReco-v1_0004_file_index.json"
+      },
+      {
+        "checksum": "adler32:d0176157",
+        "size": 6413,
+        "type": "index.txt",
+        "uri": "root://eospublic.cern.ch//eos/opendata/cms/Run2010A/Mu/AOD/Apr21ReReco-v1/file-indexes/CMS_Run2010A_Mu_AOD_Apr21ReReco-v1_0004_file_index.txt"
+      },
+      {
+        "checksum": "adler32:20b39e99",
+        "size": 11312,
+        "type": "index.json",
+        "uri": "root://eospublic.cern.ch//eos/opendata/cms/Run2010A/Mu/AOD/Apr21ReReco-v1/file-indexes/CMS_Run2010A_Mu_AOD_Apr21ReReco-v1_0005_file_index.json"
+      },
+      {
+        "checksum": "adler32:fc9ef811",
+        "size": 5203,
+        "type": "index.txt",
+        "uri": "root://eospublic.cern.ch//eos/opendata/cms/Run2010A/Mu/AOD/Apr21ReReco-v1/file-indexes/CMS_Run2010A_Mu_AOD_Apr21ReReco-v1_0005_file_index.txt"
+      },
+      {
+        "checksum": "adler32:e80b7150",
+        "size": 2370,
+        "type": "index.json",
+        "uri": "root://eospublic.cern.ch//eos/opendata/cms/Run2010A/Mu/AOD/Apr21ReReco-v1/file-indexes/CMS_Run2010A_Mu_AOD_Apr21ReReco-v1_0006_file_index.json"
+      },
+      {
+        "checksum": "adler32:3d934100",
+        "size": 1089,
+        "type": "index.txt",
+        "uri": "root://eospublic.cern.ch//eos/opendata/cms/Run2010A/Mu/AOD/Apr21ReReco-v1/file-indexes/CMS_Run2010A_Mu_AOD_Apr21ReReco-v1_0006_file_index.txt"
+      },
+      {
+        "checksum": "adler32:1b528b4f",
+        "size": 529,
+        "type": "index.json",
+        "uri": "root://eospublic.cern.ch//eos/opendata/cms/Run2010A/Mu/AOD/Apr21ReReco-v1/file-indexes/CMS_Run2010A_Mu_AOD_Apr21ReReco-v1_0007_file_index.json"
+      },
+      {
+        "checksum": "adler32:6aea474c",
+        "size": 242,
+        "type": "index.txt",
+        "uri": "root://eospublic.cern.ch//eos/opendata/cms/Run2010A/Mu/AOD/Apr21ReReco-v1/file-indexes/CMS_Run2010A_Mu_AOD_Apr21ReReco-v1_0007_file_index.txt"
+      },
+      {
+        "checksum": "adler32:9cad9985",
+        "size": 4480,
+        "type": "index.json",
+        "uri": "root://eospublic.cern.ch//eos/opendata/cms/Run2010A/Mu/AOD/Apr21ReReco-v1/file-indexes/CMS_Run2010A_Mu_AOD_Apr21ReReco-v1_0008_file_index.json"
+      },
+      {
+        "checksum": "adler32:e7c75b94",
+        "size": 2057,
+        "type": "index.txt",
+        "uri": "root://eospublic.cern.ch//eos/opendata/cms/Run2010A/Mu/AOD/Apr21ReReco-v1/file-indexes/CMS_Run2010A_Mu_AOD_Apr21ReReco-v1_0008_file_index.txt"
+      },
+      {
+        "checksum": "adler32:f54ccd8f",
+        "size": 3685,
+        "type": "index.json",
+        "uri": "root://eospublic.cern.ch//eos/opendata/cms/Run2010A/Mu/AOD/Apr21ReReco-v1/file-indexes/CMS_Run2010A_Mu_AOD_Apr21ReReco-v1_0009_file_index.json"
+      },
+      {
+        "checksum": "adler32:81e3f33a",
+        "size": 1694,
+        "type": "index.txt",
+        "uri": "root://eospublic.cern.ch//eos/opendata/cms/Run2010A/Mu/AOD/Apr21ReReco-v1/file-indexes/CMS_Run2010A_Mu_AOD_Apr21ReReco-v1_0009_file_index.txt"
+      },
+      {
+        "checksum": "adler32:8dde27f7",
+        "size": 14731,
+        "type": "index.json",
+        "uri": "root://eospublic.cern.ch//eos/opendata/cms/Run2010A/Mu/AOD/Apr21ReReco-v1/file-indexes/CMS_Run2010A_Mu_AOD_Apr21ReReco-v1_0012_file_index.json"
+      },
+      {
+        "checksum": "adler32:1f07c940",
+        "size": 6776,
+        "type": "index.txt",
+        "uri": "root://eospublic.cern.ch//eos/opendata/cms/Run2010A/Mu/AOD/Apr21ReReco-v1/file-indexes/CMS_Run2010A_Mu_AOD_Apr21ReReco-v1_0012_file_index.txt"
+      },
+      {
+        "checksum": "adler32:f6537bcc",
+        "size": 16049,
+        "type": "index.json",
+        "uri": "root://eospublic.cern.ch//eos/opendata/cms/Run2010A/Mu/AOD/Apr21ReReco-v1/file-indexes/CMS_Run2010A_Mu_AOD_Apr21ReReco-v1_0016_file_index.json"
+      },
+      {
+        "checksum": "adler32:9e5878a1",
+        "size": 7381,
+        "type": "index.txt",
+        "uri": "root://eospublic.cern.ch//eos/opendata/cms/Run2010A/Mu/AOD/Apr21ReReco-v1/file-indexes/CMS_Run2010A_Mu_AOD_Apr21ReReco-v1_0016_file_index.txt"
+      },
+      {
+        "checksum": "adler32:e3a0a057",
+        "size": 1581,
+        "type": "index.json",
+        "uri": "root://eospublic.cern.ch//eos/opendata/cms/Run2010A/Mu/AOD/Apr21ReReco-v1/file-indexes/CMS_Run2010A_Mu_AOD_Apr21ReReco-v1_0017_file_index.json"
+      },
+      {
+        "checksum": "adler32:41a2d5c8",
+        "size": 726,
+        "type": "index.txt",
+        "uri": "root://eospublic.cern.ch//eos/opendata/cms/Run2010A/Mu/AOD/Apr21ReReco-v1/file-indexes/CMS_Run2010A_Mu_AOD_Apr21ReReco-v1_0017_file_index.txt"
+      },
+      {
+        "checksum": "adler32:00ddd601",
+        "size": 7630,
+        "type": "index.json",
+        "uri": "root://eospublic.cern.ch//eos/opendata/cms/Run2010A/Mu/AOD/Apr21ReReco-v1/file-indexes/CMS_Run2010A_Mu_AOD_Apr21ReReco-v1_0018_file_index.json"
+      },
+      {
+        "checksum": "adler32:7b4f06e6",
+        "size": 3509,
+        "type": "index.txt",
+        "uri": "root://eospublic.cern.ch//eos/opendata/cms/Run2010A/Mu/AOD/Apr21ReReco-v1/file-indexes/CMS_Run2010A_Mu_AOD_Apr21ReReco-v1_0018_file_index.txt"
+      },
+      {
+        "checksum": "adler32:9b80580e",
+        "size": 13942,
+        "type": "index.json",
+        "uri": "root://eospublic.cern.ch//eos/opendata/cms/Run2010A/Mu/AOD/Apr21ReReco-v1/file-indexes/CMS_Run2010A_Mu_AOD_Apr21ReReco-v1_0019_file_index.json"
+      },
+      {
+        "checksum": "adler32:72205ee2",
+        "size": 6413,
+        "type": "index.txt",
+        "uri": "root://eospublic.cern.ch//eos/opendata/cms/Run2010A/Mu/AOD/Apr21ReReco-v1/file-indexes/CMS_Run2010A_Mu_AOD_Apr21ReReco-v1_0019_file_index.txt"
+      },
+      {
+        "checksum": "adler32:a5b7e4f0",
+        "size": 1844,
+        "type": "index.json",
+        "uri": "root://eospublic.cern.ch//eos/opendata/cms/Run2010A/Mu/AOD/Apr21ReReco-v1/file-indexes/CMS_Run2010A_Mu_AOD_Apr21ReReco-v1_0020_file_index.json"
+      },
+      {
+        "checksum": "adler32:737bf882",
+        "size": 847,
+        "type": "index.txt",
+        "uri": "root://eospublic.cern.ch//eos/opendata/cms/Run2010A/Mu/AOD/Apr21ReReco-v1/file-indexes/CMS_Run2010A_Mu_AOD_Apr21ReReco-v1_0020_file_index.txt"
+      }
+    ],
     "license": {
       "attribution": "CC0"
     },
@@ -2979,6 +3565,272 @@
       "size": 4184825186174
     },
     "experiment": "CMS",
+    "files": [
+      {
+        "checksum": "adler32:e9a92f8a",
+        "size": 305983,
+        "type": "index.json",
+        "uri": "root://eospublic.cern.ch//eos/opendata/cms/Run2010A/MinimumBias/AOD/Apr21ReReco-v1/file-indexes/CMS_Run2010A_MinimumBias_AOD_Apr21ReReco-v1_0000_file_index.json"
+      },
+      {
+        "checksum": "adler32:a0ec502c",
+        "size": 145860,
+        "type": "index.txt",
+        "uri": "root://eospublic.cern.ch//eos/opendata/cms/Run2010A/MinimumBias/AOD/Apr21ReReco-v1/file-indexes/CMS_Run2010A_MinimumBias_AOD_Apr21ReReco-v1_0000_file_index.txt"
+      },
+      {
+        "checksum": "adler32:d6273373",
+        "size": 161506,
+        "type": "index.json",
+        "uri": "root://eospublic.cern.ch//eos/opendata/cms/Run2010A/MinimumBias/AOD/Apr21ReReco-v1/file-indexes/CMS_Run2010A_MinimumBias_AOD_Apr21ReReco-v1_0001_file_index.json"
+      },
+      {
+        "checksum": "adler32:6385452d",
+        "size": 76960,
+        "type": "index.txt",
+        "uri": "root://eospublic.cern.ch//eos/opendata/cms/Run2010A/MinimumBias/AOD/Apr21ReReco-v1/file-indexes/CMS_Run2010A_MinimumBias_AOD_Apr21ReReco-v1_0001_file_index.txt"
+      },
+      {
+        "checksum": "adler32:3ad91e4e",
+        "size": 4899,
+        "type": "index.json",
+        "uri": "root://eospublic.cern.ch//eos/opendata/cms/Run2010A/MinimumBias/AOD/Apr21ReReco-v1/file-indexes/CMS_Run2010A_MinimumBias_AOD_Apr21ReReco-v1_0002_file_index.json"
+      },
+      {
+        "checksum": "adler32:6c2bbf88",
+        "size": 2340,
+        "type": "index.txt",
+        "uri": "root://eospublic.cern.ch//eos/opendata/cms/Run2010A/MinimumBias/AOD/Apr21ReReco-v1/file-indexes/CMS_Run2010A_MinimumBias_AOD_Apr21ReReco-v1_0002_file_index.txt"
+      },
+      {
+        "checksum": "adler32:2d821f03",
+        "size": 6812,
+        "type": "index.json",
+        "uri": "root://eospublic.cern.ch//eos/opendata/cms/Run2010A/MinimumBias/AOD/Apr21ReReco-v1/file-indexes/CMS_Run2010A_MinimumBias_AOD_Apr21ReReco-v1_0003_file_index.json"
+      },
+      {
+        "checksum": "adler32:66a3d2cb",
+        "size": 3250,
+        "type": "index.txt",
+        "uri": "root://eospublic.cern.ch//eos/opendata/cms/Run2010A/MinimumBias/AOD/Apr21ReReco-v1/file-indexes/CMS_Run2010A_MinimumBias_AOD_Apr21ReReco-v1_0003_file_index.txt"
+      },
+      {
+        "checksum": "adler32:3ac96abd",
+        "size": 3267,
+        "type": "index.json",
+        "uri": "root://eospublic.cern.ch//eos/opendata/cms/Run2010A/MinimumBias/AOD/Apr21ReReco-v1/file-indexes/CMS_Run2010A_MinimumBias_AOD_Apr21ReReco-v1_0004_file_index.json"
+      },
+      {
+        "checksum": "adler32:9ff8d591",
+        "size": 1560,
+        "type": "index.txt",
+        "uri": "root://eospublic.cern.ch//eos/opendata/cms/Run2010A/MinimumBias/AOD/Apr21ReReco-v1/file-indexes/CMS_Run2010A_MinimumBias_AOD_Apr21ReReco-v1_0004_file_index.txt"
+      },
+      {
+        "checksum": "adler32:68026fa2",
+        "size": 63672,
+        "type": "index.json",
+        "uri": "root://eospublic.cern.ch//eos/opendata/cms/Run2010A/MinimumBias/AOD/Apr21ReReco-v1/file-indexes/CMS_Run2010A_MinimumBias_AOD_Apr21ReReco-v1_0005_file_index.json"
+      },
+      {
+        "checksum": "adler32:8302ba5b",
+        "size": 30420,
+        "type": "index.txt",
+        "uri": "root://eospublic.cern.ch//eos/opendata/cms/Run2010A/MinimumBias/AOD/Apr21ReReco-v1/file-indexes/CMS_Run2010A_MinimumBias_AOD_Apr21ReReco-v1_0005_file_index.txt"
+      },
+      {
+        "checksum": "adler32:c75dc051",
+        "size": 36181,
+        "type": "index.json",
+        "uri": "root://eospublic.cern.ch//eos/opendata/cms/Run2010A/MinimumBias/AOD/Apr21ReReco-v1/file-indexes/CMS_Run2010A_MinimumBias_AOD_Apr21ReReco-v1_0006_file_index.json"
+      },
+      {
+        "checksum": "adler32:26cc4e8c",
+        "size": 17290,
+        "type": "index.txt",
+        "uri": "root://eospublic.cern.ch//eos/opendata/cms/Run2010A/MinimumBias/AOD/Apr21ReReco-v1/file-indexes/CMS_Run2010A_MinimumBias_AOD_Apr21ReReco-v1_0006_file_index.txt"
+      },
+      {
+        "checksum": "adler32:ca32c19a",
+        "size": 23693,
+        "type": "index.json",
+        "uri": "root://eospublic.cern.ch//eos/opendata/cms/Run2010A/MinimumBias/AOD/Apr21ReReco-v1/file-indexes/CMS_Run2010A_MinimumBias_AOD_Apr21ReReco-v1_0007_file_index.json"
+      },
+      {
+        "checksum": "adler32:21004cf6",
+        "size": 11310,
+        "type": "index.txt",
+        "uri": "root://eospublic.cern.ch//eos/opendata/cms/Run2010A/MinimumBias/AOD/Apr21ReReco-v1/file-indexes/CMS_Run2010A_MinimumBias_AOD_Apr21ReReco-v1_0007_file_index.txt"
+      },
+      {
+        "checksum": "adler32:f43c17e7",
+        "size": 32643,
+        "type": "index.json",
+        "uri": "root://eospublic.cern.ch//eos/opendata/cms/Run2010A/MinimumBias/AOD/Apr21ReReco-v1/file-indexes/CMS_Run2010A_MinimumBias_AOD_Apr21ReReco-v1_0008_file_index.json"
+      },
+      {
+        "checksum": "adler32:008454db",
+        "size": 15600,
+        "type": "index.txt",
+        "uri": "root://eospublic.cern.ch//eos/opendata/cms/Run2010A/MinimumBias/AOD/Apr21ReReco-v1/file-indexes/CMS_Run2010A_MinimumBias_AOD_Apr21ReReco-v1_0008_file_index.txt"
+      },
+      {
+        "checksum": "adler32:b7ec32e5",
+        "size": 21219,
+        "type": "index.json",
+        "uri": "root://eospublic.cern.ch//eos/opendata/cms/Run2010A/MinimumBias/AOD/Apr21ReReco-v1/file-indexes/CMS_Run2010A_MinimumBias_AOD_Apr21ReReco-v1_0009_file_index.json"
+      },
+      {
+        "checksum": "adler32:50bdee6d",
+        "size": 10140,
+        "type": "index.txt",
+        "uri": "root://eospublic.cern.ch//eos/opendata/cms/Run2010A/MinimumBias/AOD/Apr21ReReco-v1/file-indexes/CMS_Run2010A_MinimumBias_AOD_Apr21ReReco-v1_0009_file_index.txt"
+      },
+      {
+        "checksum": "adler32:c32c8b30",
+        "size": 43552,
+        "type": "index.json",
+        "uri": "root://eospublic.cern.ch//eos/opendata/cms/Run2010A/MinimumBias/AOD/Apr21ReReco-v1/file-indexes/CMS_Run2010A_MinimumBias_AOD_Apr21ReReco-v1_0010_file_index.json"
+      },
+      {
+        "checksum": "adler32:16157635",
+        "size": 20800,
+        "type": "index.txt",
+        "uri": "root://eospublic.cern.ch//eos/opendata/cms/Run2010A/MinimumBias/AOD/Apr21ReReco-v1/file-indexes/CMS_Run2010A_MinimumBias_AOD_Apr21ReReco-v1_0010_file_index.txt"
+      },
+      {
+        "checksum": "adler32:751f499a",
+        "size": 63653,
+        "type": "index.json",
+        "uri": "root://eospublic.cern.ch//eos/opendata/cms/Run2010A/MinimumBias/AOD/Apr21ReReco-v1/file-indexes/CMS_Run2010A_MinimumBias_AOD_Apr21ReReco-v1_0011_file_index.json"
+      },
+      {
+        "checksum": "adler32:be91a7ac",
+        "size": 30420,
+        "type": "index.txt",
+        "uri": "root://eospublic.cern.ch//eos/opendata/cms/Run2010A/MinimumBias/AOD/Apr21ReReco-v1/file-indexes/CMS_Run2010A_MinimumBias_AOD_Apr21ReReco-v1_0011_file_index.txt"
+      },
+      {
+        "checksum": "adler32:9a30d788",
+        "size": 31557,
+        "type": "index.json",
+        "uri": "root://eospublic.cern.ch//eos/opendata/cms/Run2010A/MinimumBias/AOD/Apr21ReReco-v1/file-indexes/CMS_Run2010A_MinimumBias_AOD_Apr21ReReco-v1_0012_file_index.json"
+      },
+      {
+        "checksum": "adler32:63e9a9e9",
+        "size": 15080,
+        "type": "index.txt",
+        "uri": "root://eospublic.cern.ch//eos/opendata/cms/Run2010A/MinimumBias/AOD/Apr21ReReco-v1/file-indexes/CMS_Run2010A_MinimumBias_AOD_Apr21ReReco-v1_0012_file_index.txt"
+      },
+      {
+        "checksum": "adler32:07cc647f",
+        "size": 19604,
+        "type": "index.json",
+        "uri": "root://eospublic.cern.ch//eos/opendata/cms/Run2010A/MinimumBias/AOD/Apr21ReReco-v1/file-indexes/CMS_Run2010A_MinimumBias_AOD_Apr21ReReco-v1_0013_file_index.json"
+      },
+      {
+        "checksum": "adler32:8c55f61b",
+        "size": 9360,
+        "type": "index.txt",
+        "uri": "root://eospublic.cern.ch//eos/opendata/cms/Run2010A/MinimumBias/AOD/Apr21ReReco-v1/file-indexes/CMS_Run2010A_MinimumBias_AOD_Apr21ReReco-v1_0013_file_index.txt"
+      },
+      {
+        "checksum": "adler32:c9f37759",
+        "size": 30212,
+        "type": "index.json",
+        "uri": "root://eospublic.cern.ch//eos/opendata/cms/Run2010A/MinimumBias/AOD/Apr21ReReco-v1/file-indexes/CMS_Run2010A_MinimumBias_AOD_Apr21ReReco-v1_0014_file_index.json"
+      },
+      {
+        "checksum": "adler32:0941ead4",
+        "size": 14430,
+        "type": "index.txt",
+        "uri": "root://eospublic.cern.ch//eos/opendata/cms/Run2010A/MinimumBias/AOD/Apr21ReReco-v1/file-indexes/CMS_Run2010A_MinimumBias_AOD_Apr21ReReco-v1_0014_file_index.txt"
+      },
+      {
+        "checksum": "adler32:71f77be6",
+        "size": 79155,
+        "type": "index.json",
+        "uri": "root://eospublic.cern.ch//eos/opendata/cms/Run2010A/MinimumBias/AOD/Apr21ReReco-v1/file-indexes/CMS_Run2010A_MinimumBias_AOD_Apr21ReReco-v1_0015_file_index.json"
+      },
+      {
+        "checksum": "adler32:e5465c30",
+        "size": 37830,
+        "type": "index.txt",
+        "uri": "root://eospublic.cern.ch//eos/opendata/cms/Run2010A/MinimumBias/AOD/Apr21ReReco-v1/file-indexes/CMS_Run2010A_MinimumBias_AOD_Apr21ReReco-v1_0015_file_index.txt"
+      },
+      {
+        "checksum": "adler32:3ec4f9bd",
+        "size": 18229,
+        "type": "index.json",
+        "uri": "root://eospublic.cern.ch//eos/opendata/cms/Run2010A/MinimumBias/AOD/Apr21ReReco-v1/file-indexes/CMS_Run2010A_MinimumBias_AOD_Apr21ReReco-v1_0016_file_index.json"
+      },
+      {
+        "checksum": "adler32:5ef1366a",
+        "size": 8710,
+        "type": "index.txt",
+        "uri": "root://eospublic.cern.ch//eos/opendata/cms/Run2010A/MinimumBias/AOD/Apr21ReReco-v1/file-indexes/CMS_Run2010A_MinimumBias_AOD_Apr21ReReco-v1_0016_file_index.txt"
+      },
+      {
+        "checksum": "adler32:ac911da3",
+        "size": 21222,
+        "type": "index.json",
+        "uri": "root://eospublic.cern.ch//eos/opendata/cms/Run2010A/MinimumBias/AOD/Apr21ReReco-v1/file-indexes/CMS_Run2010A_MinimumBias_AOD_Apr21ReReco-v1_0017_file_index.json"
+      },
+      {
+        "checksum": "adler32:e963e4ee",
+        "size": 10140,
+        "type": "index.txt",
+        "uri": "root://eospublic.cern.ch//eos/opendata/cms/Run2010A/MinimumBias/AOD/Apr21ReReco-v1/file-indexes/CMS_Run2010A_MinimumBias_AOD_Apr21ReReco-v1_0017_file_index.txt"
+      },
+      {
+        "checksum": "adler32:4c93a50c",
+        "size": 25571,
+        "type": "index.json",
+        "uri": "root://eospublic.cern.ch//eos/opendata/cms/Run2010A/MinimumBias/AOD/Apr21ReReco-v1/file-indexes/CMS_Run2010A_MinimumBias_AOD_Apr21ReReco-v1_0018_file_index.json"
+      },
+      {
+        "checksum": "adler32:ca6454e9",
+        "size": 12220,
+        "type": "index.txt",
+        "uri": "root://eospublic.cern.ch//eos/opendata/cms/Run2010A/MinimumBias/AOD/Apr21ReReco-v1/file-indexes/CMS_Run2010A_MinimumBias_AOD_Apr21ReReco-v1_0018_file_index.txt"
+      },
+      {
+        "checksum": "adler32:a77dda6b",
+        "size": 15235,
+        "type": "index.json",
+        "uri": "root://eospublic.cern.ch//eos/opendata/cms/Run2010A/MinimumBias/AOD/Apr21ReReco-v1/file-indexes/CMS_Run2010A_MinimumBias_AOD_Apr21ReReco-v1_0019_file_index.json"
+      },
+      {
+        "checksum": "adler32:c6b78922",
+        "size": 7280,
+        "type": "index.txt",
+        "uri": "root://eospublic.cern.ch//eos/opendata/cms/Run2010A/MinimumBias/AOD/Apr21ReReco-v1/file-indexes/CMS_Run2010A_MinimumBias_AOD_Apr21ReReco-v1_0019_file_index.txt"
+      },
+      {
+        "checksum": "adler32:d009605e",
+        "size": 23395,
+        "type": "index.json",
+        "uri": "root://eospublic.cern.ch//eos/opendata/cms/Run2010A/MinimumBias/AOD/Apr21ReReco-v1/file-indexes/CMS_Run2010A_MinimumBias_AOD_Apr21ReReco-v1_0020_file_index.json"
+      },
+      {
+        "checksum": "adler32:29b61b4a",
+        "size": 11180,
+        "type": "index.txt",
+        "uri": "root://eospublic.cern.ch//eos/opendata/cms/Run2010A/MinimumBias/AOD/Apr21ReReco-v1/file-indexes/CMS_Run2010A_MinimumBias_AOD_Apr21ReReco-v1_0020_file_index.txt"
+      },
+      {
+        "checksum": "adler32:8e0bb0c6",
+        "size": 3539,
+        "type": "index.json",
+        "uri": "root://eospublic.cern.ch//eos/opendata/cms/Run2010A/MinimumBias/AOD/Apr21ReReco-v1/file-indexes/CMS_Run2010A_MinimumBias_AOD_Apr21ReReco-v1_0021_file_index.json"
+      },
+      {
+        "checksum": "adler32:ce12fb5b",
+        "size": 1690,
+        "type": "index.txt",
+        "uri": "root://eospublic.cern.ch//eos/opendata/cms/Run2010A/MinimumBias/AOD/Apr21ReReco-v1/file-indexes/CMS_Run2010A_MinimumBias_AOD_Apr21ReReco-v1_0021_file_index.txt"
+      }
+    ],
     "license": {
       "attribution": "CC0"
     },
@@ -3075,6 +3927,200 @@
       "size": 1617738934008
     },
     "experiment": "CMS",
+    "files": [
+      {
+        "checksum": "adler32:60b50b8c",
+        "size": 202243,
+        "type": "index.json",
+        "uri": "root://eospublic.cern.ch//eos/opendata/cms/Run2010A/JetMETTauMonitor/AOD/Apr21ReReco-v1/file-indexes/CMS_Run2010A_JetMETTauMonitor_AOD_Apr21ReReco-v1_0000_file_index.json"
+      },
+      {
+        "checksum": "adler32:c3761574",
+        "size": 98280,
+        "type": "index.txt",
+        "uri": "root://eospublic.cern.ch//eos/opendata/cms/Run2010A/JetMETTauMonitor/AOD/Apr21ReReco-v1/file-indexes/CMS_Run2010A_JetMETTauMonitor_AOD_Apr21ReReco-v1_0000_file_index.txt"
+      },
+      {
+        "checksum": "adler32:e89109be",
+        "size": 1942,
+        "type": "index.json",
+        "uri": "root://eospublic.cern.ch//eos/opendata/cms/Run2010A/JetMETTauMonitor/AOD/Apr21ReReco-v1/file-indexes/CMS_Run2010A_JetMETTauMonitor_AOD_Apr21ReReco-v1_0001_file_index.json"
+      },
+      {
+        "checksum": "adler32:388e1dc8",
+        "size": 945,
+        "type": "index.txt",
+        "uri": "root://eospublic.cern.ch//eos/opendata/cms/Run2010A/JetMETTauMonitor/AOD/Apr21ReReco-v1/file-indexes/CMS_Run2010A_JetMETTauMonitor_AOD_Apr21ReReco-v1_0001_file_index.txt"
+      },
+      {
+        "checksum": "adler32:62e18ab7",
+        "size": 5266,
+        "type": "index.json",
+        "uri": "root://eospublic.cern.ch//eos/opendata/cms/Run2010A/JetMETTauMonitor/AOD/Apr21ReReco-v1/file-indexes/CMS_Run2010A_JetMETTauMonitor_AOD_Apr21ReReco-v1_0002_file_index.json"
+      },
+      {
+        "checksum": "adler32:0128089b",
+        "size": 2565,
+        "type": "index.txt",
+        "uri": "root://eospublic.cern.ch//eos/opendata/cms/Run2010A/JetMETTauMonitor/AOD/Apr21ReReco-v1/file-indexes/CMS_Run2010A_JetMETTauMonitor_AOD_Apr21ReReco-v1_0002_file_index.txt"
+      },
+      {
+        "checksum": "adler32:e69134e8",
+        "size": 3055,
+        "type": "index.json",
+        "uri": "root://eospublic.cern.ch//eos/opendata/cms/Run2010A/JetMETTauMonitor/AOD/Apr21ReReco-v1/file-indexes/CMS_Run2010A_JetMETTauMonitor_AOD_Apr21ReReco-v1_0004_file_index.json"
+      },
+      {
+        "checksum": "adler32:ba5ac189",
+        "size": 1485,
+        "type": "index.txt",
+        "uri": "root://eospublic.cern.ch//eos/opendata/cms/Run2010A/JetMETTauMonitor/AOD/Apr21ReReco-v1/file-indexes/CMS_Run2010A_JetMETTauMonitor_AOD_Apr21ReReco-v1_0004_file_index.txt"
+      },
+      {
+        "checksum": "adler32:96c7c02e",
+        "size": 1667,
+        "type": "index.json",
+        "uri": "root://eospublic.cern.ch//eos/opendata/cms/Run2010A/JetMETTauMonitor/AOD/Apr21ReReco-v1/file-indexes/CMS_Run2010A_JetMETTauMonitor_AOD_Apr21ReReco-v1_0005_file_index.json"
+      },
+      {
+        "checksum": "adler32:1ffcf588",
+        "size": 810,
+        "type": "index.txt",
+        "uri": "root://eospublic.cern.ch//eos/opendata/cms/Run2010A/JetMETTauMonitor/AOD/Apr21ReReco-v1/file-indexes/CMS_Run2010A_JetMETTauMonitor_AOD_Apr21ReReco-v1_0005_file_index.txt"
+      },
+      {
+        "checksum": "adler32:fa62e081",
+        "size": 837,
+        "type": "index.json",
+        "uri": "root://eospublic.cern.ch//eos/opendata/cms/Run2010A/JetMETTauMonitor/AOD/Apr21ReReco-v1/file-indexes/CMS_Run2010A_JetMETTauMonitor_AOD_Apr21ReReco-v1_0006_file_index.json"
+      },
+      {
+        "checksum": "adler32:47af7a98",
+        "size": 405,
+        "type": "index.txt",
+        "uri": "root://eospublic.cern.ch//eos/opendata/cms/Run2010A/JetMETTauMonitor/AOD/Apr21ReReco-v1/file-indexes/CMS_Run2010A_JetMETTauMonitor_AOD_Apr21ReReco-v1_0006_file_index.txt"
+      },
+      {
+        "checksum": "adler32:7b9fa409",
+        "size": 4445,
+        "type": "index.json",
+        "uri": "root://eospublic.cern.ch//eos/opendata/cms/Run2010A/JetMETTauMonitor/AOD/Apr21ReReco-v1/file-indexes/CMS_Run2010A_JetMETTauMonitor_AOD_Apr21ReReco-v1_0010_file_index.json"
+      },
+      {
+        "checksum": "adler32:feb08b59",
+        "size": 2160,
+        "type": "index.txt",
+        "uri": "root://eospublic.cern.ch//eos/opendata/cms/Run2010A/JetMETTauMonitor/AOD/Apr21ReReco-v1/file-indexes/CMS_Run2010A_JetMETTauMonitor_AOD_Apr21ReReco-v1_0010_file_index.txt"
+      },
+      {
+        "checksum": "adler32:980362f9",
+        "size": 14716,
+        "type": "index.json",
+        "uri": "root://eospublic.cern.ch//eos/opendata/cms/Run2010A/JetMETTauMonitor/AOD/Apr21ReReco-v1/file-indexes/CMS_Run2010A_JetMETTauMonitor_AOD_Apr21ReReco-v1_0011_file_index.json"
+      },
+      {
+        "checksum": "adler32:c8ec7092",
+        "size": 7155,
+        "type": "index.txt",
+        "uri": "root://eospublic.cern.ch//eos/opendata/cms/Run2010A/JetMETTauMonitor/AOD/Apr21ReReco-v1/file-indexes/CMS_Run2010A_JetMETTauMonitor_AOD_Apr21ReReco-v1_0011_file_index.txt"
+      },
+      {
+        "checksum": "adler32:c661ea59",
+        "size": 11361,
+        "type": "index.json",
+        "uri": "root://eospublic.cern.ch//eos/opendata/cms/Run2010A/JetMETTauMonitor/AOD/Apr21ReReco-v1/file-indexes/CMS_Run2010A_JetMETTauMonitor_AOD_Apr21ReReco-v1_0012_file_index.json"
+      },
+      {
+        "checksum": "adler32:e94a877d",
+        "size": 5535,
+        "type": "index.txt",
+        "uri": "root://eospublic.cern.ch//eos/opendata/cms/Run2010A/JetMETTauMonitor/AOD/Apr21ReReco-v1/file-indexes/CMS_Run2010A_JetMETTauMonitor_AOD_Apr21ReReco-v1_0012_file_index.txt"
+      },
+      {
+        "checksum": "adler32:b8183329",
+        "size": 3054,
+        "type": "index.json",
+        "uri": "root://eospublic.cern.ch//eos/opendata/cms/Run2010A/JetMETTauMonitor/AOD/Apr21ReReco-v1/file-indexes/CMS_Run2010A_JetMETTauMonitor_AOD_Apr21ReReco-v1_0013_file_index.json"
+      },
+      {
+        "checksum": "adler32:c275c09c",
+        "size": 1485,
+        "type": "index.txt",
+        "uri": "root://eospublic.cern.ch//eos/opendata/cms/Run2010A/JetMETTauMonitor/AOD/Apr21ReReco-v1/file-indexes/CMS_Run2010A_JetMETTauMonitor_AOD_Apr21ReReco-v1_0013_file_index.txt"
+      },
+      {
+        "checksum": "adler32:5f96521b",
+        "size": 2221,
+        "type": "index.json",
+        "uri": "root://eospublic.cern.ch//eos/opendata/cms/Run2010A/JetMETTauMonitor/AOD/Apr21ReReco-v1/file-indexes/CMS_Run2010A_JetMETTauMonitor_AOD_Apr21ReReco-v1_0014_file_index.json"
+      },
+      {
+        "checksum": "adler32:1107460b",
+        "size": 1080,
+        "type": "index.txt",
+        "uri": "root://eospublic.cern.ch//eos/opendata/cms/Run2010A/JetMETTauMonitor/AOD/Apr21ReReco-v1/file-indexes/CMS_Run2010A_JetMETTauMonitor_AOD_Apr21ReReco-v1_0014_file_index.txt"
+      },
+      {
+        "checksum": "adler32:37b51395",
+        "size": 3890,
+        "type": "index.json",
+        "uri": "root://eospublic.cern.ch//eos/opendata/cms/Run2010A/JetMETTauMonitor/AOD/Apr21ReReco-v1/file-indexes/CMS_Run2010A_JetMETTauMonitor_AOD_Apr21ReReco-v1_0015_file_index.json"
+      },
+      {
+        "checksum": "adler32:91d93b5d",
+        "size": 1890,
+        "type": "index.txt",
+        "uri": "root://eospublic.cern.ch//eos/opendata/cms/Run2010A/JetMETTauMonitor/AOD/Apr21ReReco-v1/file-indexes/CMS_Run2010A_JetMETTauMonitor_AOD_Apr21ReReco-v1_0015_file_index.txt"
+      },
+      {
+        "checksum": "adler32:079212d2",
+        "size": 3888,
+        "type": "index.json",
+        "uri": "root://eospublic.cern.ch//eos/opendata/cms/Run2010A/JetMETTauMonitor/AOD/Apr21ReReco-v1/file-indexes/CMS_Run2010A_JetMETTauMonitor_AOD_Apr21ReReco-v1_0016_file_index.json"
+      },
+      {
+        "checksum": "adler32:a9053b10",
+        "size": 1890,
+        "type": "index.txt",
+        "uri": "root://eospublic.cern.ch//eos/opendata/cms/Run2010A/JetMETTauMonitor/AOD/Apr21ReReco-v1/file-indexes/CMS_Run2010A_JetMETTauMonitor_AOD_Apr21ReReco-v1_0016_file_index.txt"
+      },
+      {
+        "checksum": "adler32:b0ed1124",
+        "size": 3881,
+        "type": "index.json",
+        "uri": "root://eospublic.cern.ch//eos/opendata/cms/Run2010A/JetMETTauMonitor/AOD/Apr21ReReco-v1/file-indexes/CMS_Run2010A_JetMETTauMonitor_AOD_Apr21ReReco-v1_0017_file_index.json"
+      },
+      {
+        "checksum": "adler32:19b73aef",
+        "size": 1890,
+        "type": "index.txt",
+        "uri": "root://eospublic.cern.ch//eos/opendata/cms/Run2010A/JetMETTauMonitor/AOD/Apr21ReReco-v1/file-indexes/CMS_Run2010A_JetMETTauMonitor_AOD_Apr21ReReco-v1_0017_file_index.txt"
+      },
+      {
+        "checksum": "adler32:0ad90958",
+        "size": 1947,
+        "type": "index.json",
+        "uri": "root://eospublic.cern.ch//eos/opendata/cms/Run2010A/JetMETTauMonitor/AOD/Apr21ReReco-v1/file-indexes/CMS_Run2010A_JetMETTauMonitor_AOD_Apr21ReReco-v1_0018_file_index.json"
+      },
+      {
+        "checksum": "adler32:acd11d03",
+        "size": 945,
+        "type": "index.txt",
+        "uri": "root://eospublic.cern.ch//eos/opendata/cms/Run2010A/JetMETTauMonitor/AOD/Apr21ReReco-v1/file-indexes/CMS_Run2010A_JetMETTauMonitor_AOD_Apr21ReReco-v1_0018_file_index.txt"
+      },
+      {
+        "checksum": "adler32:bec64b37",
+        "size": 280,
+        "type": "index.json",
+        "uri": "root://eospublic.cern.ch//eos/opendata/cms/Run2010A/JetMETTauMonitor/AOD/Apr21ReReco-v1/file-indexes/CMS_Run2010A_JetMETTauMonitor_AOD_Apr21ReReco-v1_0019_file_index.json"
+      },
+      {
+        "checksum": "adler32:e91b28db",
+        "size": 135,
+        "type": "index.txt",
+        "uri": "root://eospublic.cern.ch//eos/opendata/cms/Run2010A/JetMETTauMonitor/AOD/Apr21ReReco-v1/file-indexes/CMS_Run2010A_JetMETTauMonitor_AOD_Apr21ReReco-v1_0019_file_index.txt"
+      }
+    ],
     "license": {
       "attribution": "CC0"
     },
@@ -3171,6 +4217,152 @@
       "size": 1023722573699
     },
     "experiment": "CMS",
+    "files": [
+      {
+        "checksum": "adler32:f89c9f08",
+        "size": 117523,
+        "type": "index.json",
+        "uri": "root://eospublic.cern.ch//eos/opendata/cms/Run2010A/JetMETTau/AOD/Apr21ReReco-v1/file-indexes/CMS_Run2010A_JetMETTau_AOD_Apr21ReReco-v1_0000_file_index.json"
+      },
+      {
+        "checksum": "adler32:46f1599d",
+        "size": 55552,
+        "type": "index.txt",
+        "uri": "root://eospublic.cern.ch//eos/opendata/cms/Run2010A/JetMETTau/AOD/Apr21ReReco-v1/file-indexes/CMS_Run2010A_JetMETTau_AOD_Apr21ReReco-v1_0000_file_index.txt"
+      },
+      {
+        "checksum": "adler32:e8967991",
+        "size": 4323,
+        "type": "index.json",
+        "uri": "root://eospublic.cern.ch//eos/opendata/cms/Run2010A/JetMETTau/AOD/Apr21ReReco-v1/file-indexes/CMS_Run2010A_JetMETTau_AOD_Apr21ReReco-v1_0001_file_index.json"
+      },
+      {
+        "checksum": "adler32:f7c55f39",
+        "size": 2048,
+        "type": "index.txt",
+        "uri": "root://eospublic.cern.ch//eos/opendata/cms/Run2010A/JetMETTau/AOD/Apr21ReReco-v1/file-indexes/CMS_Run2010A_JetMETTau_AOD_Apr21ReReco-v1_0001_file_index.txt"
+      },
+      {
+        "checksum": "adler32:d020f641",
+        "size": 1893,
+        "type": "index.json",
+        "uri": "root://eospublic.cern.ch//eos/opendata/cms/Run2010A/JetMETTau/AOD/Apr21ReReco-v1/file-indexes/CMS_Run2010A_JetMETTau_AOD_Apr21ReReco-v1_0002_file_index.json"
+      },
+      {
+        "checksum": "adler32:7c0a09b8",
+        "size": 896,
+        "type": "index.txt",
+        "uri": "root://eospublic.cern.ch//eos/opendata/cms/Run2010A/JetMETTau/AOD/Apr21ReReco-v1/file-indexes/CMS_Run2010A_JetMETTau_AOD_Apr21ReReco-v1_0002_file_index.txt"
+      },
+      {
+        "checksum": "adler32:aac81f55",
+        "size": 1083,
+        "type": "index.json",
+        "uri": "root://eospublic.cern.ch//eos/opendata/cms/Run2010A/JetMETTau/AOD/Apr21ReReco-v1/file-indexes/CMS_Run2010A_JetMETTau_AOD_Apr21ReReco-v1_0003_file_index.json"
+      },
+      {
+        "checksum": "adler32:1b829814",
+        "size": 512,
+        "type": "index.txt",
+        "uri": "root://eospublic.cern.ch//eos/opendata/cms/Run2010A/JetMETTau/AOD/Apr21ReReco-v1/file-indexes/CMS_Run2010A_JetMETTau_AOD_Apr21ReReco-v1_0003_file_index.txt"
+      },
+      {
+        "checksum": "adler32:78bf4073",
+        "size": 2163,
+        "type": "index.json",
+        "uri": "root://eospublic.cern.ch//eos/opendata/cms/Run2010A/JetMETTau/AOD/Apr21ReReco-v1/file-indexes/CMS_Run2010A_JetMETTau_AOD_Apr21ReReco-v1_0004_file_index.json"
+      },
+      {
+        "checksum": "adler32:5dd730ad",
+        "size": 1024,
+        "type": "index.txt",
+        "uri": "root://eospublic.cern.ch//eos/opendata/cms/Run2010A/JetMETTau/AOD/Apr21ReReco-v1/file-indexes/CMS_Run2010A_JetMETTau_AOD_Apr21ReReco-v1_0004_file_index.txt"
+      },
+      {
+        "checksum": "adler32:24611e65",
+        "size": 1085,
+        "type": "index.json",
+        "uri": "root://eospublic.cern.ch//eos/opendata/cms/Run2010A/JetMETTau/AOD/Apr21ReReco-v1/file-indexes/CMS_Run2010A_JetMETTau_AOD_Apr21ReReco-v1_0005_file_index.json"
+      },
+      {
+        "checksum": "adler32:e0fe97ac",
+        "size": 512,
+        "type": "index.txt",
+        "uri": "root://eospublic.cern.ch//eos/opendata/cms/Run2010A/JetMETTau/AOD/Apr21ReReco-v1/file-indexes/CMS_Run2010A_JetMETTau_AOD_Apr21ReReco-v1_0005_file_index.txt"
+      },
+      {
+        "checksum": "adler32:a94013dd",
+        "size": 2973,
+        "type": "index.json",
+        "uri": "root://eospublic.cern.ch//eos/opendata/cms/Run2010A/JetMETTau/AOD/Apr21ReReco-v1/file-indexes/CMS_Run2010A_JetMETTau_AOD_Apr21ReReco-v1_0006_file_index.json"
+      },
+      {
+        "checksum": "adler32:70bba18f",
+        "size": 1408,
+        "type": "index.txt",
+        "uri": "root://eospublic.cern.ch//eos/opendata/cms/Run2010A/JetMETTau/AOD/Apr21ReReco-v1/file-indexes/CMS_Run2010A_JetMETTau_AOD_Apr21ReReco-v1_0006_file_index.txt"
+      },
+      {
+        "checksum": "adler32:ff28ad9b",
+        "size": 1623,
+        "type": "index.json",
+        "uri": "root://eospublic.cern.ch//eos/opendata/cms/Run2010A/JetMETTau/AOD/Apr21ReReco-v1/file-indexes/CMS_Run2010A_JetMETTau_AOD_Apr21ReReco-v1_0007_file_index.json"
+      },
+      {
+        "checksum": "adler32:bef5e37c",
+        "size": 768,
+        "type": "index.txt",
+        "uri": "root://eospublic.cern.ch//eos/opendata/cms/Run2010A/JetMETTau/AOD/Apr21ReReco-v1/file-indexes/CMS_Run2010A_JetMETTau_AOD_Apr21ReReco-v1_0007_file_index.txt"
+      },
+      {
+        "checksum": "adler32:0daeaf1c",
+        "size": 1623,
+        "type": "index.json",
+        "uri": "root://eospublic.cern.ch//eos/opendata/cms/Run2010A/JetMETTau/AOD/Apr21ReReco-v1/file-indexes/CMS_Run2010A_JetMETTau_AOD_Apr21ReReco-v1_0008_file_index.json"
+      },
+      {
+        "checksum": "adler32:7a6ce3a7",
+        "size": 768,
+        "type": "index.txt",
+        "uri": "root://eospublic.cern.ch//eos/opendata/cms/Run2010A/JetMETTau/AOD/Apr21ReReco-v1/file-indexes/CMS_Run2010A_JetMETTau_AOD_Apr21ReReco-v1_0008_file_index.txt"
+      },
+      {
+        "checksum": "adler32:965eccbc",
+        "size": 2707,
+        "type": "index.json",
+        "uri": "root://eospublic.cern.ch//eos/opendata/cms/Run2010A/JetMETTau/AOD/Apr21ReReco-v1/file-indexes/CMS_Run2010A_JetMETTau_AOD_Apr21ReReco-v1_0010_file_index.json"
+      },
+      {
+        "checksum": "adler32:ec537b18",
+        "size": 1280,
+        "type": "index.txt",
+        "uri": "root://eospublic.cern.ch//eos/opendata/cms/Run2010A/JetMETTau/AOD/Apr21ReReco-v1/file-indexes/CMS_Run2010A_JetMETTau_AOD_Apr21ReReco-v1_0010_file_index.txt"
+      },
+      {
+        "checksum": "adler32:af6acc60",
+        "size": 2703,
+        "type": "index.json",
+        "uri": "root://eospublic.cern.ch//eos/opendata/cms/Run2010A/JetMETTau/AOD/Apr21ReReco-v1/file-indexes/CMS_Run2010A_JetMETTau_AOD_Apr21ReReco-v1_0011_file_index.json"
+      },
+      {
+        "checksum": "adler32:3c0e7aa6",
+        "size": 1280,
+        "type": "index.txt",
+        "uri": "root://eospublic.cern.ch//eos/opendata/cms/Run2010A/JetMETTau/AOD/Apr21ReReco-v1/file-indexes/CMS_Run2010A_JetMETTau_AOD_Apr21ReReco-v1_0011_file_index.txt"
+      },
+      {
+        "checksum": "adler32:e551a09e",
+        "size": 3513,
+        "type": "index.json",
+        "uri": "root://eospublic.cern.ch//eos/opendata/cms/Run2010A/JetMETTau/AOD/Apr21ReReco-v1/file-indexes/CMS_Run2010A_JetMETTau_AOD_Apr21ReReco-v1_0013_file_index.json"
+      },
+      {
+        "checksum": "adler32:8305eca6",
+        "size": 1664,
+        "type": "index.txt",
+        "uri": "root://eospublic.cern.ch//eos/opendata/cms/Run2010A/JetMETTau/AOD/Apr21ReReco-v1/file-indexes/CMS_Run2010A_JetMETTau_AOD_Apr21ReReco-v1_0013_file_index.txt"
+      }
+    ],
     "license": {
       "attribution": "CC0"
     },
@@ -3267,6 +4459,92 @@
       "size": 2299653921999
     },
     "experiment": "CMS",
+    "files": [
+      {
+        "checksum": "adler32:28affa83",
+        "size": 125554,
+        "type": "index.json",
+        "uri": "root://eospublic.cern.ch//eos/opendata/cms/Run2010A/JetMET/AOD/Apr21ReReco-v1/file-indexes/CMS_Run2010A_JetMET_AOD_Apr21ReReco-v1_0000_file_index.json"
+      },
+      {
+        "checksum": "adler32:2d3c442c",
+        "size": 58625,
+        "type": "index.txt",
+        "uri": "root://eospublic.cern.ch//eos/opendata/cms/Run2010A/JetMET/AOD/Apr21ReReco-v1/file-indexes/CMS_Run2010A_JetMET_AOD_Apr21ReReco-v1_0000_file_index.txt"
+      },
+      {
+        "checksum": "adler32:b2bcfd80",
+        "size": 90533,
+        "type": "index.json",
+        "uri": "root://eospublic.cern.ch//eos/opendata/cms/Run2010A/JetMET/AOD/Apr21ReReco-v1/file-indexes/CMS_Run2010A_JetMET_AOD_Apr21ReReco-v1_0001_file_index.json"
+      },
+      {
+        "checksum": "adler32:383f9327",
+        "size": 42375,
+        "type": "index.txt",
+        "uri": "root://eospublic.cern.ch//eos/opendata/cms/Run2010A/JetMET/AOD/Apr21ReReco-v1/file-indexes/CMS_Run2010A_JetMET_AOD_Apr21ReReco-v1_0001_file_index.txt"
+      },
+      {
+        "checksum": "adler32:b2becb62",
+        "size": 159483,
+        "type": "index.json",
+        "uri": "root://eospublic.cern.ch//eos/opendata/cms/Run2010A/JetMET/AOD/Apr21ReReco-v1/file-indexes/CMS_Run2010A_JetMET_AOD_Apr21ReReco-v1_0002_file_index.json"
+      },
+      {
+        "checksum": "adler32:1ffc8b77",
+        "size": 74625,
+        "type": "index.txt",
+        "uri": "root://eospublic.cern.ch//eos/opendata/cms/Run2010A/JetMET/AOD/Apr21ReReco-v1/file-indexes/CMS_Run2010A_JetMET_AOD_Apr21ReReco-v1_0002_file_index.txt"
+      },
+      {
+        "checksum": "adler32:776e5e1e",
+        "size": 64619,
+        "type": "index.json",
+        "uri": "root://eospublic.cern.ch//eos/opendata/cms/Run2010A/JetMET/AOD/Apr21ReReco-v1/file-indexes/CMS_Run2010A_JetMET_AOD_Apr21ReReco-v1_0003_file_index.json"
+      },
+      {
+        "checksum": "adler32:c6aeac3f",
+        "size": 30250,
+        "type": "index.txt",
+        "uri": "root://eospublic.cern.ch//eos/opendata/cms/Run2010A/JetMET/AOD/Apr21ReReco-v1/file-indexes/CMS_Run2010A_JetMET_AOD_Apr21ReReco-v1_0003_file_index.txt"
+      },
+      {
+        "checksum": "adler32:04e8995c",
+        "size": 47285,
+        "type": "index.json",
+        "uri": "root://eospublic.cern.ch//eos/opendata/cms/Run2010A/JetMET/AOD/Apr21ReReco-v1/file-indexes/CMS_Run2010A_JetMET_AOD_Apr21ReReco-v1_0004_file_index.json"
+      },
+      {
+        "checksum": "adler32:aeab6370",
+        "size": 22125,
+        "type": "index.txt",
+        "uri": "root://eospublic.cern.ch//eos/opendata/cms/Run2010A/JetMET/AOD/Apr21ReReco-v1/file-indexes/CMS_Run2010A_JetMET_AOD_Apr21ReReco-v1_0004_file_index.txt"
+      },
+      {
+        "checksum": "adler32:07be9ace",
+        "size": 38495,
+        "type": "index.json",
+        "uri": "root://eospublic.cern.ch//eos/opendata/cms/Run2010A/JetMET/AOD/Apr21ReReco-v1/file-indexes/CMS_Run2010A_JetMET_AOD_Apr21ReReco-v1_0005_file_index.json"
+      },
+      {
+        "checksum": "adler32:6b29ac92",
+        "size": 18000,
+        "type": "index.txt",
+        "uri": "root://eospublic.cern.ch//eos/opendata/cms/Run2010A/JetMET/AOD/Apr21ReReco-v1/file-indexes/CMS_Run2010A_JetMET_AOD_Apr21ReReco-v1_0005_file_index.txt"
+      },
+      {
+        "checksum": "adler32:d888fd6f",
+        "size": 21391,
+        "type": "index.json",
+        "uri": "root://eospublic.cern.ch//eos/opendata/cms/Run2010A/JetMET/AOD/Apr21ReReco-v1/file-indexes/CMS_Run2010A_JetMET_AOD_Apr21ReReco-v1_0006_file_index.json"
+      },
+      {
+        "checksum": "adler32:06647b99",
+        "size": 10000,
+        "type": "index.txt",
+        "uri": "root://eospublic.cern.ch//eos/opendata/cms/Run2010A/JetMET/AOD/Apr21ReReco-v1/file-indexes/CMS_Run2010A_JetMET_AOD_Apr21ReReco-v1_0006_file_index.txt"
+      }
+    ],
     "license": {
       "attribution": "CC0"
     },
@@ -3363,6 +4641,248 @@
       "size": 3014222017833
     },
     "experiment": "CMS",
+    "files": [
+      {
+        "checksum": "adler32:c97010fa",
+        "size": 273491,
+        "type": "index.json",
+        "uri": "root://eospublic.cern.ch//eos/opendata/cms/Run2010A/EGMonitor/AOD/Apr21ReReco-v1/file-indexes/CMS_Run2010A_EGMonitor_AOD_Apr21ReReco-v1_0000_file_index.json"
+      },
+      {
+        "checksum": "adler32:47a5c7ea",
+        "size": 129280,
+        "type": "index.txt",
+        "uri": "root://eospublic.cern.ch//eos/opendata/cms/Run2010A/EGMonitor/AOD/Apr21ReReco-v1/file-indexes/CMS_Run2010A_EGMonitor_AOD_Apr21ReReco-v1_0000_file_index.txt"
+      },
+      {
+        "checksum": "adler32:07385733",
+        "size": 79310,
+        "type": "index.json",
+        "uri": "root://eospublic.cern.ch//eos/opendata/cms/Run2010A/EGMonitor/AOD/Apr21ReReco-v1/file-indexes/CMS_Run2010A_EGMonitor_AOD_Apr21ReReco-v1_0001_file_index.json"
+      },
+      {
+        "checksum": "adler32:e952b726",
+        "size": 37504,
+        "type": "index.txt",
+        "uri": "root://eospublic.cern.ch//eos/opendata/cms/Run2010A/EGMonitor/AOD/Apr21ReReco-v1/file-indexes/CMS_Run2010A_EGMonitor_AOD_Apr21ReReco-v1_0001_file_index.txt"
+      },
+      {
+        "checksum": "adler32:4fd04099",
+        "size": 2163,
+        "type": "index.json",
+        "uri": "root://eospublic.cern.ch//eos/opendata/cms/Run2010A/EGMonitor/AOD/Apr21ReReco-v1/file-indexes/CMS_Run2010A_EGMonitor_AOD_Apr21ReReco-v1_0002_file_index.json"
+      },
+      {
+        "checksum": "adler32:386c3280",
+        "size": 1024,
+        "type": "index.txt",
+        "uri": "root://eospublic.cern.ch//eos/opendata/cms/Run2010A/EGMonitor/AOD/Apr21ReReco-v1/file-indexes/CMS_Run2010A_EGMonitor_AOD_Apr21ReReco-v1_0002_file_index.txt"
+      },
+      {
+        "checksum": "adler32:d9079440",
+        "size": 38990,
+        "type": "index.json",
+        "uri": "root://eospublic.cern.ch//eos/opendata/cms/Run2010A/EGMonitor/AOD/Apr21ReReco-v1/file-indexes/CMS_Run2010A_EGMonitor_AOD_Apr21ReReco-v1_0003_file_index.json"
+      },
+      {
+        "checksum": "adler32:fec18ab2",
+        "size": 18432,
+        "type": "index.txt",
+        "uri": "root://eospublic.cern.ch//eos/opendata/cms/Run2010A/EGMonitor/AOD/Apr21ReReco-v1/file-indexes/CMS_Run2010A_EGMonitor_AOD_Apr21ReReco-v1_0003_file_index.txt"
+      },
+      {
+        "checksum": "adler32:8763348a",
+        "size": 4053,
+        "type": "index.json",
+        "uri": "root://eospublic.cern.ch//eos/opendata/cms/Run2010A/EGMonitor/AOD/Apr21ReReco-v1/file-indexes/CMS_Run2010A_EGMonitor_AOD_Apr21ReReco-v1_0005_file_index.json"
+      },
+      {
+        "checksum": "adler32:64673cfc",
+        "size": 1920,
+        "type": "index.txt",
+        "uri": "root://eospublic.cern.ch//eos/opendata/cms/Run2010A/EGMonitor/AOD/Apr21ReReco-v1/file-indexes/CMS_Run2010A_EGMonitor_AOD_Apr21ReReco-v1_0005_file_index.txt"
+      },
+      {
+        "checksum": "adler32:9bd7ae79",
+        "size": 1625,
+        "type": "index.json",
+        "uri": "root://eospublic.cern.ch//eos/opendata/cms/Run2010A/EGMonitor/AOD/Apr21ReReco-v1/file-indexes/CMS_Run2010A_EGMonitor_AOD_Apr21ReReco-v1_0006_file_index.json"
+      },
+      {
+        "checksum": "adler32:6deae4b5",
+        "size": 768,
+        "type": "index.txt",
+        "uri": "root://eospublic.cern.ch//eos/opendata/cms/Run2010A/EGMonitor/AOD/Apr21ReReco-v1/file-indexes/CMS_Run2010A_EGMonitor_AOD_Apr21ReReco-v1_0006_file_index.txt"
+      },
+      {
+        "checksum": "adler32:907f6bf9",
+        "size": 14854,
+        "type": "index.json",
+        "uri": "root://eospublic.cern.ch//eos/opendata/cms/Run2010A/EGMonitor/AOD/Apr21ReReco-v1/file-indexes/CMS_Run2010A_EGMonitor_AOD_Apr21ReReco-v1_0007_file_index.json"
+      },
+      {
+        "checksum": "adler32:8431340c",
+        "size": 7040,
+        "type": "index.txt",
+        "uri": "root://eospublic.cern.ch//eos/opendata/cms/Run2010A/EGMonitor/AOD/Apr21ReReco-v1/file-indexes/CMS_Run2010A_EGMonitor_AOD_Apr21ReReco-v1_0007_file_index.txt"
+      },
+      {
+        "checksum": "adler32:3450c7e9",
+        "size": 11351,
+        "type": "index.json",
+        "uri": "root://eospublic.cern.ch//eos/opendata/cms/Run2010A/EGMonitor/AOD/Apr21ReReco-v1/file-indexes/CMS_Run2010A_EGMonitor_AOD_Apr21ReReco-v1_0008_file_index.json"
+      },
+      {
+        "checksum": "adler32:4a984459",
+        "size": 5376,
+        "type": "index.txt",
+        "uri": "root://eospublic.cern.ch//eos/opendata/cms/Run2010A/EGMonitor/AOD/Apr21ReReco-v1/file-indexes/CMS_Run2010A_EGMonitor_AOD_Apr21ReReco-v1_0008_file_index.txt"
+      },
+      {
+        "checksum": "adler32:2ddbcd3e",
+        "size": 2705,
+        "type": "index.json",
+        "uri": "root://eospublic.cern.ch//eos/opendata/cms/Run2010A/EGMonitor/AOD/Apr21ReReco-v1/file-indexes/CMS_Run2010A_EGMonitor_AOD_Apr21ReReco-v1_0009_file_index.json"
+      },
+      {
+        "checksum": "adler32:cf947db2",
+        "size": 1280,
+        "type": "index.txt",
+        "uri": "root://eospublic.cern.ch//eos/opendata/cms/Run2010A/EGMonitor/AOD/Apr21ReReco-v1/file-indexes/CMS_Run2010A_EGMonitor_AOD_Apr21ReReco-v1_0009_file_index.txt"
+      },
+      {
+        "checksum": "adler32:f3b25479",
+        "size": 11893,
+        "type": "index.json",
+        "uri": "root://eospublic.cern.ch//eos/opendata/cms/Run2010A/EGMonitor/AOD/Apr21ReReco-v1/file-indexes/CMS_Run2010A_EGMonitor_AOD_Apr21ReReco-v1_0010_file_index.json"
+      },
+      {
+        "checksum": "adler32:841f8fae",
+        "size": 5632,
+        "type": "index.txt",
+        "uri": "root://eospublic.cern.ch//eos/opendata/cms/Run2010A/EGMonitor/AOD/Apr21ReReco-v1/file-indexes/CMS_Run2010A_EGMonitor_AOD_Apr21ReReco-v1_0010_file_index.txt"
+      },
+      {
+        "checksum": "adler32:db4847e0",
+        "size": 273,
+        "type": "index.json",
+        "uri": "root://eospublic.cern.ch//eos/opendata/cms/Run2010A/EGMonitor/AOD/Apr21ReReco-v1/file-indexes/CMS_Run2010A_EGMonitor_AOD_Apr21ReReco-v1_0011_file_index.json"
+      },
+      {
+        "checksum": "adler32:955d2628",
+        "size": 128,
+        "type": "index.txt",
+        "uri": "root://eospublic.cern.ch//eos/opendata/cms/Run2010A/EGMonitor/AOD/Apr21ReReco-v1/file-indexes/CMS_Run2010A_EGMonitor_AOD_Apr21ReReco-v1_0011_file_index.txt"
+      },
+      {
+        "checksum": "adler32:0fa692d2",
+        "size": 7297,
+        "type": "index.json",
+        "uri": "root://eospublic.cern.ch//eos/opendata/cms/Run2010A/EGMonitor/AOD/Apr21ReReco-v1/file-indexes/CMS_Run2010A_EGMonitor_AOD_Apr21ReReco-v1_0012_file_index.json"
+      },
+      {
+        "checksum": "adler32:040d06b5",
+        "size": 3456,
+        "type": "index.txt",
+        "uri": "root://eospublic.cern.ch//eos/opendata/cms/Run2010A/EGMonitor/AOD/Apr21ReReco-v1/file-indexes/CMS_Run2010A_EGMonitor_AOD_Apr21ReReco-v1_0012_file_index.txt"
+      },
+      {
+        "checksum": "adler32:3c30f53b",
+        "size": 1900,
+        "type": "index.json",
+        "uri": "root://eospublic.cern.ch//eos/opendata/cms/Run2010A/EGMonitor/AOD/Apr21ReReco-v1/file-indexes/CMS_Run2010A_EGMonitor_AOD_Apr21ReReco-v1_0013_file_index.json"
+      },
+      {
+        "checksum": "adler32:67720a81",
+        "size": 896,
+        "type": "index.txt",
+        "uri": "root://eospublic.cern.ch//eos/opendata/cms/Run2010A/EGMonitor/AOD/Apr21ReReco-v1/file-indexes/CMS_Run2010A_EGMonitor_AOD_Apr21ReReco-v1_0013_file_index.txt"
+      },
+      {
+        "checksum": "adler32:9eb906e4",
+        "size": 6765,
+        "type": "index.json",
+        "uri": "root://eospublic.cern.ch//eos/opendata/cms/Run2010A/EGMonitor/AOD/Apr21ReReco-v1/file-indexes/CMS_Run2010A_EGMonitor_AOD_Apr21ReReco-v1_0014_file_index.json"
+      },
+      {
+        "checksum": "adler32:68c5baf5",
+        "size": 3200,
+        "type": "index.txt",
+        "uri": "root://eospublic.cern.ch//eos/opendata/cms/Run2010A/EGMonitor/AOD/Apr21ReReco-v1/file-indexes/CMS_Run2010A_EGMonitor_AOD_Apr21ReReco-v1_0014_file_index.txt"
+      },
+      {
+        "checksum": "adler32:777f5fd5",
+        "size": 3254,
+        "type": "index.json",
+        "uri": "root://eospublic.cern.ch//eos/opendata/cms/Run2010A/EGMonitor/AOD/Apr21ReReco-v1/file-indexes/CMS_Run2010A_EGMonitor_AOD_Apr21ReReco-v1_0015_file_index.json"
+      },
+      {
+        "checksum": "adler32:b116ca47",
+        "size": 1536,
+        "type": "index.txt",
+        "uri": "root://eospublic.cern.ch//eos/opendata/cms/Run2010A/EGMonitor/AOD/Apr21ReReco-v1/file-indexes/CMS_Run2010A_EGMonitor_AOD_Apr21ReReco-v1_0015_file_index.txt"
+      },
+      {
+        "checksum": "adler32:7f2b6086",
+        "size": 32136,
+        "type": "index.json",
+        "uri": "root://eospublic.cern.ch//eos/opendata/cms/Run2010A/EGMonitor/AOD/Apr21ReReco-v1/file-indexes/CMS_Run2010A_EGMonitor_AOD_Apr21ReReco-v1_0016_file_index.json"
+      },
+      {
+        "checksum": "adler32:7192c17c",
+        "size": 15232,
+        "type": "index.txt",
+        "uri": "root://eospublic.cern.ch//eos/opendata/cms/Run2010A/EGMonitor/AOD/Apr21ReReco-v1/file-indexes/CMS_Run2010A_EGMonitor_AOD_Apr21ReReco-v1_0016_file_index.txt"
+      },
+      {
+        "checksum": "adler32:2bb73572",
+        "size": 4053,
+        "type": "index.json",
+        "uri": "root://eospublic.cern.ch//eos/opendata/cms/Run2010A/EGMonitor/AOD/Apr21ReReco-v1/file-indexes/CMS_Run2010A_EGMonitor_AOD_Apr21ReReco-v1_0017_file_index.json"
+      },
+      {
+        "checksum": "adler32:17903d4a",
+        "size": 1920,
+        "type": "index.txt",
+        "uri": "root://eospublic.cern.ch//eos/opendata/cms/Run2010A/EGMonitor/AOD/Apr21ReReco-v1/file-indexes/CMS_Run2010A_EGMonitor_AOD_Apr21ReReco-v1_0017_file_index.txt"
+      },
+      {
+        "checksum": "adler32:17685fca",
+        "size": 3243,
+        "type": "index.json",
+        "uri": "root://eospublic.cern.ch//eos/opendata/cms/Run2010A/EGMonitor/AOD/Apr21ReReco-v1/file-indexes/CMS_Run2010A_EGMonitor_AOD_Apr21ReReco-v1_0018_file_index.json"
+      },
+      {
+        "checksum": "adler32:9769cb10",
+        "size": 1536,
+        "type": "index.txt",
+        "uri": "root://eospublic.cern.ch//eos/opendata/cms/Run2010A/EGMonitor/AOD/Apr21ReReco-v1/file-indexes/CMS_Run2010A_EGMonitor_AOD_Apr21ReReco-v1_0018_file_index.txt"
+      },
+      {
+        "checksum": "adler32:fb41243b",
+        "size": 16488,
+        "type": "index.json",
+        "uri": "root://eospublic.cern.ch//eos/opendata/cms/Run2010A/EGMonitor/AOD/Apr21ReReco-v1/file-indexes/CMS_Run2010A_EGMonitor_AOD_Apr21ReReco-v1_0019_file_index.json"
+      },
+      {
+        "checksum": "adler32:c3271b0b",
+        "size": 7808,
+        "type": "index.txt",
+        "uri": "root://eospublic.cern.ch//eos/opendata/cms/Run2010A/EGMonitor/AOD/Apr21ReReco-v1/file-indexes/CMS_Run2010A_EGMonitor_AOD_Apr21ReReco-v1_0019_file_index.txt"
+      },
+      {
+        "checksum": "adler32:9e8948db",
+        "size": 273,
+        "type": "index.json",
+        "uri": "root://eospublic.cern.ch//eos/opendata/cms/Run2010A/EGMonitor/AOD/Apr21ReReco-v1/file-indexes/CMS_Run2010A_EGMonitor_AOD_Apr21ReReco-v1_0020_file_index.json"
+      },
+      {
+        "checksum": "adler32:9885264d",
+        "size": 128,
+        "type": "index.txt",
+        "uri": "root://eospublic.cern.ch//eos/opendata/cms/Run2010A/EGMonitor/AOD/Apr21ReReco-v1/file-indexes/CMS_Run2010A_EGMonitor_AOD_Apr21ReReco-v1_0020_file_index.txt"
+      }
+    ],
     "license": {
       "attribution": "CC0"
     },
@@ -3459,6 +4979,248 @@
       "size": 4486583998147
     },
     "experiment": "CMS",
+    "files": [
+      {
+        "checksum": "adler32:8bc35e56",
+        "size": 219430,
+        "type": "index.json",
+        "uri": "root://eospublic.cern.ch//eos/opendata/cms/Run2010A/EG/AOD/Apr21ReReco-v1/file-indexes/CMS_Run2010A_EG_AOD_Apr21ReReco-v1_0000_file_index.json"
+      },
+      {
+        "checksum": "adler32:381ca866",
+        "size": 100672,
+        "type": "index.txt",
+        "uri": "root://eospublic.cern.ch//eos/opendata/cms/Run2010A/EG/AOD/Apr21ReReco-v1/file-indexes/CMS_Run2010A_EG_AOD_Apr21ReReco-v1_0000_file_index.txt"
+      },
+      {
+        "checksum": "adler32:d83ad508",
+        "size": 24229,
+        "type": "index.json",
+        "uri": "root://eospublic.cern.ch//eos/opendata/cms/Run2010A/EG/AOD/Apr21ReReco-v1/file-indexes/CMS_Run2010A_EG_AOD_Apr21ReReco-v1_0001_file_index.json"
+      },
+      {
+        "checksum": "adler32:cacfb3b4",
+        "size": 11132,
+        "type": "index.txt",
+        "uri": "root://eospublic.cern.ch//eos/opendata/cms/Run2010A/EG/AOD/Apr21ReReco-v1/file-indexes/CMS_Run2010A_EG_AOD_Apr21ReReco-v1_0001_file_index.txt"
+      },
+      {
+        "checksum": "adler32:1532a516",
+        "size": 28933,
+        "type": "index.json",
+        "uri": "root://eospublic.cern.ch//eos/opendata/cms/Run2010A/EG/AOD/Apr21ReReco-v1/file-indexes/CMS_Run2010A_EG_AOD_Apr21ReReco-v1_0002_file_index.json"
+      },
+      {
+        "checksum": "adler32:d5e2300d",
+        "size": 13310,
+        "type": "index.txt",
+        "uri": "root://eospublic.cern.ch//eos/opendata/cms/Run2010A/EG/AOD/Apr21ReReco-v1/file-indexes/CMS_Run2010A_EG_AOD_Apr21ReReco-v1_0002_file_index.txt"
+      },
+      {
+        "checksum": "adler32:331c4dfd",
+        "size": 47190,
+        "type": "index.json",
+        "uri": "root://eospublic.cern.ch//eos/opendata/cms/Run2010A/EG/AOD/Apr21ReReco-v1/file-indexes/CMS_Run2010A_EG_AOD_Apr21ReReco-v1_0003_file_index.json"
+      },
+      {
+        "checksum": "adler32:b49bb258",
+        "size": 21659,
+        "type": "index.txt",
+        "uri": "root://eospublic.cern.ch//eos/opendata/cms/Run2010A/EG/AOD/Apr21ReReco-v1/file-indexes/CMS_Run2010A_EG_AOD_Apr21ReReco-v1_0003_file_index.txt"
+      },
+      {
+        "checksum": "adler32:fbccac3e",
+        "size": 115897,
+        "type": "index.json",
+        "uri": "root://eospublic.cern.ch//eos/opendata/cms/Run2010A/EG/AOD/Apr21ReReco-v1/file-indexes/CMS_Run2010A_EG_AOD_Apr21ReReco-v1_0004_file_index.json"
+      },
+      {
+        "checksum": "adler32:dfbebbb3",
+        "size": 53240,
+        "type": "index.txt",
+        "uri": "root://eospublic.cern.ch//eos/opendata/cms/Run2010A/EG/AOD/Apr21ReReco-v1/file-indexes/CMS_Run2010A_EG_AOD_Apr21ReReco-v1_0004_file_index.txt"
+      },
+      {
+        "checksum": "adler32:d96467d2",
+        "size": 77783,
+        "type": "index.json",
+        "uri": "root://eospublic.cern.ch//eos/opendata/cms/Run2010A/EG/AOD/Apr21ReReco-v1/file-indexes/CMS_Run2010A_EG_AOD_Apr21ReReco-v1_0005_file_index.json"
+      },
+      {
+        "checksum": "adler32:122c9b91",
+        "size": 35695,
+        "type": "index.txt",
+        "uri": "root://eospublic.cern.ch//eos/opendata/cms/Run2010A/EG/AOD/Apr21ReReco-v1/file-indexes/CMS_Run2010A_EG_AOD_Apr21ReReco-v1_0005_file_index.txt"
+      },
+      {
+        "checksum": "adler32:5dbbb47e",
+        "size": 37875,
+        "type": "index.json",
+        "uri": "root://eospublic.cern.ch//eos/opendata/cms/Run2010A/EG/AOD/Apr21ReReco-v1/file-indexes/CMS_Run2010A_EG_AOD_Apr21ReReco-v1_0006_file_index.json"
+      },
+      {
+        "checksum": "adler32:7fa3d596",
+        "size": 17424,
+        "type": "index.txt",
+        "uri": "root://eospublic.cern.ch//eos/opendata/cms/Run2010A/EG/AOD/Apr21ReReco-v1/file-indexes/CMS_Run2010A_EG_AOD_Apr21ReReco-v1_0006_file_index.txt"
+      },
+      {
+        "checksum": "adler32:c439e0f7",
+        "size": 15520,
+        "type": "index.json",
+        "uri": "root://eospublic.cern.ch//eos/opendata/cms/Run2010A/EG/AOD/Apr21ReReco-v1/file-indexes/CMS_Run2010A_EG_AOD_Apr21ReReco-v1_0007_file_index.json"
+      },
+      {
+        "checksum": "adler32:cfc322b1",
+        "size": 7139,
+        "type": "index.txt",
+        "uri": "root://eospublic.cern.ch//eos/opendata/cms/Run2010A/EG/AOD/Apr21ReReco-v1/file-indexes/CMS_Run2010A_EG_AOD_Apr21ReReco-v1_0007_file_index.txt"
+      },
+      {
+        "checksum": "adler32:97ab46e4",
+        "size": 57016,
+        "type": "index.json",
+        "uri": "root://eospublic.cern.ch//eos/opendata/cms/Run2010A/EG/AOD/Apr21ReReco-v1/file-indexes/CMS_Run2010A_EG_AOD_Apr21ReReco-v1_0008_file_index.json"
+      },
+      {
+        "checksum": "adler32:77e4c596",
+        "size": 26136,
+        "type": "index.txt",
+        "uri": "root://eospublic.cern.ch//eos/opendata/cms/Run2010A/EG/AOD/Apr21ReReco-v1/file-indexes/CMS_Run2010A_EG_AOD_Apr21ReReco-v1_0008_file_index.txt"
+      },
+      {
+        "checksum": "adler32:fa600f6b",
+        "size": 14745,
+        "type": "index.json",
+        "uri": "root://eospublic.cern.ch//eos/opendata/cms/Run2010A/EG/AOD/Apr21ReReco-v1/file-indexes/CMS_Run2010A_EG_AOD_Apr21ReReco-v1_0009_file_index.json"
+      },
+      {
+        "checksum": "adler32:e15eb77c",
+        "size": 6776,
+        "type": "index.txt",
+        "uri": "root://eospublic.cern.ch//eos/opendata/cms/Run2010A/EG/AOD/Apr21ReReco-v1/file-indexes/CMS_Run2010A_EG_AOD_Apr21ReReco-v1_0009_file_index.txt"
+      },
+      {
+        "checksum": "adler32:ea377f97",
+        "size": 17132,
+        "type": "index.json",
+        "uri": "root://eospublic.cern.ch//eos/opendata/cms/Run2010A/EG/AOD/Apr21ReReco-v1/file-indexes/CMS_Run2010A_EG_AOD_Apr21ReReco-v1_0010_file_index.json"
+      },
+      {
+        "checksum": "adler32:2752f2e8",
+        "size": 7865,
+        "type": "index.txt",
+        "uri": "root://eospublic.cern.ch//eos/opendata/cms/Run2010A/EG/AOD/Apr21ReReco-v1/file-indexes/CMS_Run2010A_EG_AOD_Apr21ReReco-v1_0010_file_index.txt"
+      },
+      {
+        "checksum": "adler32:697894b7",
+        "size": 28945,
+        "type": "index.json",
+        "uri": "root://eospublic.cern.ch//eos/opendata/cms/Run2010A/EG/AOD/Apr21ReReco-v1/file-indexes/CMS_Run2010A_EG_AOD_Apr21ReReco-v1_0011_file_index.json"
+      },
+      {
+        "checksum": "adler32:230b253c",
+        "size": 13310,
+        "type": "index.txt",
+        "uri": "root://eospublic.cern.ch//eos/opendata/cms/Run2010A/EG/AOD/Apr21ReReco-v1/file-indexes/CMS_Run2010A_EG_AOD_Apr21ReReco-v1_0011_file_index.txt"
+      },
+      {
+        "checksum": "adler32:7dd42282",
+        "size": 39278,
+        "type": "index.json",
+        "uri": "root://eospublic.cern.ch//eos/opendata/cms/Run2010A/EG/AOD/Apr21ReReco-v1/file-indexes/CMS_Run2010A_EG_AOD_Apr21ReReco-v1_0012_file_index.json"
+      },
+      {
+        "checksum": "adler32:5bec852e",
+        "size": 18029,
+        "type": "index.txt",
+        "uri": "root://eospublic.cern.ch//eos/opendata/cms/Run2010A/EG/AOD/Apr21ReReco-v1/file-indexes/CMS_Run2010A_EG_AOD_Apr21ReReco-v1_0012_file_index.txt"
+      },
+      {
+        "checksum": "adler32:d69e2918",
+        "size": 33434,
+        "type": "index.json",
+        "uri": "root://eospublic.cern.ch//eos/opendata/cms/Run2010A/EG/AOD/Apr21ReReco-v1/file-indexes/CMS_Run2010A_EG_AOD_Apr21ReReco-v1_0013_file_index.json"
+      },
+      {
+        "checksum": "adler32:608f7da3",
+        "size": 15367,
+        "type": "index.txt",
+        "uri": "root://eospublic.cern.ch//eos/opendata/cms/Run2010A/EG/AOD/Apr21ReReco-v1/file-indexes/CMS_Run2010A_EG_AOD_Apr21ReReco-v1_0013_file_index.txt"
+      },
+      {
+        "checksum": "adler32:9d49f47b",
+        "size": 9734,
+        "type": "index.json",
+        "uri": "root://eospublic.cern.ch//eos/opendata/cms/Run2010A/EG/AOD/Apr21ReReco-v1/file-indexes/CMS_Run2010A_EG_AOD_Apr21ReReco-v1_0014_file_index.json"
+      },
+      {
+        "checksum": "adler32:c3c9179d",
+        "size": 4477,
+        "type": "index.txt",
+        "uri": "root://eospublic.cern.ch//eos/opendata/cms/Run2010A/EG/AOD/Apr21ReReco-v1/file-indexes/CMS_Run2010A_EG_AOD_Apr21ReReco-v1_0014_file_index.txt"
+      },
+      {
+        "checksum": "adler32:aba315f5",
+        "size": 45109,
+        "type": "index.json",
+        "uri": "root://eospublic.cern.ch//eos/opendata/cms/Run2010A/EG/AOD/Apr21ReReco-v1/file-indexes/CMS_Run2010A_EG_AOD_Apr21ReReco-v1_0015_file_index.json"
+      },
+      {
+        "checksum": "adler32:a2c890ae",
+        "size": 20691,
+        "type": "index.txt",
+        "uri": "root://eospublic.cern.ch//eos/opendata/cms/Run2010A/EG/AOD/Apr21ReReco-v1/file-indexes/CMS_Run2010A_EG_AOD_Apr21ReReco-v1_0015_file_index.txt"
+      },
+      {
+        "checksum": "adler32:7463770a",
+        "size": 29803,
+        "type": "index.json",
+        "uri": "root://eospublic.cern.ch//eos/opendata/cms/Run2010A/EG/AOD/Apr21ReReco-v1/file-indexes/CMS_Run2010A_EG_AOD_Apr21ReReco-v1_0016_file_index.json"
+      },
+      {
+        "checksum": "adler32:2052923b",
+        "size": 13673,
+        "type": "index.txt",
+        "uri": "root://eospublic.cern.ch//eos/opendata/cms/Run2010A/EG/AOD/Apr21ReReco-v1/file-indexes/CMS_Run2010A_EG_AOD_Apr21ReReco-v1_0016_file_index.txt"
+      },
+      {
+        "checksum": "adler32:5b1a8ec9",
+        "size": 31862,
+        "type": "index.json",
+        "uri": "root://eospublic.cern.ch//eos/opendata/cms/Run2010A/EG/AOD/Apr21ReReco-v1/file-indexes/CMS_Run2010A_EG_AOD_Apr21ReReco-v1_0017_file_index.json"
+      },
+      {
+        "checksum": "adler32:ffc3abe3",
+        "size": 14641,
+        "type": "index.txt",
+        "uri": "root://eospublic.cern.ch//eos/opendata/cms/Run2010A/EG/AOD/Apr21ReReco-v1/file-indexes/CMS_Run2010A_EG_AOD_Apr21ReReco-v1_0017_file_index.txt"
+      },
+      {
+        "checksum": "adler32:5445a779",
+        "size": 25071,
+        "type": "index.json",
+        "uri": "root://eospublic.cern.ch//eos/opendata/cms/Run2010A/EG/AOD/Apr21ReReco-v1/file-indexes/CMS_Run2010A_EG_AOD_Apr21ReReco-v1_0018_file_index.json"
+      },
+      {
+        "checksum": "adler32:21881ad1",
+        "size": 11495,
+        "type": "index.txt",
+        "uri": "root://eospublic.cern.ch//eos/opendata/cms/Run2010A/EG/AOD/Apr21ReReco-v1/file-indexes/CMS_Run2010A_EG_AOD_Apr21ReReco-v1_0018_file_index.txt"
+      },
+      {
+        "checksum": "adler32:bf86bff7",
+        "size": 24218,
+        "type": "index.json",
+        "uri": "root://eospublic.cern.ch//eos/opendata/cms/Run2010A/EG/AOD/Apr21ReReco-v1/file-indexes/CMS_Run2010A_EG_AOD_Apr21ReReco-v1_0019_file_index.json"
+      },
+      {
+        "checksum": "adler32:acc0acb4",
+        "size": 11132,
+        "type": "index.txt",
+        "uri": "root://eospublic.cern.ch//eos/opendata/cms/Run2010A/EG/AOD/Apr21ReReco-v1/file-indexes/CMS_Run2010A_EG_AOD_Apr21ReReco-v1_0019_file_index.txt"
+      }
+    ],
     "license": {
       "attribution": "CC0"
     },
@@ -3555,6 +5317,272 @@
       "size": 5252574106904
     },
     "experiment": "CMS",
+    "files": [
+      {
+        "checksum": "adler32:03cc2595",
+        "size": 286354,
+        "type": "index.json",
+        "uri": "root://eospublic.cern.ch//eos/opendata/cms/Run2010A/Commissioning/AOD/Apr21ReReco-v1/file-indexes/CMS_Run2010A_Commissioning_AOD_Apr21ReReco-v1_0000_file_index.json"
+      },
+      {
+        "checksum": "adler32:1912fd44",
+        "size": 137544,
+        "type": "index.txt",
+        "uri": "root://eospublic.cern.ch//eos/opendata/cms/Run2010A/Commissioning/AOD/Apr21ReReco-v1/file-indexes/CMS_Run2010A_Commissioning_AOD_Apr21ReReco-v1_0000_file_index.txt"
+      },
+      {
+        "checksum": "adler32:2723fbd1",
+        "size": 169778,
+        "type": "index.json",
+        "uri": "root://eospublic.cern.ch//eos/opendata/cms/Run2010A/Commissioning/AOD/Apr21ReReco-v1/file-indexes/CMS_Run2010A_Commissioning_AOD_Apr21ReReco-v1_0001_file_index.json"
+      },
+      {
+        "checksum": "adler32:8c64a9f1",
+        "size": 81576,
+        "type": "index.txt",
+        "uri": "root://eospublic.cern.ch//eos/opendata/cms/Run2010A/Commissioning/AOD/Apr21ReReco-v1/file-indexes/CMS_Run2010A_Commissioning_AOD_Apr21ReReco-v1_0001_file_index.txt"
+      },
+      {
+        "checksum": "adler32:b5501293",
+        "size": 51560,
+        "type": "index.json",
+        "uri": "root://eospublic.cern.ch//eos/opendata/cms/Run2010A/Commissioning/AOD/Apr21ReReco-v1/file-indexes/CMS_Run2010A_Commissioning_AOD_Apr21ReReco-v1_0002_file_index.json"
+      },
+      {
+        "checksum": "adler32:1aac664e",
+        "size": 24816,
+        "type": "index.txt",
+        "uri": "root://eospublic.cern.ch//eos/opendata/cms/Run2010A/Commissioning/AOD/Apr21ReReco-v1/file-indexes/CMS_Run2010A_Commissioning_AOD_Apr21ReReco-v1_0002_file_index.txt"
+      },
+      {
+        "checksum": "adler32:5a0a8b5d",
+        "size": 14802,
+        "type": "index.json",
+        "uri": "root://eospublic.cern.ch//eos/opendata/cms/Run2010A/Commissioning/AOD/Apr21ReReco-v1/file-indexes/CMS_Run2010A_Commissioning_AOD_Apr21ReReco-v1_0003_file_index.json"
+      },
+      {
+        "checksum": "adler32:8e5874f1",
+        "size": 7128,
+        "type": "index.txt",
+        "uri": "root://eospublic.cern.ch//eos/opendata/cms/Run2010A/Commissioning/AOD/Apr21ReReco-v1/file-indexes/CMS_Run2010A_Commissioning_AOD_Apr21ReReco-v1_0003_file_index.txt"
+      },
+      {
+        "checksum": "adler32:bf1562a5",
+        "size": 35635,
+        "type": "index.json",
+        "uri": "root://eospublic.cern.ch//eos/opendata/cms/Run2010A/Commissioning/AOD/Apr21ReReco-v1/file-indexes/CMS_Run2010A_Commissioning_AOD_Apr21ReReco-v1_0004_file_index.json"
+      },
+      {
+        "checksum": "adler32:9a2c5657",
+        "size": 17160,
+        "type": "index.txt",
+        "uri": "root://eospublic.cern.ch//eos/opendata/cms/Run2010A/Commissioning/AOD/Apr21ReReco-v1/file-indexes/CMS_Run2010A_Commissioning_AOD_Apr21ReReco-v1_0004_file_index.txt"
+      },
+      {
+        "checksum": "adler32:e110b766",
+        "size": 39756,
+        "type": "index.json",
+        "uri": "root://eospublic.cern.ch//eos/opendata/cms/Run2010A/Commissioning/AOD/Apr21ReReco-v1/file-indexes/CMS_Run2010A_Commissioning_AOD_Apr21ReReco-v1_0005_file_index.json"
+      },
+      {
+        "checksum": "adler32:d20cb024",
+        "size": 19140,
+        "type": "index.txt",
+        "uri": "root://eospublic.cern.ch//eos/opendata/cms/Run2010A/Commissioning/AOD/Apr21ReReco-v1/file-indexes/CMS_Run2010A_Commissioning_AOD_Apr21ReReco-v1_0005_file_index.txt"
+      },
+      {
+        "checksum": "adler32:1bff42eb",
+        "size": 18371,
+        "type": "index.json",
+        "uri": "root://eospublic.cern.ch//eos/opendata/cms/Run2010A/Commissioning/AOD/Apr21ReReco-v1/file-indexes/CMS_Run2010A_Commissioning_AOD_Apr21ReReco-v1_0006_file_index.json"
+      },
+      {
+        "checksum": "adler32:1f897a7d",
+        "size": 8844,
+        "type": "index.txt",
+        "uri": "root://eospublic.cern.ch//eos/opendata/cms/Run2010A/Commissioning/AOD/Apr21ReReco-v1/file-indexes/CMS_Run2010A_Commissioning_AOD_Apr21ReReco-v1_0006_file_index.txt"
+      },
+      {
+        "checksum": "adler32:7480f692",
+        "size": 14269,
+        "type": "index.json",
+        "uri": "root://eospublic.cern.ch//eos/opendata/cms/Run2010A/Commissioning/AOD/Apr21ReReco-v1/file-indexes/CMS_Run2010A_Commissioning_AOD_Apr21ReReco-v1_0007_file_index.json"
+      },
+      {
+        "checksum": "adler32:bcc222ce",
+        "size": 6864,
+        "type": "index.txt",
+        "uri": "root://eospublic.cern.ch//eos/opendata/cms/Run2010A/Commissioning/AOD/Apr21ReReco-v1/file-indexes/CMS_Run2010A_Commissioning_AOD_Apr21ReReco-v1_0007_file_index.txt"
+      },
+      {
+        "checksum": "adler32:283aed56",
+        "size": 72339,
+        "type": "index.json",
+        "uri": "root://eospublic.cern.ch//eos/opendata/cms/Run2010A/Commissioning/AOD/Apr21ReReco-v1/file-indexes/CMS_Run2010A_Commissioning_AOD_Apr21ReReco-v1_0008_file_index.json"
+      },
+      {
+        "checksum": "adler32:8525550f",
+        "size": 34848,
+        "type": "index.txt",
+        "uri": "root://eospublic.cern.ch//eos/opendata/cms/Run2010A/Commissioning/AOD/Apr21ReReco-v1/file-indexes/CMS_Run2010A_Commissioning_AOD_Apr21ReReco-v1_0008_file_index.txt"
+      },
+      {
+        "checksum": "adler32:aa1a7e08",
+        "size": 72916,
+        "type": "index.json",
+        "uri": "root://eospublic.cern.ch//eos/opendata/cms/Run2010A/Commissioning/AOD/Apr21ReReco-v1/file-indexes/CMS_Run2010A_Commissioning_AOD_Apr21ReReco-v1_0009_file_index.json"
+      },
+      {
+        "checksum": "adler32:3826a2c0",
+        "size": 35112,
+        "type": "index.txt",
+        "uri": "root://eospublic.cern.ch//eos/opendata/cms/Run2010A/Commissioning/AOD/Apr21ReReco-v1/file-indexes/CMS_Run2010A_Commissioning_AOD_Apr21ReReco-v1_0009_file_index.txt"
+      },
+      {
+        "checksum": "adler32:e1719a5b",
+        "size": 4387,
+        "type": "index.json",
+        "uri": "root://eospublic.cern.ch//eos/opendata/cms/Run2010A/Commissioning/AOD/Apr21ReReco-v1/file-indexes/CMS_Run2010A_Commissioning_AOD_Apr21ReReco-v1_0010_file_index.json"
+      },
+      {
+        "checksum": "adler32:f46680c5",
+        "size": 2112,
+        "type": "index.txt",
+        "uri": "root://eospublic.cern.ch//eos/opendata/cms/Run2010A/Commissioning/AOD/Apr21ReReco-v1/file-indexes/CMS_Run2010A_Commissioning_AOD_Apr21ReReco-v1_0010_file_index.txt"
+      },
+      {
+        "checksum": "adler32:1b6462b8",
+        "size": 55633,
+        "type": "index.json",
+        "uri": "root://eospublic.cern.ch//eos/opendata/cms/Run2010A/Commissioning/AOD/Apr21ReReco-v1/file-indexes/CMS_Run2010A_Commissioning_AOD_Apr21ReReco-v1_0011_file_index.json"
+      },
+      {
+        "checksum": "adler32:4a20c294",
+        "size": 26796,
+        "type": "index.txt",
+        "uri": "root://eospublic.cern.ch//eos/opendata/cms/Run2010A/Commissioning/AOD/Apr21ReReco-v1/file-indexes/CMS_Run2010A_Commissioning_AOD_Apr21ReReco-v1_0011_file_index.txt"
+      },
+      {
+        "checksum": "adler32:b7f49ef8",
+        "size": 6316,
+        "type": "index.json",
+        "uri": "root://eospublic.cern.ch//eos/opendata/cms/Run2010A/Commissioning/AOD/Apr21ReReco-v1/file-indexes/CMS_Run2010A_Commissioning_AOD_Apr21ReReco-v1_0012_file_index.json"
+      },
+      {
+        "checksum": "adler32:20a99969",
+        "size": 3036,
+        "type": "index.txt",
+        "uri": "root://eospublic.cern.ch//eos/opendata/cms/Run2010A/Commissioning/AOD/Apr21ReReco-v1/file-indexes/CMS_Run2010A_Commissioning_AOD_Apr21ReReco-v1_0012_file_index.txt"
+      },
+      {
+        "checksum": "adler32:72c16d94",
+        "size": 55691,
+        "type": "index.json",
+        "uri": "root://eospublic.cern.ch//eos/opendata/cms/Run2010A/Commissioning/AOD/Apr21ReReco-v1/file-indexes/CMS_Run2010A_Commissioning_AOD_Apr21ReReco-v1_0013_file_index.json"
+      },
+      {
+        "checksum": "adler32:a385c3e6",
+        "size": 26796,
+        "type": "index.txt",
+        "uri": "root://eospublic.cern.ch//eos/opendata/cms/Run2010A/Commissioning/AOD/Apr21ReReco-v1/file-indexes/CMS_Run2010A_Commissioning_AOD_Apr21ReReco-v1_0013_file_index.txt"
+      },
+      {
+        "checksum": "adler32:7f974cc4",
+        "size": 36497,
+        "type": "index.json",
+        "uri": "root://eospublic.cern.ch//eos/opendata/cms/Run2010A/Commissioning/AOD/Apr21ReReco-v1/file-indexes/CMS_Run2010A_Commissioning_AOD_Apr21ReReco-v1_0014_file_index.json"
+      },
+      {
+        "checksum": "adler32:5c9bd289",
+        "size": 17556,
+        "type": "index.txt",
+        "uri": "root://eospublic.cern.ch//eos/opendata/cms/Run2010A/Commissioning/AOD/Apr21ReReco-v1/file-indexes/CMS_Run2010A_Commissioning_AOD_Apr21ReReco-v1_0014_file_index.txt"
+      },
+      {
+        "checksum": "adler32:a8b4ccfc",
+        "size": 53159,
+        "type": "index.json",
+        "uri": "root://eospublic.cern.ch//eos/opendata/cms/Run2010A/Commissioning/AOD/Apr21ReReco-v1/file-indexes/CMS_Run2010A_Commissioning_AOD_Apr21ReReco-v1_0015_file_index.json"
+      },
+      {
+        "checksum": "adler32:3a835e4a",
+        "size": 25608,
+        "type": "index.txt",
+        "uri": "root://eospublic.cern.ch//eos/opendata/cms/Run2010A/Commissioning/AOD/Apr21ReReco-v1/file-indexes/CMS_Run2010A_Commissioning_AOD_Apr21ReReco-v1_0015_file_index.txt"
+      },
+      {
+        "checksum": "adler32:3b1d3493",
+        "size": 24940,
+        "type": "index.json",
+        "uri": "root://eospublic.cern.ch//eos/opendata/cms/Run2010A/Commissioning/AOD/Apr21ReReco-v1/file-indexes/CMS_Run2010A_Commissioning_AOD_Apr21ReReco-v1_0016_file_index.json"
+      },
+      {
+        "checksum": "adler32:f14d4193",
+        "size": 12012,
+        "type": "index.txt",
+        "uri": "root://eospublic.cern.ch//eos/opendata/cms/Run2010A/Commissioning/AOD/Apr21ReReco-v1/file-indexes/CMS_Run2010A_Commissioning_AOD_Apr21ReReco-v1_0016_file_index.txt"
+      },
+      {
+        "checksum": "adler32:ee18e6b1",
+        "size": 24663,
+        "type": "index.json",
+        "uri": "root://eospublic.cern.ch//eos/opendata/cms/Run2010A/Commissioning/AOD/Apr21ReReco-v1/file-indexes/CMS_Run2010A_Commissioning_AOD_Apr21ReReco-v1_0017_file_index.json"
+      },
+      {
+        "checksum": "adler32:14771826",
+        "size": 11880,
+        "type": "index.txt",
+        "uri": "root://eospublic.cern.ch//eos/opendata/cms/Run2010A/Commissioning/AOD/Apr21ReReco-v1/file-indexes/CMS_Run2010A_Commissioning_AOD_Apr21ReReco-v1_0017_file_index.txt"
+      },
+      {
+        "checksum": "adler32:96bf076a",
+        "size": 18133,
+        "type": "index.json",
+        "uri": "root://eospublic.cern.ch//eos/opendata/cms/Run2010A/Commissioning/AOD/Apr21ReReco-v1/file-indexes/CMS_Run2010A_Commissioning_AOD_Apr21ReReco-v1_0018_file_index.json"
+      },
+      {
+        "checksum": "adler32:b13556e0",
+        "size": 8712,
+        "type": "index.txt",
+        "uri": "root://eospublic.cern.ch//eos/opendata/cms/Run2010A/Commissioning/AOD/Apr21ReReco-v1/file-indexes/CMS_Run2010A_Commissioning_AOD_Apr21ReReco-v1_0018_file_index.txt"
+      },
+      {
+        "checksum": "adler32:375a063e",
+        "size": 67696,
+        "type": "index.json",
+        "uri": "root://eospublic.cern.ch//eos/opendata/cms/Run2010A/Commissioning/AOD/Apr21ReReco-v1/file-indexes/CMS_Run2010A_Commissioning_AOD_Apr21ReReco-v1_0019_file_index.json"
+      },
+      {
+        "checksum": "adler32:468aab46",
+        "size": 32604,
+        "type": "index.txt",
+        "uri": "root://eospublic.cern.ch//eos/opendata/cms/Run2010A/Commissioning/AOD/Apr21ReReco-v1/file-indexes/CMS_Run2010A_Commissioning_AOD_Apr21ReReco-v1_0019_file_index.txt"
+      },
+      {
+        "checksum": "adler32:3a96bddf",
+        "size": 111280,
+        "type": "index.json",
+        "uri": "root://eospublic.cern.ch//eos/opendata/cms/Run2010A/Commissioning/AOD/Apr21ReReco-v1/file-indexes/CMS_Run2010A_Commissioning_AOD_Apr21ReReco-v1_0020_file_index.json"
+      },
+      {
+        "checksum": "adler32:406a84ed",
+        "size": 53592,
+        "type": "index.txt",
+        "uri": "root://eospublic.cern.ch//eos/opendata/cms/Run2010A/Commissioning/AOD/Apr21ReReco-v1/file-indexes/CMS_Run2010A_Commissioning_AOD_Apr21ReReco-v1_0020_file_index.txt"
+      },
+      {
+        "checksum": "adler32:0b41abb1",
+        "size": 59735,
+        "type": "index.json",
+        "uri": "root://eospublic.cern.ch//eos/opendata/cms/Run2010A/Commissioning/AOD/Apr21ReReco-v1/file-indexes/CMS_Run2010A_Commissioning_AOD_Apr21ReReco-v1_0021_file_index.json"
+      },
+      {
+        "checksum": "adler32:fd6019b1",
+        "size": 28776,
+        "type": "index.txt",
+        "uri": "root://eospublic.cern.ch//eos/opendata/cms/Run2010A/Commissioning/AOD/Apr21ReReco-v1/file-indexes/CMS_Run2010A_Commissioning_AOD_Apr21ReReco-v1_0021_file_index.txt"
+      }
+    ],
     "license": {
       "attribution": "CC0"
     },


### PR DESCRIPTION
(closes #2451)

Adds files indexes to Run2010A primary dataset

