### PR TITLE
facets: use filter of filtered query

### DIFF
--- a/cernopendata/config.py
+++ b/cernopendata/config.py
@@ -386,7 +386,7 @@ RECORDS_REST_FACETS = {
                 field='keywords.keyword',
                 order=dict(_key='asc'))),
         ),
-        'post_filters': dict(
+        'filters': dict(
             type=terms_filter('type.primary.keyword'),
             subtype=terms_filter('type.secondary.keyword'),
             experiment=terms_filter('experiment.keyword'),


### PR DESCRIPTION
closes #3098 

I did some investigation on how numbers are displayed in front of facets and found out that number of aggregation after every query effects the count shown in front of every facet.

>  As far as search hits are concerned, they are the same thing, i.e. the hits will be correctly filtered according to either the filter in a `filtered`  query or the filter in the `post_filter`.
   However, as far as `aggregations` are concerned, the end result will not be the same. The difference between both comes down to what document set the `aggregations` will be computed on.
    - If the filter is in a `filtered` query, then `aggregations` will be computed on the document set selected by our query(ies) and the filter(s) in the filtered query, i.e. the same set of documents that we will get in the response.
    - If the filter is in a `post_filter`, then the `aggregations` will be computed on the document set selected by our various query(ies). Once aggregations have been computed on that document set, the latter is further filtered by the filter(s) in our `post_filter` before returning the matching documents.

To sum it up:

- a `filtered query` affects both search results and aggregations
- while a `post_filter` only affects the search results but NOT the aggregations

That's the reason I went for `filter` in current PR.

