### PR TITLE
CMS: update nanoaod tag

### DIFF
--- a/cernopendata/modules/fixtures/data/records/cms-derived-nanoaod-outreach-higgstautau.json
+++ b/cernopendata/modules/fixtures/data/records/cms-derived-nanoaod-outreach-higgstautau.json
@@ -247,7 +247,8 @@
     "date_published": "2019",
     "distribution": {
       "formats": [
-        "root"
+        "root",
+        "nanoaod"
       ],
       "number_events": 476963,
       "number_files": 1,
@@ -554,7 +555,8 @@
     "date_published": "2019",
     "distribution": {
       "formats": [
-        "root"
+        "root",
+        "nanoaod"
       ],
       "number_events": 491653,
       "number_files": 1,
@@ -861,7 +863,8 @@
     "date_published": "2019",
     "distribution": {
       "formats": [
-        "root"
+        "root",
+        "nanoaod"
       ],
       "number_events": 30458871,
       "number_files": 1,
@@ -1168,7 +1171,8 @@
     "date_published": "2019",
     "distribution": {
       "formats": [
-        "root"
+        "root",
+        "nanoaod"
       ],
       "number_events": 6423106,
       "number_files": 1,
@@ -1475,7 +1479,8 @@
     "date_published": "2019",
     "distribution": {
       "formats": [
-        "root"
+        "root",
+        "nanoaod"
       ],
       "number_events": 29784800,
       "number_files": 1,
@@ -1782,7 +1787,8 @@
     "date_published": "2019",
     "distribution": {
       "formats": [
-        "root"
+        "root",
+        "nanoaod"
       ],
       "number_events": 30693853,
       "number_files": 1,
@@ -2089,7 +2095,8 @@
     "date_published": "2019",
     "distribution": {
       "formats": [
-        "root"
+        "root",
+        "nanoaod"
       ],
       "number_events": 15241144,
       "number_files": 1,
@@ -2366,7 +2373,8 @@
     "date_published": "2019",
     "distribution": {
       "formats": [
-        "root"
+        "root",
+        "nanoaod"
       ],
       "number_events": 35647508,
       "number_files": 1,
@@ -2643,7 +2651,8 @@
     "date_published": "2019",
     "distribution": {
       "formats": [
-        "root"
+        "root",
+        "nanoaod"
       ],
       "number_events": 51303171,
       "number_files": 1,


### PR DESCRIPTION
(closes #2822)

Adds nanoaod tag to the Htautau example files so that they appear in search