### PR TITLE
Update VM

### DIFF
--- a/cernopendata/modules/fixtures/data/docs/cms-virtual-machine-2011/cms-virtual-machine-2011.md
+++ b/cernopendata/modules/fixtures/data/docs/cms-virtual-machine-2011/cms-virtual-machine-2011.md
@@ -12,16 +12,16 @@ VirtualBox is a free, open source and multiplatform application to run virtual m
 
 You will need administrative ("root") privileges on every platform to perform the installation of VirtualBox.
 
-Note: the latest tested version of VirtualBox working with this CMS-specific CernVM image is 5.2.2. If you have troubles with the latest version of VirtualBox, pick that one: the full history of VirtualBox versions is available [on a different page][installVB2].
+Note: the latest tested version of VirtualBox working with this CMS-specific CernVM image is 6.0.22. If you have troubles with the latest version of VirtualBox, pick that one: the full history of VirtualBox versions is available [on a different page][installVB2].
 
 
 ### Downloading and Creating a Virtual Machine
 
 **Important**: Before you download the CernVM, note that the imported settings may not always work on your host machine. Please see [Issues and Limitations](#issue) or [the CMS guide to troubleshooting](/docs/cms-guide-troubleshooting) if you encounter any problems with booting the VM.
 
-Next download the CMS-specific CernVM image as OVA file from: [CMS VM Image for 2011 CMS Open Data][cmsvmimage2011]. It is recommended using the version "CMS-OpenData-1.5.1". This VM Image can be used for data from 2011 and 2012 (for data from 2010 follow the instruction in [CMS 2010 Virtual Machines: How to install](/docs/cms-virtual-machine-2010)).
+Next download the CMS-specific CernVM image as OVA file from: [CMS VM Image for 2011 CMS Open Data][cmsvmimage2011]. It is recommended using the version "CMS-OpenData-1.5.2". This VM Image can be used for data from 2011 and 2012 (for data from 2010 follow the instruction in [CMS 2010 Virtual Machines: How to install](/docs/cms-virtual-machine-2010)).
 
-By double clicking the downloaded file, VirtualBox imports the image with ready-to-run settings. Then, you launch the CMS-specific CernVM, which boots into the graphical user interface and sets up the CMS environment. Be patient, it will take a while.
+By double clicking the downloaded file, VirtualBox imports the image with ready-to-run settings. In VirtualBox version 6, you need to unselect "import disks as VDI" on the initial import screen. Then, you launch the CMS-specific CernVM, which boots into the graphical user interface and sets up the CMS environment. Be patient, it will take a while.
 
 
 ## <a name="test">Step 2: How to Test & Validate?</a>
@@ -30,7 +30,7 @@ The validation procedure tests that the CMS environment is installed and operati
 
 ### Set up the CMS environment and run a demo analyzer
 
-In the "CMS-OpenData-1.5.1" VM, open a terminal from the "CMS Shell" icon from the desktop (only if using the other VM versions, "CMS-Open-Data-1.2.0" or "CMS-Open-Data-1.3.0", open a terminal with the X terminal emulator from an icon bottom-left of the VM screen, in "CMS-OpenData-1.5.1" this will open a shell with an operating system incompatible with the CMS software release to be used).
+In the "CMS-OpenData-1.5.2" VM, open a terminal from the "CMS Shell" icon from the desktop (only if using the other VM versions, "CMS-Open-Data-1.2.0" or "CMS-Open-Data-1.3.0", open a terminal with the X terminal emulator from an icon bottom-left of the VM screen, in "CMS-OpenData-1.5.1" this will open a shell with an operating system incompatible with the CMS software release to be used).
 
 Execute the following command; this command builds the local release area (the directory structure) for CMSSW, and only needs to be run once (note that it may take a while):
 

--- a/cernopendata/modules/fixtures/data/records/cms-tools-vm-image-Run2011A.json
+++ b/cernopendata/modules/fixtures/data/records/cms-tools-vm-image-Run2011A.json
@@ -1,7 +1,7 @@
 [
   {
     "abstract": {
-      "description": " <p>This virtual machine image provides CMS computing environment to be used with the 2011 and 2012 CMS open data. The virtual machine is based on the CernVM (cernvm.cern.ch) and uses Scientific Linux CERN. The image gets the CMS software (CMSSW) from /cvmfs/cms.cern.ch and the jobs running on the CMS open data VM read the condition data from /cvmfs/cms-opendata-conddb.cern.ch. Access to the data is through XRootD.</p> <p>CMS-OpenData-1.5.2.ova is recommended. It has a 40G virtual hard disk and a 20G cvmfs cache, which is large enough for condition data for full event range for 2012 data (see <a href=\"/docs/cms-guide-for-condition-database\">the CMS guide to the condition database</a> for further details). It has an embedded CERN Scientific Linux 6 (slc6) shell, where all CMS software specific commands should be executed. Additionally, it has a CERN CentOS 7 (cc7) shell, which can be used in the same session.</p> <p>The earlier versions CMS-Open-Data-1.2.0.ova and Open-Data-1.3.0.ova are slc6 only.  CMS-Open-Data-1.2.0.ova has a 20G virtual hard disk and a 10G cvmfs cache. CMS-Open-Data-1.3.0.ova has a 40G virtual hard disk and a 20G cvmfs cache. </p>  <p>For known issues and limitations see</p>",
+      "description": " <p>This virtual machine image provides CMS computing environment to be used with the 2011 and 2012 CMS open data. The virtual machine is based on the CernVM (cernvm.cern.ch) and uses Scientific Linux CERN. The image gets the CMS software (CMSSW) from /cvmfs/cms.cern.ch and the jobs running on the CMS open data VM read the condition data from /cvmfs/cms-opendata-conddb.cern.ch. Access to the data is through XRootD.</p> <p>CMS-OpenData-1.5.2.ova is recommended. It has a 40G virtual hard disk and a 20G cvmfs cache, which is large enough for condition data for full event range for 2012 data (see <a href=\"/docs/cms-guide-for-condition-database\">the CMS guide to the condition database</a> for further details). It has an embedded CERN Scientific Linux 6 (slc6) shell, where all CMS software specific commands should be executed. Additionally, it has a CERN CentOS 7 (cc7) shell, which can be used in the same session.</p> <p>The versions earlier than CMS-OpenData-1.5.2.ova are deprecated; please use the latest available version.</p>  <p>For known issues and limitations see</p>",
       "links": [
         {
           "title": "CMS Virtual Machines - Known Issues and Limitations",
@@ -25,8 +25,8 @@
       "formats": [
         "ova"
       ],
-      "number_files": 3,
-      "size": 57528320
+      "number_files": 4,
+      "size": 78376960
     },
     "experiment": "CMS",
     "files": [
@@ -43,6 +43,11 @@
       {
         "checksum": "adler32:4fc34c4a",
         "size": 20654080,
+        "uri": "root://eospublic.cern.ch//eos/opendata/cms/environment/1.5.1/CMS-OpenData-1.5.1.ova"
+      },
+      {
+        "checksum": "adler32:7b838c74",
+        "size": 20848640,
         "uri": "root://eospublic.cern.ch//eos/opendata/cms/environment/1.5.2/CMS-OpenData-1.5.2.ova"
       }
     ],
@@ -56,7 +61,10 @@
           "recid": "253"
         },
         {
-          "recid": FIXME
+          "recid": "254"
+        },
+        {
+          "recid": "256"
         }
       ]
     },
@@ -247,12 +255,12 @@
         "txt"
       ],
       "number_files": 3,
-      "size": FIXME
+      "size": 4585
     },
     "experiment": "CMS",
     "files": [
       {
-        "checksum": "adler32:a1353787",
+        "checksum": "adler32:a0103784",
         "size": 181,
         "uri": "root://eospublic.cern.ch//eos/opendata/cms/environment/1.5.2/cernvm-script"
       },
@@ -268,7 +276,7 @@
       }
     ],
     "publisher": "CERN Open Data Portal",
-    "recid": FIXME,
+    "recid": "256",
     "relations": [
       {
         "description": "The final CERN VM image can be found here:",

--- a/cernopendata/modules/fixtures/data/records/cms-tools-vm-image-Run2011A.json
+++ b/cernopendata/modules/fixtures/data/records/cms-tools-vm-image-Run2011A.json
@@ -1,7 +1,7 @@
 [
   {
     "abstract": {
-      "description": " <p>This virtual machine image provides CMS computing environment to be used with the 2011 and 2012 CMS open data. The virtual machine is based on the CernVM (cernvm.cern.ch) and uses Scientific Linux CERN. The image gets the CMS software (CMSSW) from /cvmfs/cms.cern.ch and the jobs running on the CMS open data VM read the condition data from /cvmfs/cms-opendata-conddb.cern.ch. Access to the data is through XRootD.</p> <p>CMS-OpenData-1.5.1.ova is recommended. It has a 40G virtual hard disk and a 20G cvmfs cache, which is large enough for condition data for full event range for 2012 data (see <a href=\"/docs/cms-guide-for-condition-database\">the CMS guide to the condition database</a> for further details). It has an embedded CERN Scientific Linux 6 (slc6) shell, where all CMS software specific commands should be executed. Additionally, it has a CERN CentOS 7 (cc7) shell, which can be used in the same session.</p> <p>The earlier versions CMS-Open-Data-1.2.0.ova and Open-Data-1.3.0.ova are slc6 only.  CMS-Open-Data-1.2.0.ova has a 20G virtual hard disk and a 10G cvmfs cache. CMS-Open-Data-1.3.0.ova has a 40G virtual hard disk and a 20G cvmfs cache. </p>  <p>For known issues and limitations see</p>",
+      "description": " <p>This virtual machine image provides CMS computing environment to be used with the 2011 and 2012 CMS open data. The virtual machine is based on the CernVM (cernvm.cern.ch) and uses Scientific Linux CERN. The image gets the CMS software (CMSSW) from /cvmfs/cms.cern.ch and the jobs running on the CMS open data VM read the condition data from /cvmfs/cms-opendata-conddb.cern.ch. Access to the data is through XRootD.</p> <p>CMS-OpenData-1.5.2.ova is recommended. It has a 40G virtual hard disk and a 20G cvmfs cache, which is large enough for condition data for full event range for 2012 data (see <a href=\"/docs/cms-guide-for-condition-database\">the CMS guide to the condition database</a> for further details). It has an embedded CERN Scientific Linux 6 (slc6) shell, where all CMS software specific commands should be executed. Additionally, it has a CERN CentOS 7 (cc7) shell, which can be used in the same session.</p> <p>The earlier versions CMS-Open-Data-1.2.0.ova and Open-Data-1.3.0.ova are slc6 only.  CMS-Open-Data-1.2.0.ova has a 20G virtual hard disk and a 10G cvmfs cache. CMS-Open-Data-1.3.0.ova has a 40G virtual hard disk and a 20G cvmfs cache. </p>  <p>For known issues and limitations see</p>",
       "links": [
         {
           "title": "CMS Virtual Machines - Known Issues and Limitations",
@@ -43,7 +43,7 @@
       {
         "checksum": "adler32:4fc34c4a",
         "size": 20654080,
-        "uri": "root://eospublic.cern.ch//eos/opendata/cms/environment/1.5.1/CMS-OpenData-1.5.1.ova"
+        "uri": "root://eospublic.cern.ch//eos/opendata/cms/environment/1.5.2/CMS-OpenData-1.5.2.ova"
       }
     ],
     "methodology": {
@@ -56,7 +56,7 @@
           "recid": "253"
         },
         {
-          "recid": "254"
+          "recid": FIXME
         }
       ]
     },
@@ -223,6 +223,75 @@
     },
     "usage": {
       "description": " <p> First, you need to run a normal Micro-CernVM, using your own context so you can login. Copy the attached files to the running VM and then   login.</p>\n <p>Inside the VM, you first need a copy of the latest Micro-CernVM release as a template for the Open Data image. Download it, inside the running VM, from: <a href=\"http://cernvm.cern.ch/releases/production/cernvm4-micro-2018.10-1.hdd\">http://cernvm.cern.ch/releases/production/cernvm4-micro-2018.10-1.hdd</a>  placing it in the same directory as the other files. </p>\n <p> Run the script:<code>./cernvm-script </code>which will produce some output on the terminal, and then finish. </p>\n      <p>The result should be a file with the title coming from the -n field in the script. In this case, the file we're interested in is: <code>CMS-OpenData-1.5.1.ova </code>which can be copied from the running VM to elsewhere. </p> "
+    }
+  },
+  {
+    "abstract": {
+      "description": " <p>The scripts provided create the CMS virtual machine image based on <a href=\"https://cernvm.cern.ch\">CernVM</a>, with Scientific Linux CERN 6 (slc6).</p> "
+    },
+    "accelerator": "CERN-LHC",
+    "authors": [
+      {
+        "name": "Blomer, Jakob"
+      }
+    ],
+    "collections": [
+      "CMS-Tools"
+    ],
+    "date_created": [
+      "2011"
+    ],
+    "date_published": "2020",
+    "distribution": {
+      "formats": [
+        "txt"
+      ],
+      "number_files": 3,
+      "size": FIXME
+    },
+    "experiment": "CMS",
+    "files": [
+      {
+        "checksum": "adler32:a1353787",
+        "size": 181,
+        "uri": "root://eospublic.cern.ch//eos/opendata/cms/environment/1.5.2/cernvm-script"
+      },
+      {
+        "checksum": "adler32:084361f5",
+        "size": 4252,
+        "uri": "root://eospublic.cern.ch//eos/opendata/cms/environment/1.5.2/cms-user-data.txt"
+      },
+      {
+        "checksum": "adler32:786f33c7",
+        "size": 152,
+        "uri": "root://eospublic.cern.ch//eos/opendata/cms/environment/1.5.2/opendata-desktop-settings"
+      }
+    ],
+    "publisher": "CERN Open Data Portal",
+    "recid": FIXME,
+    "relations": [
+      {
+        "description": "The final CERN VM image can be found here:",
+        "recid": "252",
+        "type": "isRelatedTo"
+      }
+    ],
+    "run_period": [
+      "Run2011A",
+      "Run2012A",
+      "Run2012B",
+      "Run2012C",
+      "Run2012D"
+    ],
+    "title": "Contextualisation scripts to create the CMS VM Image version 1.5.2",
+    "type": {
+      "primary": "Environment",
+      "secondary": [
+        "VM"
+      ]
+    },
+    "usage": {
+      "description": " <p> First, you need to run a normal Micro-CernVM, using your own context so you can login. Copy the attached files to the running VM and then   login.</p>\n <p>Inside the VM, you first need a copy of the latest Micro-CernVM release as a template for the Open Data image. Download it, inside the running VM, from: <a href=\"http://cernvm.cern.ch/releases/production/cernvm4-micro-2020.04-1.hdd\">http://cernvm.cern.ch/releases/production/cernvm4-micro-2020.04-1.hdd</a>  placing it in the same directory as the other files. </p>\n <p> Run the script:<code>./cernvm-script </code>which will produce some output on the terminal, and then finish. </p>\n      <p>The result should be a file with the title coming from the -n field in the script. In this case, the file we're interested in is: <code>CMS-OpenData-1.5.2.ova </code>which can be copied from the running VM to elsewhere. </p> "
     }
   }
 ]


### PR DESCRIPTION
(closes #2847)

Adds the new VM and its Contextualisation scripts record. Updates the instructions

To do:
- copy the ova file from  http://cernvm.cern.ch/releases/CMS-OpenData-1.5.2.ova to /eos/opendata/cms/environment/1.5.2/CMS-OpenData-1.5.2.ova
- give a record number for the script record 
- copy the cernvm-script.txt #2847 to /eos/opendata/cms/environment/1.5.2/cernvm-script
- copy the unchanged /eos/opendata/cms/environment/1.5.1/cms-user-data.txt and /eos/opendata/cms/environment/1.5.2/opendata-desktop-settings to /eos/opendata/cms/environment/1.5.2/