### PR TITLE
records: add file indexes to 2010 Commissioning

### DIFF
--- a/cernopendata/modules/fixtures/data/records/cms-primary-datasets-Commissioning2010.json
+++ b/cernopendata/modules/fixtures/data/records/cms-primary-datasets-Commissioning2010.json
@@ -35,6 +35,32 @@
       "size": 1863373595440
     },
     "experiment": "CMS",
+    "files": [
+      {
+        "checksum": "adler32:b8cf7915",
+        "size": 154188,
+        "type": "index.json",
+        "uri": "root://eospublic.cern.ch//eos/opendata/cms/Commissioning10/MinimumBias/RECO/07JunReReco_900GeV/file-indexes/CMS_Commissioning10_MinimumBias_RECO_07JunReReco_900GeV_0000_file_index.json"
+      },
+      {
+        "checksum": "adler32:99742b55",
+        "size": 76822,
+        "type": "index.txt",
+        "uri": "root://eospublic.cern.ch//eos/opendata/cms/Commissioning10/MinimumBias/RECO/07JunReReco_900GeV/file-indexes/CMS_Commissioning10_MinimumBias_RECO_07JunReReco_900GeV_0000_file_index.txt"
+      },
+      {
+        "checksum": "adler32:387eafd5",
+        "size": 6273,
+        "type": "index.json",
+        "uri": "root://eospublic.cern.ch//eos/opendata/cms/Commissioning10/MinimumBias/RECO/07JunReReco_900GeV/file-indexes/CMS_Commissioning10_MinimumBias_RECO_07JunReReco_900GeV_0001_file_index.json"
+      },
+      {
+        "checksum": "adler32:075fc93f",
+        "size": 3124,
+        "type": "index.txt",
+        "uri": "root://eospublic.cern.ch//eos/opendata/cms/Commissioning10/MinimumBias/RECO/07JunReReco_900GeV/file-indexes/CMS_Commissioning10_MinimumBias_RECO_07JunReReco_900GeV_0001_file_index.txt"
+      }
+    ],
     "license": {
       "attribution": "CC0"
     },
@@ -131,6 +157,104 @@
       "size": 5525720585210
     },
     "experiment": "CMS",
+    "files": [
+      {
+        "checksum": "adler32:485b15e7",
+        "size": 283532,
+        "type": "index.json",
+        "uri": "root://eospublic.cern.ch//eos/opendata/cms/Commissioning10/MinimumBias/RECO/May19ReReco-v1/file-indexes/CMS_Commissioning10_MinimumBias_RECO_May19ReReco-v1_0000_file_index.json"
+      },
+      {
+        "checksum": "adler32:a4e42428",
+        "size": 139242,
+        "type": "index.txt",
+        "uri": "root://eospublic.cern.ch//eos/opendata/cms/Commissioning10/MinimumBias/RECO/May19ReReco-v1/file-indexes/CMS_Commissioning10_MinimumBias_RECO_May19ReReco-v1_0000_file_index.txt"
+      },
+      {
+        "checksum": "adler32:dd51589b",
+        "size": 107345,
+        "type": "index.json",
+        "uri": "root://eospublic.cern.ch//eos/opendata/cms/Commissioning10/MinimumBias/RECO/May19ReReco-v1/file-indexes/CMS_Commissioning10_MinimumBias_RECO_May19ReReco-v1_0001_file_index.json"
+      },
+      {
+        "checksum": "adler32:aca805ae",
+        "size": 52716,
+        "type": "index.txt",
+        "uri": "root://eospublic.cern.ch//eos/opendata/cms/Commissioning10/MinimumBias/RECO/May19ReReco-v1/file-indexes/CMS_Commissioning10_MinimumBias_RECO_May19ReReco-v1_0001_file_index.txt"
+      },
+      {
+        "checksum": "adler32:5e3067a3",
+        "size": 2251,
+        "type": "index.json",
+        "uri": "root://eospublic.cern.ch//eos/opendata/cms/Commissioning10/MinimumBias/RECO/May19ReReco-v1/file-indexes/CMS_Commissioning10_MinimumBias_RECO_May19ReReco-v1_0002_file_index.json"
+      },
+      {
+        "checksum": "adler32:b2c758ab",
+        "size": 1104,
+        "type": "index.txt",
+        "uri": "root://eospublic.cern.ch//eos/opendata/cms/Commissioning10/MinimumBias/RECO/May19ReReco-v1/file-indexes/CMS_Commissioning10_MinimumBias_RECO_May19ReReco-v1_0002_file_index.txt"
+      },
+      {
+        "checksum": "adler32:3880ce60",
+        "size": 1689,
+        "type": "index.json",
+        "uri": "root://eospublic.cern.ch//eos/opendata/cms/Commissioning10/MinimumBias/RECO/May19ReReco-v1/file-indexes/CMS_Commissioning10_MinimumBias_RECO_May19ReReco-v1_0004_file_index.json"
+      },
+      {
+        "checksum": "adler32:92d9021f",
+        "size": 828,
+        "type": "index.txt",
+        "uri": "root://eospublic.cern.ch//eos/opendata/cms/Commissioning10/MinimumBias/RECO/May19ReReco-v1/file-indexes/CMS_Commissioning10_MinimumBias_RECO_May19ReReco-v1_0004_file_index.txt"
+      },
+      {
+        "checksum": "adler32:bba465b7",
+        "size": 2251,
+        "type": "index.json",
+        "uri": "root://eospublic.cern.ch//eos/opendata/cms/Commissioning10/MinimumBias/RECO/May19ReReco-v1/file-indexes/CMS_Commissioning10_MinimumBias_RECO_May19ReReco-v1_0006_file_index.json"
+      },
+      {
+        "checksum": "adler32:079457ff",
+        "size": 1104,
+        "type": "index.txt",
+        "uri": "root://eospublic.cern.ch//eos/opendata/cms/Commissioning10/MinimumBias/RECO/May19ReReco-v1/file-indexes/CMS_Commissioning10_MinimumBias_RECO_May19ReReco-v1_0006_file_index.txt"
+      },
+      {
+        "checksum": "adler32:6156b294",
+        "size": 5342,
+        "type": "index.json",
+        "uri": "root://eospublic.cern.ch//eos/opendata/cms/Commissioning10/MinimumBias/RECO/May19ReReco-v1/file-indexes/CMS_Commissioning10_MinimumBias_RECO_May19ReReco-v1_0007_file_index.json"
+      },
+      {
+        "checksum": "adler32:d4b1303b",
+        "size": 2622,
+        "type": "index.txt",
+        "uri": "root://eospublic.cern.ch//eos/opendata/cms/Commissioning10/MinimumBias/RECO/May19ReReco-v1/file-indexes/CMS_Commissioning10_MinimumBias_RECO_May19ReReco-v1_0007_file_index.txt"
+      },
+      {
+        "checksum": "adler32:24404cfa",
+        "size": 284,
+        "type": "index.json",
+        "uri": "root://eospublic.cern.ch//eos/opendata/cms/Commissioning10/MinimumBias/RECO/May19ReReco-v1/file-indexes/CMS_Commissioning10_MinimumBias_RECO_May19ReReco-v1_0010_file_index.json"
+      },
+      {
+        "checksum": "adler32:d5bc2ab2",
+        "size": 138,
+        "type": "index.txt",
+        "uri": "root://eospublic.cern.ch//eos/opendata/cms/Commissioning10/MinimumBias/RECO/May19ReReco-v1/file-indexes/CMS_Commissioning10_MinimumBias_RECO_May19ReReco-v1_0010_file_index.txt"
+      },
+      {
+        "checksum": "adler32:900eadc6",
+        "size": 5342,
+        "type": "index.json",
+        "uri": "root://eospublic.cern.ch//eos/opendata/cms/Commissioning10/MinimumBias/RECO/May19ReReco-v1/file-indexes/CMS_Commissioning10_MinimumBias_RECO_May19ReReco-v1_0011_file_index.json"
+      },
+      {
+        "checksum": "adler32:0d3f2e8f",
+        "size": 2622,
+        "type": "index.txt",
+        "uri": "root://eospublic.cern.ch//eos/opendata/cms/Commissioning10/MinimumBias/RECO/May19ReReco-v1/file-indexes/CMS_Commissioning10_MinimumBias_RECO_May19ReReco-v1_0011_file_index.txt"
+      }
+    ],
     "license": {
       "attribution": "CC0"
     },
@@ -191,7 +315,7 @@
       ]
     }
   },
-   {
+  {
     "abstract": {
       "description": "<p>ZeroBias primary dataset in RECO format from the 0.9 and 7 TeV Commissioning runs of 2010. This dataset includes the data from <a href=\"http://inspirehep.net/record/1227802/\">the CASTOR calorimeter</a>, which covers the very forward region in the CMS experiment (-6.6 < eta < -5.2). </p> <p> The list of validated runs, which must be applied to all analyses, can be found in</p>",
       "links": [
@@ -230,6 +354,128 @@
       "size": 10009271150212
     },
     "experiment": "CMS",
+    "files": [
+      {
+        "checksum": "adler32:6eb492f4",
+        "size": 375859,
+        "type": "index.json",
+        "uri": "root://eospublic.cern.ch//eos/opendata/cms/Commissioning10/ZeroBias/RECO/May19ReReco-v1/file-indexes/CMS_Commissioning10_ZeroBias_RECO_May19ReReco-v1_0000_file_index.json"
+      },
+      {
+        "checksum": "adler32:14044ca1",
+        "size": 182520,
+        "type": "index.txt",
+        "uri": "root://eospublic.cern.ch//eos/opendata/cms/Commissioning10/ZeroBias/RECO/May19ReReco-v1/file-indexes/CMS_Commissioning10_ZeroBias_RECO_May19ReReco-v1_0000_file_index.txt"
+      },
+      {
+        "checksum": "adler32:ac94d19f",
+        "size": 278003,
+        "type": "index.json",
+        "uri": "root://eospublic.cern.ch//eos/opendata/cms/Commissioning10/ZeroBias/RECO/May19ReReco-v1/file-indexes/CMS_Commissioning10_ZeroBias_RECO_May19ReReco-v1_0001_file_index.json"
+      },
+      {
+        "checksum": "adler32:52d56ec5",
+        "size": 135000,
+        "type": "index.txt",
+        "uri": "root://eospublic.cern.ch//eos/opendata/cms/Commissioning10/ZeroBias/RECO/May19ReReco-v1/file-indexes/CMS_Commissioning10_ZeroBias_RECO_May19ReReco-v1_0001_file_index.txt"
+      },
+      {
+        "checksum": "adler32:55e1774d",
+        "size": 128995,
+        "type": "index.json",
+        "uri": "root://eospublic.cern.ch//eos/opendata/cms/Commissioning10/ZeroBias/RECO/May19ReReco-v1/file-indexes/CMS_Commissioning10_ZeroBias_RECO_May19ReReco-v1_0002_file_index.json"
+      },
+      {
+        "checksum": "adler32:1a14f8c9",
+        "size": 62640,
+        "type": "index.txt",
+        "uri": "root://eospublic.cern.ch//eos/opendata/cms/Commissioning10/ZeroBias/RECO/May19ReReco-v1/file-indexes/CMS_Commissioning10_ZeroBias_RECO_May19ReReco-v1_0002_file_index.txt"
+      },
+      {
+        "checksum": "adler32:b5c43b0f",
+        "size": 5841,
+        "type": "index.json",
+        "uri": "root://eospublic.cern.ch//eos/opendata/cms/Commissioning10/ZeroBias/RECO/May19ReReco-v1/file-indexes/CMS_Commissioning10_ZeroBias_RECO_May19ReReco-v1_0007_file_index.json"
+      },
+      {
+        "checksum": "adler32:16547129",
+        "size": 2835,
+        "type": "index.txt",
+        "uri": "root://eospublic.cern.ch//eos/opendata/cms/Commissioning10/ZeroBias/RECO/May19ReReco-v1/file-indexes/CMS_Commissioning10_ZeroBias_RECO_May19ReReco-v1_0007_file_index.txt"
+      },
+      {
+        "checksum": "adler32:e9d44e4f",
+        "size": 52823,
+        "type": "index.json",
+        "uri": "root://eospublic.cern.ch//eos/opendata/cms/Commissioning10/ZeroBias/RECO/May19ReReco-v1/file-indexes/CMS_Commissioning10_ZeroBias_RECO_May19ReReco-v1_0018_file_index.json"
+      },
+      {
+        "checksum": "adler32:7e6d1b37",
+        "size": 25650,
+        "type": "index.txt",
+        "uri": "root://eospublic.cern.ch//eos/opendata/cms/Commissioning10/ZeroBias/RECO/May19ReReco-v1/file-indexes/CMS_Commissioning10_ZeroBias_RECO_May19ReReco-v1_0018_file_index.txt"
+      },
+      {
+        "checksum": "adler32:cb74f4c1",
+        "size": 2783,
+        "type": "index.json",
+        "uri": "root://eospublic.cern.ch//eos/opendata/cms/Commissioning10/ZeroBias/RECO/May19ReReco-v1/file-indexes/CMS_Commissioning10_ZeroBias_RECO_May19ReReco-v1_0032_file_index.json"
+      },
+      {
+        "checksum": "adler32:ada4a2a3",
+        "size": 1350,
+        "type": "index.txt",
+        "uri": "root://eospublic.cern.ch//eos/opendata/cms/Commissioning10/ZeroBias/RECO/May19ReReco-v1/file-indexes/CMS_Commissioning10_ZeroBias_RECO_May19ReReco-v1_0032_file_index.txt"
+      },
+      {
+        "checksum": "adler32:42c94c54",
+        "size": 281,
+        "type": "index.json",
+        "uri": "root://eospublic.cern.ch//eos/opendata/cms/Commissioning10/ZeroBias/RECO/May19ReReco-v1/file-indexes/CMS_Commissioning10_ZeroBias_RECO_May19ReReco-v1_0039_file_index.json"
+      },
+      {
+        "checksum": "adler32:3cdf29d0",
+        "size": 135,
+        "type": "index.txt",
+        "uri": "root://eospublic.cern.ch//eos/opendata/cms/Commissioning10/ZeroBias/RECO/May19ReReco-v1/file-indexes/CMS_Commissioning10_ZeroBias_RECO_May19ReReco-v1_0039_file_index.txt"
+      },
+      {
+        "checksum": "adler32:b42b317e",
+        "size": 1115,
+        "type": "index.json",
+        "uri": "root://eospublic.cern.ch//eos/opendata/cms/Commissioning10/ZeroBias/RECO/May19ReReco-v1/file-indexes/CMS_Commissioning10_ZeroBias_RECO_May19ReReco-v1_0045_file_index.json"
+      },
+      {
+        "checksum": "adler32:520ea863",
+        "size": 540,
+        "type": "index.txt",
+        "uri": "root://eospublic.cern.ch//eos/opendata/cms/Commissioning10/ZeroBias/RECO/May19ReReco-v1/file-indexes/CMS_Commissioning10_ZeroBias_RECO_May19ReReco-v1_0045_file_index.txt"
+      },
+      {
+        "checksum": "adler32:e9884bdc",
+        "size": 281,
+        "type": "index.json",
+        "uri": "root://eospublic.cern.ch//eos/opendata/cms/Commissioning10/ZeroBias/RECO/May19ReReco-v1/file-indexes/CMS_Commissioning10_ZeroBias_RECO_May19ReReco-v1_0046_file_index.json"
+      },
+      {
+        "checksum": "adler32:3c6829c3",
+        "size": 135,
+        "type": "index.txt",
+        "uri": "root://eospublic.cern.ch//eos/opendata/cms/Commissioning10/ZeroBias/RECO/May19ReReco-v1/file-indexes/CMS_Commissioning10_ZeroBias_RECO_May19ReReco-v1_0046_file_index.txt"
+      },
+      {
+        "checksum": "adler32:e6cc992e",
+        "size": 561,
+        "type": "index.json",
+        "uri": "root://eospublic.cern.ch//eos/opendata/cms/Commissioning10/ZeroBias/RECO/May19ReReco-v1/file-indexes/CMS_Commissioning10_ZeroBias_RECO_May19ReReco-v1_10004_file_index.json"
+      },
+      {
+        "checksum": "adler32:42da545c",
+        "size": 272,
+        "type": "index.txt",
+        "uri": "root://eospublic.cern.ch//eos/opendata/cms/Commissioning10/ZeroBias/RECO/May19ReReco-v1/file-indexes/CMS_Commissioning10_ZeroBias_RECO_May19ReReco-v1_10004_file_index.txt"
+      }
+    ],
     "license": {
       "attribution": "CC0"
     },


### PR DESCRIPTION
(closes #2343)

Adds files indexes to 2010 Commissioning primary datasets

