### PR TITLE
search: fetch most recent news

### DIFF
--- a/cernopendata/config.py
+++ b/cernopendata/config.py
@@ -284,7 +284,7 @@ RECORDS_REST_SORT_OPTIONS = {
             order=1,
         ),
         'mostrecent': dict(
-            fields=['recid'],
+            fields=['-created'],
             title='Most recent',
             default_order='desc',
             order=1,


### PR DESCRIPTION
* Gets the most recent news articles when calling the search API with a 'mostrecent'
  argument

* Closes #3095