### PR TITLE
Record for 2020 CMS data policy 

### DIFF
--- a/cernopendata/modules/fixtures/data/records/data-policies.json
+++ b/cernopendata/modules/fixtures/data/records/data-policies.json
@@ -7,8 +7,8 @@
     "authors": [
       {
         "affiliation": "U. Edinburgh",
-        "rorid": "01nrxwf90",
-        "name": "Clarke, Peter"
+        "name": "Clarke, Peter",
+        "rorid": "01nrxwf90"
       }
     ],
     "collaboration": {
@@ -90,9 +90,8 @@
     "recid": "411",
     "relations": [
       {
-        "doi": "10.7483/OPENDATA.CMS.7347.JDWH",
-        "recid": "414",
-        "title": "2018 CMS data preservation, re-use and open access policy",
+        "description": "This document is replaced by a new revision of the CMS data policy in",
+        "recid": "415",
         "type": "isChildOf"
       }
     ],
@@ -138,7 +137,56 @@
     },
     "publisher": "CERN Open Data Portal",
     "recid": "414",
+    "relations": [
+      {
+        "description": "This document is replaced by a new revision of the CMS data policy in",
+        "recid": "415",
+        "type": "isChildOf"
+      }
+    ],
     "title": "2018 CMS data preservation, re-use and open access policy",
+    "type": {
+      "primary": "Documentation",
+      "secondary": [
+        "Policy"
+      ]
+    }
+  },
+  {
+    "abstract": {
+      "description": "This document describes the CMS collaboration's policy on long-term data preservation, re-use and open access. The policy was first approved by the CMS Collaboration Board in March 2012. It was updated in 2020 and this updated policy has been approved by the CMS Collaboration Board in September 2020."
+    },
+    "accelerator": "CERN LHC",
+    "collaboration": {
+      "name": "CMS collaboration"
+    },
+    "collections": [
+      "Data-Policies"
+    ],
+    "date_published": "2020",
+    "distribution": {
+      "formats": [
+        "pdf"
+      ]
+    },
+    "doi": "10.7483/OPENDATA.CMS.1BNU.8V1W",
+    "experiment": "CMS",
+    "files": [
+      {
+        "checksum": "adler32:a0c0edb3",
+        "size": 109931,
+        "uri": "root://eospublic.cern.ch//eos/opendata/cms/documentation/CMS-Data-Policy-1.3.pdf"
+      }
+    ],
+    "language": "English",
+    "prepublication": {
+      "date": "2020-09-25",
+      "place": "Geneva",
+      "publisher": "CERN"
+    },
+    "publisher": "CERN Open Data Portal",
+    "recid": "415",
+    "title": "2020 CMS data preservation, re-use and open access policy",
     "type": {
       "primary": "Documentation",
       "secondary": [


### PR DESCRIPTION
(closes #2892 )

Created a new record for the 2020 update of the CMS data policy. Adds links to the updated policy in the older versions.
Needs:
- [x] DOI
- [x] the file from https://cms-docdb.cern.ch/cgi-bin/PublicDocDB/RetrieveFile?docid=6032&filename=CMSDataPolicy-v1.3.pdf&version=3