### PR TITLE
records: CMS Run2011A pp HI file information

### DIFF
--- a/cernopendata/modules/fixtures/data/records/cms-primary-datasets-HIpp-Run2011A.json
+++ b/cernopendata/modules/fixtures/data/records/cms-primary-datasets-HIpp-Run2011A.json
@@ -40,6 +40,20 @@
       "size": 6570934150548
     },
     "experiment": "CMS",
+    "files": [
+      {
+        "checksum": "adler32:c82b6958",
+        "size": 410028,
+        "type": "index.json",
+        "uri": "root://eospublic.cern.ch//eos/opendata/cms/Run2011A/AllPhysics2760/RECO/16Jul2011-v1/file-indexes/CMS_Run2011A_AllPhysics2760_RECO_16Jul2011-v1_root_file_index.json"
+      },
+      {
+        "checksum": "adler32:8dc0a9c2",
+        "size": 196812,
+        "type": "index.txt",
+        "uri": "root://eospublic.cern.ch//eos/opendata/cms/Run2011A/AllPhysics2760/RECO/16Jul2011-v1/file-indexes/CMS_Run2011A_AllPhysics2760_RECO_16Jul2011-v1_root_file_index.txt"
+      }
+    ],
     "license": {
       "attribution": "CC0"
     },
@@ -145,6 +159,20 @@
       "size": 275113247233
     },
     "experiment": "CMS",
+    "files": [
+      {
+        "checksum": "adler32:4ee25b54",
+        "size": 19366,
+        "type": "index.json",
+        "uri": "root://eospublic.cern.ch//eos/opendata/cms/Nov2011_HI/AllPhysics2760/RECO/SD_JetHI-276TeV_ppRereco/file-indexes/CMS_Nov2011_HI_AllPhysics2760_RECO_SD_JetHI-276TeV_ppRereco_root_file_index.json"
+      },
+      {
+        "checksum": "adler32:5ff48894",
+        "size": 9782,
+        "type": "index.txt",
+        "uri": "root://eospublic.cern.ch//eos/opendata/cms/Nov2011_HI/AllPhysics2760/RECO/SD_JetHI-276TeV_ppRereco/file-indexes/CMS_Nov2011_HI_AllPhysics2760_RECO_SD_JetHI-276TeV_ppRereco_root_file_index.txt"
+      }
+    ],
     "license": {
       "attribution": "CC0"
     },
@@ -250,6 +278,20 @@
       "size": 682687665680
     },
     "experiment": "CMS",
+    "files": [
+      {
+        "checksum": "adler32:e5b47848",
+        "size": 48963,
+        "type": "index.json",
+        "uri": "root://eospublic.cern.ch//eos/opendata/cms/Nov2011_HI/AllPhysics2760/RECO/SD_MuHI-276TeV_ppRereco/file-indexes/CMS_Nov2011_HI_AllPhysics2760_RECO_SD_MuHI-276TeV_ppRereco_root_file_index.json"
+      },
+      {
+        "checksum": "adler32:b1ad039b",
+        "size": 24650,
+        "type": "index.txt",
+        "uri": "root://eospublic.cern.ch//eos/opendata/cms/Nov2011_HI/AllPhysics2760/RECO/SD_MuHI-276TeV_ppRereco/file-indexes/CMS_Nov2011_HI_AllPhysics2760_RECO_SD_MuHI-276TeV_ppRereco_root_file_index.txt"
+      }
+    ],
     "license": {
       "attribution": "CC0"
     },
@@ -355,6 +397,20 @@
       "size": 315011898981
     },
     "experiment": "CMS",
+    "files": [
+      {
+        "checksum": "adler32:4938d83d",
+        "size": 22486,
+        "type": "index.json",
+        "uri": "root://eospublic.cern.ch//eos/opendata/cms/Nov2011_HI/AllPhysics2760/RECO/SD_PhotonHI-276TeV_ppRereco/file-indexes/CMS_Nov2011_HI_AllPhysics2760_RECO_SD_PhotonHI-276TeV_ppRereco_root_file_index.json"
+      },
+      {
+        "checksum": "adler32:891bab18",
+        "size": 11473,
+        "type": "index.txt",
+        "uri": "root://eospublic.cern.ch//eos/opendata/cms/Nov2011_HI/AllPhysics2760/RECO/SD_PhotonHI-276TeV_ppRereco/file-indexes/CMS_Nov2011_HI_AllPhysics2760_RECO_SD_PhotonHI-276TeV_ppRereco_root_file_index.txt"
+      }
+    ],
     "license": {
       "attribution": "CC0"
     },
@@ -460,6 +516,20 @@
       "size": 938807720938
     },
     "experiment": "CMS",
+    "files": [
+      {
+        "checksum": "adler32:d5813a3f",
+        "size": 41321,
+        "type": "index.json",
+        "uri": "root://eospublic.cern.ch//eos/opendata/cms/Run2011A/MinBias0Tesla0/RECO/PromptReco-v5/file-indexes/CMS_Run2011A_MinBias0Tesla0_RECO_PromptReco-v5_root_file_index.json"
+      },
+      {
+        "checksum": "adler32:b19fdd5e",
+        "size": 20440,
+        "type": "index.txt",
+        "uri": "root://eospublic.cern.ch//eos/opendata/cms/Run2011A/MinBias0Tesla0/RECO/PromptReco-v5/file-indexes/CMS_Run2011A_MinBias0Tesla0_RECO_PromptReco-v5_root_file_index.txt"
+      }
+    ],
     "license": {
       "attribution": "CC0"
     },
@@ -565,6 +635,20 @@
       "size": 930327865484
     },
     "experiment": "CMS",
+    "files": [
+      {
+        "checksum": "adler32:38fa5d63",
+        "size": 40473,
+        "type": "index.json",
+        "uri": "root://eospublic.cern.ch//eos/opendata/cms/Run2011A/MinBias0Tesla1/RECO/PromptReco-v5/file-indexes/CMS_Run2011A_MinBias0Tesla1_RECO_PromptReco-v5_root_file_index.json"
+      },
+      {
+        "checksum": "adler32:6fc361c9",
+        "size": 20020,
+        "type": "index.txt",
+        "uri": "root://eospublic.cern.ch//eos/opendata/cms/Run2011A/MinBias0Tesla1/RECO/PromptReco-v5/file-indexes/CMS_Run2011A_MinBias0Tesla1_RECO_PromptReco-v5_root_file_index.txt"
+      }
+    ],
     "license": {
       "attribution": "CC0"
     },
@@ -670,6 +754,20 @@
       "size": 938692947699
     },
     "experiment": "CMS",
+    "files": [
+      {
+        "checksum": "adler32:99ba6707",
+        "size": 40474,
+        "type": "index.json",
+        "uri": "root://eospublic.cern.ch//eos/opendata/cms/Run2011A/MinBias0Tesla2/RECO/PromptReco-v5/file-indexes/CMS_Run2011A_MinBias0Tesla2_RECO_PromptReco-v5_root_file_index.json"
+      },
+      {
+        "checksum": "adler32:2eda69e0",
+        "size": 20020,
+        "type": "index.txt",
+        "uri": "root://eospublic.cern.ch//eos/opendata/cms/Run2011A/MinBias0Tesla2/RECO/PromptReco-v5/file-indexes/CMS_Run2011A_MinBias0Tesla2_RECO_PromptReco-v5_root_file_index.txt"
+      }
+    ],
     "license": {
       "attribution": "CC0"
     },


### PR DESCRIPTION
Adds file information for CMS Run2011A pp HI reference datasets.
Closes #2938.