### PR TITLE
templates: fix ROR links

### DIFF
--- a/cernopendata/templates/cernopendata_records_ui/records/record_detail.html
+++ b/cernopendata/templates/cernopendata_records_ui/records/record_detail.html
@@ -16,9 +16,9 @@
                  <i>(
                      {% for affiliation in affiliations %}
                          {% if rorids[loop.index0] %}
-                             <a href="https://ror.org/{{ rorids[loop.index0] }}"><img src="{{ url_for('static', filename='img/rorid.png') }}" height="14" alt=""></a>
+                             <a href="https://ror.org/{{ rorids[loop.index0] | trim }}"><img src="{{ url_for('static', filename='img/rorid.png') }}" height="14" alt=""></a>
                          {% endif %}
-                         {{ affiliation }}
+                         {{ affiliation | trim }}
                          {% if not loop.last %}
                              ;
                          {% endif %}

--- a/cernopendata/templates/cernopendata_records_ui/records/record_detail.html
+++ b/cernopendata/templates/cernopendata_records_ui/records/record_detail.html
@@ -26,10 +26,15 @@
                  )</i>
             {% endif %}
             {% if not loop.last %}
-                 ;
+                ;
             {% endif %}
         {% endfor %}
-        {% if record.collaboration %} {{ record.collaboration.name }} {% endif %}
+        {% if record.collaboration %}
+            {% if record.authors %}
+                ;
+            {% endif %}
+            {{ record.collaboration.name }}
+        {% endif %}
     </p>
 
     {% if record.doi %}


### PR DESCRIPTION
Fixes ROR links for authors with multiple affiliations where values
were not properly trimmed regarding whitespace.

Signed-off-by: Tibor Šimko <tibor.simko@cern.ch>