### PR TITLE
facets: Add event_number facet

### DIFF
--- a/cernopendata/config.py
+++ b/cernopendata/config.py
@@ -315,6 +315,38 @@ RECORDS_REST_FACETS = {
             signature=dict(terms=dict(
                 field='signature.keyword',
                 order=dict(_term='asc'))),
+            event_number= {
+                'range': {
+                    'field': 'distribution.number_events',
+                    'ranges': [
+                        {
+                            'key' : '0 - 999',
+                            'from': 0,
+                            'to': 999
+                        },
+                        {
+                            'key' : '1000 - 9999',
+                            'from': 1000,
+                            'to': 9999
+                        },
+                        {
+                            'key' : '10 000 - 99 999',
+                            'from': 10000,
+                            'to': 99999
+                        },
+                        {
+                            'key' : '100 000 - 999 999',
+                            'from': 100000,
+                            'to': 999999
+                        },
+                        {
+                            'key' : '1 000 000 -',
+                            'from': 1000000,
+                            'to': 100000000
+                        }
+                    ]
+                }
+            }
         ),
         'post_filters': dict(
             experiment=terms_filter('experiment.keyword'),
@@ -332,6 +364,7 @@ RECORDS_REST_FACETS = {
             collections=terms_filter('collections.keyword'),
             availability=terms_filter('distribution.availability.keyword'),
             signature=terms_filter('signature.keyword'),
+            event_number= None,
         )
     }
 }

--- a/cernopendata/config.py
+++ b/cernopendata/config.py
@@ -30,7 +30,7 @@ import os
 
 from invenio_records_files.api import _Record
 from invenio_records_rest.config import RECORDS_REST_ENDPOINTS
-from invenio_records_rest.facets import terms_filter
+from invenio_records_rest.facets import range_filter, terms_filter
 from invenio_records_rest.utils import allow_all
 
 from cernopendata.modules.pages.config import *
@@ -315,34 +315,38 @@ RECORDS_REST_FACETS = {
             signature=dict(terms=dict(
                 field='signature.keyword',
                 order=dict(_term='asc'))),
-            event_number= {
+            event_number={
                 'range': {
                     'field': 'distribution.number_events',
                     'ranges': [
                         {
-                            'key' : '0 - 999',
+                            'key': '0--999',
                             'from': 0,
                             'to': 999
                         },
                         {
-                            'key' : '1000 - 9999',
+                            'key': '1000--9999',
                             'from': 1000,
                             'to': 9999
                         },
                         {
-                            'key' : '10 000 - 99 999',
+                            'key': '10000--99999',
                             'from': 10000,
                             'to': 99999
                         },
                         {
-                            'key' : '100 000 - 999 999',
+                            'key': '100000--999999',
                             'from': 100000,
                             'to': 999999
                         },
                         {
-                            'key' : '1 000 000 -',
+                            'key': '1000000--9999999',
                             'from': 1000000,
-                            'to': 100000000
+                            'to': 9999999
+                        },
+                        {
+                            'key': '10000000--',
+                            'from': 10000000
                         }
                     ]
                 }
@@ -364,7 +368,7 @@ RECORDS_REST_FACETS = {
             collections=terms_filter('collections.keyword'),
             availability=terms_filter('distribution.availability.keyword'),
             signature=terms_filter('signature.keyword'),
-            event_number= None,
+            event_number=range_filter('distribution.number_events')
         )
     }
 }

--- a/cernopendata/mappings/records/record-v1.0.0.json
+++ b/cernopendata/mappings/records/record-v1.0.0.json
@@ -94,6 +94,9 @@
               },
               "type": "text",
               "copy_to": "availability"
+            },
+            "number_events": {
+              "type": "integer"
             }
           },
           "type": "object"

--- a/cernopendata/templates/cernopendata/search.html
+++ b/cernopendata/templates/cernopendata/search.html
@@ -60,7 +60,7 @@
                  <div class="card card-style">
                      <div class="card-body content-style">
                          <invenio-search-facets
-                          order="type,experiment,year,file_type,collision_type,collision_energy,category,run,signature,keywords"
+                          order="type,experiment,year,file_type,collision_type,collision_energy,category,run,event_number,signature,keywords"
                           template="{{ url_for('static', filename='templates/cernopendata_search_ui/facets.html') }}">
                          </invenio-search-facets>
                      </div>


### PR DESCRIPTION
- Adds 'event_number'-facet to Open Data Portal.
- NOTE! Implementation for the range_filter is still required. At the moment, filter is missing and therefore the facet doesn't work correctly.
(addresses #2785)

Signed-off-by: Juha-Matti Teuho <juha.teuho@gmail.com>