### PR TITLE
records: correct GT for CMS 2012 primary datasets

### DIFF
--- a/cernopendata/modules/fixtures/data/records/cms-primary-datasets-Run2012B.json
+++ b/cernopendata/modules/fixtures/data/records/cms-primary-datasets-Run2012B.json
@@ -204,7 +204,7 @@
       "Run2012B"
     ],
     "system_details": {
-      "global_tag": "FT_53_LV5_AN1",
+      "global_tag": "FT53_V21A_AN6",
       "release": "CMSSW_5_3_32"
     },
     "title": "/BJetPlusX/Run2012B-22Jan2013-v1/AOD",

--- a/cernopendata/modules/fixtures/data/records/cms-primary-datasets-Run2012C.json
+++ b/cernopendata/modules/fixtures/data/records/cms-primary-datasets-Run2012C.json
@@ -246,7 +246,7 @@
       "Run2012C"
     ],
     "system_details": {
-      "global_tag": "FT_53_LV5_AN1",
+      "global_tag": "FT53_V21A_AN6",
       "release": "CMSSW_5_3_32"
     },
     "title": "/BJetPlusX/Run2012C-22Jan2013-v1/AOD",

--- a/cernopendata/modules/fixtures/data/records/cms-raw-datasets-Run2012B.json
+++ b/cernopendata/modules/fixtures/data/records/cms-raw-datasets-Run2012B.json
@@ -61,7 +61,7 @@
       "Run2012B"
     ],
     "system_details": {
-      "global_tag": "FT_53_LV5_AN1",
+      "global_tag": "FT53_V21A_AN6",
       "release": "CMSSW_5_3_32"
     },
     "title": "/MinimumBias/Run2012B-v1/RAW",


### PR DESCRIPTION
(closes #2790)

Corrects GT to be used in analysis in system_details

To do while merging:
- change all records as now the first one in the file (FT_53_LV5_AN1 -> FT53_V21A_AN6)

