### PR TITLE
CMS: Add keyword to HI sw records

### DIFF
--- a/cernopendata/modules/fixtures/data/records/cms-tools-heavyion-examples.json
+++ b/cernopendata/modules/fixtures/data/records/cms-tools-heavyion-examples.json
@@ -18,6 +18,9 @@
     ],
     "date_published": "2020",
     "experiment": "CMS",
+    "keywords": [
+      "heavy-ion physics"
+    ],
     "license": {
       "attribution": "GNU General Public License (GPL) version 3"
     },
@@ -77,6 +80,9 @@
     ],
     "date_published": "2020",
     "experiment": "CMS",
+    "keywords": [
+      "heavy-ion physics"
+    ],
     "license": {
       "attribution": "GNU General Public License (GPL) version 3"
     },


### PR DESCRIPTION
(closes #2958)

Adds heavy-ion physics keyword to the new HI SW records 466 and 467