### PR TITLE
docs: ALICE data policy update

### DIFF
--- a/cernopendata/modules/fixtures/data/records/data-policies.json
+++ b/cernopendata/modules/fixtures/data/records/data-policies.json
@@ -196,7 +196,7 @@
   },
   {
     "abstract": {
-      "description": "This document contains the ALICE data preservation strategy and policy."
+      "description": "<p>This document contains the ALICE data preservation strategy and policy from 2013.<p><p>The ALICE open data strategy was updated in November 2020 following the joint <a href=\"/record/416\">CERN Open Data Policy for LHC Experiments</a>. Please see that document for more details.</p>"
     },
     "accelerator": "CERN LHC",
     "collaboration": {
@@ -276,6 +276,44 @@
     "publisher": "CERN Open Data Portal",
     "recid": "413",
     "title": "ATLAS Data Access Policy",
+    "type": {
+      "primary": "Documentation",
+      "secondary": [
+        "Policy"
+      ]
+    }
+  },
+  {
+    "abstract": {
+      "description": "This document defines the CERN Open Data policy for the LHC experiments (ALICE, ATLAS, CMS and LHCb). The policy has been endorsed by the collaboration boards of these experiments."
+    },
+    "accelerator": "CERN LHC",
+    "collections": [
+      "Data-Policies"
+    ],
+    "date_published": "2020",
+    "distribution": {
+      "formats": [
+        "pdf"
+      ]
+    },
+    "experiment": "",
+    "files": [
+      {
+        "checksum": "adler32:3f46761e",
+        "size": 173093,
+        "uri": "root://eospublic.cern.ch//eos/opendata/alice/documentation/CERN-OPEN-2020-013.pdf"
+      }
+    ],
+    "language": "English",
+    "prepublication": {
+      "date": "2020-11-20",
+      "place": "Geneva",
+      "publisher": "CERN"
+    },
+    "publisher": "CERN Open Data Portal",
+    "recid": "416",
+    "title": "CERN Open Data Policy for the LHC Experiments ",
     "type": {
       "primary": "Documentation",
       "secondary": [


### PR DESCRIPTION
Adds CERN Open Data policy for LHC Experiments document to the
existing ALICE data policy document. Closes #3168.