### PR TITLE
records: CMS raw sample leading text

### DIFF
--- a/cernopendata/modules/fixtures/data/records/cms-raw-datasets-Run2010B.json
+++ b/cernopendata/modules/fixtures/data/records/cms-raw-datasets-Run2010B.json
@@ -76,7 +76,7 @@
       "description": "<p>These data are in RAW format and not directly usable in analysis. The reconstructed data reprocessed from these RAW data are included in the data of <a href=\"/record/8\">this record</a>. \n  The reconstruction step can be repeated with the configuration file below and the resulting AOD has been confirmed to be identical with the original one with comparison code available in <a href=\"/record/464\">Validation code to plot basic physics objects from AOD</a></p>",
       "links": [
         {
-          "description": "Example configuration file for reconstruction",
+          "description": "Configuration file for reconstruction",
           "url": "/eos/opendata/cms/configuration-files/RAWtoAOD/raw_MinimumBias10.py"
         }
       ]
@@ -176,7 +176,7 @@
       "description": "<p>These data are in RAW format and not directly usable in analysis. The reconstructed data reprocessed from these RAW data are included in the data of <a href=\"/record/14\">this record</a>. \n    The reconstruction step can be repeated with the configuration file below and the resulting AOD has been confirmed to be identical with the original one with comparison code available in <a href=\"/record/464\">Validation code to plot basic physics objects from AOD</a> </p>",
       "links": [
         {
-          "description": "Example configuration file for reconstruction",
+          "description": "Configuration file for reconstruction",
           "url": "/eos/opendata/cms/configuration-files/RAWtoAOD/raw_Mu10.py"
         }
       ]
@@ -276,7 +276,7 @@
       "description": "<p>These data are in RAW format and not directly usable in analysis. The reconstructed data reprocessed from these RAW data are included in the data of <a href=\"/record/4\">this record</a>. \n    The reconstruction step can be repeated with the configuration file below and the resulting AOD has been confirmed to be identical with the original one with comparison code available in <a href=\"/record/464\">Validation code to plot basic physics objects from AOD</a> </p>",
       "links": [
         {
-          "description": "Example configuration file for reconstruction",
+          "description": "Configuration file for reconstruction",
           "url": "/eos/opendata/cms/configuration-files/RAWtoAOD/raw_Electron10.py"
         }
       ]
@@ -376,7 +376,7 @@
       "description": "<p>These data are in RAW format and not directly usable in analysis. The reconstructed data reprocessed from these RAW data are included in the data of <a href=\"/record/5\">this record</a>. \n    The reconstruction step can be repeated with the configuration file attached to this record and the resulting AOD has been confirmed to be identical with the original one with comparison code available in <a href=\"/record/464\">Validation code to plot basic physics objects from AOD</a> </p>",
       "links": [
         {
-          "description": "Example configuration file for reconstruction",
+          "description": "Configuration file for reconstruction",
           "url": "/eos/opendata/cms/configuration-files/RAWtoAOD/raw_Jet10.py"
         }
       ]

--- a/cernopendata/modules/fixtures/data/records/cms-raw-datasets-Run2011A.json
+++ b/cernopendata/modules/fixtures/data/records/cms-raw-datasets-Run2011A.json
@@ -170,7 +170,7 @@
       "description": "<p>These data are in RAW format and not directly usable in analysis. The reconstructed data reprocessed from these RAW data are included in the data of <a href=\"/record/32\">this record</a>. \n    The reconstruction step can be repeated with the configuration file below and the resulting AOD has been confirmed to be identical with the original one with comparison code available in <a href=\"/record/464\">Validation code to plot basic physics objects from AOD</a> </p>",
       "links": [
         {
-          "description": "Example configuration file for reconstruction",
+          "description": "Configuration file for reconstruction",
           "url": "/eos/opendata/cms/configuration-files/RAWtoAOD/raw_SingleMu11.py"
         }
       ]
@@ -270,7 +270,7 @@
       "description": "<p>These data are in RAW format and not directly usable in analysis. The reconstructed data reprocessed from these RAW data are included in the data of <a href=\"/record/31\">this record</a>. \n    The reconstruction step can be repeated with the configuration file below and the resulting AOD has been confirmed to be identical with the original one with comparison code available in <a href=\"/record/464\">Validation code to plot basic physics objects from AOD</a> </p>",
       "links": [
         {
-          "description": "Example configuration file for reconstruction",
+          "description": "Configuration file for reconstruction",
           "url": "/eos/opendata/cms/configuration-files/RAWtoAOD/raw_SingleElectron11.py"
         }
       ]
@@ -370,7 +370,7 @@
       "description": "<p>These data are in RAW format and not directly usable in analysis. The reconstructed data reprocessed from these RAW data are included in the data of <a href=\"/record/16\">this record</a>. \n    The reconstruction step can be repeated with the configuration file below and the resulting AOD has been confirmed to be identical with the original one with comparison code available in <a href=\"/record/464\">Validation code to plot basic physics objects from AOD</a> </p>",
       "links": [
         {
-          "description": "Example configuration file for reconstruction",
+          "description": "Configuration file for reconstruction",
           "url": "/eos/opendata/cms/configuration-files/RAWtoAOD/raw_DoubleElectron11.py"
         }
       ]
@@ -470,7 +470,7 @@
       "description": "<p>These data are in RAW format and not directly usable in analysis. The reconstructed data reprocessed from these RAW data are included in the data of <a href=\"/record/17\">this record</a>. \n    The reconstruction step can be repeated with the configuration file below and the resulting AOD has been confirmed to be identical with the original one with comparison code available in <a href=\"/record/464\">Validation code to plot basic physics objects from AOD</a> </p>",
       "links": [
         {
-          "description": "Example configuration file for reconstruction",
+          "description": "Configuration file for reconstruction",
           "url": "/eos/opendata/cms/configuration-files/RAWtoAOD/raw_DoubleMu11.py"
         }
       ]
@@ -570,7 +570,7 @@
       "description": "<p>These data are in RAW format and not directly usable in analysis. The reconstructed data reprocessed from these RAW data are included in the data of <a href=\"/record/17\">this record</a>. \n    The reconstruction step can be repeated with the configuration file below and the resulting AOD has been confirmed to be identical with the original one with comparison code available in <a href=\"/record/464\">Validation code to plot basic physics objects from AOD</a> </p>",
       "links": [
         {
-          "description": "Example configuration file for reconstruction",
+          "description": "Configuration file for reconstruction",
           "url": "/eos/opendata/cms/configuration-files/RAWtoAOD/raw_Jet11.py"
         }
       ]


### PR DESCRIPTION
For 2010 and 2011 records, use "Configuration file..." leading text,
since the files are precise.

For 2012 records, keep using "Example configuration file..." leading
text.

Closes #2799.

Signed-off-by: Tibor Šimko <tibor.simko@cern.ch>