### PR TITLE
records: more DOIs for CMS 2012 and 2015 records

### DIFF
--- a/cernopendata/modules/fixtures/data/records/cms-pileup-datasets-2012.json
+++ b/cernopendata/modules/fixtures/data/records/cms-pileup-datasets-2012.json
@@ -35,7 +35,7 @@
       "number_files": 2954,
       "size": 10708466553936
     },
-    "doi": "10.5072/OPENDATA.CMS.07II.3X1D",
+    "doi": "10.7483/OPENDATA.CMS.07II.3X1D",
     "experiment": "CMS",
     "files": [
       {

--- a/cernopendata/modules/fixtures/data/records/cms-simulated-datasets-2012-added.json
+++ b/cernopendata/modules/fixtures/data/records/cms-simulated-datasets-2012-added.json
@@ -36,6 +36,7 @@
       "number_files": 3615,
       "size": 14238961401225
     },
+    "doi": "10.7483/OPENDATA.3GIM.7SPW",
     "experiment": "CMS",
     "files": [
       {

--- a/cernopendata/modules/fixtures/data/records/cms-tools-nanoaod-outreach-dimuon-spectrum-julia.json
+++ b/cernopendata/modules/fixtures/data/records/cms-tools-nanoaod-outreach-dimuon-spectrum-julia.json
@@ -21,6 +21,7 @@
       "number_files": 1,
       "size": 227876
     },
+    "doi": "10.7483/OPENDATA.KS4A.BD5W",
     "experiment": "CMS",
     "files": [
       {


### PR DESCRIPTION
Adds DOIs for CMS 2015 analysis example and CMS 2012 added dataset
records.

Fixes DOI for CMS 2012 pile-up record.  (Not released yet.)

Closes #3214.