### PR TITLE
frontend: migrate glossary to Semantic UI

### DIFF
--- a/cernopendata/config.py
+++ b/cernopendata/config.py
@@ -76,6 +76,7 @@ APP_DEFAULT_SECURE_HEADERS = {
         'script-src': [
             "'self'",
             "'unsafe-eval'",
+            "'unsafe-inline'",
             "https://cdnjs.cloudflare.com",
         ],
         'font-src': [

--- a/cernopendata/modules/theme/assets/semantic-ui/scss/styles.scss
+++ b/cernopendata/modules/theme/assets/semantic-ui/scss/styles.scss
@@ -37,7 +37,6 @@ body {
 }
 
 .detail-page {
-
     .ui.segment {
         font-weight: $font-light;
         border: none;
@@ -50,7 +49,7 @@ body {
         h1 {
             font-size: 1.8em;
             margin-top: 0.5em;
-            margin-bottom: .5rem;
+            margin-bottom: 0.5rem;
         }
 
         h2 {
@@ -58,13 +57,8 @@ body {
             margin-top: 1em;
         }
 
-        h3 {
-            margin-top: 1em;
-            font-size: 1.6em;
-        }
-
         hr {
-            border: 0;
+            border: none;
             border-top: 1px solid rgba(0,0,0,.1);
         }
 
@@ -407,6 +401,7 @@ a {
 
         &:hover {
             background-color: darken($light-blue, $darken-on-hover);
+            color: white;
         }
 
     }
@@ -416,6 +411,7 @@ a {
 
         &:hover {
             background-color: darken($medium-blue, $darken-on-hover);
+            color: white;
         }
     }
 
@@ -425,6 +421,7 @@ a {
 
         &:hover {
             background-color: darken(#0f6d7c, $darken-on-hover);
+            color: white;
         }
 
     }
@@ -435,6 +432,7 @@ a {
 
         &:hover {
             background-color: darken(#0a454e, $darken-on-hover);
+            color: white;
         }
     }
 
@@ -444,6 +442,7 @@ a {
 
         &:hover {
             background-color: darken(#08244e, $darken-on-hover);
+            color: white;
         }
     }
 
@@ -453,6 +452,7 @@ a {
 
         &:hover {
             background-color: darken(#7c818f, $darken-on-hover);
+            color: white;
         }
     }
 
@@ -462,6 +462,7 @@ a {
 
         &:hover {
             background-color: darken(#406184, $darken-on-hover);
+            color: white;
         }
     }
 }

--- a/cernopendata/templates/cernopendata_records_ui/docs/detail.html
+++ b/cernopendata/templates/cernopendata_records_ui/docs/detail.html
@@ -12,10 +12,10 @@
                     <small>{{ record.author}} </small>
                     </p>
                     <p class="badges-box">
-                    {% if record.type %} <a class="badge badge-type" href="/search?type={{ record.type.primary }}">{{ record.type.primary }}</a>
+                    {% if record.type %} <a class="ui label badge-type" href="/search?type={{ record.type.primary }}">{{ record.type.primary }}</a>
                     {% if record.type.secondary %}
                     {% for type in record.type.secondary %}
-                    <a class="badge badge-subtype" href="/search?type={{ record.type.primary }}&subtype={{ type }}">{{ type }}</a>
+                    <a class="ui label badge-subtype" href="/search?type={{ record.type.primary }}&subtype={{ type }}">{{ type }}</a>
                     {% endfor %}
                     {% endif %}
                     {% endif %}
@@ -45,7 +45,7 @@
         <div class="three wide column">
             <div class="ui segment">
                 <div>
-                    <h4> Related </h4>
+                    <h4>Related</h4>
                     <p>
                     <div class="ui list">
                         {% for related in record.related %}

--- a/cernopendata/templates/cernopendata_records_ui/terms/detail.html
+++ b/cernopendata/templates/cernopendata_records_ui/terms/detail.html
@@ -1,42 +1,40 @@
 {%- extends "invenio_records_ui/detail.html" %}
 
 {%- block page_body %}
-<div class="container-fluid background">
-    <div class="container detail-page" ng-app="recordApp">
-        <div class="row">
-            <div class="col-md">
-                <div class="card card-style">
-                    <div class="card-body">
-                        <h1 class="d-inline"> {{ record.anchor }} </h1>
-                        <br>
-                        <p class="definition-paragraph">{{ record.definition }}</p>
-                        {% if record.links %}
-                        <div>
-                            <span>
-                                <strong>Links: </strong>
-                                {% for r in record.links %}
-                                    <a target="_blank" href="{{r.url}}">{{r.text}}</a>
-                                {% endfor %}
-                            </span>
-                        </div>
-                        {% endif %}
-                        {% if record.see_also or record.experiment %}
-                        <div>
-                        <p class="badges-box">
-                            <span>
-                                <strong>See also: </strong>
-                                {% if record.experiment %}
-                                    {% for exp in record.experiment %}
-                                        <a class="badge badge-experiment" href="/search?experiment={{ exp.name }}">{{ exp.name }}</a>
-                                    {% endfor %}
-                                {% endif %}
-                                {% for term in record.see_also%}
-                                <a href="/glossary/{{term.term}}"><span class="badge badge-tag">{{ term.term }}</span></a>
-                                {% endfor %}
-                            </span>
-                        </div>
-                        {% endif %}
+<div class="ui one column centered grid container detail-page">
+    <div class="row">
+        <div class="sixteen wide column">
+            <div class="ui segment">
+                <div class="card-body">
+                    <h1> {{ record.anchor }} </h1>
+                    <br>
+                    <p class="definition-paragraph">{{ record.definition }}</p>
+                    {% if record.links %}
+                    <div>
+                        <span>
+                            <strong>Links: </strong>
+                            {% for r in record.links %}
+                                <a target="_blank" href="{{r.url}}">{{r.text}}</a>
+                            {% endfor %}
+                        </span>
                     </div>
+                    {% endif %}
+                    {% if record.see_also or record.experiment %}
+                    <div>
+                    <p class="badges-box">
+                        <span>
+                            <strong>See also: </strong>
+                            {% if record.experiment %}
+                                {% for exp in record.experiment %}
+                                    <a class="ui label badge-experiment" href="/search?experiment={{ exp.name }}">{{ exp.name }}</a>
+                                {% endfor %}
+                            {% endif %}
+                            {% for term in record.see_also%}
+                            <a href="/glossary/{{term.term}}"><span class="ui label badge-tag">{{ term.term }}</span></a>
+                            {% endfor %}
+                        </span>
+                    </div>
+                    {% endif %}
                 </div>
             </div>
         </div>

--- a/cernopendata/templates/cernopendata_theme/page.html
+++ b/cernopendata/templates/cernopendata_theme/page.html
@@ -15,7 +15,7 @@
 
 {%- block body_inner %}
   <!--Wrapper for page content to push down footer-->
-  <div class="footer-wrap">
+  <div class="footer-wrap background">
     <!-- Begin page content -->
     {%- block page_header %}
     {% include 'cernopendata_theme/header.html' %}


### PR DESCRIPTION
* Closes #3003.

Depends on (and includes) https://github.com/cernopendata/opendata.cern.ch/issues/3004.

This can be tested with any of the records [listed here](http://opendata.cern.ch/search?page=1&size=20&type=Glossary&sort=title). To populate them locally:
```
$ docker exec -i -t opendatacernch_web_1 /code/scripts/populate-instance.sh --skip-records
```