### PR TITLE
records: ALICE heavy-ion physics keywords

### DIFF
--- a/cernopendata/modules/fixtures/data/records/alice-analysis-modules.json
+++ b/cernopendata/modules/fixtures/data/records/alice-analysis-modules.json
@@ -23,6 +23,9 @@
         "uri": "root://eospublic.cern.ch//eos/opendata/alice/modules/PtAnalysis.tgz"
       }
     ],
+    "keywords": [
+      "heavy-ion physics"
+    ],
     "publisher": "CERN Open Data Portal",
     "recid": "1200",
     "title": "ALICE simple analysis demonstrator",
@@ -67,6 +70,7 @@
       }
     ],
     "keywords": [
+      "heavy-ion physics",
       "masterclass"
     ],
     "publisher": "CERN Open Data Portal",
@@ -113,6 +117,7 @@
       }
     ],
     "keywords": [
+      "heavy-ion physics",
       "masterclass"
     ],
     "publisher": "CERN Open Data Portal",
@@ -154,6 +159,9 @@
         "size": 42540,
         "uri": "root://eospublic.cern.ch//eos/opendata/alice/modules/bootstrap.tgz"
       }
+    ],
+    "keywords": [
+      "heavy-ion physics"
     ],
     "publisher": "CERN Open Data Portal",
     "recid": "1203",

--- a/cernopendata/modules/fixtures/data/records/alice-reconstructed-data.json
+++ b/cernopendata/modules/fixtures/data/records/alice-reconstructed-data.json
@@ -112,6 +112,9 @@
         "uri": "root://eospublic.cern.ch//eos/opendata/alice/2010/LHC10h/000138275/ESD/file-indexes/ALICE_LHC10h_PbPb_ESD_138275_file_index.txt"
       }
     ],
+    "keywords": [
+      "heavy-ion physics"
+    ],
     "license": {
       "attribution": "CC0"
     },
@@ -181,6 +184,9 @@
         "type": "index.txt",
         "uri": "root://eospublic.cern.ch//eos/opendata/alice/2010/LHC10h/000139038/ESD/file-indexes/ALICE_LHC10h_PbPb_ESD_139038_file_index.txt"
       }
+    ],
+    "keywords": [
+      "heavy-ion physics"
     ],
     "license": {
       "attribution": "CC0"
@@ -252,6 +258,9 @@
         "uri": "root://eospublic.cern.ch//eos/opendata/alice/2010/LHC10h/000139173/ESD/file-indexes/ALICE_LHC10h_PbPb_ESD_139173_file_index.txt"
       }
     ],
+    "keywords": [
+      "heavy-ion physics"
+    ],
     "license": {
       "attribution": "CC0"
     },
@@ -321,6 +330,9 @@
         "type": "index.txt",
         "uri": "root://eospublic.cern.ch//eos/opendata/alice/2010/LHC10h/000139437/ESD/file-indexes/ALICE_LHC10h_PbPb_ESD_139437_file_index.txt"
       }
+    ],
+    "keywords": [
+      "heavy-ion physics"
     ],
     "license": {
       "attribution": "CC0"
@@ -392,6 +404,9 @@
         "uri": "root://eospublic.cern.ch//eos/opendata/alice/2010/LHC10h/000139438/ESD/file-indexes/ALICE_LHC10h_PbPb_ESD_139438_file_index.txt"
       }
     ],
+    "keywords": [
+      "heavy-ion physics"
+    ],
     "license": {
       "attribution": "CC0"
     },
@@ -461,6 +476,9 @@
         "type": "index.txt",
         "uri": "root://eospublic.cern.ch//eos/opendata/alice/2010/LHC10h/000139465/ESD/file-indexes/ALICE_LHC10h_PbPb_ESD_139465_file_index.txt"
       }
+    ],
+    "keywords": [
+      "heavy-ion physics"
     ],
     "license": {
       "attribution": "CC0"


### PR DESCRIPTION
Adds "heavy-ion physics" keyword to ALICE records. Only PbPb datasets,
since the published pp dataset samples are not of the heavy-ion
reference run nature. Checked with Mihaela Gheata and Stefano Piano.