### PR TITLE
frontend: fix markdown rendered pages

### DIFF
--- a/cernopendata/modules/fixtures/data/docs/cms-simulated-dataset-names/cms-simulated-dataset-names.md
+++ b/cernopendata/modules/fixtures/data/docs/cms-simulated-dataset-names/cms-simulated-dataset-names.md
@@ -40,7 +40,7 @@ To unify this part CMS uses the following conventions:
 
 The following conventions are applied for the most common particles:
 
-<table class="table table-condensed">
+<table class="ui very basic collapsing table">
 
 <thead>
 
@@ -237,7 +237,7 @@ Units are added to integers in `COMENERGY`, i.e. `7TeV`, `10TeV`, `900GeV`, `236
 
 The generators used are:
 
-<table class="table table-condensed">
+<table class="ui very basic collapsing table">
 
 <thead>
 

--- a/cernopendata/modules/fixtures/data/docs/cms-virtual-machine-2010/cms-virtual-machine-2010.md
+++ b/cernopendata/modules/fixtures/data/docs/cms-virtual-machine-2010/cms-virtual-machine-2010.md
@@ -4,8 +4,7 @@ The CMS-specific VM includes the [ROOT framework](http://root.cern.ch/) and [CMS
 2.  [How to Test & Validate?](#testvalidate2010)
 3.  [Issues & Limitations](#issues2010)
 
-## <a name="install2010"></a>Step 1: How to install a CERN Virtual Machine
-
+## <a name="install2010">Step 1: How to install a CERN Virtual Machine</a>
 ### Installing VirtualBox
 
 VirtualBox is a free, open source and multiplatform application to run virtual machines: you can [download](https://www.VirtualBox.org/wiki/Downloads) the package for your platform from the Downloads page.
@@ -22,7 +21,7 @@ Next download the CMS-specific CernVM image as OVA file from: [CMS VM Image for 
 
 By double clicking the downloaded file, VirtualBox imports the image with ready-to-run settings. In VirtualBox version 6, you need to unselect "import disks as VDI" on the initial import screen. Then, you launch the CMS-specific CernVM, which boots into the graphical user interface and sets up the CMS environment. Be patient, it will take a while.
 
-## <a name="testvalidate2010"></a>Step 2: How to Test & Validate?
+## <a name="testvalidate2010">Step 2: How to Test & Validate?</a>
 
 The validation procedure tests that the CMS environment is installed and operational on your virtual machine, and that you have access to the ROOT files. You may skip this step if you want, and head straight to [Getting Started with CMS data](/docs/cms-getting-started-2010). However, these steps give you a quick introduction to the CMS environment.
 
@@ -107,7 +106,7 @@ Severity # Occurrences Total Occurrences
 System 3 3
 ```
 
-## <a name="issues2010"></a>Known Issues & Limitations
+## <a name="issues2010">Known Issues & Limitations</a>
 
 ### Validation report
 

--- a/cernopendata/modules/theme/assets/semantic-ui/scss/styles.scss
+++ b/cernopendata/modules/theme/assets/semantic-ui/scss/styles.scss
@@ -66,6 +66,21 @@ body {
             font-weight: $font-heavy;
         }
 
+        pre {
+            overflow: auto;
+            code {
+                color: inherit;
+            }
+        }
+
+        code {
+            background-color: transparent;
+        }
+
+        a[name] {
+            color: inherit;
+        }
+
         .cite-paragraph {
             font-weight: $font-light;
             line-height: 1.2;

--- a/cernopendata/templates/cernopendata_pages/md_template.html
+++ b/cernopendata/templates/cernopendata_pages/md_template.html
@@ -1,12 +1,8 @@
 {%- extends config.BASE_TEMPLATE %}
 
 {% block page_body %}
-<div class="container">
-  <div class="row">
-    <div class="col-md-10">
-      {{ content|markdown|safe }}
-    </div>
-  </div>
+<div>
+    {{ content|markdown|safe }}
 </div>
 {% endblock  page_body %}
 


### PR DESCRIPTION
* Fixes horizontal scrolling for code blocks.

* Removes code background color coming in new versions of Python
  markdown package.

Used `find ./ -name "*.md" | xargs grep -e "</.*>" ` to find markdown files using HTML

Closes #3007 