### PR TITLE
CMS 2015 pileup info

### DIFF
--- a/cernopendata/modules/fixtures/data/docs/cms-guide-pileup-simulation/cms-guide-pileup-simulation.md
+++ b/cernopendata/modules/fixtures/data/docs/cms-guide-pileup-simulation/cms-guide-pileup-simulation.md
@@ -10,6 +10,10 @@ Monte Carlo simulation of pileup is controlled by the code and configuration fil
 
 2. For each bunch crossing, both in- and out-of-time, the number of interactions is randomly sampled from a poisson distribution with a mean equal to the value chosen in (1). Note that this implies that all bunches have the same instantaneous luminosity, rather than allowing for bunch-to-bunch luminosity variation. In practice, the spread of bunch-by-bunch luminosities is much smaller than the poisson distribution, so this effect is negligible. One might evolve the simulation to include such features as the beginning or end of bunch trains, where the out-of-time pileup will have a significantly different luminosity structure (i.e., there is none, either before or after a given event). Since the bunch trains are quite long, this effect of ignoring these variations is likely to be negligible as well. The number of interactions that is actually included in each bunch crossing is also recorded. (`num_PU_vertices_`).
 
+## Pileup Distributions from Data
+
+The pileup distributions measured from data are available in [the CMS Luminosity information page](https://twiki.cern.ch/twiki/bin/view/CMSPublic/LumiPublicResults).
+
 ## Monte Carlo Pileup Distributions
 
 The "ideal" distributions input for each year's Monte Carlo production samples are catalogued on [this page](https://twiki.cern.ch/twiki/bin/view/CMSPublic/Pileup_MC_Gen_Scenarios), which contains the actual numerical contents of each bin represented in the plots below.
@@ -30,6 +34,10 @@ Pileup distribution used to generate the 2012 Monte Carlo samples:
 
 <p align="center">
 <img src="/static/docs/cms-pileup-simulation/MC2012_PU.png" width="70%"></p>
+
+### 2015
+
+For the 2015 data, the distribution measured from the [2012 collision data](https://twiki.cern.ch/twiki/bin/view/CMSPublic/LumiPublicResults#2012_proton_proton_8_TeV_collisi), scaled by 4/5 to correspond to the estimated mean number of interactions per crossing in 2015, was used to generated the Monte Carlo events.
 
 ## Disclaimer
 


### PR DESCRIPTION
Closes #3162 

Adds a description of the 2015 pileup profile to `docs/cms-guide-pileup-simulation`