### PR TITLE
Update luminosity description

### DIFF
--- a/cernopendata/modules/fixtures/data/records/cms-luminosity-information.json
+++ b/cernopendata/modules/fixtures/data/records/cms-luminosity-information.json
@@ -43,6 +43,7 @@
     "publisher": "CERN Open Data Portal",
     "recid": "1050",
     "run_period": [
+      "Run2010A",
       "Run2010B"
     ],
     "title": "CMS luminosity information, for 2010 CMS open data",
@@ -55,7 +56,7 @@
   },
   {
     "abstract": {
-      "description": " <p>The integrated luminosity for validated runs and luminosity sections of the 2011 public data (RunA) is available in the table <a href=\"/record/1051/files/2011RunAlumi.txt\">2011RunAlumi.txt</a>. (The integrated luminosity for validated runs and luminosity sections of all 2011 p-p data taking is available in <a href=\"/record/1051/files/2011lumi.txt\">2011lumi.txt</a>.)</p>\n<p>In your estimate for the integrated luminosity, check for which runs the trigger you have selected is active and sum the values for those runs. The uncertainty in the luminosity measurement of 2011 data should be considered as 2.2% (reference <a href=\"https://cds.cern.ch/record/1434360/files/SMP-12-008-pas.pdf\">CMS PAS SMP-12-008</a>).</p>\n<p>If you are using prescaled triggers, you can find the trigger prescale factors as shown in <a href=\"/record/5004\">the trigger example</a>. The change of prescales (run, lumi section, index of prescales) is recorded in\n<a href=\"/record/1051/files/prescale2011.txt\">prescale2011.txt</a>.</p>\n<p> For luminosity calculation, a detailed list of luminosity by lumi section is provided in <a href=\"/record/1051/files/2011lumibyls.csv\">2011lumibyls.csv</a> for the <a href=\"/record/1001\">list of validated runs</a> and lumi sections.</p> "
+      "description": " <p>The integrated luminosity for validated runs and luminosity sections of all 2011 p-p data taking is available in the table <a href=\"/record/1051/files/2011lumi.txt\">2011lumi.txt</a>. It includes 2011 RunA and RunB. The values for 2011 RunA data taking are also available separately in <a href=\"/record/1051/files/2011RunAlumi.txt\">2011RunAlumi.txt</a>.</p>\n<p>In your estimate for the integrated luminosity, check for which runs the trigger you have selected is active and sum the values for those runs. The uncertainty in the luminosity measurement of 2011 data should be considered as 2.2% (reference <a href=\"https://cds.cern.ch/record/1434360/files/SMP-12-008-pas.pdf\">CMS PAS SMP-12-008</a>).</p>\n<p>If you are using prescaled triggers, you can find the trigger prescale factors as shown in <a href=\"/record/5004\">the trigger example</a>. The change of prescales (run, lumi section, index of prescales) is recorded in\n<a href=\"/record/1051/files/prescale2011.txt\">prescale2011.txt</a>.</p>\n<p> For luminosity calculation, a detailed list of luminosity by lumi section is provided in <a href=\"/record/1051/files/2011lumibyls.csv\">2011lumibyls.csv</a> for the <a href=\"/record/1001\">list of validated runs</a> and lumi sections.</p> "
     },
     "accelerator": "CERN-LHC",
     "collaboration": {
@@ -102,7 +103,8 @@
     "publisher": "CERN Open Data Portal",
     "recid": "1051",
     "run_period": [
-      "Run2011A"
+      "Run2011A",
+      "Run2011B"
     ],
     "title": "CMS luminosity information, for 2011 CMS open data",
     "type": {


### PR DESCRIPTION
(closes #2864)

 Updates the description wording to take into account that all 2011 data is public.
@caredg  Is there something we should add w.r.t  #2737 ?