### PR TITLE
ui: small improvements on search page styling

### DIFF
--- a/cernopendata/modules/theme/assets/semantic-ui/js/search/app.js
+++ b/cernopendata/modules/theme/assets/semantic-ui/js/search/app.js
@@ -31,4 +31,5 @@ const initSearchApp = createSearchAppInit({
   "LayoutSwitcher.element": CODLayoutSwitcher,
   "ResultsGrid.container": null,
   "Count.element": ResultsCount,
+  "SearchApp.searchbarContainer": () => null,
 });

--- a/cernopendata/modules/theme/assets/semantic-ui/scss/search.scss
+++ b/cernopendata/modules/theme/assets/semantic-ui/scss/search.scss
@@ -1,6 +1,6 @@
 .content {
   .header {
-    font-size: 1em !important;
+    font-size: 1.2em !important;
   }
 }
 
@@ -8,4 +8,21 @@
   a {
     text-decoration: none;
   }
+}
+
+.result-options {
+  margin-top: 20px;
+}
+
+.four.wide.column {
+  margin-top: -70px !important;
+}
+
+.center.aligned.eight.wide.column {
+  margin-left: -130px;
+}
+
+.right.aligned.four.wide.column {
+  margin-top: 0px !important;
+  margin-left: 60px;
 }

--- a/cernopendata/modules/theme/assets/semantic-ui/scss/styles.scss
+++ b/cernopendata/modules/theme/assets/semantic-ui/scss/styles.scss
@@ -38,6 +38,7 @@ body {
         border-radius: unset;
         box-shadow: unset;
         margin-bottom: 1em;
+        font-size: 1em !important;
 
         h1 {
             font-size: 1.8em;
@@ -522,15 +523,5 @@ a {
             font-size: 12px;
             padding: 5px;
         }
-    }
-}
-
-.file-availability-disclaimer {
-    padding: 15px;
-    background-color: #f4f4f4;
-    margin: 10px 0;
-
-    p {
-        margin: 0;
     }
 }

--- a/cernopendata/templates/cernopendata_records_ui/records/record_detail.html
+++ b/cernopendata/templates/cernopendata_records_ui/records/record_detail.html
@@ -147,15 +147,14 @@
         </div>
 
         {% if record.distribution.get("availability", "online") != "online" %}
-
-        <div class="file-availability-disclaimer">
-            <h6>Availability: <strong style="color: {{ '#a24d4d' if record.distribution.availability else '#af7c2a' }}">{{record.distribution.availability | upper}}</strong>
-            </h6>
+        <div class="ui info message">
+            <div class="header">
+                Availability: <strong style="color: {{ '#a24d4d' if record.distribution.availability else '#af7c2a' }}">{{record.distribution.availability | upper}}</strong>
+            </div>
             <p>Please note that this dataset is released with the bibliographic information content only. The dataset files are not available online as of yet. If you are interested in accessing the files, please <a href="mailto:opendata-support@cern.ch">contact us</a>. Note that the file transfer to online storage may take several weeks or months in case of large amount of data.</p>
         </div>
         {% endif %}
     {% endif %}
-
 
     {% if record.system_details %}
     <div>


### PR DESCRIPTION
closes #3045
closes #3057

- increased general font size in the records page to unify it across the application
- fixed pagination bug
- removed additional search box
- pushed facets to the top and aligned to `results found`

Screenshot:
![Screenshot from 2021-02-10 16-56-53](https://user-images.githubusercontent.com/4990025/107535425-02840a00-6bc1-11eb-9667-06c62507daac.png)

- also fixed styling of "availability" box (https://github.com/cernopendata/opendata.cern.ch/issues/3057)
To test, please use:
```
docker-compose exec web cernopendata fixtures records -f /code/cernopendata/modules/fixtures/data/records/cms-simulated-datasets-2012.json --mode insert-or-replace
```
and check `http://localhost:5000/record/13072`

For comparison on the left side is the new style, on the right is what we currently have:
![Screenshot from 2021-02-11 12-37-46](https://user-images.githubusercontent.com/4990025/107660814-f3688f00-6c88-11eb-89aa-4567d34ab3a3.png)

