### PR TITLE
frontend: migrates glossary bundle to webpack

### DIFF
--- a/cernopendata/modules/theme/assets/semantic-ui/js/glossary/jquery.zglossary.css
+++ b/cernopendata/modules/theme/assets/semantic-ui/js/glossary/jquery.zglossary.css
@@ -38,7 +38,5 @@ span.glossaryTerm {
 	top: -5px;
 	width: 20px;
 	height: 20px;
-	background: url('ui_close_sm.gif') no-repeat;
 	cursor: pointer;
 }
-#glossaryTip > #glossaryClose { background: url('ui_close_sm.png') no-repeat; }

--- a/cernopendata/modules/theme/assets/semantic-ui/js/glossary/jquery.zglossary.js
+++ b/cernopendata/modules/theme/assets/semantic-ui/js/glossary/jquery.zglossary.js
@@ -1,6 +1,8 @@
-(function($){
+import jquery from "jquery/dist/jquery";
 
-	$.fn.glossary = function(url, options, exp) {
+(function (jquery) {
+
+	jquery.fn.glossary = function(url, options, exp) {
 
 		// Set plugin defaults
 		var defaults = {
@@ -10,14 +12,14 @@
 			linktarget: '_blank',
 			showonce: false
 		};
-		var options = $.extend(defaults, options);
+		var options = jquery.extend(defaults, options);
 		var id = 1;
 
 		// Functions
 		return this.each(function(i, e) {
 
 			// Ensure any exclude tags are uppercase for comparisons
-			$.each(options.excludetags, function(i,e) { options.excludetags[i] = e.toUpperCase(); });
+			jquery.each(options.excludetags, function(i,e) { options.excludetags[i] = e.toUpperCase(); });
 
 			// Function to find and add term
 			var _addTerm = function(e, term, type, def) {
@@ -37,8 +39,8 @@
 					// Check if the term is found
 					if (pos >= 0) {
 						// Check for excluded tagsnew
-						if (( jQuery.inArray($(e).parent().get(0).tagName,options.excludetags) > -1) ||
-							( $(e).parent().hasClass('no-glossary') )
+						if (( jquery.inArray(jquery(e).parent().get(0).tagName,options.excludetags) > -1) ||
+							( jquery(e).parent().hasClass('no-glossary') )
 						){} else {
 
 							// Create link element
@@ -52,9 +54,9 @@
 								spannode.href = '#';
 								// spannode.title = 'Click for \''+ term +'\' definition';
 								spannode.className = 'glossaryTerm';
-								$(spannode).hover(
+								jquery(spannode).hover(
 									function(e) {
-										$.glossaryTip('<'+ options.tiptag +'>'+ term + '</'+ options.tiptag +'><p>'+ def +'</p>', {mouse_event: e})
+										jquery.glossaryTip('<'+ options.tiptag +'>'+ term + '</'+ options.tiptag +'><p>'+ def +'</p>', {mouse_event: e})
 										return false;
 									},
 									function(e) {
@@ -116,7 +118,7 @@
 			};
 
 			// Get glossary list items
-			$.ajax({
+			jquery.ajax({
 				type: 'GET',
 				url: url,
 				dataType: 'json',
@@ -126,7 +128,7 @@
 
 						var count = data.length;
 						for (var i=0; i<count; i++) {
-							move_on = false;
+							var move_on = false;
 
 							// Find term in text
 							var item = data[i];
@@ -164,17 +166,17 @@
 	// Glossary tip popup
 	var glossaryTip = function() {}
 
-	$.extend(glossaryTip.prototype, {
+	jquery.extend(glossaryTip.prototype, {
 
 		setup: function(){
 
-			if ($('#glossaryTip').length) {
-				$('#glossaryTip').remove();
+			if (jquery('#glossaryTip').length) {
+				jquery('#glossaryTip').remove();
 			}
-			glossaryTip.holder = $('<div id="glossaryTip" style="max-width:260px;"><div id="glossaryClose"></div></div>');
-			glossaryTip.content = $('<div id="glossaryContent"></div>');
+			glossaryTip.holder = jquery('<div id="glossaryTip" style="max-width:260px;"><div id="glossaryClose"></div></div>');
+			glossaryTip.content = jquery('<div id="glossaryContent"></div>');
 
-			$('body').append(glossaryTip.holder.append(glossaryTip.content));
+			jquery('body').append(glossaryTip.holder.append(glossaryTip.content));
 		},
 
 		show: function(content, event){
@@ -201,14 +203,14 @@
 
 	});
 
-	$.glossaryTip = function(content, event) {
-		var tip = $.glossaryTip.instance;
+	jquery.glossaryTip = function(content, event) {
+		var tip = jquery.glossaryTip.instance;
 
-		if (!tip) { tip = $.glossaryTip.instance = new glossaryTip(); }
+		if (!tip) { tip = jquery.glossaryTip.instance = new glossaryTip(); }
 
 		tip.setup();
 		tip.show(content, event);
 
 		return tip;
 	}
-})(jQuery);
+})(jquery);

--- a/cernopendata/modules/theme/bundles.py
+++ b/cernopendata/modules/theme/bundles.py
@@ -73,21 +73,6 @@ visualise_css = NpmBundle(
     }
 )
 
-glossary_js = NpmBundle(
-    'js/glossary/jquery.zglossary.js',
-    output='gen/glossary.%(version)s.js',
-    npm={},
-)
-
-glossary_css = NpmBundle(
-    'js/glossary/jquery.zglossary.css',
-    filters='node-scss, cleancss',
-    output='gen/cernopendata.glossary.%(version)s.css',
-    npm={
-        "bootstrap-sass": "~3.3.5",
-    }
-)
-
 opera_js = NpmBundle(
     'node_modules/demobbed-viewer/js/lib/d3.min.js',
     'node_modules/demobbed-viewer/js/lib/jquery.min.js',

--- a/cernopendata/modules/theme/webpack.py
+++ b/cernopendata/modules/theme/webpack.py
@@ -47,3 +47,18 @@ theme = WebpackThemeBundle(
         ),
     }
 )
+
+
+glossary = WebpackThemeBundle(
+    __name__,
+    'assets',
+    default='semantic-ui',
+    themes={
+        'semantic-ui': dict(
+            entry={
+                'glossary_js': './js/glossary/jquery.zglossary.js',
+                'glossary_css': './js/glossary/jquery.zglossary.css',
+            },
+        )
+    }
+)

--- a/cernopendata/templates/cernopendata_theme/page.html
+++ b/cernopendata/templates/cernopendata_theme/page.html
@@ -3,7 +3,7 @@
 {% block css %}
     {{ super() }}
     {{ webpack['cernopendata_css.css'] }}
-    {# {%- assets "cernopendata_glossary_css" %} <link href="{{ ASSET_URL }}" rel="stylesheet"> {%- endassets %} #}
+    {{ webpack['glossary_css.css'] }}
     {# {%- assets "codemirror_css" %} <link href="{{ ASSET_URL }}" rel="stylesheet"> {%- endassets %} #}
     <!-- HTML5 shim and Respond.js for IE8 support of HTML5 elements and media queries -->
     <!--[if lt IE 9]>
@@ -40,7 +40,7 @@
 {%- block javascript %}
   {{ super() }}
   {{ webpack['cernopendata_js.js'] }}
-  {# {% assets "cernopendata_glossary_js" %}<script src="{{ ASSET_URL }}"></script>{% endassets %} #}
+  {{ webpack['glossary_js.js'] }}
   {# {% assets "cernopendata_search_js" %}<script src="{{ ASSET_URL }}"></script>{% endassets %} #}
   {# {% assets "codemirror_js" %}<script src="{{ ASSET_URL }}"></script>{% endassets %} #}
 
@@ -49,9 +49,6 @@
     <script>
         $(document).ready(function () {
           $('body').glossary('/glossary/json');
-
-          var reference = document.querySelector('.my-button');
-          $('[data-toggle="popover"]').popover('show')
         });
     </script>
   {% endblock %}

--- a/setup.py
+++ b/setup.py
@@ -128,6 +128,7 @@ setup(
         ],
         'invenio_assets.webpack': [
             'cernopendata_theme = cernopendata.modules.theme.webpack:theme',
+            'cernopendata_glossary = cernopendata.modules.theme.webpack:glossary',
         ],
         # 'invenio_assets.bundles': [
             # 'cernopendata_front_js = cernopendata.modules.theme.bundles'
@@ -138,10 +139,6 @@ setup(
             # 'cernopendata.modules.theme.bundles:visualise_js',
             # 'cernopendata_search_js = cernopendata.modules.theme.bundles'
             # ':search_js',
-            # 'cernopendata_glossary_js = cernopendata.modules.theme.bundles'
-            # ':glossary_js',
-            # 'cernopendata_glossary_css = cernopendata.modules.theme.bundles'
-            # ':glossary_css',
             # 'opera_js = cernopendata.modules.theme.bundles'
             # ':opera_js',
             # 'opera_css = cernopendata.modules.theme.bundles'


### PR DESCRIPTION
The glossary can be tested, among others, with the following records:
- Docs: prod - http://opendata.cern.ch/docs/about-opera, local - http://0.0.0.0:5000/docs/about-opera
- Record: prod - http://opendata.cern.ch/record/48, local - http://0.0.0.0:5000/record/48
E.g.:
![image](https://user-images.githubusercontent.com/9035606/105707145-c25f2f00-5f12-11eb-9863-38562a3e7fb5.png)


* Addresses #2997.