### PR TITLE
records: fix link in CMS rec 465

### DIFF
--- a/cernopendata/modules/fixtures/data/records/cms-validation-code-Castor2010.json
+++ b/cernopendata/modules/fixtures/data/records/cms-validation-code-Castor2010.json
@@ -60,7 +60,7 @@
       ]
     },
     "usage": {
-      "description": " <p>Run this software in the CMS Open Data container or in the the CERN Virtual Machine for 2010 CMS data installed. For the container, follow the instructions for 2010 data in <a href=\"docs/cms-guide-docker\">Running CMS analysis code using Docker</a>. For the virtual machine, follow the instructions in step 1 at <a href=\"/VM/CMS/2010\">How to install a CERN Virtual Machine</a>.</p> "
+      "description": " <p>Run this software in the CMS Open Data container or in the the CERN Virtual Machine for 2010 CMS data installed. For the container, follow the instructions for 2010 data in <a href=\"/docs/cms-guide-docker\">Running CMS analysis code using Docker</a>. For the virtual machine, follow the instructions in step 1 at <a href=\"/VM/CMS/2010\">How to install a CERN Virtual Machine</a>.</p> "
     },
     "use_with": {
       "description": "Use this with MinimumBias primary datasets from Commissioning period 2010, Run2010A or Run2010B, and the corresponding simulated data (see instructions in the code repository for more details).",


### PR DESCRIPTION
(closes #2911)

Fixes the link to the docker instructions