### PR TITLE
records: fix CMS VM 2011 link

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -49,7 +49,8 @@ jobs:
 
       - name: Check compliance with Python coding style conventions
         run: |
-          pip install --upgrade pip
+          pip install --upgrade "pip<20.3"
+          pip install --upgrade "setuptools<=44.0.0"
           pip install pycodestyle
           ./run-tests.sh --check-pycodestyle
 
@@ -66,7 +67,8 @@ jobs:
 
       - name: Check compliance with Python docstring conventions
         run: |
-          pip install --upgrade pip
+          pip install --upgrade "pip<20.3"
+          pip install --upgrade "setuptools<=44.0.0"
           pip install pydocstyle
           ./run-tests.sh --check-pydocstyle
 
@@ -83,7 +85,8 @@ jobs:
 
       - name: Check Python manifest completeness
         run: |
-          pip install --upgrade pip
+          pip install --upgrade "pip<20.3"
+          pip install --upgrade "setuptools<=44.0.0"
           pip install check-manifest
           ./run-tests.sh --check-manifest
 
@@ -117,7 +120,8 @@ jobs:
 
       - name: Check isort
         run: |
-          pip install --upgrade pip
+          pip install --upgrade "pip<20.3"
+          pip install --upgrade "setuptools<=44.0.0"
           pip install isort
           ./run-tests.sh --check-isort
 

--- a/cernopendata/modules/fixtures/data/records/cms-pileup-datasets-2012.json
+++ b/cernopendata/modules/fixtures/data/records/cms-pileup-datasets-2012.json
@@ -91,7 +91,7 @@
       "links": [
         {
           "description": "How to install the CMS Virtual Machine",
-          "url": "/docs/cms-virtual-machine-2012"
+          "url": "/docs/cms-virtual-machine-2011"
         },
         {
           "description": "Getting started with CMS open data",


### PR DESCRIPTION
Fixes records to point to proper CMS VM 2011 link also for 2012 records.
Closes #3088.