### PR TITLE
records: CMS 2015 pile-up DOI 

### DIFF
--- a/cernopendata/modules/fixtures/data/records/cms-pileup-datasets-2011.json
+++ b/cernopendata/modules/fixtures/data/records/cms-pileup-datasets-2011.json
@@ -35,7 +35,34 @@
       "number_files": 3064,
       "size": 10955144670537
     },
+    "doi": "10.7483/OPENDATA.CMS.NLAX.GJXC",
     "experiment": "CMS",
+    "files": [
+      {
+        "checksum": "adler32:8d20c740",
+        "size": 170829,
+        "type": "index.txt",
+        "uri": "root://eospublic.cern.ch//eos/opendata/cms/MonteCarlo2011/Summer11LegDR/MinBias_TuneZ2_7TeV-pythia6/GEN-SIM/START53_LV4-v1/file-indexes/CMS_MonteCarlo2011_Summer11LegDR_MinBias_TuneZ2_7TeV-pythia6_GEN-SIM_START53_LV4-v1_10000_file_index.txt"
+      },
+      {
+        "checksum": "adler32:d7aa978f",
+        "size": 33003,
+        "type": "index.txt",
+        "uri": "root://eospublic.cern.ch//eos/opendata/cms/MonteCarlo2011/Summer11LegDR/MinBias_TuneZ2_7TeV-pythia6/GEN-SIM/START53_LV4-v1/file-indexes/CMS_MonteCarlo2011_Summer11LegDR_MinBias_TuneZ2_7TeV-pythia6_GEN-SIM_START53_LV4-v1_10001_file_index.txt"
+      },
+      {
+        "checksum": "adler32:e70dd205",
+        "size": 170829,
+        "type": "index.txt",
+        "uri": "root://eospublic.cern.ch//eos/opendata/cms/MonteCarlo2011/Summer11LegDR/MinBias_TuneZ2_7TeV-pythia6/GEN-SIM/START53_LV4-v1/file-indexes/CMS_MonteCarlo2011_Summer11LegDR_MinBias_TuneZ2_7TeV-pythia6_GEN-SIM_START53_LV4-v1_30000_file_index.txt"
+      },
+      {
+        "checksum": "adler32:17fb0b42",
+        "size": 149283,
+        "type": "index.txt",
+        "uri": "root://eospublic.cern.ch//eos/opendata/cms/MonteCarlo2011/Summer11LegDR/MinBias_TuneZ2_7TeV-pythia6/GEN-SIM/START53_LV4-v1/file-indexes/CMS_MonteCarlo2011_Summer11LegDR_MinBias_TuneZ2_7TeV-pythia6_GEN-SIM_START53_LV4-v1_30001_file_index.txt"
+      }
+    ],
     "license": {
       "attribution": "CC0"
     },

--- a/cernopendata/modules/fixtures/data/records/cms-pileup-datasets-2012.json
+++ b/cernopendata/modules/fixtures/data/records/cms-pileup-datasets-2012.json
@@ -35,7 +35,46 @@
       "number_files": 2954,
       "size": 10708466553936
     },
+    "doi": "10.5072/OPENDATA.CMS.07II.3X1D",
     "experiment": "CMS",
+    "files": [
+      {
+        "checksum": "adler32:d37b94f6",
+        "size": 315686,
+        "type": "index.json",
+        "uri": "root://eospublic.cern.ch//eos/opendata/cms/MonteCarlo2012/Summer12/MinBias_TuneZ2star_8TeV-pythia6/GEN-SIM/START50_V13-v3/file-indexes/CMS_MonteCarlo2012_Summer12_MinBias_TuneZ2star_8TeV-pythia6_GEN-SIM_START50_V13-v3_0000_file_index.json"
+      },
+      {
+        "checksum": "adler32:bfe09be2",
+        "size": 168831,
+        "type": "index.txt",
+        "uri": "root://eospublic.cern.ch//eos/opendata/cms/MonteCarlo2012/Summer12/MinBias_TuneZ2star_8TeV-pythia6/GEN-SIM/START50_V13-v3/file-indexes/CMS_MonteCarlo2012_Summer12_MinBias_TuneZ2star_8TeV-pythia6_GEN-SIM_START50_V13-v3_0000_file_index.txt"
+      },
+      {
+        "checksum": "adler32:89068ffe",
+        "size": 316001,
+        "type": "index.json",
+        "uri": "root://eospublic.cern.ch//eos/opendata/cms/MonteCarlo2012/Summer12/MinBias_TuneZ2star_8TeV-pythia6/GEN-SIM/START50_V13-v3/file-indexes/CMS_MonteCarlo2012_Summer12_MinBias_TuneZ2star_8TeV-pythia6_GEN-SIM_START50_V13-v3_0001_file_index.json"
+      },
+      {
+        "checksum": "adler32:b247ab9c",
+        "size": 169000,
+        "type": "index.txt",
+        "uri": "root://eospublic.cern.ch//eos/opendata/cms/MonteCarlo2012/Summer12/MinBias_TuneZ2star_8TeV-pythia6/GEN-SIM/START50_V13-v3/file-indexes/CMS_MonteCarlo2012_Summer12_MinBias_TuneZ2star_8TeV-pythia6_GEN-SIM_START50_V13-v3_0001_file_index.txt"
+      },
+      {
+        "checksum": "adler32:88a9d070",
+        "size": 301782,
+        "type": "index.json",
+        "uri": "root://eospublic.cern.ch//eos/opendata/cms/MonteCarlo2012/Summer12/MinBias_TuneZ2star_8TeV-pythia6/GEN-SIM/START50_V13-v3/file-indexes/CMS_MonteCarlo2012_Summer12_MinBias_TuneZ2star_8TeV-pythia6_GEN-SIM_START50_V13-v3_0002_file_index.json"
+      },
+      {
+        "checksum": "adler32:d8ddb2f4",
+        "size": 161395,
+        "type": "index.txt",
+        "uri": "root://eospublic.cern.ch//eos/opendata/cms/MonteCarlo2012/Summer12/MinBias_TuneZ2star_8TeV-pythia6/GEN-SIM/START50_V13-v3/file-indexes/CMS_MonteCarlo2012_Summer12_MinBias_TuneZ2star_8TeV-pythia6_GEN-SIM_START50_V13-v3_0002_file_index.txt"
+      }
+    ],
     "license": {
       "attribution": "CC0"
     },

--- a/cernopendata/modules/fixtures/data/records/cms-simulated-datasets-2015-pileup.json
+++ b/cernopendata/modules/fixtures/data/records/cms-simulated-datasets-2015-pileup.json
@@ -278,7 +278,7 @@
       "release": "CMSSW_7_6_7"
     },
     "title": "/MinBias_TuneCUETP8M1_13TeV-pythia8/RunIISummer15GS-MCRUN2_71_V1-v2/GEN-SIM",
-    "title_additional": "Simulated pile-up dataset MinBias_TuneCUETP8M1_13TeV-pythia8 in GEN-SIM format for 2018 collision data",
+    "title_additional": "Simulated pile-up dataset MinBias_TuneCUETP8M1_13TeV-pythia8 in GEN-SIM format for 2015 collision data",
     "type": {
       "primary": "Dataset",
       "secondary": [

--- a/cernopendata/modules/fixtures/data/records/cms-simulated-datasets-2015-pileup.json
+++ b/cernopendata/modules/fixtures/data/records/cms-simulated-datasets-2015-pileup.json
@@ -35,6 +35,7 @@
       "number_files": 11786,
       "size": 39477329370961
     },
+    "doi": "10.7483/OPENDATA.CMS.VV3J.DIZS",
     "experiment": "CMS",
     "files": [
       {

--- a/cernopendata/modules/fixtures/data/records/data-policies.json
+++ b/cernopendata/modules/fixtures/data/records/data-policies.json
@@ -297,6 +297,7 @@
         "pdf"
       ]
     },
+    "doi": "10.7483/OPENDATA.0XO6.HYY1",
     "experiment": "",
     "files": [
       {


### PR DESCRIPTION
Adds DOI to the CMS 2015 pile-up record. Closes #3199.