### PR TITLE
CMS - 2020 HI records

### DIFF
--- a/cernopendata/modules/fixtures/data/records/cms-primary-datasets-HIRun2010.json
+++ b/cernopendata/modules/fixtures/data/records/cms-primary-datasets-HIRun2010.json
@@ -40,6 +40,20 @@
       "size": 19336281599911
     },
     "experiment": "CMS",
+    "files": [
+      {
+        "checksum": "adler32:44e5147f",
+        "size": 1575978,
+        "type": "index.json",
+        "uri": "root://eospublic.cern.ch//eos/opendata/cms/hidata/HIRun2010/HICorePhysics/RECO/PromptReco-v3/file-indexes/CMS_HIRun2010_HICorePhysics_PromptReco-v3_RECO_file_index.json"
+      },
+      {
+        "checksum": "adler32:12b0ad66",
+        "size": 799092,
+        "type": "index.txt",
+        "uri": "root://eospublic.cern.ch//eos/opendata/cms/hidata/HIRun2010/HICorePhysics/RECO/PromptReco-v3/file-indexes/CMS_HIRun2010_HICorePhysics_PromptReco-v3_RECO_file_index.txt"
+      }
+    ],
     "license": {
       "attribution": "CC0"
     },
@@ -145,6 +159,20 @@
       "size": 166030973333340
     },
     "experiment": "CMS",
+    "files": [
+      {
+        "checksum": "adler32:cb873e1e",
+        "size": 8963908,
+        "type": "index.json",
+        "uri": "root://eospublic.cern.ch//eos/opendata/cms/hidata/HIRun2010/HIAllPhysics/RECO/ZS-v2/file-indexes/CMS_HIRun2010_HIAllPhysics_ZS-v2_RECO_file_index.json"
+      },
+      {
+        "checksum": "adler32:b27bab6d",
+        "size": 4285665,
+        "type": "index.txt",
+        "uri": "root://eospublic.cern.ch//eos/opendata/cms/hidata/HIRun2010/HIAllPhysics/RECO/ZS-v2/file-indexes/CMS_HIRun2010_HIAllPhysics_ZS-v2_RECO_file_index.txt"
+      }
+    ],
     "license": {
       "attribution": "CC0"
     },

--- a/cernopendata/modules/fixtures/data/records/cms-primary-datasets-HIRun2010.json
+++ b/cernopendata/modules/fixtures/data/records/cms-primary-datasets-HIRun2010.json
@@ -1,0 +1,212 @@
+[
+  {
+    "abstract": {
+      "description": "<p>HICorePhysics primary dataset from the 2.76 TeV Pb-Pb run of 2010.</p> <p> The list of validated runs, which must be applied to all analyses, either with the full validation or for an analysis requiring only muons, can be found in</p>",
+      "links": [
+        {
+          "description": "Validated runs, full validation",
+          "recid": "14202"
+        },
+        {
+          "description": "Validated runs, muons only",
+          "recid": "14203"
+        }
+      ]
+    },
+    "accelerator": "CERN-LHC",
+    "collaboration": {
+      "name": "CMS collaboration",
+      "recid": "450"
+    },
+    "collections": [
+      "CMS-Primary-Datasets"
+    ],
+    "collision_information": {
+      "energy": "2.76TeV",
+      "type": "PbPb"
+    },
+    "date_created": [
+      "2010"
+    ],
+    "date_published": "2020",
+    "date_reprocessed": "2010",
+    "distribution": {
+      "formats": [
+        "root",
+        "reco"
+      ],
+      "number_events": 5964915,
+      "number_files": 5436,
+      "size": 19336281599911
+    },
+    "experiment": "CMS",
+    "license": {
+      "attribution": "CC0"
+    },
+    "methodology": {
+      "description": "<p>During the heavy-ion run, events were directed to this primary dataset through several different HLT trigger paths, which can be studied and selected with the example usage code linked below.</p>"
+    },
+    "publisher": "CERN Open Data Portal",
+    "recid": "14010",
+    "relations": [
+      {
+        "title": "/HICorePhysics/HIRun2010-v1/RAW",
+        "type": "isChildOf"
+      }
+    ],
+    "run_period": [
+      "HIRun2010"
+    ],
+    "system_details": {
+      "global_tag": "GR_R_39X_V6B::All",
+      "release": "CMSSW_3_9_2_patch5"
+    },
+    "title": "/HICorePhysics/HIRun2010-PromptReco-v3/RECO",
+    "title_additional": "HICorePhysics primary dataset in RECO format from the 2.76 TeV Pb-Pb run of 2010 (/HICorePhysics/HIRun2010-PromptReco-v3/RECO)",
+    "type": {
+      "primary": "Dataset",
+      "secondary": [
+        "Collision"
+      ]
+    },
+    "usage": {
+      "description": "You can access these data through the CMS Open Data container or the CMS Virtual Machine. See the instructions for setting up one of the two alternative environments and getting started with CMS heavy-ion data data in",
+      "links": [
+        {
+          "description": "Running CMS analysis code using Docker",
+          "url": "/docs/cms-guide-docker"
+        },
+        {
+          "description": "How to install the CMS Virtual Machine",
+          "url": "/docs/cms-virtual-machine-2010"
+        },
+        {
+          "description": "Usage example for CMS 2010 heavy-ion data",
+          "recid": "466"
+        }
+      ]
+    },
+    "validation": {
+      "description": "During data taking all the runs recorded by CMS are certified as good for physics analysis if all subdetectors, trigger, lumi and physics objects (tracking, electron, muon, photon, jet and MET) show the expected performance. Certification is based first on the offline shifters evaluation and later on the feedback provided by detector and Physics Object Group experts. Based on the above information, which is stored in a specific database called Run Registry, the Data Quality Monitoring group verifies the consistency of the certification and prepares a json file of certified runs to be used for physics analysis. For each reprocessing of the raw data, the above mentioned steps are repeated. For more information see:",
+      "links": [
+        {
+          "description": "CMS data quality monitoring: Systems and experiences",
+          "url": "http://iopscience.iop.org/1742-6596/219/7/072020/pdf/1742-6596_219_7_072020.pdf"
+        },
+        {
+          "description": "The CMS Data Quality Monitoring software experience and future improvements",
+          "url": "http://cds.cern.ch/record/1631039/files/CR2013_418.pdf"
+        },
+        {
+          "description": "The CMS data quality monitoring software: experience and future prospects",
+          "url": "http://iopscience.iop.org/1742-6596/513/3/032024/pdf/1742-6596_513_3_032024.pdf"
+        }
+      ]
+    }
+  },
+  {
+    "abstract": {
+      "description": "<p>HIAllPhysics primary dataset from the 2.76 TeV Pb-Pb run of 2010.</p> <p> The list of validated runs, which must be applied to all analyses, either with the full validation or for an analysis requiring only muons, can be found in</p>",
+      "links": [
+        {
+          "description": "Validated runs, full validation",
+          "recid": "14202"
+        },
+        {
+          "description": "Validated runs, muons only",
+          "recid": "14203"
+        }
+      ]
+    },
+    "accelerator": "CERN-LHC",
+    "collaboration": {
+      "name": "CMS collaboration",
+      "recid": "450"
+    },
+    "collections": [
+      "CMS-Primary-Datasets"
+    ],
+    "collision_information": {
+      "energy": "2.76TeV",
+      "type": "PbPb"
+    },
+    "date_created": [
+      "2010"
+    ],
+    "date_published": "2020",
+    "date_reprocessed": "2010",
+    "distribution": {
+      "formats": [
+        "root",
+        "reco"
+      ],
+      "number_events": 75482193,
+      "number_files": 28954,
+      "size": 166030973333340
+    },
+    "experiment": "CMS",
+    "license": {
+      "attribution": "CC0"
+    },
+    "methodology": {
+      "description": "<p>During the heavy-ion run, events were directed to this primary dataset through several different HLT trigger paths, which can be studied and selected with the example usage code linked below.</p>"
+    },
+    "publisher": "CERN Open Data Portal",
+    "recid": "14011",
+    "relations": [
+      {
+        "title": "/HIAllPhysics/HIRun2010-v1/RAW",
+        "type": "isChildOf"
+      }
+    ],
+    "run_period": [
+      "HIRun2010"
+    ],
+    "system_details": {
+      "global_tag": "GR_R_39X_V6B::All",
+      "release": "CMSSW_3_9_2_patch5"
+    },
+    "title": "/HIAllPhysics/HIRun2010-ZS-v2/RECO",
+    "title_additional": "HIAllPhysics primary dataset in RECO format from the 2.76 TeV Pb-Pb run of 2010 (/HIAllPhysics/HIRun2010-ZS-v2/RECO)",
+    "type": {
+      "primary": "Dataset",
+      "secondary": [
+        "Collision"
+      ]
+    },
+    "usage": {
+      "description": "You can access these data through the CMS Open Data container or the CMS Virtual Machine. See the instructions for setting up one of the two alternative environments and getting started with CMS heavy-ion data data in",
+      "links": [
+        {
+          "description": "Running CMS analysis code using Docker",
+          "url": "/docs/cms-guide-docker"
+        },
+        {
+          "description": "How to install the CMS Virtual Machine",
+          "url": "/docs/cms-virtual-machine-2010"
+        },
+        {
+          "description": "Usage example for CMS 2010 heavy-ion data",
+          "recid": "466"
+        }
+      ]
+    },
+    "validation": {
+      "description": "During data taking all the runs recorded by CMS are certified as good for physics analysis if all subdetectors, trigger, lumi and physics objects (tracking, electron, muon, photon, jet and MET) show the expected performance. Certification is based first on the offline shifters evaluation and later on the feedback provided by detector and Physics Object Group experts. Based on the above information, which is stored in a specific database called Run Registry, the Data Quality Monitoring group verifies the consistency of the certification and prepares a json file of certified runs to be used for physics analysis. For each reprocessing of the raw data, the above mentioned steps are repeated. For more information see:",
+      "links": [
+        {
+          "description": "CMS data quality monitoring: Systems and experiences",
+          "url": "http://iopscience.iop.org/1742-6596/219/7/072020/pdf/1742-6596_219_7_072020.pdf"
+        },
+        {
+          "description": "The CMS Data Quality Monitoring software experience and future improvements",
+          "url": "http://cds.cern.ch/record/1631039/files/CR2013_418.pdf"
+        },
+        {
+          "description": "The CMS data quality monitoring software: experience and future prospects",
+          "url": "http://iopscience.iop.org/1742-6596/513/3/032024/pdf/1742-6596_513_3_032024.pdf"
+        }
+      ]
+    }
+  }
+]


### PR DESCRIPTION
(closes #2910 )

These records have very limited provenance information as it is not recorded in DAS. Some generic information could possibly be added.