### PR TITLE
templates: fix ALICE

### DIFF
--- a/cernopendata/templates/cernopendata_theme/header.html
+++ b/cernopendata/templates/cernopendata_theme/header.html
@@ -30,7 +30,7 @@
       </span>
       <div class="menu dropdown-items">
         <div class="item"><a href="/docs/about">CERN Open Data</a></div>
-        <div class="item"><a href="/docs/about-adivce">AdivCE</a></div>
+        <div class="item"><a href="/docs/about-alice">ALICE</a></div>
         <div class="item"><a href="/docs/about-atlas">ATLAS</a></div>
         <div class="item"><a href="/docs/about-cms">CMS</a></div>
         <div class="item"><a href="/docs/about-lhcb">LHCb</a></div>


### PR DESCRIPTION
@mvidalgarcia Noticed ALICE typo, probably happened due to `li -> div` element automated editor replacements. Perhaps you can recall (and check) other parts of the code base where `<li>` vs `li` replacements (when moving to Semantic UI) could have caused similar typos?