### PR TITLE
docker: elasticsearch 7.16.1

### DIFF
--- a/docker-compose-dev.yml
+++ b/docker-compose-dev.yml
@@ -173,7 +173,7 @@ services:
 
   elasticsearch:
     restart: "unless-stopped"
-    image: elasticsearch:7.9.3
+    image: elasticsearch:7.16.1
     # Uncomment if DEBUG logging needs to enabled for Elasticsearch
     # command: ["elasticsearch", "-Elogger.level=DEBUG"]
     restart: "unless-stopped"

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -164,7 +164,7 @@ services:
 
   elasticsearch:
     restart: "always"
-    image: elasticsearch:7.9.3
+    image: elasticsearch:7.16.1
     command: ["elasticsearch", "-E", "logger.org.elasticsearch.deprecation=error"]
     restart: "unless-stopped"
     environment:


### PR DESCRIPTION
Updates elasticsearch docker image to 7.16.1 which is fixing the
possible Log4Shell CVE vulnerability.