### PR TITLE
ui: improved styling of search page

### DIFF
--- a/cernopendata/modules/theme/assets/semantic-ui/scss/search.scss
+++ b/cernopendata/modules/theme/assets/semantic-ui/scss/search.scss
@@ -33,10 +33,15 @@
 
 .result-options {
   margin-top: 20px;
+  min-height: 75px;
 }
 
-.row > .four.wide.column {
+.ui.grid.relaxed > .row:not(.result-options) > .four.wide.column {
   margin-top: -70px;
+}
+
+.footer {
+  margin-top: 1em;
 }
 
 .center.aligned.eight.wide.column {


### PR DESCRIPTION
addresses #3080

Fixed:
- When some item is selected from the facet list the whole facet box bounces up for fraction of a second
- On `No results found!` state facet box is rendered incorrectly
- Footer images are off on search page
- Added some space between footer and facets/search results