### PR TITLE
glossary: ignore terms inside MathJax expressions

### DIFF
--- a/cernopendata/modules/theme/assets/semantic-ui/js/glossary/jquery.zglossary.js
+++ b/cernopendata/modules/theme/assets/semantic-ui/js/glossary/jquery.zglossary.js
@@ -27,13 +27,13 @@ import jquery from "jquery/dist/jquery";
 				var skip = 0;
 
 				// Check the element is a text node
-				if (e.nodeType == 3) {
+				if (e.nodeType == 3 && e.textContent.trim().length) {
 
 					// Case insensistive matching option
 					if (options.ignorecase) {
-						var pos = e.data.toLowerCase().search(new RegExp('\\b'+patfmt.toLowerCase()+'\\b'));
+						var pos = e.data.toLowerCase().search(new RegExp('(?<!\\\\)\\b'+patfmt.toLowerCase()+'\\b'));
 					} else {
-						var pos = e.data.search(new RegExp('\\b'+patfmt+'\\b'));
+						var pos = e.data.search(new RegExp('(?<!\\\\)\\b'+patfmt+'\\b'));
 					}
 
 					// Check if the term is found

--- a/cernopendata/templates/cernopendata_theme/page.html
+++ b/cernopendata/templates/cernopendata_theme/page.html
@@ -56,14 +56,13 @@
   {%- block mathjax_support %}
     <script type="text/x-mathjax-config">
       MathJax.Hub.Config({
-        extensions: ["tex2jax.js"],
         jax: ["input/TeX", "output/HTML-CSS"],
         tex2jax: {
           inlineMath: [ ['$','$'], ["\\(","\\)"] ],
           displayMath: [ ['$$','$$'], ["\\[","\\]"] ],
           processEscapes: true
         },
-        "HTML-CSS": { availableFonts: ["TeX"] }
+        "HTML-CSS": { availableFonts: ["TeX"], matchFontHeight: false }
       });
     </script>
 


### PR DESCRIPTION
* Avoids that strings like `\tau` get rendered as a glossary
  term tooltips, instead of a MathJax expressions.

* Closes #3043.