### PR TITLE
installation: xrootd 4.12.2

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,7 +1,7 @@
 # -*- coding: utf-8 -*-
 #
 # This file is part of CERN Open Data Portal.
-# Copyright (C) 2015, 2016, 2017, 2018 CERN.
+# Copyright (C) 2015, 2016, 2017, 2018, 2020 CERN.
 #
 # CERN Open Data Portal is free software; you can redistribute it
 # and/or modify it under the terms of the GNU General Public License as
@@ -22,10 +22,10 @@
 # waive the privileges and immunities granted to it by virtue of its status
 # as an Intergovernmental Organization or submit itself to any jurisdiction.
 
-# Use CentOS7:
+# Use CentOS7
 FROM centos:7
 
-# Install CERN Open Data Portal web node pre-requisites:
+# Install CERN Open Data Portal web node pre-requisites
 RUN yum update -y && \
     yum install -y \
         ca-certificates \
@@ -50,46 +50,43 @@ RUN yum update -y && \
         python-devel \
         python-pip
 
-# Install pinned xrootd version and their dependencies:
+# Install latest stable xrootd 4.12.2 version and its dependencies
 RUN yum install -y \
-        expect \
-        policycoreutils \
-        selinux-policy && \
-    rpm -Uvh \
-      http://xrootd.web.cern.ch/xrootd/sw/releases/4.7.1/rpms/user_xrootd/slc7/x86_64/xrootd-libs-4.7.1-1.el7.x86_64.rpm \
-      http://xrootd.web.cern.ch/xrootd/sw/releases/4.7.1/rpms/user_xrootd/slc7/x86_64/xrootd-server-libs-4.7.1-1.el7.x86_64.rpm \
-      http://xrootd.web.cern.ch/xrootd/sw/releases/4.7.1/rpms/user_xrootd/slc7/x86_64/xrootd-server-4.7.1-1.el7.x86_64.rpm \
-      http://xrootd.web.cern.ch/xrootd/sw/releases/4.7.1/rpms/user_xrootd/slc7/x86_64/xrootd-selinux-4.7.1-1.el7.noarch.rpm \
-      http://xrootd.web.cern.ch/xrootd/sw/releases/4.7.1/rpms/user_xrootd/slc7/x86_64/xrootd-client-devel-4.7.1-1.el7.x86_64.rpm \
-      http://xrootd.web.cern.ch/xrootd/sw/releases/4.7.1/rpms/user_xrootd/slc7/x86_64/xrootd-client-4.7.1-1.el7.x86_64.rpm \
-      http://xrootd.web.cern.ch/xrootd/sw/releases/4.7.1/rpms/user_xrootd/slc7/x86_64/xrootd-client-libs-4.7.1-1.el7.x86_64.rpm \
-      http://xrootd.web.cern.ch/xrootd/sw/releases/4.7.1/rpms/user_xrootd/slc7/x86_64/xrootd-devel-4.7.1-1.el7.x86_64.rpm \
-      http://xrootd.web.cern.ch/xrootd/sw/releases/4.7.1/rpms/user_xrootd/slc7/x86_64/xrootd-4.7.1-1.el7.x86_64.rpm \
-      http://xrootd.web.cern.ch/xrootd/sw/releases/4.7.1/rpms/user_xrootd/slc7/x86_64/xrootd-python-4.7.1-1.el7.x86_64.rpm
+        xrootd-4.12.2 \
+        xrootd-client-4.12.2 \
+        xrootd-client-devel-4.12.2 \
+        xrootd-python-4.12.2
 
-# Clean after ourselves:
+# Clean after ourselves
 RUN yum clean -y all
 
-# Configuration for CERN Open Data Portal instance:
+# Configuration for CERN Open Data Portal instance
 ENV APP_INSTANCE_PATH=/usr/local/var/cernopendata/var/cernopendata-instance
 
+# Upgrade pip and install some python/node packages
 RUN pip install --upgrade pip==9 setuptools==42.0.2 wheel==0.33.6 && \
     npm install -g node-sass@3.8.0 clean-css@3.4.24 requirejs uglify-js jsonlint
 
+# Install xrootdpyfs from GitHub, since xrootd-4.12.2-compatible version was not released on PyPI yet
+RUN pip install xrootd==4.12.2 \
+      'git+https://github.com/inveniosoftware/xrootdpyfs.git@1151a7a4c219dad11eb0020af4c19f94928469e3#egg=xrootdpyfs'
+
+# Install requirements
 ADD requirements-production-local-forks.txt /tmp
 ADD requirements-production.txt /tmp
 RUN pip install -r /tmp/requirements-production-local-forks.txt
 RUN pip install -r /tmp/requirements-production.txt
 
-# Add CERN Open Data Portal sources to `code` and work there:
+# Add CERN Open Data Portal sources to `code` and work there
 WORKDIR /code
 ADD . /code
 
+# Create instance
 RUN /code/scripts/create-instance.sh && \
     chgrp -R 0 ${APP_INSTANCE_PATH} && \
     chmod -R g=u ${APP_INSTANCE_PATH}
 
-# uWSGI configuration
+# Condigure uWSGI
 ARG UWSGI_WSGI_MODULE=cernopendata.wsgi:application
 ENV UWSGI_WSGI_MODULE ${UWSGI_WSGI_MODULE:-cernopendata.wsgi:application}
 ARG UWSGI_PORT=5000
@@ -106,9 +103,10 @@ ENV DEBUG=${DEBUG:-""}
 # Install Python packages needed for development
 RUN if [ "$DEBUG" ]; then pip install -r requirements-dev.txt; fi;
 
+# Change user from root to invenio for better security
 RUN adduser --uid 1000 invenio --gid 0 && \
     chown -R invenio:root /code
 USER 1000
 
-# Start the CERN Open Data Portal application:
+# Start the CERN Open Data Portal application
 CMD uwsgi --module ${UWSGI_WSGI_MODULE} --socket 0.0.0.0:${UWSGI_PORT} --master --processes ${UWSGI_PROCESSES} --threads ${UWSGI_THREADS} --stats /tmp/stats.socket

--- a/requirements-production.txt
+++ b/requirements-production.txt
@@ -151,4 +151,4 @@ webencodings==0.5.1
 Werkzeug==0.14.1
 whichcraft==0.4.1
 WTForms==2.1
-xrootdpyfs==0.1.5
+xrootdpyfs==0.1.6


### PR DESCRIPTION
Upgrades XRootD to the latest stable 4.12.2 version. This fixes recent
Docker building troubles, and will also help in the stability of
downloading big files as per the latest xrootdpyfs improvements.

Note: the commit uses xrootdpyfs from GitHub, as the new stable
version was not released on PyPI yet.

Closes #2258.

Signed-off-by: Tibor Šimko <tibor.simko@cern.ch>