### PR TITLE
CMS: update HI sw repository

### DIFF
--- a/cernopendata/modules/fixtures/data/records/cms-tools-heavyion-examples.json
+++ b/cernopendata/modules/fixtures/data/records/cms-tools-heavyion-examples.json
@@ -17,7 +17,23 @@
       "2010"
     ],
     "date_published": "2020",
+    "distribution": {
+      "formats": [
+        "cc",
+        "py",
+        "zip"
+      ],
+      "number_files": 1,
+      "size": 543575
+    },
     "experiment": "CMS",
+    "files": [
+      {
+        "checksum": "adler32:a4432001",
+        "size": 543575,
+        "uri": "root://eospublic.cern.ch//eos/opendata/cms/software/HiForestProducerTool/HiForestProducerTool-10.1.0.zip"
+      }
+    ],
     "keywords": [
       "heavy-ion physics"
     ],
@@ -79,7 +95,23 @@
       "2011"
     ],
     "date_published": "2020",
+    "distribution": {
+      "formats": [
+        "cc",
+        "py",
+        "zip"
+      ],
+      "number_files": 1,
+      "size": 47874
+    },
     "experiment": "CMS",
+    "files": [
+      {
+        "checksum": "adler32:5f911e10",
+        "size": 47874,
+        "uri": "root://eospublic.cern.ch//eos/opendata/cms/software/HiForestProducerTool/HiForestProducerTool-11.1.0.zip"
+      }
+    ],
     "keywords": [
       "heavy-ion physics"
     ],

--- a/cernopendata/modules/fixtures/data/records/cms-tools-heavyion-examples.json
+++ b/cernopendata/modules/fixtures/data/records/cms-tools-heavyion-examples.json
@@ -30,7 +30,7 @@
       "HIRun2010"
     ],
     "source_code_repository": {
-      "url": "https://github.com/cms-legacydata-analyses/HiForestProducerTool/tree/2010"
+      "url": "https://github.com/cms-opendata-analyses/HiForestProducerTool/tree/2010"
     },
     "system_details": {
       "description": "Use this code with the CMS Open Data VM environment or the corresponding Docker container",
@@ -47,7 +47,7 @@
       ]
     },
     "usage": {
-      "description": "<p>If you do not have the CERN Virtual Machine for 2010 CMS data installed, follow the instructions in step 1 at <a href=\"/VM/CMS/2010\">How to install a CERN Virtual Machine</a>. Or, alternatively, install the corresponding <a href=\"/docs/cms-guide-docker\">Docker container</a>.</p>\n\t\t\t<p>To run the analysis, follow the instructions at <a href=\"https://github.com/cms-legacydata-analyses/HiForestProducerTool/tree/2010\">https://github.com/cms-legacydata-analyses/HiForestProducerTool/tree/2010</a>.</p> "
+      "description": "<p>If you do not have the CERN Virtual Machine for 2010 CMS data installed, follow the instructions in step 1 at <a href=\"/VM/CMS/2010\">How to install a CERN Virtual Machine</a>. Or, alternatively, install the corresponding <a href=\"/docs/cms-guide-docker\">Docker container</a>.</p>\n\t\t\t<p>To run the analysis, follow the instructions at <a href=\"https://github.com/cms-opendata-analyses/HiForestProducerTool/tree/2010\">https://github.com/cms-opendata-analyses/HiForestProducerTool/tree/2010</a>.</p> "
     },
     "use_with": {
       "description": "Use this with CMS heavy-ion 2010 primary datasets",
@@ -92,7 +92,7 @@
       "HIRun2011"
     ],
     "source_code_repository": {
-      "url": "https://github.com/cms-legacydata-analyses/HiForestProducerTool/tree/2011"
+      "url": "https://github.com/cms-opendata-analyses/HiForestProducerTool/tree/2011"
     },
     "system_details": {
       "description": "Use this code with the slc5-based 2010 CMS Open Data VM environment or the corresponding Docker container",
@@ -109,7 +109,7 @@
       ]
     },
     "usage": {
-      "description": "<p>If you do not have the CERN Virtual Machine for 2011 CMS data installed, follow the instructions in step 1 at <a href=\"/VM/CMS\">How to install a CERN Virtual Machine</a>. Or, alternatively, install the corresponding <a href=\"/docs/cms-guide-docker\">Docker container</a>.</p>\n\t\t\t<p>To run the analysis, follow the instructions at <a href=\"https://github.com/cms-legacydata-analyses/HiForestProducerTool/tree/2011\">https://github.com/cms-legacydata-analyses/HiForestProducerTool/tree/2011</a>.</p> "
+      "description": "<p>If you do not have the CERN Virtual Machine for 2011 CMS data installed, follow the instructions in step 1 at <a href=\"/VM/CMS\">How to install a CERN Virtual Machine</a>. Or, alternatively, install the corresponding <a href=\"/docs/cms-guide-docker\">Docker container</a>.</p>\n\t\t\t<p>To run the analysis, follow the instructions at <a href=\"https://github.com/cms-opendata-analyses/HiForestProducerTool/tree/2011\">https://github.com/cms-opendata-analyses/HiForestProducerTool/tree/2011</a>.</p> "
     },
     "use_with": {
       "description": "Use this with",


### PR DESCRIPTION
(closes #2946)

Updates the HI example repository links.

To-do:
- add the respective zip files from https://github.com/cms-opendata-analyses/HiForestProducerTool/tags