### PR TITLE
records: CMS 2011 MC BuToKstarMuMuV2 missing files

### DIFF
--- a/cernopendata/modules/fixtures/data/records/cms-simulated-datasets-Run2011A.json
+++ b/cernopendata/modules/fixtures/data/records/cms-simulated-datasets-Run2011A.json
@@ -13369,14 +13369,14 @@
     "experiment": "CMS",
     "files": [
       {
-        "checksum": "adler32:89ad1f29",
-        "size": 1030622,
+        "checksum": "adler32:f83f7ee4",
+        "size": 1030966,
         "type": "index.json",
         "uri": "root://eospublic.cern.ch//eos/opendata/cms/MonteCarlo2011/Summer11LegDR/BuToKstarMuMuV2_EtaPtFilter_7TeV-pythia6-evtgen/AODSIM/PU_S13_START53_LV6-v1/file-indexes/CMS_MonteCarlo2011_Summer11LegDR_BuToKstarMuMuV2_EtaPtFilter_7TeV-pythia6-evtgen_AODSIM_PU_S13_START53_LV6-v1_00000_file_index.json"
       },
       {
-        "checksum": "adler32:07f6d57c",
-        "size": 590212,
+        "checksum": "adler32:c765138d",
+        "size": 590409,
         "type": "index.txt",
         "uri": "root://eospublic.cern.ch//eos/opendata/cms/MonteCarlo2011/Summer11LegDR/BuToKstarMuMuV2_EtaPtFilter_7TeV-pythia6-evtgen/AODSIM/PU_S13_START53_LV6-v1/file-indexes/CMS_MonteCarlo2011_Summer11LegDR_BuToKstarMuMuV2_EtaPtFilter_7TeV-pythia6-evtgen_AODSIM_PU_S13_START53_LV6-v1_00000_file_index.txt"
       },


### PR DESCRIPTION
* Amends record fixtures after recovering missing file for CMS 2011 MC
  BuToKstarMuMuV2 dataset. (addresses #2710)

Signed-off-by: Tibor Simko <tibor.simko@cern.ch>