### PR TITLE
Update castor record

### DIFF
--- a/cernopendata/modules/fixtures/data/records/cms-primary-datasets-Commissioning2010.json
+++ b/cernopendata/modules/fixtures/data/records/cms-primary-datasets-Commissioning2010.json
@@ -294,6 +294,9 @@
           "url": "/docs/cms-virtual-machine-2010"
         },
         {
+          "recid": "465"
+        },
+        {
           "description": "Analysis recipe to use CASTOR objects with 2010 CMS OpenData",
           "url": "https://twiki.cern.ch/twiki/bin/view/CMSPublic/CASTOROpenData2010"
         }


### PR DESCRIPTION
(closes #2854 )

Updates the commissioning record to refer to castor sw for "How to use"