### PR TITLE
records: CMS educational data updates

### DIFF
--- a/cernopendata/modules/fixtures/data/records/cms-csv-files.json
+++ b/cernopendata/modules/fixtures/data/records/cms-csv-files.json
@@ -121,6 +121,44 @@
     "collections": [
       "CMS-Derived-Datasets"
     ],
+    "dataset_semantics": [
+      {
+        "description": "The run number of the event.",
+        "variable": "Run"
+      },
+      {
+        "description": "The event number.",
+        "variable": "Event"
+      },
+      {
+        "description": "The total energy of the muon GeV).",
+        "variable": "E"
+      },
+      {
+        "description": "The components of the momemtum of the muon (GeV).",
+        "variable": "px,py,pz"
+      },
+      {
+        "description": "The transverse momentum of the muon (GeV).",
+        "variable": "pt"
+      },
+      {
+        "description": "The pseudorapidity of the muon.",
+        "variable": "eta"
+      },
+      {
+        "description": "The phi angle of the muon (rad).",
+        "variable": "phi"
+      },
+      {
+        "description": "The charge of the muon.",
+        "variable": "Q"
+      },
+      {
+        "description": "The invariant mass of two muons (GeV).",
+        "variable": "M"
+      }
+    ],
     "date_created": [
       "2010"
     ],
@@ -189,6 +227,9 @@
         "size": 1517640,
         "uri": "root://eospublic.cern.ch//eos/opendata/cms/Run2010B/Mu/CSV/Apr21ReReco-v1/MuRun2010B_9.csv"
       }
+    ],
+    "keywords": [
+      "education"
     ],
     "methodology": {
       "description": "The events in this derived dataset were selected because of the presence of precisely two muons with invariant mass between 2-110 GeV, one of which is a high-quality \"global\" muon. More information on the selections applied for the Mu primary dataset can be found there.",

--- a/cernopendata/modules/fixtures/data/records/cms-derived-csv-2012.json
+++ b/cernopendata/modules/fixtures/data/records/cms-derived-csv-2012.json
@@ -85,6 +85,9 @@
         "uri": "root://eospublic.cern.ch//eos/opendata/cms/derived-data/run1-physics-candidates/higgs/13424-v5/Hto4l_2012C_2.ig"
       }
     ],
+    "keywords": [
+      "education"
+    ],
     "license": {
       "attribution": "CC0"
     },

--- a/cernopendata/modules/fixtures/data/records/cms-derived-csv-Run2011A.json
+++ b/cernopendata/modules/fixtures/data/records/cms-derived-csv-Run2011A.json
@@ -102,6 +102,9 @@
         "variable": "isoHcal"
       }
     ],
+    "date_created": [
+      "2011"
+    ],
     "date_published": "2017",
     "distribution": {
       "formats": [
@@ -150,6 +153,9 @@
         "size": 2599212,
         "uri": "root://eospublic.cern.ch//eos/opendata/cms/Run2011A/DoubleMu/CSV/12Oct2013-v1/Ymumu.csv"
       }
+    ],
+    "keywords": [
+      "education"
     ],
     "license": {
       "attribution": "CC0"

--- a/cernopendata/modules/fixtures/data/records/cms-masterclass-files.json
+++ b/cernopendata/modules/fixtures/data/records/cms-masterclass-files.json
@@ -12,6 +12,10 @@
     "collections": [
       "CMS-Derived-Datasets"
     ],
+    "date_created": [
+      "2011",
+      "2012"
+    ],
     "date_published": "2014",
     "distribution": {
       "formats": [
@@ -53,6 +57,9 @@
         "size": 1619,
         "uri": "root://eospublic.cern.ch//eos/opendata/cms/masterclass-2014/diphoton.json"
       }
+    ],
+    "keywords": [
+      "education"
     ],
     "license": {
       "attribution": "CC0"
@@ -102,6 +109,51 @@
     ],
     "collections": [
       "CMS-Derived-Datasets"
+    ],
+    "dataset_semantics": [
+      {
+        "description": "Combination of T and G, where T stands for tracker muon and G stands for global muon.",
+        "variable": "Type"
+      },
+      {
+        "description": "The run number of the event.",
+        "variable": "Run"
+      },
+      {
+        "description": "The event number.",
+        "variable": "Event"
+      },
+      {
+        "description": "The total energy of the muon GeV).",
+        "variable": "E"
+      },
+      {
+        "description": "The components of the momemtum of the muon (GeV).",
+        "variable": "px,py,pz"
+      },
+      {
+        "description": "The transverse momentum of the muon (GeV).",
+        "variable": "pt"
+      },
+      {
+        "description": "The pseudorapidity of the muon.",
+        "variable": "eta"
+      },
+      {
+        "description": "The phi angle of the muon (rad).",
+        "variable": "phi"
+      },
+      {
+        "description": "The charge of the muon.",
+        "variable": "Q"
+      },
+      {
+        "description": "The invariant mass of two muons (GeV).",
+        "variable": "M"
+      }
+    ],
+    "date_created": [
+      "2010"
     ],
     "date_published": "2014",
     "distribution": {
@@ -225,6 +277,9 @@
         "uri": "root://eospublic.cern.ch//eos/opendata/cms/masterclass-2014/dimuon-Jpsi_6.ig"
       }
     ],
+    "keywords": [
+      "education"
+    ],
     "license": {
       "attribution": "CC0"
     },
@@ -270,6 +325,47 @@
     ],
     "collections": [
       "CMS-Derived-Datasets"
+    ],
+    "dataset_semantics": [
+      {
+        "description": "The run number of the event.",
+        "variable": "Run"
+      },
+      {
+        "description": "The event number.",
+        "variable": "Event"
+      },
+      {
+        "description": "The total energy of the electron (GeV).",
+        "variable": "E"
+      },
+      {
+        "description": "The components of the momemtum of the electron (GeV).",
+        "variable": "px,py,pz"
+      },
+      {
+        "description": "The transverse momentum of the electron (GeV).",
+        "variable": "pt"
+      },
+      {
+        "description": "The pseudorapidity of the electron.",
+        "variable": "eta"
+      },
+      {
+        "description": "The phi angle of the electron (rad).",
+        "variable": "phi"
+      },
+      {
+        "description": "The charge of the electron.",
+        "variable": "Q"
+      },
+      {
+        "description": "The invariant mass of two electrons (GeV).",
+        "variable": "M"
+      }
+    ],
+    "date_created": [
+      "2010"
     ],
     "date_published": "2014",
     "distribution": {
@@ -393,6 +489,9 @@
         "uri": "root://eospublic.cern.ch//eos/opendata/cms/masterclass-2014/dielectron-Jpsi.json"
       }
     ],
+    "keywords": [
+      "education"
+    ],
     "license": {
       "attribution": "CC0"
     },
@@ -438,6 +537,51 @@
     ],
     "collections": [
       "CMS-Derived-Datasets"
+    ],
+    "dataset_semantics": [
+      {
+        "description": "Combination of T and G, where T stands for tracker muon and G stands for global muon.",
+        "variable": "Type"
+      },
+      {
+        "description": "The run number of the event.",
+        "variable": "Run"
+      },
+      {
+        "description": "The event number.",
+        "variable": "Event"
+      },
+      {
+        "description": "The total energy of the muon GeV).",
+        "variable": "E"
+      },
+      {
+        "description": "The components of the momemtum of the muon (GeV).",
+        "variable": "px,py,pz"
+      },
+      {
+        "description": "The transverse momentum of the muon (GeV).",
+        "variable": "pt"
+      },
+      {
+        "description": "The pseudorapidity of the muon.",
+        "variable": "eta"
+      },
+      {
+        "description": "The phi angle of the muon (rad).",
+        "variable": "phi"
+      },
+      {
+        "description": "The charge of the muon.",
+        "variable": "Q"
+      },
+      {
+        "description": "The invariant mass of two muons (GeV).",
+        "variable": "M"
+      }
+    ],
+    "date_created": [
+      "2010"
     ],
     "date_published": "2014",
     "distribution": {
@@ -511,6 +655,9 @@
         "uri": "root://eospublic.cern.ch//eos/opendata/cms/masterclass-2014/dimuon_6.ig"
       }
     ],
+    "keywords": [
+      "education"
+    ],
     "license": {
       "attribution": "CC0"
     },
@@ -556,6 +703,47 @@
     ],
     "collections": [
       "CMS-Derived-Datasets"
+    ],
+    "dataset_semantics": [
+      {
+        "description": "The run number of the event.",
+        "variable": "Run"
+      },
+      {
+        "description": "The event number.",
+        "variable": "Event"
+      },
+      {
+        "description": "The total energy of the electron (GeV).",
+        "variable": "E"
+      },
+      {
+        "description": "The components of the momemtum of the electron (GeV).",
+        "variable": "px,py,pz"
+      },
+      {
+        "description": "The transverse momentum of the electron (GeV).",
+        "variable": "pt"
+      },
+      {
+        "description": "The pseudorapidity of the electron.",
+        "variable": "eta"
+      },
+      {
+        "description": "The phi angle of the electron (rad).",
+        "variable": "phi"
+      },
+      {
+        "description": "The charge of the electron.",
+        "variable": "Q"
+      },
+      {
+        "description": "The invariant mass of two electrons (GeV).",
+        "variable": "M"
+      }
+    ],
+    "date_created": [
+      "2010"
     ],
     "date_published": "2014",
     "distribution": {
@@ -629,6 +817,9 @@
         "uri": "root://eospublic.cern.ch//eos/opendata/cms/masterclass-2014/dielectron_9.ig"
       }
     ],
+    "keywords": [
+      "education"
+    ],
     "license": {
       "attribution": "CC0"
     },
@@ -674,6 +865,47 @@
     ],
     "collections": [
       "CMS-Derived-Datasets"
+    ],
+    "dataset_semantics": [
+      {
+        "description": "The run number of the event.",
+        "variable": "Run"
+      },
+      {
+        "description": "The event number.",
+        "variable": "Event"
+      },
+      {
+        "description": "The total energy of the electron (GeV).",
+        "variable": "E"
+      },
+      {
+        "description": "The components of the momemtum of the electron (GeV).",
+        "variable": "px,py,pz"
+      },
+      {
+        "description": "The transverse momentum of the electron (GeV).",
+        "variable": "pt"
+      },
+      {
+        "description": "The pseudorapidity of the electron.",
+        "variable": "eta"
+      },
+      {
+        "description": "The phi angle of the electron (rad).",
+        "variable": "phi"
+      },
+      {
+        "description": "The charge of the electron.",
+        "variable": "Q"
+      },
+      {
+        "description": "The invariant mass of two electrons (GeV).",
+        "variable": "M"
+      }
+    ],
+    "date_created": [
+      "2010"
     ],
     "date_published": "2014",
     "distribution": {
@@ -797,6 +1029,9 @@
         "uri": "root://eospublic.cern.ch//eos/opendata/cms/masterclass-2014/dielectron-Upsilon.json"
       }
     ],
+    "keywords": [
+      "education"
+    ],
     "license": {
       "attribution": "CC0"
     },
@@ -842,6 +1077,51 @@
     ],
     "collections": [
       "CMS-Derived-Datasets"
+    ],
+    "dataset_semantics": [
+      {
+        "description": "Electron track reconstruction type.",
+        "variable": "Type"
+      },
+      {
+        "description": "The run number of the event.",
+        "variable": "Run"
+      },
+      {
+        "description": "The event number.",
+        "variable": "Event"
+      },
+      {
+        "description": "The total energy of the electron (GeV).",
+        "variable": "E"
+      },
+      {
+        "description": "The components of the momemtum of the electron (GeV).",
+        "variable": "px,py,pz"
+      },
+      {
+        "description": "The transverse momentum of the electron (GeV).",
+        "variable": "pt"
+      },
+      {
+        "description": "The pseudorapidity of the electron.",
+        "variable": "eta"
+      },
+      {
+        "description": "The phi angle of the electron (rad).",
+        "variable": "phi"
+      },
+      {
+        "description": "The charge of the electron.",
+        "variable": "Q"
+      },
+      {
+        "description": "The invariant mass of two electrons (GeV).",
+        "variable": "M"
+      }
+    ],
+    "date_created": [
+      "2010"
     ],
     "date_published": "2014",
     "distribution": {
@@ -890,6 +1170,9 @@
         "uri": "root://eospublic.cern.ch//eos/opendata/cms/masterclass-2014/Zee_4.ig"
       }
     ],
+    "keywords": [
+      "education"
+    ],
     "license": {
       "attribution": "CC0"
     },
@@ -935,6 +1218,51 @@
     ],
     "collections": [
       "CMS-Derived-Datasets"
+    ],
+    "dataset_semantics": [
+      {
+        "description": "Combination of T and G, where T stands for tracker muon and G stands for global muon.",
+        "variable": "Type"
+      },
+      {
+        "description": "The run number of the event.",
+        "variable": "Run"
+      },
+      {
+        "description": "The event number.",
+        "variable": "Event"
+      },
+      {
+        "description": "The total energy of the muon GeV).",
+        "variable": "E"
+      },
+      {
+        "description": "The components of the momemtum of the muon (GeV).",
+        "variable": "px,py,pz"
+      },
+      {
+        "description": "The transverse momentum of the muon (GeV).",
+        "variable": "pt"
+      },
+      {
+        "description": "The pseudorapidity of the muon.",
+        "variable": "eta"
+      },
+      {
+        "description": "The phi angle of the muon (rad).",
+        "variable": "phi"
+      },
+      {
+        "description": "The charge of the muon.",
+        "variable": "Q"
+      },
+      {
+        "description": "The invariant mass of two muons (GeV).",
+        "variable": "M"
+      }
+    ],
+    "date_created": [
+      "2010"
     ],
     "date_published": "2014",
     "distribution": {
@@ -983,6 +1311,9 @@
         "uri": "root://eospublic.cern.ch//eos/opendata/cms/masterclass-2014/Zmumu.json"
       }
     ],
+    "keywords": [
+      "education"
+    ],
     "license": {
       "attribution": "CC0"
     },
@@ -1028,6 +1359,51 @@
     ],
     "collections": [
       "CMS-Derived-Datasets"
+    ],
+    "dataset_semantics": [
+      {
+        "description": "The run number of the event.",
+        "variable": "Run"
+      },
+      {
+        "description": "The event number.",
+        "variable": "Event"
+      },
+      {
+        "description": "The total energy of the electron (GeV).",
+        "variable": "E"
+      },
+      {
+        "description": "The components of the momemtum of the electron (GeV).",
+        "variable": "px,py,pz"
+      },
+      {
+        "description": "The transverse momentum of the electron (GeV).",
+        "variable": "pt"
+      },
+      {
+        "description": "The pseudorapidity of the electron.",
+        "variable": "eta"
+      },
+      {
+        "description": "The phi angle of the electron (rad).",
+        "variable": "phi"
+      },
+      {
+        "description": "The charge of the electron.",
+        "variable": "Q"
+      },
+      {
+        "description": "The missing transverse momentum of the event (GeV).",
+        "variable": "MET"
+      },
+      {
+        "description": "The phi angle of the missing transverse momentum (rad).",
+        "variable": "phiMET"
+      }
+    ],
+    "date_created": [
+      "2010"
     ],
     "date_published": "2014",
     "distribution": {
@@ -1101,6 +1477,9 @@
         "uri": "root://eospublic.cern.ch//eos/opendata/cms/masterclass-2014/Wenu_6.ig"
       }
     ],
+    "keywords": [
+      "education"
+    ],
     "license": {
       "attribution": "CC0"
     },
@@ -1146,6 +1525,51 @@
     ],
     "collections": [
       "CMS-Derived-Datasets"
+    ],
+    "dataset_semantics": [
+      {
+        "description": "The run number of the event.",
+        "variable": "Run"
+      },
+      {
+        "description": "The event number.",
+        "variable": "Event"
+      },
+      {
+        "description": "The total energy of the muon GeV).",
+        "variable": "E"
+      },
+      {
+        "description": "The components of the momemtum of the muon (GeV).",
+        "variable": "px,py,pz"
+      },
+      {
+        "description": "The transverse momentum of the muon (GeV).",
+        "variable": "pt"
+      },
+      {
+        "description": "The pseudorapidity of the muon.",
+        "variable": "eta"
+      },
+      {
+        "description": "The phi angle of the muon (rad).",
+        "variable": "phi"
+      },
+      {
+        "description": "The charge of the muon.",
+        "variable": "Q"
+      },
+      {
+        "description": "The missing transverse momentum of the event (GeV).",
+        "variable": "MET"
+      },
+      {
+        "description": "The phi angle of the missing transverse momentum (rad).",
+        "variable": "phiMET"
+      }
+    ],
+    "date_created": [
+      "2010"
     ],
     "date_published": "2014",
     "distribution": {
@@ -1219,6 +1643,9 @@
         "uri": "root://eospublic.cern.ch//eos/opendata/cms/masterclass-2014/Wmunu_6.ig"
       }
     ],
+    "keywords": [
+      "education"
+    ],
     "license": {
       "attribution": "CC0"
     },
@@ -1264,6 +1691,9 @@
     ],
     "collections": [
       "CMS-Derived-Datasets"
+    ],
+    "date_created": [
+      "2010"
     ],
     "date_published": "2014",
     "distribution": {
@@ -1661,6 +2091,9 @@
         "size": 728576,
         "uri": "root://eospublic.cern.ch//eos/opendata/cms/masterclass-2014/masterclass-2014.xls"
       }
+    ],
+    "keywords": [
+      "masterclass"
     ],
     "license": {
       "attribution": "CC0"


### PR DESCRIPTION
*  Adds education keyword and dataset semantics to outreach records.
   (addresses #2774)

Co-authored-by: Juha-Matti Teuho <juha.teuho@gmail.com>
Signed-off-by: Linda Hemmann <linda.hemmann@gmail.com>