### PR TITLE
 records: mvp for ror ids

### DIFF
--- a/cernopendata/modules/fixtures/data/records/atlas-higgs-challenge-2014.json
+++ b/cernopendata/modules/fixtures/data/records/atlas-higgs-challenge-2014.json
@@ -214,17 +214,20 @@
     "accelerator": "CERN-LHC",
     "authors": [
       {
-        "affiliation": "LAL, IN2P3/CNRS & University Paris-Sud, France",
+        "affiliation": "Orsay, LAL; Paris, IN2P3; Orsay",
+        "rorid": "046w3ze59; 03fd77x13; 028rypz17",
         "name": "Adam-Bourdarios, Claire",
         "orcid": "0000-0002-2634-4958"
       },
       {
-        "affiliation": "Physics Department, Royal Holloway, University of London, UK",
+        "affiliation": "Royal Holloway, U. of London",
+        "rorid": "04g2vpn86",
         "name": "Cowan, Glen",
         "orcid": "0000-0001-8363-9827"
       },
       {
-        "affiliation": "TAO team, INRIA & LRI, CNRS & University Paris-Sud, France",
+        "affiliation": "INRIA, Saclay; LRI, Paris 11; Orsay",
+        "rorid": "02kvxyf05; 04e3ktk27; 028rypz17",
         "name": "Germain, Cecile",
         "orcid": "0000-0002-9764-9783"
       },
@@ -234,12 +237,14 @@
         "orcid": "0000-0002-9266-1783"
       },
       {
-        "affiliation": "LAL, IN2P3/CNRS & University Paris-Sud, France",
+        "affiliation": "Orsay, LAL; Paris, IN2P3; Orsay",
+        "rorid": "046w3ze59; 03fd77x13; 028rypz17",
         "name": "Kégl, Balázs",
         "orcid": "0000-0001-5610-1060"
       },
       {
-        "affiliation": "LAL, IN2P3/CNRS & University Paris-Sud, France",
+        "affiliation": "Orsay, LAL; Paris, IN2P3; Orsay",
+        "rorid": "046w3ze59; 03fd77x13; 028rypz17",
         "name": "Rousseau, David",
         "orcid": "0000-0001-7613-8063"
       }
@@ -297,7 +302,8 @@
     "accelerator": "CERN-LHC",
     "authors": [
       {
-        "affiliation": "LAL, IN2P3/CNRS & University Paris-Sud, France",
+        "affiliation": "Orsay, LAL; Paris, IN2P3; Orsay",
+        "rorid": "046w3ze59; 03fd77x13; 028rypz17",
         "name": "Kégl, Balázs",
         "orcid": "0000-0001-5610-1060"
       }
@@ -337,10 +343,14 @@
         "orcid": "0000-0003-4913-6104"
       },
       {
+        "affiliation": "Orsay, LAL; Paris, IN2P3; Orsay",
+        "rorid": "046w3ze59; 03fd77x13; 028rypz17",
         "name": "Kégl, Balázs",
         "orcid": "0000-0001-5610-1060"
       },
       {
+        "affiliation": "Orsay, LAL; Paris, IN2P3; Orsay",
+        "rorid": "046w3ze59; 03fd77x13; 028rypz17",
         "name": "Rousseau, David",
         "orcid": "0000-0001-7613-8063"
       }

--- a/cernopendata/modules/fixtures/data/records/cms-learning-resources.json
+++ b/cernopendata/modules/fixtures/data/records/cms-learning-resources.json
@@ -278,7 +278,8 @@
     "accelerator": "CERN-LHC",
     "authors": [
       {
-        "affiliation": "University of Helsinki",
+        "affiliation": "Helsinki Inst. of Phys.",
+        "rorid": "01x2x1522",
         "name": "Lehti, Sami",
         "orcid": "0000-0003-1370-5598"
       }

--- a/cernopendata/modules/fixtures/data/records/cms-open-data-instructions.json
+++ b/cernopendata/modules/fixtures/data/records/cms-open-data-instructions.json
@@ -61,7 +61,8 @@
     "accelerator": "CERN-LHC",
     "authors": [
       {
-        "affiliation": "Lapland University of Applied Sciences",
+        "affiliation": "Lapland, U. Appl. Sci.",
+        "rorid": "047h64h89",
         "name": "Puhakka, Anssi"
       }
     ],

--- a/cernopendata/modules/fixtures/data/records/cms-tools-ana-Run2011A.json
+++ b/cernopendata/modules/fixtures/data/records/cms-tools-ana-Run2011A.json
@@ -10,6 +10,8 @@
         "orcid": "0000-0002-7145-630X"
       },
       {
+        "affiliation": "Helsinki Inst. of Phys.",
+        "rorid": "01x2x1522",
         "name": "Lassila-Perini, Kati",
         "orcid": "0000-0002-5502-1795"
       }
@@ -104,6 +106,8 @@
         "orcid": "0000-0002-7145-630X"
       },
       {
+        "affiliation": "Helsinki Inst. of Phys.",
+        "rorid": "01x2x1522",
         "name": "Lassila-Perini, Kati",
         "orcid": "0000-0002-5502-1795"
       }

--- a/cernopendata/modules/fixtures/data/records/cms-tools-reco.json
+++ b/cernopendata/modules/fixtures/data/records/cms-tools-reco.json
@@ -6,6 +6,8 @@
     "accelerator": "CERN-LHC",
     "authors": [
       {
+        "affiliation": "Helsinki Inst. of Phys.",
+        "rorid": "01x2x1522",
         "name": "Lassila-Perini, Kati",
         "orcid": "0000-0002-5502-1795"
       }
@@ -78,6 +80,8 @@
     "accelerator": "CERN-LHC",
     "authors": [
       {
+        "affiliation": "Helsinki Inst. of Phys.",
+        "rorid": "01x2x1522",
         "name": "Lassila-Perini, Kati",
         "orcid": "0000-0002-5502-1795"
       }

--- a/cernopendata/modules/fixtures/data/records/data-policies.json
+++ b/cernopendata/modules/fixtures/data/records/data-policies.json
@@ -7,6 +7,7 @@
     "authors": [
       {
         "affiliation": "U. Edinburgh",
+        "rorid": "01nrxwf90",
         "name": "Clarke, Peter"
       }
     ],


### PR DESCRIPTION
 * Adds ROR IDs to any records that had affiliation information
 * Standardises affiliations in accordance with the INSPIRE institutions
 database (not possible for Lapland University, ChaLearn ~~and INRIA~~,
 those were added in approximation)
 * (closes #2894)

Signed-off-by: Artemis Lavasa <artemis.lavasa@cern.ch>