### PR TITLE
ui: fix CMS visualiser documentation arrangement

### DIFF
--- a/cernopendata/modules/theme/assets/semantic-ui/scss/styles.scss
+++ b/cernopendata/modules/theme/assets/semantic-ui/scss/styles.scss
@@ -355,13 +355,6 @@ a {
 .custom-breadcrumb {
     margin-bottom: 0;
 }
-//
-
-// Need help previewer
-.screen-s {
-    width: 100%;
-    height: auto;
-}
 
 .card-body h4 a {
     font-size: 20px;

--- a/cernopendata/modules/theme/static/assets/ispy/ispy.css
+++ b/cernopendata/modules/theme/static/assets/ispy/ispy.css
@@ -1,0 +1,12 @@
+.ispy-help-img {
+    width: 100%;
+    height: auto;
+}
+
+.ispy-help-item {
+    padding: 5px !important;
+}
+
+.ispy-help-row {
+    margin: 0 !important;
+}

--- a/cernopendata/modules/theme/static/assets/ispy/ispy.css
+++ b/cernopendata/modules/theme/static/assets/ispy/ispy.css
@@ -3,10 +3,10 @@
     height: auto;
 }
 
-.ispy-help-item {
-    padding: 5px !important;
+.bootstrap-ispy .ispy-help-item {
+    padding: 5px;
 }
 
-.ispy-help-row {
-    margin: 0 !important;
+.bootstrap-ispy .ispy-help-row {
+    margin: 0;
 }

--- a/cernopendata/templates/cernopendata_ispy/ispy_css.html
+++ b/cernopendata/templates/cernopendata_ispy/ispy_css.html
@@ -4,3 +4,4 @@
 <link rel="stylesheet" href="{{ url_for('static', filename='node_modules/ispy-webgl/css/font-awesome.min.css') }}">
 <link rel="stylesheet" href="{{ url_for('static', filename='assets/ispy/bootstrap-prefixed.css') }}">
 <link rel="stylesheet" href="{{ url_for('static', filename='assets/ispy/ispy-prefixed.css') }}">
+<link rel="stylesheet" href="{{ url_for('static', filename='assets/ispy/ispy.css') }}">

--- a/cernopendata/templates/cernopendata_ispy/ispy_help.html
+++ b/cernopendata/templates/cernopendata_ispy/ispy_help.html
@@ -34,7 +34,7 @@
             </div>
             <div class="col-sm-6 ispy-help-item">
               <i class="fa fa-home"></i> Returns the event display to its initial orientation. <i
-              class="fa fa-search-plus"></i> and <i class="fa fa-search-minus"></i> Zoom in and out.<br/><img
+              class="fa fa-search-plus"></i>/<i class="fa fa-search-minus"></i> Zoom in/out.<br/><img
               class="ispy-help-img" src="{{ url_for('static', filename='img/iSpy-Online-graphics/start.gif')}}">
             </div>
             <div class="col-sm-6 ispy-help-item">

--- a/cernopendata/templates/cernopendata_ispy/ispy_help.html
+++ b/cernopendata/templates/cernopendata_ispy/ispy_help.html
@@ -22,41 +22,41 @@
             Each button comes with a tool-tip: hover over the button to know its functionality.
           </p>
           <p>
-          <div class="row">
-            <div class="col-sm-6">
-              <i class="fa fa-folder-open"></i> Open <kbd>.ig</kbd> files from the server.<br/><img class="screen-s"
+          <div class="row ispy-help-row">
+            <div class="col-sm-6 ispy-help-item">
+              <i class="fa fa-folder-open"></i> Open <kbd>.ig</kbd> files from the server.<br/><img class="ispy-help-img"
                                                                                                     src="{{ url_for('static', filename='img/iSpy-Online-graphics/open.gif') }}">
             </div>
-            <div class="col-sm-6">
+            <div class="col-sm-6 ispy-help-item">
               <i class="fa fa-step-backward"></i> and <i class="fa fa-step-forward"></i> Navigate to previous and next
-              events in the <kbd>.ig</kbd> file you loaded.<br/><img class="screen-s"
+              events in the <kbd>.ig</kbd> file you loaded.<br/><img class="ispy-help-img"
                                                                      src="{{ url_for('static', filename='img/iSpy-Online-graphics/prevnext.gif')}}">
             </div>
-            <div class="col-sm-6">
+            <div class="col-sm-6 ispy-help-item">
               <i class="fa fa-home"></i> Returns the event display to its initial orientation. <i
               class="fa fa-search-plus"></i> and <i class="fa fa-search-minus"></i> Zoom in and out.<br/><img
-              class="screen-s" src="{{ url_for('static', filename='img/iSpy-Online-graphics/start.gif')}}">
+              class="ispy-help-img" src="{{ url_for('static', filename='img/iSpy-Online-graphics/start.gif')}}">
             </div>
-            <div class="col-sm-6">
+            <div class="col-sm-6 ispy-help-item">
               <img src="{{ url_for('static', filename='img/iSpy-Online-graphics/z-plane.png')}}">, <img
               src="{{ url_for('static', filename='img/iSpy-Online-graphics/y-plane.png')}}"> and <img
               src="{{ url_for('static', filename='img/iSpy-Online-graphics/x-plane.png')}}"> View the collision event
               along
-              one of three axes.<br/><img class="screen-s"
+              one of three axes.<br/><img class="ispy-help-img"
                                           src="{{ url_for('static', filename='img/iSpy-Online-graphics/axes.gif')}}">
             </div>
-            <div class="col-sm-6">
+            <div class="col-sm-6 ispy-help-item">
               <img src="{{ url_for('static', filename='img/iSpy-Online-graphics/perspective-projection.png')}}"> and
               <img
                 src="{{ url_for('static', filename='img/iSpy-Online-graphics/orthographic-projection.png')}}"> Switch
               between
-              a perspective projection and an orthographic projection.<br/><img class="screen-s"
+              a perspective projection and an orthographic projection.<br/><img class="ispy-help-img"
                                                                                 src="{{ url_for('static', filename='img/iSpy-Online-graphics/projection.gif')}}">
             </div>
-            <div class="col-sm-6">
+            <div class="col-sm-6 ispy-help-item">
               <i class="fa fa-gear"></i> Use the settings button to invert the colours of the display or display the
               frame
-              rate.<br/><img class="screen-s"
+              rate.<br/><img class="ispy-help-img"
                              src="{{ url_for('static', filename='img/iSpy-Online-graphics/settings.gif')}}">
             </div>
           </div>
@@ -76,7 +76,7 @@
             <div class="col-sm-6">
               Click on the checkboxes to show or hide the CMS sub-detectors, particle tracks and hits, and
               more.<br/><img
-              class="screen-s" src="{{ url_for('static', filename='img/iSpy-Online-graphics/detector.gif')}}">
+              class="ispy-help-img" src="{{ url_for('static', filename='img/iSpy-Online-graphics/detector.gif')}}">
             </div>
             <!--
             <li>


### PR DESCRIPTION
closes #3069

- Removed some css leftovers from global styles and created a separate file for custom ispy css

Result:
![Screenshot from 2021-02-16 11-03-34](https://user-images.githubusercontent.com/4990025/108047907-a6006f00-7046-11eb-9caa-2f5b3085361d.png)
