### PR TITLE
histograms: load first plot by default

### DIFF
--- a/cernopendata/modules/theme/assets/semantic-ui/js/visualise/visualise_histograms.js
+++ b/cernopendata/modules/theme/assets/semantic-ui/js/visualise/visualise_histograms.js
@@ -104,6 +104,10 @@ jQuery(function ($) {
     $('#backtohisto').show();
   });
 
+  function loadInitialHistogram() {
+    $('#parameter-button-row div button')[0].click();
+  }
+
   function loadFile(input) {
     //$('#filename').html(input.file.split('/').pop());
     // $('#filedropdown').button('loading');
@@ -125,18 +129,14 @@ jQuery(function ($) {
         // $('#filedropdown').button('reset');
         $('#filedropdown').html(input.name + ' ');
         $('#filedropdown').append('<span class="caret"></span>');
+        loadInitialHistogram();
       }
     );
   }
 
   // Load a file automatically...
-  loadFile(input_files[0]);
   //...and activate the first histogram
-  // Q: do we want to do this on every file load?
-
-  setTimeout(function () {
-    $('#parameter-button-row div button')[0].click();
-  }, 1000);
+  loadFile(input_files[0]);
 
   $.each(input_files, function (f) {
     $('#filelist').append(
@@ -254,7 +254,7 @@ jQuery(function ($) {
 
       var bininput = "<div class='ui action input'>";
       bininput +=
-        "<input type='number' min='1' name='binwidth' placeholder='Set bin width' style='width: 70%;'>";
+        "<input type='number' min='1' name='binwidth' placeholder='Set bin width'>";
       bininput +=
         "<button class='ui button binw " + parameter + "'>Set</button>";
       bininput += "</div>";

--- a/cernopendata/modules/theme/assets/semantic-ui/scss/visualise.scss
+++ b/cernopendata/modules/theme/assets/semantic-ui/scss/visualise.scss
@@ -1,49 +1,71 @@
-#vis-histograms {
-  color: #606D75;
-}
+$histograms-dark-grey: #6c757d;
 
-#vis-histograms .previewer {
-  background-color: #f4f4f4;
-  border-radius: 4px;
-  margin-bottom: 35px;
-  color: #606D75;
-  margin-bottom: 20px;
-}
+.vis-histograms {
+  color: $histograms-dark-grey;
 
-#vis-histograms #flot-plots {
-  background-color: #fff;
-  margin-bottom: 15px;
-  min-height: 300px;
-  height: auto;
-  margin-right: 0;
-  margin-left: 0;
-}
+  .previewer {
+    border-radius: 4px;
+    color: $histograms-dark-grey;
+    margin-bottom: 20px;
+  }
 
-#vis-histograms #howto > div{
-  background-color: #f4f4f4;
-  border-radius: 4px;
-  pre {
-    overflow-y: hidden;
-    overflow-x: auto;
+  #flot-plots {
+    background-color: white;
+    margin-bottom: 15px;
+    min-height: 300px;
+    height: auto;
+    margin-right: 0;
+    margin-left: 0;
+  }
+
+  #howto > div {
+    border-radius: 4px;
+    pre {
+      overflow-y: hidden;
+      overflow-x: auto;
+    }
+  }
+
+  .plot-control {
+    margin-left: 2em !important;
+  }
+
+  .ui.button {
+    padding: 0.8em;
+    margin: 0;
+    font-weight: 500;
+
+    &.toggle.active {
+      background-color: $histograms-dark-grey !important;
+    }
+
+    &.undoselect {
+      margin-left: 4em;
+    }
+  }
+
+  .ui.action.input {
+    margin-left: 1em;
+    max-width: 150px;
+  }
+
+  .ui.grid {
+    margin-top: 0rem;
+    .row {
+      padding-left: 1rem;
+    }
+  }
+
+  .ui.selection.dropdown {
+    background-color: $histograms-dark-grey;
+    .text {
+      color: white !important;
+    }
   }
 }
 
-#vis-histograms .ui.button.toggle.active {
-  background-color: #545b62 !important;
-}
-
-#vis-histograms .ui.grid {
-  margin-top: 0rem;
-  .row {
-    padding-left: 1rem;
-  }
-}
-
-#vis-histograms .ui.selection.dropdown {
-  background-color: #6c757d;
-  .text {
-    color: #ffffff;
-  }
+#parameter-button-row .item {
+  margin-left: 0.5em;
 }
 
 .xlabel {

--- a/cernopendata/templates/cernopendata_pages/visualise_histograms.html
+++ b/cernopendata/templates/cernopendata_pages/visualise_histograms.html
@@ -12,7 +12,7 @@
 
 {% block page_body %}
 
-<div id="vis-histograms" class="ui one centered column grid container">
+<div class="ui one centered column grid container vis-histograms">
   <div class="row">
     <div class="left aligned column">
       <a id="backtohisto" href="#"><span


### PR DESCRIPTION
closes #3052

This fix loads first plot by default once a new event type is selected and on initial page load. It solves the race condition described [here](https://github.com/cernopendata/opendata.cern.ch/issues/3052#issuecomment-777310981).

Also, some styling improvements are done. Here is how it looks like now:
![Screenshot_2021-02-12 CERN Open Data Portal](https://user-images.githubusercontent.com/4990025/107770946-536b3e00-6d3a-11eb-9204-a6fc4e70ef7d.png)


To test please see the instructions [here](https://github.com/cernopendata/opendata.cern.ch/pull/3032)