### PR TITLE
docker: set JVM log4j option

### DIFF
--- a/docker-compose-dev.yml
+++ b/docker-compose-dev.yml
@@ -167,13 +167,13 @@ services:
 
   elasticsearch:
     restart: "unless-stopped"
-    image: elasticsearch:5
+    image: elasticsearch:5.6.16
     # Uncomment if DEBUG logging needs to enabled for Elasticsearch
     # command: ["elasticsearch", "-Elogger.level=DEBUG"]
     environment:
       - bootstrap.memory_lock=true
       # set to reasonable values on production
-      - "ES_JAVA_OPTS=-Xms512m -Xmx512m"
+      - "ES_JAVA_OPTS=-Xms512m -Xmx512m -Dlog4j2.formatMsgNoLookups=true"
     ports:
       - "9200:9200"
       - "9300:9300"

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -164,12 +164,12 @@ services:
 
   elasticsearch:
     restart: "always"
-    image: elasticsearch:5
+    image: elasticsearch:5.6.16
     command: ["elasticsearch", "-E", "logger.org.elasticsearch.deprecation=error"]
     environment:
       - bootstrap.memory_lock=true
       # set to reasonable values on production
-      - "ES_JAVA_OPTS=-Xms512m -Xmx512m"
+      - "ES_JAVA_OPTS=-Xms512m -Xmx512m -Dlog4j2.formatMsgNoLookups=true"
     volumes:
       - elasticsearch_data:/usr/share/elasticsearch/data/elasticsearch
     ports:


### PR DESCRIPTION
Adds JVM log4j option to protect against RCE vulnerability.