### PR TITLE
docker: more dependency packages

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -29,6 +29,7 @@ FROM centos:7
 RUN yum update -y && \
     yum install -y \
         ca-certificates \
+        cmake \
         curl \
         git \
         rlwrap \
@@ -40,9 +41,11 @@ RUN yum update -y && \
     yum groupinstall -y "Development Tools" && \
     yum install -y \
         libffi-devel \
+        libuuid-devel \
         libxml2-devel \
         libxslt-devel \
         npm \
+        openssl-devel \
         jq \
         python-devel \
         python-pip


### PR DESCRIPTION
* Adds more dependency packages in order to fix the build failures that
  started to appear with new CentOS 7 related updates.

Signed-off-by: Tibor Šimko <tibor.simko@cern.ch>