### PR TITLE
Update for CMS docker guide

### DIFF
--- a/cernopendata/modules/fixtures/data/docs/cms-getting-started-2015/cms-getting-started-2015.md
+++ b/cernopendata/modules/fixtures/data/docs/cms-getting-started-2015/cms-getting-started-2015.md
@@ -203,7 +203,7 @@ $ cmsRun PhysObjectExtractor/python/poet_cfg.py
 
 The configuration file sets it to run over 1000 events in a simulated dataset.
 
-If you are using the CMS open data container, open the graphical window in the container by typing
+If you are using the CMS open data container with the VNC application installed (see the [container guide page](/docs/cms-guide-docker)), open the graphical window in the container by typing
 
 ```shell
 $ start_vnc

--- a/cernopendata/modules/fixtures/data/docs/cms-guide-docker/cms-guide-docker.md
+++ b/cernopendata/modules/fixtures/data/docs/cms-guide-docker/cms-guide-docker.md
@@ -1,18 +1,31 @@
 ## Introduction
 
-As an alternative to using a virtual machine, you can run CMS analysis code in a [Docker](https://www.docker.com/) container. If you have not already installed Docker instructions for installation are [provided by Docker](https://docs.docker.com/install/).
+As an alternative to using a virtual machine, you can run CMS analysis code in a [Docker](https://www.docker.com/) container. If you have not already installed Docker instructions for installation are [provided by Docker](https://docs.docker.com/install/). For an introduction, you can also follow the links provided in [the CMS Open data guide](https://cms-opendata-guide.web.cern.ch/tools/docker/).
 
-## Fetch and create a CMSSW image and start a container
+## Available CMSSW container images
 
-### Instructions for 2011/2012 data
+For the first access of each set of CMS open data, you will need a specific container image containing the software corresponding to that particular set of data. The following images are available:
+
+| CMS open data | CMSSW version | Container image (dockerhub) | Alternative image location (GitLab) |
+| ------------- |-------------| -----| -----: |
+| 2015 proton-proton | CMSSW_7_6_7 | cmsopendata/cmssw_7_6_7 (not yet) | [link](https://gitlab.cern.ch/cms-cloud/cmssw-docker/container_registry/10519) |
+| 2011-2012 proton-proton | CMSSW_5_3_32 | cmsopendata/cmssw_5_3_32 cmsopendata/cmssw_5_3_32_vnc | [link](https://gitlab.cern.ch/cms-cloud/cmssw-docker-opendata/container_registry/10289) <br /> [link](https://gitlab.cern.ch/cms-cloud/cmssw-docker-opendata/container_registry/10290) |
+| 2011 heavy-ion | CMSSW_4_4_7 | cmsopendata/cmssw_4_4_7 (not yet) | [link](https://gitlab.cern.ch/cms-cloud/cmssw-docker/container_registry/8237) |
+| 2010 proton-proton | CMSSW_4_2_8 | cmsopendata/cmssw_4_2_8 | [link](https://gitlab.cern.ch/cms-cloud/cmssw-docker/container_registry/7721) |
+| 2010 proton-proton with CASTOR calorimeter | CMSSW_4_2_8_lowpupatch1 | cmsopendata/cmssw_4_2_8_lowpupatch1 | [link](https://gitlab.cern.ch/cms-cloud/cmssw-docker/container_registry/10519) |
+| 2010 heavy-ion | CMSSW_3_9_2_patch5 | cmsopendata/cmssw_3_9_2_patch5 (not yet) | [link](https://gitlab.cern.ch/cms-cloud/cmssw-docker/container_registry/8225) |
+
+## Fetch a CMSSW image and start a container
+
+In the following instructions, make sure to replace the CMSSW version and the container image name according to the table above. These commands are for 2011-2012 proton-proton data, with the CMSSW version CMSSSW_5_3_32 and the cmssw_5_3_32 container image.
 
 Once Docker is installed, you can fetch a CMSSW image, and create and start a container using the `docker run` command:
 
 ```sh
-docker run --name opendata -it cmsopendata/cmssw_5_3_32 /bin/bash
+docker run --name my_od -it cmsopendata/cmssw_5_3_32 /bin/bash
 ```
 
-Here we fetch the `CMSSW_5_3_32` docker image from [dockerhub](https://hub.docker.com/u/cmsopendata) and name the container `opendata`. For heavy-ion data from 2011, the docker image to use is [the CMSSW_4_4_7 image](https://gitlab.cern.ch/cms-cloud/cmssw-docker/container_registry/eyJuYW1lIjoiY21zLWNsb3VkL2Ntc3N3LWRvY2tlci9jbXNzd180XzRfNy1zbGM1X2FtZDY0X2djYzQzNCIsInRhZ3NfcGF0aCI6Ii9jbXMtY2xvdWQvY21zc3ctZG9ja2VyL3JlZ2lzdHJ5L3JlcG9zaXRvcnkvODIzNy90YWdzP2Zvcm1hdD1qc29uIiwiaWQiOjgyMzd9) from the CMS GitLab image registry.
+Here we fetch the `cmssw_5_3_32` docker image from [dockerhub](https://hub.docker.com/u/cmsopendata) and name the container `my_od`.
 
 This will install a stand-alone CMSSW image (a few gigabytes). Therefore this may take a few minutes. However, the image will only have to be downloaded once. The following will appear in your terminal once you type the `docker run` command:
 
@@ -34,103 +47,88 @@ Once done, you should see the commmand prompt for the CMSSW instance within Dock
 cmsusr@eb9ecf54fd2a ~/CMSSW_5_3_32/src $
 ```
 
-### Instructions for 2010 data
-
-Once Docker is installed, you can fetch a CMSSW image and create and start a container using the `docker run` command:
-
-```sh
-docker run --name opendata-2010 -it cmsopendata/cmssw_4_2_8 /bin/bash
-```
-
-Here we fetch the `CMSSW_4_2_8` docker image from [dockerhub](https://hub.docker.com/u/cmsopendata) and name the container `opendata-2010`. For low-luminosity data taken with the Castor calorimeter, the docker image CMSSW_4_2_8_lowpupatch1 should be used. For heavy-ion data from 2010, the docker image to use is [the CMSSW_3_9_2_patch5 image](https://gitlab.cern.ch/cms-cloud/cmssw-docker/container_registry/eyJuYW1lIjoiY21zLWNsb3VkL2Ntc3N3LWRvY2tlci9jbXNzd18zXzlfMl9wYXRjaDUtc2xjNV9hbWQ2NF9nY2M0MzQiLCJ0YWdzX3BhdGgiOiIvY21zLWNsb3VkL2Ntc3N3LWRvY2tlci9yZWdpc3RyeS9yZXBvc2l0b3J5LzgyMjUvdGFncz9mb3JtYXQ9anNvbiIsImlkIjo4MjI1fQ==) from the CMS GitLab image registry.
-
-As described [in this GitHub repository](https://github.com/clelange/cmssw-docker/), this will install a stand-alone CMSSW image that is a few GBs. Therefore this may take a few minutes. However, the image will only have to be downloaded once. The following will appear in your terminal once you type the `docker run` command:
-
-```console
-Unable to find image 'cmsopendata/cmssw_4_2_8' locally
-latest: Pulling from cmsopendata/cmssw_4_2_8
-acb4e939ccb9: Pull complete
-99519598bf9e: Pull complete
-bd33a5d7d5de: Pull complete
-Digest: sha256:511ece0c921dffa39470c785e5cade41bfd25f8ebc4e7ac72e6a622bb1a477c9
-Status: Downloaded newer image for cmsopendata/cmssw_4_2_8:latest
-Setting up CMSSW_4_2_8
-CMSSW should now be available.
-```
-
-Once done, you should see the commmand prompt for the CMSSW instance within Docker:
-
-```console
-cmsusr@b3dad0c0068a ~/CMSSW_4_2_8/src $
-```
-
 ## Further instructions
 
-### Install and run CMS analysis code
+### Install and run CMS example code
 
-Now we can try an example analysis like [DimuonSpectrum2011](https://github.com/cms-opendata-analyses/DimuonSpectrum2011), which analyses 2011 and 2012 data.
+Now you can try an example code like [Physics Object Extractor Tool (POET)](https://github.com/cms-legacydata-analyses/PhysObjectExtractorTool) which has separate "branches" for different data. The following commands are for 2012 data (branch name `2012`). For 2015 data, you would have fetched the cmssw_7_6_7 container image, be working in `~/CMSSW_7_6_7/src` area, and the branch name to be used would be `2015MiniAOD`.
 
-In the command prompt in `~/CMSSW_5_3_32/src` run the following commands:
+In the command prompt in `~/CMSSW_<version>/src` run the following commands:
 
 ```sh
-mkdir WorkDir
-cd WorkDir
-git clone git://github.com/cms-opendata-analyses/DimuonSpectrum2011.git
+git clone -b 2012 git://github.com/cms-legacydata-analyses/PhysObjectExtractorTool.git
+cd PhysObjectExtractorTool
 ```
 
-Move to the `DimuonSpectrum2011` directory and build with the `scram` command:
+Move to the `PhysObjectExtractor` directory and compile with the `scram` command:
 
 ```sh
-cd DimuonSpectrum2011
+cd PhysObjectExtractor
 scram b
 ```
 
 Once the code is built, you can run the example analysis:
 
 ```sh
-cmsRun demoanalyzer_cfg.py
+cmsRun python/poet_cfg.py
 ```
 
-which will produce a file `DoubleMu.root`.
+which will produce a file `myoutput.root`.
 
 ### Copying files
 
 In order to copy files out of a running container, open another terminal and run (for example) the following command:
 
 ```sh
-docker cp opendata:/home/cmsusr/CMSSW_5_3_32/src/WorkDir/DimuonSpectrum2011/DoubleMu.root .
+docker cp my_od:/home/cmsusr/CMSSW_5_3_32/src/PhysObjectExtractorTool/PhysObjectExtractor/myoutput.root .
 ```
 
 Likewise, in order to copy a file into a running container:
 
 
 ```sh
-docker cp <my file> opendata:/home/cmsusr/CMSSW_5_3_32/src/
+docker cp <my file> my_od:/home/cmsusr/CMSSW_5_3_32/src/
 ```
 
-### X11 forwarding with docker on linux
+### Graphics with X11 forwarding with docker on Linux
 
-If you want to use ROOT or some other program from within the container that needs X11-forwarding for the graphics to pop up, on linux, you can start the container with
+If you want to use ROOT or some other program from within the container that needs X11-forwarding for the graphics to pop up, on Linux, you can start the container with
 
 ```sh
-docker run -it --net=host --env="DISPLAY" --volume="$HOME/.Xauthority:/root/.Xauthority:rw" cmsopendata/cmssw_5_3_32 /bin/bash
+docker run -it --name my_od --net=host --env="DISPLAY" -v $HOME/.Xauthority:/home/cmsusr/.Xauthority:rw  cmsopendata/cmssw_5_3_32:latest /bin/bash
 ```
 
-Once in the container, you can type
+### Graphics with VNC
+
+For opening graphics windows, as an alternative to X11 forwarding, you can install a VNC server on you local computer (Linux, MacOS or Windows), and use the container image with a VNC application installed. In this case, you can start the container with
 
 ```sh
-cmsenv
-root
+docker run -it --name my_od -P -p 5901:5901 cmsopendata/cmssw_5_3_32_vnc:latest /bin/bash
 ```
 
-If it has worked, you’ll see the ROOT splash screen.
+and start the VNC application in the container with
+
+```sh
+start_vnc
+```
+
+### Using ROOT
+
+If you have set up X11 forwarding or use a container with VNC as explained above, you can explore the example output file with ROOT. Start ROOT with
+
+```sh
+root myoutput.root
+```
+
+If it has worked, you’ll see the ROOT splash screen. If you are already familiar with ROOT, you can explore the example root file. If you are new to ROOT, have a quick look to [the Getting started page](/docs/cms-getting-started-2015), or follow the links in [the CMS open data guide](https://cms-opendata-guide.web.cern.ch/tools/root/), and note that you can exit root with `.q`.
+
 
 
 ### Exiting and restarting a container
 
 When you want to exit the container simply type `exit`.
 
-If you want to restart the container (e.g. the one named `opendata`) and return to your work then use the command `docker start -i opendata`.
+If you want to restart the container (e.g. the one named `my_od`) and return to your work then use the command `docker start -i my_od`.
 
 If the container was created and started using the `--rm` option (e.g. `docker run --rm`) then the container will be removed when you exit. You can create a new container from the image using `docker run`.
 
@@ -160,16 +158,18 @@ initrd=\initrd.img panic=-1 pty.legacy_count=0 nr_cpus=4 vsyscall=emulate
 
 ### Accessing cvmfs from a container
 
-In order to access the snapshots of CMS database conditions when running CMSSW jobs, one would usually need access to the universal namespace `/cvmfs` (CernVM-File System).  In Linux and macOS it is possible to "see" the cvmfs space by installing the cvmfs client following [the offcial instructions](https://cvmfs.readthedocs.io).  In essence, there are two basic ways to achieve this:
+The CMS open data container images contain the software needed for analysis, and the CMS condition database can be accessed from predefined locations. Therefore, when using these containers, access to the namespace `/cvmfs` (CernVM-File System) for software and condition data access is not mandatory.
 
-The preferred option (working for 2010 and 2011 containers) is to [install](https://cvmfs.readthedocs.io/en/stable/cpt-quickstart.html) the cvmfs client locally, on the host machine, and [mount](https://cvmfs.readthedocs.io/en/stable/cpt-configure.html#bind-mount-from-the-host) it on the container:
+If desired, it is possible to "see" the cvmfs space by installing the cvmfs client following [the official instructions](https://cvmfs.readthedocs.io). In essence, there are two basic ways to achieve this:
+
+The preferred option is to [install](https://cvmfs.readthedocs.io/en/stable/cpt-quickstart.html) the cvmfs client locally, on the host machine, and [mount](https://cvmfs.readthedocs.io/en/stable/cpt-configure.html#bind-mount-from-the-host) it on the container:
 
 ```sh
-docker run --name opendata -it -v "/cvmfs:/cvmfs:shared" cmsopendata/cmssw_5_3_32 /bin/bash
+docker run --name my_od -it -v "/cvmfs:/cvmfs:shared" cmsopendata/cmssw_5_3_32 /bin/bash
 ```
 
-The other option is to [install](https://cvmfs.readthedocs.io/en/stable/cpt-quickstart.html) the cvmfs client directly in the container after it is created (only working for the 2011 container).  For this, the container needs to get started in [privileged](https://cvmfs.readthedocs.io/en/stable/cpt-configure.html#mount-inside-a-container) mode like
+The other option is to [install](https://cvmfs.readthedocs.io/en/stable/cpt-quickstart.html) the cvmfs client directly in the container after it is created (only working for the slc6-based containers).  For this, the container needs to get started in [privileged](https://cvmfs.readthedocs.io/en/stable/cpt-configure.html#mount-inside-a-container) mode like
 
 ```sh
-docker run --privileged --name opendata -it cmsopendata/cmssw_5_3_32 /bin/bash
+docker run --privileged --name my_od -it cmsopendata/cmssw_5_3_32 /bin/bash
 ```


### PR DESCRIPTION
closes #3163 

Updates the CMS docker guide page for 2015 data. 
Adds a link to it from the CMS getting started 2015.