### PR TITLE
Validated run 2015

### DIFF
--- a/cernopendata/modules/fixtures/data/records/cms-validated-runs-ppRun2.json
+++ b/cernopendata/modules/fixtures/data/records/cms-validated-runs-ppRun2.json
@@ -1,0 +1,132 @@
+[
+  {
+    "abstract": {
+      "description": "<p>This file describes which luminosity sections in which runs are considered good and should be processed.</p> <p>This list covers proton-proton data taking in 2015, between run numbers 253659 and 260627.</p>"
+    },
+    "accelerator": "CERN-LHC",
+    "collaboration": {
+      "name": "CMS Collaboration",
+      "recid": "14210"
+    },
+    "collections": [
+      "CMS-Validated-Runs",
+      "CMS-Validation-Utilities"
+    ],
+    "date_created": [
+      "2015"
+    ],
+    "date_published": "2021",
+    "distribution": {
+      "formats": [
+        "txt"
+      ]
+    },
+    "experiment": "CMS",
+    "files": [
+      {
+        "checksum": "adler32:a92efa8b",
+        "size": 3588,
+        "uri": "/eos/opendata/cms/validated-runs/2015/Cert_13TeV_16Dec2015ReReco_Collisions15_25ns_JSON_v2.txt"
+      }
+    ],
+    "publisher": "CERN Open Data Portal",
+    "recid": "14210",
+    "run_period": [
+      "Run2015C",
+      "Run2015D"
+    ],
+    "title": "CMS list of validated runs Cert_13TeV_16Dec2015ReReco_Collisions15_25ns_JSON_v2.txt",
+    "title_additional": "CMS list of validated runs for primary datasets of 2015 data taking",
+    "type": {
+      "primary": "Environment",
+      "secondary": [
+        "Validation"
+      ]
+    },
+    "usage": {
+      "description": "<p>Add the following lines in the configuration file for a cmsRun job: <br /> <pre>   import FWCore.ParameterSet.Config as cms</pre><pre>   import FWCore.PythonUtilities.LumiList as LumiList</pre><pre>   goodJSON = 'Cert_13TeV_16Dec2015ReReco_Collisions15_25ns_JSON_v2.txt'</pre><pre>   myLumis = LumiList.LumiList(filename = goodJSON).getCMSSWString().split(',') </pre></p><p> Add the file path if needed in the file name.</p><p> Add the following statements after the <code>process.source</code> input file definition: <br /><pre>   process.source.lumisToProcess = cms.untracked.VLuminosityBlockRange()</pre><pre>   process.source.lumisToProcess.extend(myLumis)</pre></p><p>Note that the two last statements must be placed after the <code>process.source</code> statement defining the input files.</p>"
+    },
+    "validation": {
+      "description": "During data taking all the runs recorded by CMS are certified as good for physics analysis if all subdetectors, trigger, lumi and physics objects (tracking, electron, muon, photon, jet and MET) show the expected performance. Certification is based first on the offline shifters evaluation and later on the feedback provided by detector and Physics Object Group experts. Based on the above information, which is stored in a specific database called Run Registry, the Data Quality Monitoring group verifies the consistency of the certification and prepares a json file of certified runs to be used for physics analysis. For each reprocessing of the raw data, the above mentioned steps are repeated. For more information see:",
+      "links": [
+        {
+          "description": "CMS data quality monitoring: Systems and experiences",
+          "url": "http://iopscience.iop.org/1742-6596/219/7/072020/pdf/1742-6596_219_7_072020.pdf"
+        },
+        {
+          "description": "The CMS Data Quality Monitoring software experience and future improvements",
+          "url": "http://cds.cern.ch/record/1631039/files/CR2013_418.pdf"
+        },
+        {
+          "description": "The CMS data quality monitoring software: experience and future prospects",
+          "url": "http://iopscience.iop.org/1742-6596/513/3/032024/pdf/1742-6596_513_3_032024.pdf"
+        }
+      ]
+    }
+  },
+  {
+    "abstract": {
+      "description": "<p>This file describes which luminosity sections in which runs are considered good and should be processed, for analyses requiring only valid muons.</p> <p>This list covers proton-proton data taking in 2015, between run numbers 253659 and 260627.</p>"
+    },
+    "accelerator": "CERN-LHC",
+    "collaboration": {
+      "name": "CMS Collaboration",
+      "recid": "450"
+    },
+    "collections": [
+      "CMS-Validated-Runs",
+      "CMS-Validation-Utilities"
+    ],
+    "date_created": [
+      "2015"
+    ],
+    "date_published": "2021",
+    "distribution": {
+      "formats": [
+        "txt"
+      ]
+    },
+    "experiment": "CMS",
+    "files": [
+      {
+        "checksum": "adler32:4e71d557",
+        "size": 3408,
+        "uri": "/eos/opendata/cms/validated-runs/2015/Cert_13TeV_16Dec2015ReReco_Collisions15_25ns_JSON_MuonPhys.txt"
+      }
+    ],
+    "publisher": "CERN Open Data Portal",
+    "recid": "14211",
+    "run_period": [
+      "Run2015C",
+      "Run2015D"
+    ],
+    "title": "CMS list of validated runs Cert_13TeV_16Dec2015ReReco_Collisions15_25ns_JSON_MuonPhys.txt",
+    "title_additional": "CMS list of validated runs for primary datasets of 2015 data taking, only valid muons",
+    "type": {
+      "primary": "Environment",
+      "secondary": [
+        "Validation"
+      ]
+    },
+    "usage": {
+      "description": "<p>Add the following lines in the configuration file for a cmsRun job: <br /> <pre>   import FWCore.ParameterSet.Config as cms</pre><pre>   import FWCore.PythonUtilities.LumiList as LumiList</pre><pre>   goodJSON = 'Cert_13TeV_16Dec2015ReReco_Collisions15_25ns_JSON_MuonPhys.txt'</pre><pre>   myLumis = LumiList.LumiList(filename = goodJSON).getCMSSWString().split(',') </pre></p><p> Add the file path if needed in the file name.</p><p> Add the following statements after the <code>process.source</code> input file definition: <br /><pre>   process.source.lumisToProcess = cms.untracked.VLuminosityBlockRange()</pre><pre>   process.source.lumisToProcess.extend(myLumis)</pre></p><p>Note that the two last statements must be placed after the <code>process.source</code> statement defining the input files.</p>"
+    },
+    "validation": {
+      "description": "During data taking all the runs recorded by CMS are certified as good for physics analysis if all subdetectors, trigger, lumi and physics objects (tracking, electron, muon, photon, jet and MET) show the expected performance. Certification is based first on the offline shifters evaluation and later on the feedback provided by detector and Physics Object Group experts. Based on the above information, which is stored in a specific database called Run Registry, the Data Quality Monitoring group verifies the consistency of the certification and prepares a json file of certified runs to be used for physics analysis. For each reprocessing of the raw data, the above mentioned steps are repeated. For more information see:",
+      "links": [
+        {
+          "description": "CMS data quality monitoring: Systems and experiences",
+          "url": "http://iopscience.iop.org/1742-6596/219/7/072020/pdf/1742-6596_219_7_072020.pdf"
+        },
+        {
+          "description": "The CMS Data Quality Monitoring software experience and future improvements",
+          "url": "http://cds.cern.ch/record/1631039/files/CR2013_418.pdf"
+        },
+        {
+          "description": "The CMS data quality monitoring software: experience and future prospects",
+          "url": "http://iopscience.iop.org/1742-6596/513/3/032024/pdf/1742-6596_513_3_032024.pdf"
+        }
+      ]
+    }
+  }
+]


### PR DESCRIPTION
closes #3154

Adds the records for the validated runs for 2015 data taking. Two lists, one for full validation and the other for muon physics only.

Refers to the json files which are now available /eos/opendata/cms/upload/validated-runs2015/validated-runs2015/