### PR TITLE
docs: updated privacy policy page with RoPO

### DIFF
--- a/cernopendata/modules/fixtures/data/docs/cod-privacy-policy/cod-privacy-policy.md
+++ b/cernopendata/modules/fixtures/data/docs/cod-privacy-policy/cod-privacy-policy.md
@@ -1,1 +1,107 @@
-CERN does not track, collect or retain personal information from users of CERN Open Data Portal, except as otherwise provided herein. In order to enhance CERN Open Data Portal and monitor traffic, information such as IP addresses and cookies may be tracked and retained, as well as log files shared in aggregation with other community services. User provided information, like corrections of metadata or paper claims, will be integrated into the database without displaying its source and may shared with other services. CERN Open Data Portal will take all reasonable measures to protect the privacy of its users and to resist service interruptions, intentional attacks, or other events that may compromise the security of the CERN Open Data Portal website. If you have any questions about the CERN Open Data Portal privacy policy, please contact [opendata-support@cern.ch](mailto:opendata-support@cern.ch)
+### Privacy policy
+
+CERN does not track, collect or retain personal information from users of CERN Open Data Portal, except as otherwise provided herein. In order to enhance CERN Open Data Portal and monitor traffic, information such as IP addresses and cookies may be tracked and retained, as well as log files shared in aggregation with other community services. User provided information, like corrections of metadata or paper claims, will be integrated into the database without displaying its source and may shared with other services.
+
+CERN Open Data Portal will take all reasonable measures to protect the privacy of its users and to resist service interruptions, intentional attacks, or other events that may compromise the security of the CERN Open Data Portal website.
+
+If you have any questions about the CERN Open Data Portal privacy policy, please contact [opendata-support@cern.ch](mailto:opendata-support@cern.ch)
+
+### CERN Privacy Notice PN00913
+#
+#### How is your data used
+
+Each service at CERN is responsible for compiling its own Privacy Notice regarding the data it processes.
+
+This Privacy Notice is part of [CERN’s Layered Privacy Notice](https://cern.service-now.com/service-portal?id=layered_privacy_notice) and details the processing that is unique to CERN Open Data Portal. It does not address processing by other services on which this service may rely and which have their own Privacy Notice.
+#
+#### Personal Data we process
+
+The personal data we have, and how it's used:
+
+<table class="table">
+  <thead>
+    <tr>
+      <th>Personal Data</th>
+      <th>Purpose</th>
+      <th>Basis</th>
+      <th>Source</th>
+    </tr>
+  </thead>
+  <tbody>
+    <tr>
+      <td>Your access logs (IP address, visited URLs on CERN Open Data, and corresponding timestamp)</td>
+      <td>User support, website debugging, security auditing and to produce statistics</td>
+      <td>Legitimate interest of CERN</td>
+      <td>Automatically transferred by your web browser</td>
+    </tr>
+  </tbody>
+</table>
+
+#
+**Description of legal basis for processing of Personal Data by CERN Open Data**
+
+-    **Contract:** To fulfil a contractual relationship with the individual, or in preparation for a contract with the individual
+-    **Legal Obligation:** To comply with a legal obligation of CERN.
+-    **Consent:** By having received and recorded consent from the individual.
+-    **Legitimate interest of CERN:** In the legitimate interests of CERN supporting the professional activities of the individual or their security and safety.
+
+#
+#### Personal Data we keep
+
+The personal data we store, for how long and why:
+
+<table class="table">
+  <thead>
+    <tr>
+      <th>Personal Data</th>
+      <th>Retention Period <sup>1</sup></th>
+      <th>Purpose</th>
+    </tr>
+  </thead>
+  <tbody>
+    <tr>
+      <td>Your access logs (IP address, visited URLs on CERN Open Data, and corresponding timestamp)</td>
+      <td>Maximum 13 months from date of action</td>
+      <td>User support, website debugging, security auditing and to produce statistics</td>
+    </tr>
+  </tbody>
+</table>
+
+#
+#### Who at CERN has access
+
+In addition to yourself, personal data collected by CERN Open Data is accessible by the following services, teams or individuals at CERN:
+
+<table class="table">
+  <thead>
+    <tr>
+      <th>Personal Data</th>
+      <th>Who</th>
+      <th>Purpose</th>
+    </tr>
+  </thead>
+  <tbody>
+    <tr>
+      <td>Your access logs (IP address, visited URLs on CERN Open Data, and corresponding timestamp)</td>
+      <td>CERN Open Data administrators and CERN Services administrators (OpenShift service)</td>
+      <td>User support and service operations</td>
+    </tr>
+  </tbody>
+</table>
+
+#
+For more detailed information about personal data and privacy please refer to the [Data Privacy web site](https://privacy.web.cern.ch/).
+
+For questions regarding this Privacy Notice, please contact [opendata-support@cern.ch](mailto:opendata-support@cern.ch).
+
+For questions regarding personal data and privacy please contact the [Office of Data Privacy](https://privacy.web.cern.ch/office-data-privacy-odp).
+
+To request to exercise data subject rights please fill and submit the following [online form](https://cern.service-now.com/service-portal?id=sc_cat_item&name=data-subject-rights&se=Data-Privacy).
+
+This Privacy Notice is subject to revision.
+
+*Last revision: 2020-10-09 11:27:51*
+
+---
+
+1. The retention period may be temporarily extended for special circumstances, in accordance with the provisions of the operation circular governing data privacy.


### PR DESCRIPTION
Here's what it looks like after the changes:
![Screenshot_2021-01-14 CERN Open Data Portal](https://user-images.githubusercontent.com/4990025/104580009-0756ac00-565d-11eb-928b-c82f1fd232bf.png)

closes #2931
