### PR TITLE
Update VMs to 1.5.3 and 1.1.4

### DIFF
--- a/cernopendata/modules/fixtures/data/docs/cms-guide-for-conddb/cms-guide-for-conddb.md
+++ b/cernopendata/modules/fixtures/data/docs/cms-guide-for-conddb/cms-guide-for-conddb.md
@@ -12,7 +12,7 @@ Note that when you need to access the condition database, the first time you run
 
 ---
 
-**For 2010 collision data**, the global tag available in the  `/cvmfs` area is FT_R_42_V10A. When using the "CMS-OpenData-1.1.2" VM, it is recommended reading the condition data from there. First, set the symbolic links:
+**For 2010 collision data**, the global tag available in the  `/cvmfs` area is FT_R_42_V10A. When using the "CMS-OpenData-1.1.2" VM or a higher version, it is recommended reading the condition data from there. First, set the symbolic links:
 
 ```shell
 ln -sf /cvmfs/cms-opendata-conddb.cern.ch/FT_R_42_V10A FT_R_42_V10A
@@ -27,7 +27,7 @@ process.GlobalTag.connect = cms.string('sqlite_file:/cvmfs/cms-opendata-conddb.c
 process.GlobalTag.globaltag = 'FT_R_42_V10A::All'
 ```
 
-Note that **this only works in the "CMS-OpenData-1.1.2" version** of the 2010 CMS Open Data VM.
+Note that **this only works in the "CMS-OpenData-1.1.2" or a higher version** of the 2010 CMS Open Data VM.
 
 ---
 
@@ -46,7 +46,7 @@ process.GlobalTag.connect = cms.string('sqlite_file:/cvmfs/cms-opendata-conddb.c
 process.GlobalTag.globaltag = 'START42_V17B::All'
 ```
 
-Note that **this only works in the "CMS-OpenData-1.1.2" version** of the 2010 CMS Open Data VM.
+Note that **this only works in the "CMS-OpenData-1.1.2" or a higher version** of the 2010 CMS Open Data VM.
 
 ---
 

--- a/cernopendata/modules/fixtures/data/docs/cms-virtual-machine-2010/cms-virtual-machine-2010.md
+++ b/cernopendata/modules/fixtures/data/docs/cms-virtual-machine-2010/cms-virtual-machine-2010.md
@@ -12,15 +12,15 @@ VirtualBox is a free, open source and multiplatform application to run virtual m
 
 You will need administrative ("root") privileges on every platform to perform the installation of VirtualBox.
 
-Note: the latest tested version of VirtualBox working with this CMS-specific CernVM image is 5.2.2\. If you have troubles with the latest version of VirtualBox, pick that one: the full history of VirtualBox versions is available [on a different page.](https://www.VirtualBox.org/wiki/Download_Old_Builds)
+Note: the latest tested version of VirtualBox working with this CMS-specific CernVM image is 6.1.10\. If you have troubles with the latest version of VirtualBox, pick that one: the full history of VirtualBox versions is available [on a different page.](https://www.VirtualBox.org/wiki/Download_Old_Builds)
 
 ### Downloading and Creating a Virtual Machine
 
 **Important**: Before you download the CernVM, note that the imported settings may not always work on your host machine. Please see [Issues and Limitations](#issues2010) or [the CMS guide to troubleshooting](/docs/cms-guide-troubleshooting) if you encounter any problems with booting the VM.
 
-Next download the CMS-specific CernVM image as OVA file from: [CMS VM Image for 2010 CMS Open Data](/record/250). It is recommended using the version "CMS-OpenData-1.1.2".
+Next download the CMS-specific CernVM image as OVA file from: [CMS VM Image for 2010 CMS Open Data](/record/250). It is recommended using the version "CMS-OpenData-1.1.4".
 
-By double clicking the downloaded file, VirtualBox imports the image with ready-to-run settings. Then, you launch the CMS-specific CernVM, which boots into the graphical user interface and sets up the CMS environment.
+By double clicking the downloaded file, VirtualBox imports the image with ready-to-run settings. In VirtualBox version 6, you need to unselect "import disks as VDI" on the initial import screen. Then, you launch the CMS-specific CernVM, which boots into the graphical user interface and sets up the CMS environment. Be patient, it will take a while.
 
 ## <a name="testvalidate2010"></a>Step 2: How to Test & Validate?
 
@@ -28,13 +28,15 @@ The validation procedure tests that the CMS environment is installed and operati
 
 ### Set up the CMS environment and run a demo analyzer
 
-In the "CMS-OpenData-1.1.2" VM, open a terminal from the "CMS Shell" icon from the desktop (only if using the VM version "CMS-OpenData-1.0.0-rc7", open a terminal with the X terminal emulator from an icon bottom-left of the VM screen).
+In the "CMS-OpenData-1.1.4" VM, open a terminal from the "CMS Shell" icon from the desktop (note that the X terminal emulator from an icon bottom-left of the VM screen opens a shell with an operating system incompatible with the CMS software release to be used).
 
 Execute the following command; this command builds the local release area (the directory structure) for [CMSSW](/glossary/CMSSW), and only needs to be run once (note that it may take a while):
 
 ```shell
 cmsrel CMSSW_4_2_8
 ```
+
+Note that if you get a warning message about the current OS being SLC7, you are using a wrong terminal. Open a "CMS Shell" terminal as explained above and execute the cmsrel command there.
 
 Change to the <kbd>CMSSW_4_2_8/src/</kbd> directory:
 

--- a/cernopendata/modules/fixtures/data/docs/cms-virtual-machine-2011/cms-virtual-machine-2011.md
+++ b/cernopendata/modules/fixtures/data/docs/cms-virtual-machine-2011/cms-virtual-machine-2011.md
@@ -12,14 +12,14 @@ VirtualBox is a free, open source and multiplatform application to run virtual m
 
 You will need administrative ("root") privileges on every platform to perform the installation of VirtualBox.
 
-Note: the latest tested version of VirtualBox working with this CMS-specific CernVM image is 6.0.22. If you have troubles with the latest version of VirtualBox, pick that one: the full history of VirtualBox versions is available [on a different page][installVB2].
+Note: the latest tested version of VirtualBox working with this CMS-specific CernVM image is 6.1.10. If you have troubles with the latest version of VirtualBox, pick that one: the full history of VirtualBox versions is available [on a different page][installVB2].
 
 
 ### Downloading and Creating a Virtual Machine
 
 **Important**: Before you download the CernVM, note that the imported settings may not always work on your host machine. Please see [Issues and Limitations](#issue) or [the CMS guide to troubleshooting](/docs/cms-guide-troubleshooting) if you encounter any problems with booting the VM.
 
-Next download the CMS-specific CernVM image as OVA file from: [CMS VM Image for 2011 CMS Open Data][cmsvmimage2011]. It is recommended using the version "CMS-OpenData-1.5.2". This VM Image can be used for data from 2011 and 2012 (for data from 2010 follow the instruction in [CMS 2010 Virtual Machines: How to install](/docs/cms-virtual-machine-2010)).
+Next download the CMS-specific CernVM image as OVA file from: [CMS VM Image for 2011 CMS Open Data][cmsvmimage2011]. It is recommended using the version "CMS-OpenData-1.5.3". This VM Image can be used for data from 2011 and 2012 (for data from 2010 follow the instruction in [CMS 2010 Virtual Machines: How to install](/docs/cms-virtual-machine-2010)).
 
 By double clicking the downloaded file, VirtualBox imports the image with ready-to-run settings. In VirtualBox version 6, you need to unselect "import disks as VDI" on the initial import screen. Then, you launch the CMS-specific CernVM, which boots into the graphical user interface and sets up the CMS environment. Be patient, it will take a while.
 
@@ -30,7 +30,7 @@ The validation procedure tests that the CMS environment is installed and operati
 
 ### Set up the CMS environment and run a demo analyzer
 
-In the "CMS-OpenData-1.5.2" VM, open a terminal from the "CMS Shell" icon from the desktop (only if using the other VM versions, "CMS-Open-Data-1.2.0" or "CMS-Open-Data-1.3.0", open a terminal with the X terminal emulator from an icon bottom-left of the VM screen, in "CMS-OpenData-1.5.1" this will open a shell with an operating system incompatible with the CMS software release to be used).
+In the "CMS-OpenData-1.5.3" VM, open a terminal from the "CMS Shell" icon from the desktop (note that the X terminal emulator from an icon bottom-left of the VM screen opens a shell with an operating system incompatible with the CMS software release to be used).
 
 Execute the following command; this command builds the local release area (the directory structure) for CMSSW, and only needs to be run once (note that it may take a while):
 
@@ -38,7 +38,7 @@ Execute the following command; this command builds the local release area (the d
 cmsrel CMSSW_5_3_32
 ```
 
-Note that if you get a warning message about the current OS being SLC7, you are using a wrong terminal ("Outer Shell"). Open a "CMS Shell" terminal as explained above and execute the cmsrel command there.
+Note that if you get a warning message about the current OS being SLC7, you are using a wrong terminal. Open a "CMS Shell" terminal as explained above and execute the cmsrel command there.
 
 Change to the ```CMSSW_5_3_32/src/``` directory:
 
@@ -172,7 +172,7 @@ Please check the validation report for the VM image for our 2010 data, which may
 
 **Question:**  When I try to compile with 'scram b', I get a warning 'SCRAM warning: You are trying to compile/build for architecture slc6_amd64_gcc530 on SLC7 OS which might not work. If you know this SCRAM_ARCH/OS combination works then please first run 'scram build --ignore-arch'.'
 
-> **Answer:** You are very likely in the wrong shell of the VM machine. When using the "CMS-OpenData-1.5.1" VM, all CMSSW-specific commands (compilation, run) must be given in the "CMS Shell", which can be opened from the desk top icon, not in the "Outer shell".
+> **Answer:** You are very likely in the wrong shell of the VM machine. When using the "CMS-OpenData-1.5.X" VM, all CMSSW-specific commands (compilation, run) must be given in the "CMS Shell", which can be opened from the desk top icon, not in the "Outer shell".
 
 **Question:** On Ubuntu running the latest version of VirtualBox, an error appears when opening the CMS-specific virtual machine: the message is about a missing path to a definition file.
 

--- a/cernopendata/modules/fixtures/data/records/cms-tools-vm-image-Run2011A.json
+++ b/cernopendata/modules/fixtures/data/records/cms-tools-vm-image-Run2011A.json
@@ -1,7 +1,7 @@
 [
   {
     "abstract": {
-      "description": " <p>This virtual machine image provides CMS computing environment to be used with the 2011 and 2012 CMS open data. The virtual machine is based on the CernVM (cernvm.cern.ch) and uses Scientific Linux CERN. The image gets the CMS software (CMSSW) from /cvmfs/cms.cern.ch and the jobs running on the CMS open data VM read the condition data from /cvmfs/cms-opendata-conddb.cern.ch. Access to the data is through XRootD.</p> <p>CMS-OpenData-1.5.2.ova is recommended. It has a 40G virtual hard disk and a 20G cvmfs cache, which is large enough for condition data for full event range for 2012 data (see <a href=\"/docs/cms-guide-for-condition-database\">the CMS guide to the condition database</a> for further details). It has an embedded CERN Scientific Linux 6 (slc6) shell, where all CMS software specific commands should be executed. Additionally, it has a CERN CentOS 7 (cc7) shell, which can be used in the same session.</p> <p>The versions earlier than CMS-OpenData-1.5.2.ova are deprecated; please use the latest available version.</p>  <p>For known issues and limitations see</p>",
+      "description": " <p>This virtual machine image provides CMS computing environment to be used with the 2011 and 2012 CMS open data. The virtual machine is based on the CernVM (cernvm.cern.ch) and uses Scientific Linux CERN. The image gets the CMS software (CMSSW) from /cvmfs/cms.cern.ch and the jobs running on the CMS open data VM read the condition data from /cvmfs/cms-opendata-conddb.cern.ch. Access to the data is through XRootD.</p> <p>CMS-OpenData-1.5.3.ova is recommended. It has a 40G virtual hard disk and a 20G cvmfs cache, which is large enough for condition data for full event range for 2012 data (see <a href=\"/docs/cms-guide-for-condition-database\">the CMS guide to the condition database</a> for further details). It has an embedded CERN Scientific Linux 6 (slc6) shell, where all CMS software specific commands should be executed. Additionally, it has a CERN CentOS 7 (cc7) shell, which can be used in the same session.</p> <p>The versions earlier than CMS-OpenData-1.5.3.ova are deprecated; please use the latest available version.</p>  <p>For known issues and limitations see</p>",
       "links": [
         {
           "title": "CMS Virtual Machines - Known Issues and Limitations",
@@ -65,7 +65,11 @@
         },
         {
           "recid": "256"
+        },
+        {
+          "recid": "257"
         }
+        
       ]
     },
     "publisher": "CERN Open Data Portal",
@@ -300,6 +304,74 @@
     },
     "usage": {
       "description": " <p> First, you need to run a normal Micro-CernVM, using your own context so you can login. Copy the attached files to the running VM and then   login.</p>\n <p>Inside the VM, you first need a copy of the latest Micro-CernVM release as a template for the Open Data image. Download it, inside the running VM, from: <a href=\"http://cernvm.cern.ch/releases/production/cernvm4-micro-2020.04-1.hdd\">http://cernvm.cern.ch/releases/production/cernvm4-micro-2020.04-1.hdd</a>  placing it in the same directory as the other files. </p>\n <p> Run the script:<code>./cernvm-script </code>which will produce some output on the terminal, and then finish. </p>\n      <p>The result should be a file with the title coming from the -n field in the script. In this case, the file we're interested in is: <code>CMS-OpenData-1.5.2.ova </code>which can be copied from the running VM to elsewhere. </p> "
+    },
+    {
+    "abstract": {
+      "description": " <p>The scripts provided create the CMS virtual machine image based on <a href=\"https://cernvm.cern.ch\">CernVM</a>, with Scientific Linux CERN 6 (slc6).</p> "
+    },
+    "accelerator": "CERN-LHC",
+    "authors": [
+      {
+        "name": "Blomer, Jakob"
+      }
+    ],
+    "collections": [
+      "CMS-Tools"
+    ],
+    "date_created": [
+      "2011"
+    ],
+    "date_published": "2020",
+    "distribution": {
+      "formats": [
+        "txt"
+      ],
+      "number_files": 3,
+      "size": FIXME
+    },
+    "experiment": "CMS",
+    "files": [
+      {
+        "checksum": "FIXME",
+        "size": FIXME,
+        "uri": "root://eospublic.cern.ch//eos/opendata/cms/environment/1.5.3/cernvm-script"
+      },
+      {
+        "checksum": "FIXME",
+        "size": FIXME,
+        "uri": "root://eospublic.cern.ch//eos/opendata/cms/environment/1.5.3/cms-user-data.txt"
+      },
+      {
+        "checksum": "FIXME",
+        "size": FIXME,
+        "uri": "root://eospublic.cern.ch//eos/opendata/cms/environment/1.5.3/opendata-desktop-settings"
+      }
+    ],
+    "publisher": "CERN Open Data Portal",
+    "recid": "257",
+    "relations": [
+      {
+        "description": "The final CERN VM image can be found here:",
+        "recid": "252",
+        "type": "isRelatedTo"
+      }
+    ],
+    "run_period": [
+      "Run2011A",
+      "Run2012A",
+      "Run2012B",
+      "Run2012C",
+      "Run2012D"
+    ],
+    "title": "Contextualisation scripts to create the CMS VM Image version 1.5.3",
+    "type": {
+      "primary": "Environment",
+      "secondary": [
+        "VM"
+      ]
+    },
+    "usage": {
+      "description": " <p> First, you need to run a normal Micro-CernVM, using your own context so you can login. Copy the attached files to the running VM and then   login.</p>\n <p>Inside the VM, you first need a copy of the latest Micro-CernVM release as a template for the Open Data image. Download it, inside the running VM, from: <a href=\"https://cernvm.cern.ch/releases/ucernvm-images.2020.07-1.cernvm.x86_64/ucernvm-v4prod.2020.07-1.cernvm.x86_64.hdd\">https://cernvm.cern.ch/releases/ucernvm-images.2020.07-1.cernvm.x86_64/ucernvm-v4prod.2020.07-1.cernvm.x86_64.hdd</a>  placing it in the same directory as the other files. </p>\n <p> Run the script:<code>./cernvm-script </code>which will produce some output on the terminal, and then finish. </p>\n      <p>The result should be a file with the title coming from the -n field in the script. In this case, the file we're interested in is: <code>CMS-OpenData-1.5.3.ova </code>which can be copied from the running VM to elsewhere. </p> "
     }
   }
 ]

--- a/cernopendata/modules/fixtures/data/records/cms-tools-vm-image-Run2011A.json
+++ b/cernopendata/modules/fixtures/data/records/cms-tools-vm-image-Run2011A.json
@@ -25,8 +25,8 @@
       "formats": [
         "ova"
       ],
-      "number_files": 4,
-      "size": 78376960
+      "number_files": 5,
+      "size": 98877439
     },
     "experiment": "CMS",
     "files": [
@@ -49,6 +49,11 @@
         "checksum": "adler32:7b838c74",
         "size": 20848640,
         "uri": "root://eospublic.cern.ch//eos/opendata/cms/environment/1.5.2/CMS-OpenData-1.5.2.ova"
+      },
+      {
+        "checksum": "adler32:974b2476",
+        "size": 20500480,
+        "uri": "root://eospublic.cern.ch//eos/opendata/cms/environment/1.5.3/CMS-OpenData-1.5.3.ova"
       }
     ],
     "methodology": {
@@ -69,7 +74,6 @@
         {
           "recid": "257"
         }
-        
       ]
     },
     "publisher": "CERN Open Data Portal",
@@ -304,8 +308,9 @@
     },
     "usage": {
       "description": " <p> First, you need to run a normal Micro-CernVM, using your own context so you can login. Copy the attached files to the running VM and then   login.</p>\n <p>Inside the VM, you first need a copy of the latest Micro-CernVM release as a template for the Open Data image. Download it, inside the running VM, from: <a href=\"http://cernvm.cern.ch/releases/production/cernvm4-micro-2020.04-1.hdd\">http://cernvm.cern.ch/releases/production/cernvm4-micro-2020.04-1.hdd</a>  placing it in the same directory as the other files. </p>\n <p> Run the script:<code>./cernvm-script </code>which will produce some output on the terminal, and then finish. </p>\n      <p>The result should be a file with the title coming from the -n field in the script. In this case, the file we're interested in is: <code>CMS-OpenData-1.5.2.ova </code>which can be copied from the running VM to elsewhere. </p> "
-    },
-    {
+    }
+  },
+  {
     "abstract": {
       "description": " <p>The scripts provided create the CMS virtual machine image based on <a href=\"https://cernvm.cern.ch\">CernVM</a>, with Scientific Linux CERN 6 (slc6).</p> "
     },
@@ -327,23 +332,23 @@
         "txt"
       ],
       "number_files": 3,
-      "size": FIXME
+      "size": 4585
     },
     "experiment": "CMS",
     "files": [
       {
-        "checksum": "FIXME",
-        "size": FIXME,
+        "checksum": "adler32:a0a83785",
+        "size": 181,
         "uri": "root://eospublic.cern.ch//eos/opendata/cms/environment/1.5.3/cernvm-script"
       },
       {
-        "checksum": "FIXME",
-        "size": FIXME,
+        "checksum": "adler32:084361f5",
+        "size": 4252,
         "uri": "root://eospublic.cern.ch//eos/opendata/cms/environment/1.5.3/cms-user-data.txt"
       },
       {
-        "checksum": "FIXME",
-        "size": FIXME,
+        "checksum": "adler32:786f33c7",
+        "size": 152,
         "uri": "root://eospublic.cern.ch//eos/opendata/cms/environment/1.5.3/opendata-desktop-settings"
       }
     ],

--- a/cernopendata/modules/fixtures/data/records/cms-tools-vm-image.json
+++ b/cernopendata/modules/fixtures/data/records/cms-tools-vm-image.json
@@ -1,7 +1,7 @@
 [
   {
     "abstract": {
-      "description": "<p>The virtual machine image is based on CernVM (cernvm.cern.ch), with Scientific Linux CERN 5 (slc5), which is the environment needed for the CMSSW release to be used with the 2010 CMS open data. It gets the CMS software (CMSSW) from /cvmfs/cms.cern.ch. Access to the data is through XRootD. <br/> The \"CMS-OpenData-1.1.2.ova\" version is recommended, it has an embedded slc5 shell, where all CMS software specific commands should be executed. Additionally, it has a slc7 shell, which can be used in the same session. It has a 20G virtual hard disk and a 10G cvmfs cache and can read the condition data from /cvmfs/cms-opendata-conddb.cern.ch.</p> <p>For known issues and limitations see</p>",
+      "description": "<p>The virtual machine image is based on CernVM (cernvm.cern.ch), with Scientific Linux CERN 5 (slc5), which is the environment needed for the CMSSW release to be used with the 2010 CMS open data. It gets the CMS software (CMSSW) from /cvmfs/cms.cern.ch. Access to the data is through XRootD. <br/> The \"CMS-OpenData-1.1.4.ova\" version is recommended, it has an embedded slc5 shell, where all CMS software specific commands should be executed. Additionally, it has a slc7 shell, which can be used in the same session. It has a 20G virtual hard disk and a 10G cvmfs cache and can read the condition data from /cvmfs/cms-opendata-conddb.cern.ch.</p> <p>For known issues and limitations see</p>",
       "links": [
         {
           "title": "CMS Virtual Machines - Known Issues and Limitations",
@@ -46,6 +46,9 @@
       "links": [
         {
           "recid": "249"
+        },
+        {
+          "recid": "248"
         }
       ]
     },
@@ -143,6 +146,71 @@
     },
     "usage": {
       "description": " <p> First, you need to run a normal Micro-CernVM, using your own context so you can login. Copy the attached files to the running VM and then login.<p>Inside the VM, you first need a copy of the latest Micro-CernVM release as a template for the Open Data image. Download it, inside the running VM, from: http://cernvm.cern.ch/releases/ucernvm-images.1.18-13.cernvm.x86_64/ucernvm-slc5.1.18-13.cernvm.x86_64.hdd <br/>placing it in the same directory as the other files.<br/>Run the script:\n      <br/>./cernvm-script\n      <br/>which will produce some output on the terminal, and then finish.\n      <p>The result should be a file with the title coming from the -n field in the script. In this case, the file we're interested in is:\n      <br/>CMS-OpenData-1.0.1.ova\n      <br/>which can be copied from the running VM to elsewhere. </p>"
+    }
+  },
+  {
+    "abstract": {
+      "description": " <p>The scripts provided create the CMS virtual machine image based on <a href=\"https://cernvm.cern.ch\">CernVM</a>, with a Scientific Linux CERN 5 (slc5)</p> "
+    },
+    "accelerator": "CERN-LHC",
+    "authors": [
+      {
+        "name": "Blomer, Jakob"
+      }
+    ],
+    "collections": [
+      "CMS-Tools"
+    ],
+    "date_created": [
+      "2010"
+    ],
+    "date_published": "2020",
+    "distribution": {
+      "formats": [
+        "txt"
+      ],
+      "number_files": 3,
+      "size": FIXME
+    },
+    "experiment": "CMS",
+    "files": [
+      {
+        "checksum": "FIXME",
+        "size": FIXME,
+        "uri": "root://eospublic.cern.ch//eos/opendata/cms/environment/2010/cernvm-script"
+      },
+      {
+        "checksum": "FIXME",
+        "size": FIXME,
+        "uri": "root://eospublic.cern.ch//eos/opendata/cms/environment/2010/cms-user-data.txt"
+      },
+      {
+        "checksum": "FIXME",
+        "size": FIXME,
+        "uri": "root://eospublic.cern.ch//eos/opendata/cms/environment/2010/opendata-desktop-settings"
+      }
+    ],
+    "publisher": "CERN Open Data Portal",
+    "recid": "248",
+    "relations": [
+      {
+        "description": "The final CERN VM image can be found here:",
+        "recid": "250",
+        "type": "isRelatedTo"
+      }
+    ],
+    "run_period": [
+      "Run2010B"
+    ],
+    "title": "Contextualisation scripts to create the CMS VM Image version 1.1.4",
+    "type": {
+      "primary": "Environment",
+      "secondary": [
+        "VM"
+      ]
+    },
+    "usage": {
+      "description": " <p> First, you need to run a normal Micro-CernVM, using your own context so you can login. Copy the attached files to the running VM and then login.<p>Inside the VM, you first need a copy of the latest Micro-CernVM release as a template for the Open Data image. Download it, inside the running VM, from: https://cernvm.cern.ch/releases/ucernvm-images.2020.07-1.cernvm.x86_64/ucernvm-v4prod.2020.07-1.cernvm.x86_64.hdd <br/>placing it in the same directory as the other files.<br/>Run the script:\n      <br/>./cernvm-script\n      <br/>which will produce some output on the terminal, and then finish.\n      <p>The result should be a file with the title coming from the -n field in the script. In this case, the file we're interested in is:\n      <br/>CMS-OpenData-1.1.4.ova\n      <br/>which can be copied from the running VM to elsewhere. </p>"
     }
   }
 ]

--- a/cernopendata/modules/fixtures/data/records/cms-tools-vm-image.json
+++ b/cernopendata/modules/fixtures/data/records/cms-tools-vm-image.json
@@ -25,8 +25,8 @@
       "formats": [
         "ova"
       ],
-      "number_files": 1,
-      "size": 15155200
+      "number_files": 3,
+      "size": 55029760
     },
     "experiment": "CMS",
     "files": [
@@ -39,6 +39,11 @@
         "checksum": "adler32:f3bdda62",
         "size": 19374080,
         "uri": "root://eospublic.cern.ch//eos/opendata/cms/environment/2010/CMS-OpenData-1.1.2.ova"
+      },
+      {
+        "checksum": "adler32:cf2da029",
+        "size": 20500480,
+        "uri": "root://eospublic.cern.ch//eos/opendata/cms/environment/1.1.4/CMS-OpenData-1.1.4.ova"
       }
     ],
     "methodology": {
@@ -170,24 +175,24 @@
         "txt"
       ],
       "number_files": 3,
-      "size": FIXME
+      "size": 5301
     },
     "experiment": "CMS",
     "files": [
       {
-        "checksum": "FIXME",
-        "size": FIXME,
-        "uri": "root://eospublic.cern.ch//eos/opendata/cms/environment/2010/cernvm-script"
+        "checksum": "adler32:9ed83782",
+        "size": 181,
+        "uri": "root://eospublic.cern.ch//eos/opendata/cms/environment/1.1.4/cernvm-script"
       },
       {
-        "checksum": "FIXME",
-        "size": FIXME,
-        "uri": "root://eospublic.cern.ch//eos/opendata/cms/environment/2010/cms-user-data.txt"
+        "checksum": "adler32:50e7147c",
+        "size": 4252,
+        "uri": "root://eospublic.cern.ch//eos/opendata/cms/environment/1.1.4/cms-user-data.txt"
       },
       {
-        "checksum": "FIXME",
-        "size": FIXME,
-        "uri": "root://eospublic.cern.ch//eos/opendata/cms/environment/2010/opendata-desktop-settings"
+        "checksum": "adler32:786f33c7",
+        "size": 152,
+        "uri": "root://eospublic.cern.ch//eos/opendata/cms/environment/1.1.4/opendata-desktop-settings"
       }
     ],
     "publisher": "CERN Open Data Portal",


### PR DESCRIPTION
(closes #2847) 

To do at merge:
- vm file for record 252 from  https://cernvm.cern.ch/releases/CMS-OpenData-1.5.3.ova
- the 3 context files for the **new record 257** from root://eospublic.cern.ch//eos/opendata/cms/environment/1.5.2/

- vm file for record 250 from https://cernvm.cern.ch/releases/CMS-OpenData-1.1.4.ova
- the context file cms-user-data.txt for the **new record 248** from https://raw.githubusercontent.com/cernvm/public-contexts/master/cms-opendata.context , the two others scripts the same as 1.5.2 (see above)