### PR TITLE
records: CMS 2011 MC GluGluToHToZZTo2L2Nu missing file

### DIFF
--- a/cernopendata/modules/fixtures/data/records/cms-simulated-datasets-Run2011A.json
+++ b/cernopendata/modules/fixtures/data/records/cms-simulated-datasets-Run2011A.json
@@ -17779,14 +17779,14 @@
         "uri": "root://eospublic.cern.ch//eos/opendata/cms/MonteCarlo2011/Summer11LegDR/GluGluToHToZZTo2L2Nu_M-200_7TeV-powheg15-pythia6/AODSIM/PU_S13_START53_LV6-v1/file-indexes/CMS_MonteCarlo2011_Summer11LegDR_GluGluToHToZZTo2L2Nu_M-200_7TeV-powheg15-pythia6_AODSIM_PU_S13_START53_LV6-v1_00000_file_index.txt"
       },
       {
-        "checksum": "adler32:05215777",
-        "size": 62447,
+        "checksum": "adler32:a216b669",
+        "size": 62792,
         "type": "index.json",
         "uri": "root://eospublic.cern.ch//eos/opendata/cms/MonteCarlo2011/Summer11LegDR/GluGluToHToZZTo2L2Nu_M-200_7TeV-powheg15-pythia6/AODSIM/PU_S13_START53_LV6-v1/file-indexes/CMS_MonteCarlo2011_Summer11LegDR_GluGluToHToZZTo2L2Nu_M-200_7TeV-powheg15-pythia6_AODSIM_PU_S13_START53_LV6-v1_010000_file_index.json"
       },
       {
-        "checksum": "adler32:9ccb24df",
-        "size": 36019,
+        "checksum": "adler32:1b0961c8",
+        "size": 36218,
         "type": "index.txt",
         "uri": "root://eospublic.cern.ch//eos/opendata/cms/MonteCarlo2011/Summer11LegDR/GluGluToHToZZTo2L2Nu_M-200_7TeV-powheg15-pythia6/AODSIM/PU_S13_START53_LV6-v1/file-indexes/CMS_MonteCarlo2011_Summer11LegDR_GluGluToHToZZTo2L2Nu_M-200_7TeV-powheg15-pythia6_AODSIM_PU_S13_START53_LV6-v1_010000_file_index.txt"
       }


### PR DESCRIPTION
* Amends record fixtures after recovering missing file for CMS 2011 MC
  GluGluToHToZZTo2L2Nu simulated dataset. (closes #2710)

Signed-off-by: Tibor Šimko <tibor.simko@cern.ch>