### PR TITLE
records: DOIs for CMS NanoAOD examples

### DIFF
--- a/cernopendata/modules/fixtures/data/records/cms-derived-nanoaod-outreach-DoubleMuParked.json
+++ b/cernopendata/modules/fixtures/data/records/cms-derived-nanoaod-outreach-DoubleMuParked.json
@@ -79,16 +79,6 @@
     "relations": [
       {
         "description": "",
-        "recid": "12340",
-        "type": "isRelatedTo"
-      },
-      {
-        "description": "",
-        "recid": "12342",
-        "type": "isRelatedTo"
-      },
-      {
-        "description": "",
         "recid": "6004",
         "type": "isRelatedTo"
       },

--- a/cernopendata/modules/fixtures/data/records/cms-derived-nanoaod-outreach-DoubleMuParked.json
+++ b/cernopendata/modules/fixtures/data/records/cms-derived-nanoaod-outreach-DoubleMuParked.json
@@ -44,25 +44,6 @@
         "variable": "Muon_charge"
       }
     ],
-    "methodology": {
-     "description": "This dataset was produced with the software available in the record linked below. All other products than the muons were dropped manually from the read-out and the datasets from Run B and C were combined in a single file.",
-     "links": [
-       {
-         "recid": "12340"
-       }
-     ]
-   },
-    "validation": {
-      "description": "These data were derived from the 2012 DoubleMuParked primary datasets using only the validated runs. No further validation was done for the output.",
-    "links": [
-       {
-         "recid": "6004"
-       },
-       {
-         "recid": "6030"
-       }
-     ]
-    },
     "date_published": "2019",
     "distribution": {
       "formats": [
@@ -73,6 +54,7 @@
       "number_files": 1,
       "size": 2244449133
     },
+    "doi": "10.7483/OPENDATA.CMS.LVG5.QT81",
     "experiment": "CMS",
     "files": [
       {
@@ -83,6 +65,14 @@
     ],
     "license": {
       "attribution": "CC0"
+    },
+    "methodology": {
+      "description": "This dataset was produced with the software available in the record linked below. All other products than the muons were dropped manually from the read-out and the datasets from Run B and C were combined in a single file.",
+      "links": [
+        {
+          "recid": "12340"
+        }
+      ]
     },
     "publisher": "CERN Open Data Portal",
     "recid": "12341",
@@ -124,6 +114,17 @@
       "links": [
         {
           "recid": "12342"
+        }
+      ]
+    },
+    "validation": {
+      "description": "These data were derived from the 2012 DoubleMuParked primary datasets using only the validated runs. No further validation was done for the output.",
+      "links": [
+        {
+          "recid": "6004"
+        },
+        {
+          "recid": "6030"
         }
       ]
     }

--- a/cernopendata/modules/fixtures/data/records/cms-tools-nanoaod-outreach-dimuon-spectrum.json
+++ b/cernopendata/modules/fixtures/data/records/cms-tools-nanoaod-outreach-dimuon-spectrum.json
@@ -22,6 +22,7 @@
       "number_files": 4,
       "size": 76098
     },
+    "doi": "10.7483/OPENDATA.CMS.AAR1.4NZQ",
     "experiment": "CMS",
     "files": [
       {
@@ -125,6 +126,7 @@
       "number_files": 1,
       "size": 766445
     },
+    "doi": "10.7483/OPENDATA.CMS.944Q.PN2X",
     "experiment": "CMS",
     "files": [
       {


### PR DESCRIPTION
* Adds DOIs to the three CMS NanoAOD records. (closes #2636)

Signed-off-by: Tibor Šimko <tibor.simko@cern.ch>