### PR TITLE
frontend: migrate docs record view to Semantic UI

### DIFF
--- a/cernopendata/config.py
+++ b/cernopendata/config.py
@@ -76,7 +76,11 @@ APP_DEFAULT_SECURE_HEADERS = {
         'script-src': [
             "'self'",
             "'unsafe-eval'",
-            "'unsafe-inline'",
+            "https://cdnjs.cloudflare.com",
+        ],
+        'font-src': [
+            "'self'",
+            "data:",
             "https://cdnjs.cloudflare.com",
         ],
     },

--- a/cernopendata/modules/theme/assets/semantic-ui/scss/styles.scss
+++ b/cernopendata/modules/theme/assets/semantic-ui/scss/styles.scss
@@ -53,16 +53,58 @@ body {
     color: #fff !important;
 }
 
-.card-style {
-    border: none;
-    margin-top: 10px;
-    border-top: 2px solid lighten($dark-blue, 30%);
-    border-radius: unset;
+.detail-page {
+
+    .ui.segment {
+        font-weight: $font-light;
+        border: none;
+        margin-top: 10px;
+        border-top: 2px solid lighten($dark-blue, 30%);
+        border-radius: unset;
+        box-shadow: unset;
+        margin-bottom: 1em;
+
+        h1 {
+            font-size: 1.8em;
+            margin-top: 0.5em;
+            margin-bottom: .5rem;
+        }
+
+        h2 {
+            font-size: 1.6em;
+            margin-top: 1em;
+        }
+
+        h3 {
+            margin-top: 1em;
+            font-size: 1.6em;
+        }
+
+        hr {
+            border: 0;
+            border-top: 1px solid rgba(0,0,0,.1);
+        }
+
+        strong {
+            font-weight: $font-heavy;
+        }
+
+        .cite-paragraph {
+            font-weight: $font-light;
+            line-height: 1.2;
+            margin-bottom: 30px;
+        }
+
+        .news-content {
+            margin-top: 2em;
+        }
+
+        .definition-paragraph {
+            padding-top: 1em;
+        }
+    }
 }
 
-.card-related-pages {
-    padding-bottom: 0;
-}
 
 .col-position {
     margin-top: 10px;
@@ -499,51 +541,6 @@ a {
     background-color: $light-blue;
     border-color: $light-blue;
     color: white;
-}
-
-// DETAIL PAGE
-
-.detail-page {
-
-    font-weight: $font-light;
-
-    h1 {
-        font-size: 1.8em;
-        margin-top: 1em;
-    }
-
-    h2 {
-        font-size: 1.6em;
-        margin-top: 1em;
-    }
-
-    h3 {
-        margin-top: 1em;
-        font-size: 1.6em;
-    }
-
-    strong {
-        font-weight: $font-heavy;
-    }
-
-    .cite-paragraph {
-        font-weight: $font-light;
-        line-height: 1.2;
-        margin-bottom: 30px;
-    }
-
-    .news-content {
-        margin-top: 2em;
-    }
-
-    .definition-paragraph {
-        padding-top: 1em;
-    }
-
-    .card {
-        margin-bottom: 1em;
-        padding-bottom: 2em;
-    }
 }
 
 .modal-backdrop {

--- a/cernopendata/templates/cernopendata_records_ui/docs/detail.html
+++ b/cernopendata/templates/cernopendata_records_ui/docs/detail.html
@@ -1,64 +1,62 @@
 {%- extends "invenio_records_ui/detail.html" %}
 
 {%- block page_body %}
-<div class="container-fluid background">
-    <div class="container detail-page" ng-app="recordApp">
-        <div class="row">
-            <div class="{% if record.related %} col-md-10 {% else %} col-md {% endif %}">
-                <div class="card card-style">
-                    <div class="card-body">
-                        <h1 class="d-inline"> {{ record.title }} </h1>
-                        <p>
-                        {% if record.get('created') %} <small>{{ record.get('created') }} by </small> {% endif %}
-                        <small>{{ record.author}} </small>
-                        </p>
-                        <p class="badges-box">
-                        {% if record.type %} <a class="badge badge-type" href="/search?type={{ record.type.primary }}">{{ record.type.primary }}</a>
-                        {% if record.type.secondary %}
-                        {% for type in record.type.secondary %}
-                        <a class="badge badge-subtype" href="/search?type={{ record.type.primary }}&subtype={{ type }}">{{ type }}</a>
-                        {% endfor %}
+<div class="ui {% if record.related %}two{% else %}one{% endif %} centered column stackable grid container detail-page">
+    <div class="row">
+        <div class="{% if record.related %}thirteen wide column{% else %}sixteen wide column{% endif %}">
+            <div class="ui segment">
+                <div class="card-body">
+                    <h1> {{ record.title }} </h1>
+                    <p>
+                    {% if record.get('created') %} <small>{{ record.get('created') }} by </small> {% endif %}
+                    <small>{{ record.author}} </small>
+                    </p>
+                    <p class="badges-box">
+                    {% if record.type %} <a class="badge badge-type" href="/search?type={{ record.type.primary }}">{{ record.type.primary }}</a>
+                    {% if record.type.secondary %}
+                    {% for type in record.type.secondary %}
+                    <a class="badge badge-subtype" href="/search?type={{ record.type.primary }}&subtype={{ type }}">{{ type }}</a>
+                    {% endfor %}
+                    {% endif %}
+                    {% endif %}
+                    </p>
+                    <hr>
+                    <div class="news-content">
+                        {% if record.get("body", {}).get("format", None) == "html" %}
+                        {{record.get("body", {}).get("content", None) |safe}}
+                        {% elif record.get("body", {}).get("format", None) == "md" %}
+                        {{record.get("body", {}).get("content", None) | markdown | safe}}
                         {% endif %}
-                        {% endif %}
-                        </p>
-                        <hr>
-                        <div class="news-content">
-                            {% if record.get("body", {}).get("format", None) == "html" %}
-                            {{record.get("body", {}).get("content", None) |safe}}
-                            {% elif record.get("body", {}).get("format", None) == "md" %}
-                            {{record.get("body", {}).get("content", None) | markdown | safe}}
-                            {% endif %}
-                            {% if record.links %}
-                            <div>
-                                <span>
-                                    <strong>Links: </strong>
-                                    {% for r in record.links %}
-                                    <a target="_blank" href="{{r.url}}">{{r.url}}</a>
-                                    {% endfor %}
-                                </span>
-                            </div>
-                            {% endif %}
+                        {% if record.links %}
+                        <div>
+                            <span>
+                                <strong>Links: </strong>
+                                {% for r in record.links %}
+                                <a target="_blank" href="{{r.url}}">{{r.url}}</a>
+                                {% endfor %}
+                            </span>
                         </div>
+                        {% endif %}
                     </div>
                 </div>
             </div>
-            {% if record.related %}
-            <div class="col-md-2">
-                <div class="card card-style card-related-pages">
-                    <div class="card-body">
-                        <h4> Related </h4>
-                        <p>
+        </div>
+        {% if record.related %}
+        <div class="three wide column">
+            <div class="ui segment">
+                <div>
+                    <h4> Related </h4>
+                    <p>
+                    <div class="ui list">
                         {% for related in record.related %}
-                        <ul class="list-inline">
-                            <li><a href="{{ url_for('invenio_records_ui.{}'.format(related.type), pid_value=related.id) }}">{{ related.id | get_record_title(related.type) }}</a></li>
-                        </ul>
-                        </p>
+                        <li class="item"><a href="{{ url_for('invenio_records_ui.{}'.format(related.type), pid_value=related.id) }}">{{ related.id | get_record_title(related.type) }}</a></li>
                         {% endfor %}
                     </div>
+                    </p>
                 </div>
             </div>
-            {% endif %}
         </div>
+        {% endif %}
     </div>
 </div>
 {%- endblock %}


### PR DESCRIPTION
Closes #3004

This can be tested with any of the records [listed here](http://opendata.cern.ch/search?page=1&size=20&q=&type=Documentation&subtype=About&subtype=Activities&subtype=Authors&subtype=Guide&subtype=Help&subtype=Policy&subtype=Report). To populate them locally:
```
$ docker exec -i -t opendatacernch_web_1 /code/scripts/populate-instance.sh --skip-records
```
Special case with related records:  http://opendata.cern.ch/docs/cms-physics-objects-2010