### PR TITLE
CMS: add a keyword and change the pp  description

### DIFF
--- a/cernopendata/modules/fixtures/data/records/cms-primary-datasets-HIRun2010.json
+++ b/cernopendata/modules/fixtures/data/records/cms-primary-datasets-HIRun2010.json
@@ -54,6 +54,9 @@
         "uri": "root://eospublic.cern.ch//eos/opendata/cms/hidata/HIRun2010/HICorePhysics/RECO/PromptReco-v3/file-indexes/CMS_HIRun2010_HICorePhysics_PromptReco-v3_RECO_file_index.txt"
       }
     ],
+    "keywords": [
+      "heavy-ion physics"
+    ],
     "license": {
       "attribution": "CC0"
     },
@@ -172,6 +175,9 @@
         "type": "index.txt",
         "uri": "root://eospublic.cern.ch//eos/opendata/cms/hidata/HIRun2010/HIAllPhysics/RECO/ZS-v2/file-indexes/CMS_HIRun2010_HIAllPhysics_ZS-v2_RECO_file_index.txt"
       }
+    ],
+    "keywords": [
+      "heavy-ion physics"
     ],
     "license": {
       "attribution": "CC0"

--- a/cernopendata/modules/fixtures/data/records/cms-primary-datasets-HIRun2011.json
+++ b/cernopendata/modules/fixtures/data/records/cms-primary-datasets-HIRun2011.json
@@ -54,6 +54,9 @@
         "uri": "root://eospublic.cern.ch//eos/opendata/cms/hidata/HIRun2011/HIDiMuon/RECO/04Mar2013-v1/file-indexes/CMS_HIRun2011_HIDiMuon_RECO_04Mar2013-v1_root_file_index.txt"
       }
     ],
+    "keywords": [
+      "heavy-ion physics"
+    ],
     "license": {
       "attribution": "CC0"
     },
@@ -172,6 +175,9 @@
         "type": "index.txt",
         "uri": "root://eospublic.cern.ch//eos/opendata/cms/hidata/HIRun2011/HIHighPt/RECO/15Apr2013-v1/file-indexes/CMS_HIRun2011_HIHighPt_RECO_15Apr2013-v1_root_file_index.txt"
       }
+    ],
+    "keywords": [
+      "heavy-ion physics"
     ],
     "license": {
       "attribution": "CC0"
@@ -292,6 +298,9 @@
         "uri": "root://eospublic.cern.ch//eos/opendata/cms/hidata/HIRun2011/HIMinBiasUPC/RECO/12Jun2013-v1/file-indexes/CMS_HIRun2011_HIMinBiasUPC_RECO_12Jun2013-v1_root_file_index.txt"
       }
     ],
+    "keywords": [
+      "heavy-ion physics"
+    ],
     "license": {
       "attribution": "CC0"
     },
@@ -411,6 +420,9 @@
         "uri": "root://eospublic.cern.ch//eos/opendata/cms/hidata/HIRun2011/MinimumBias/RECO/PromptReco-v1/file-indexes/CMS_HIRun2011_MinimumBias_RECO_PromptReco-v1_root_file_index.txt"
       }
     ],
+    "keywords": [
+      "heavy-ion physics"
+    ],
     "license": {
       "attribution": "CC0"
     },
@@ -519,6 +531,9 @@
         "type": "index.txt",
         "uri": "root://eospublic.cern.ch//eos/opendata/cms/hidata/HIRun2011/ForwardTriggers/RECO/PromptReco-v1/file-indexes/CMS_HIRun2011_ForwardTriggers_RECO_PromptReco-v1_root_file_index.txt"
       }
+    ],
+    "keywords": [
+      "heavy-ion physics"
     ],
     "license": {
       "attribution": "CC0"

--- a/cernopendata/modules/fixtures/data/records/cms-primary-datasets-HIpp-Run2011A.json
+++ b/cernopendata/modules/fixtures/data/records/cms-primary-datasets-HIpp-Run2011A.json
@@ -1,7 +1,7 @@
 [
   {
     "abstract": {
-      "description": "<p>AllPhysics2760 primary dataset from the 2.76 TeV proton-proton run of 2011, reference data for heavy-ion data analysis</p> <p> The list of validated runs, which must be applied to all analyses, either with the full validation or for an analysis requiring only muons, can be found in</p>",
+      "description": "<p>AllPhysics2760 primary dataset from the 2.76 TeV proton-proton run of 2011. These proton-proton data are at the same centre-of-mass energy and have a similar trigger menu to those in Pb-Pb collisions.</p> <p> The list of validated runs, which must be applied to all analyses, either with the full validation or for an analysis requiring only muons, can be found in</p>",
       "links": [
         {
           "description": "Validated runs, full validation",
@@ -53,6 +53,9 @@
         "type": "index.txt",
         "uri": "root://eospublic.cern.ch//eos/opendata/cms/Run2011A/AllPhysics2760/RECO/16Jul2011-v1/file-indexes/CMS_Run2011A_AllPhysics2760_RECO_16Jul2011-v1_root_file_index.txt"
       }
+    ],
+    "keywords": [
+      "heavy-ion physics"
     ],
     "license": {
       "attribution": "CC0"
@@ -120,7 +123,7 @@
   },
   {
     "abstract": {
-      "description": "<p>AllPhysics2760 (JetHI) primary dataset from the 2.76 TeV proton-proton run of 2011, reference data for heavy-ion data analysis</p> <p> The list of validated runs, which must be applied to all analyses, either with the full validation or for an analysis requiring only muons, can be found in</p>",
+      "description": "<p>AllPhysics2760 (JetHI) primary dataset from the 2.76 TeV proton-proton run of 2011. These proton-proton data are at the same centre-of-mass energy and have a similar trigger menu to those in Pb-Pb collisions.</p> <p> The list of validated runs, which must be applied to all analyses, either with the full validation or for an analysis requiring only muons, can be found in</p>",
       "links": [
         {
           "description": "Validated runs, full validation",
@@ -172,6 +175,9 @@
         "type": "index.txt",
         "uri": "root://eospublic.cern.ch//eos/opendata/cms/Nov2011_HI/AllPhysics2760/RECO/SD_JetHI-276TeV_ppRereco/file-indexes/CMS_Nov2011_HI_AllPhysics2760_RECO_SD_JetHI-276TeV_ppRereco_root_file_index.txt"
       }
+    ],
+    "keywords": [
+      "heavy-ion physics"
     ],
     "license": {
       "attribution": "CC0"
@@ -239,7 +245,7 @@
   },
   {
     "abstract": {
-      "description": "<p>AllPhysics2760 (MuHI) primary dataset from the 2.76 TeV proton-proton run of 2011, reference data for heavy-ion data analysis</p> <p> The list of validated runs, which must be applied to all analyses, either with the full validation or for an analysis requiring only muons, can be found in</p>",
+      "description": "<p>AllPhysics2760 (MuHI) primary dataset from the 2.76 TeV proton-proton run of 2011. These proton-proton data are at the same centre-of-mass energy and have a similar trigger menu to those in Pb-Pb collisions.</p> <p> The list of validated runs, which must be applied to all analyses, either with the full validation or for an analysis requiring only muons, can be found in</p>",
       "links": [
         {
           "description": "Validated runs, full validation",
@@ -291,6 +297,9 @@
         "type": "index.txt",
         "uri": "root://eospublic.cern.ch//eos/opendata/cms/Nov2011_HI/AllPhysics2760/RECO/SD_MuHI-276TeV_ppRereco/file-indexes/CMS_Nov2011_HI_AllPhysics2760_RECO_SD_MuHI-276TeV_ppRereco_root_file_index.txt"
       }
+    ],
+    "keywords": [
+      "heavy-ion physics"
     ],
     "license": {
       "attribution": "CC0"
@@ -358,7 +367,7 @@
   },
   {
     "abstract": {
-      "description": "<p>AllPhysics2760 (PhotonHI) primary dataset from the 2.76 TeV proton-proton run of 2011, reference data for heavy-ion data analysis</p> <p> The list of validated runs, which must be applied to all analyses, either with the full validation or for an analysis requiring only muons, can be found in</p>",
+      "description": "<p>AllPhysics2760 (PhotonHI) primary dataset from the 2.76 TeV proton-proton run of 2011. These proton-proton data are at the same centre-of-mass energy and have a similar trigger menu to those in Pb-Pb collisions.</p> <p> The list of validated runs, which must be applied to all analyses, either with the full validation or for an analysis requiring only muons, can be found in</p>",
       "links": [
         {
           "description": "Validated runs, full validation",
@@ -410,6 +419,9 @@
         "type": "index.txt",
         "uri": "root://eospublic.cern.ch//eos/opendata/cms/Nov2011_HI/AllPhysics2760/RECO/SD_PhotonHI-276TeV_ppRereco/file-indexes/CMS_Nov2011_HI_AllPhysics2760_RECO_SD_PhotonHI-276TeV_ppRereco_root_file_index.txt"
       }
+    ],
+    "keywords": [
+      "heavy-ion physics"
     ],
     "license": {
       "attribution": "CC0"
@@ -477,7 +489,7 @@
   },
   {
     "abstract": {
-      "description": "<p>MinBias0Tesla0 primary dataset from the 7 TeV proton-proton run of 2011, reference data for heavy-ion data analysis</p> <p> The list of validated runs, which must be applied to all analyses, either with the full validation or for an analysis requiring only muons, can be found in</p>",
+      "description": "<p>MinBias0Tesla0 primary dataset from the 7 TeV proton-proton run of 2011. These proton-proton data are at the same centre-of-mass energy and have a similar trigger menu to those in Pb-Pb collisions.</p> <p> The list of validated runs, which must be applied to all analyses, either with the full validation or for an analysis requiring only muons, can be found in</p>",
       "links": [
         {
           "description": "Validated runs, full validation",
@@ -529,6 +541,9 @@
         "type": "index.txt",
         "uri": "root://eospublic.cern.ch//eos/opendata/cms/Run2011A/MinBias0Tesla0/RECO/PromptReco-v5/file-indexes/CMS_Run2011A_MinBias0Tesla0_RECO_PromptReco-v5_root_file_index.txt"
       }
+    ],
+    "keywords": [
+      "heavy-ion physics"
     ],
     "license": {
       "attribution": "CC0"
@@ -596,7 +611,7 @@
   },
   {
     "abstract": {
-      "description": "<p>MinBias0Tesla1 primary dataset from the 7 TeV proton-proton run of 2011, reference data for heavy-ion data analysis</p> <p> The list of validated runs, which must be applied to all analyses, either with the full validation or for an analysis requiring only muons, can be found in</p>",
+      "description": "<p>MinBias0Tesla1 primary dataset from the 7 TeV proton-proton run of 2011. These proton-proton data are at the same centre-of-mass energy and have a similar trigger menu to those in Pb-Pb collisions.</p> <p> The list of validated runs, which must be applied to all analyses, either with the full validation or for an analysis requiring only muons, can be found in</p>",
       "links": [
         {
           "description": "Validated runs, full validation",
@@ -648,6 +663,9 @@
         "type": "index.txt",
         "uri": "root://eospublic.cern.ch//eos/opendata/cms/Run2011A/MinBias0Tesla1/RECO/PromptReco-v5/file-indexes/CMS_Run2011A_MinBias0Tesla1_RECO_PromptReco-v5_root_file_index.txt"
       }
+    ],
+    "keywords": [
+      "heavy-ion physics"
     ],
     "license": {
       "attribution": "CC0"
@@ -715,7 +733,7 @@
   },
   {
     "abstract": {
-      "description": "<p>MinBias0Tesla2 primary dataset from the 7 TeV proton-proton run of 2011, reference data for heavy-ion data analysis</p> <p> The list of validated runs, which must be applied to all analyses, either with the full validation or for an analysis requiring only muons, can be found in</p>",
+      "description": "<p>MinBias0Tesla2 primary dataset from the 7 TeV proton-proton run of 2011. These proton-proton data are at the same centre-of-mass energy and have a similar trigger menu to those in Pb-Pb collisions.</p> <p> The list of validated runs, which must be applied to all analyses, either with the full validation or for an analysis requiring only muons, can be found in</p>",
       "links": [
         {
           "description": "Validated runs, full validation",
@@ -767,6 +785,9 @@
         "type": "index.txt",
         "uri": "root://eospublic.cern.ch//eos/opendata/cms/Run2011A/MinBias0Tesla2/RECO/PromptReco-v5/file-indexes/CMS_Run2011A_MinBias0Tesla2_RECO_PromptReco-v5_root_file_index.txt"
       }
+    ],
+    "keywords": [
+      "heavy-ion physics"
     ],
     "license": {
       "attribution": "CC0"

--- a/cernopendata/modules/fixtures/data/records/cms-validated-runs-HIRun1.json
+++ b/cernopendata/modules/fixtures/data/records/cms-validated-runs-HIRun1.json
@@ -31,6 +31,9 @@
         "uri": "root://eospublic.cern.ch//eos/opendata/cms/validated-runs/hi/2010/Cert_150436-152957_HI7TeV_StreamExpress_Collisions10_JSON_v2.txt"
       }
     ],
+    "keywords": [
+      "heavy-ion physics"
+    ],
     "publisher": "CERN Open Data Portal",
     "recid": "14202",
     "run_period": [
@@ -96,6 +99,9 @@
         "size": 1807,
         "uri": "root://eospublic.cern.ch//eos/opendata/cms/validated-runs/hi/2010/Cert_150436-152957_HI7TeV_StreamExpress_Collisions10_JSON_MuonPhys_v2.txt"
       }
+    ],
+    "keywords": [
+      "heavy-ion physics"
     ],
     "publisher": "CERN Open Data Portal",
     "recid": "14203",
@@ -163,6 +169,9 @@
         "uri": "root://eospublic.cern.ch//eos/opendata/cms/validated-runs/hi/2011/Cert_181530-183126_HI7TeV_PromptReco_Collisions11_JSON.txt"
       }
     ],
+    "keywords": [
+      "heavy-ion physics"
+    ],
     "publisher": "CERN Open Data Portal",
     "recid": "14204",
     "run_period": [
@@ -229,6 +238,9 @@
         "uri": "root://eospublic.cern.ch//eos/opendata/cms/validated-runs/hi/2011/Cert_181530-183126_HI7TeV_PromptReco_Collisions11_JSON_MuonPhys.txt"
       }
     ],
+    "keywords": [
+      "heavy-ion physics"
+    ],
     "publisher": "CERN Open Data Portal",
     "recid": "14205",
     "run_period": [
@@ -294,6 +306,9 @@
         "size": 18427,
         "uri": "root://eospublic.cern.ch//eos/opendata/cms/validated-runs/hi/2011/Cert_160404-180252_7TeV_PromptReco_Collisions11_JSON.txt"
       }
+    ],
+    "keywords": [
+      "heavy-ion physics"
     ],
     "publisher": "CERN Open Data Portal",
     "recid": "14206",
@@ -362,6 +377,9 @@
         "uri": "root://eospublic.cern.ch//eos/opendata/cms/validated-runs/hi/2011/Cert_160404-180252_7TeV_PromptReco_Collisions11_JSON_MuonPhys.txt"
       }
     ],
+    "keywords": [
+      "heavy-ion physics"
+    ],
     "publisher": "CERN Open Data Portal",
     "recid": "14207",
     "run_period": [
@@ -429,6 +447,9 @@
         "uri": "root://eospublic.cern.ch//eos/opendata/cms/validated-runs/hi/2011/Cert_161366-161474_2760GeV_PromptReco_Collisions11_JSON_MuonPhys.txt"
       }
     ],
+    "keywords": [
+      "heavy-ion physics"
+    ],
     "publisher": "CERN Open Data Portal",
     "recid": "14208",
     "run_period": [
@@ -494,6 +515,9 @@
         "size": 275,
         "uri": "root://eospublic.cern.ch//eos/opendata/cms/validated-runs/hi/2011/Cert_161366-161474_2760GeV_PromptReco_Collisions11_JSON_v2.txt"
       }
+    ],
+    "keywords": [
+      "heavy-ion physics"
     ],
     "publisher": "CERN Open Data Portal",
     "recid": "14209",


### PR DESCRIPTION
(closes #2943 )
- Adds keyword "heavy-ion physics" to all new data records and lists of validated runs
- Changes the description for the reference pp data