### PR TITLE
models: number of entries

### DIFF
--- a/cernopendata/jsonschemas/records/record-v1.0.0.json
+++ b/cernopendata/jsonschemas/records/record-v1.0.0.json
@@ -210,6 +210,10 @@
           },
           "type": "array"
         },
+        "number_entries": {
+          "description": "The total number of entries",
+          "type": "integer"
+        },
         "number_events": {
           "description": "The total number of events",
           "type": "integer"

--- a/cernopendata/templates/cernopendata_records_ui/records/record_detail.html
+++ b/cernopendata/templates/cernopendata_records_ui/records/record_detail.html
@@ -98,13 +98,16 @@
     </div>
     {% endif %}
 
-    {% if record.distribution and (record.distribution.number_events or record.distribution.number_files or record.distribution.size) %}
+    {% if record.distribution and (record.distribution.number_entries or record.distribution.number_events or record.distribution.number_files or record.distribution.size) %}
         <div class="row">
             <div class="col-md-12">
                 {% if record.type.primary == 'Dataset' %}
                 <h2>Dataset characteristics</h2>
                 {% else %}
                 <h2>Characteristics</h2>
+                {% endif %}
+                {% if record.distribution.number_entries %}
+                <span><strong>{{record.distribution.number_entries}}</strong> entries. </span>
                 {% endif %}
                 {% if record.distribution.number_events %}
                 <span><strong>{{record.distribution.number_events}}</strong> events. </span>


### PR DESCRIPTION
* Introduces ``number_entries`` into the data model and the templates. Useful
  for datasets not containing events. (closes #2622)

Signed-off-by: Tibor Simko <tibor.simko@cern.ch>