### PR TITLE
cli: fixtures glossary --file and --mode options

### DIFF
--- a/scripts/populate-instance.sh
+++ b/scripts/populate-instance.sh
@@ -32,10 +32,14 @@ sleep 20
 
 cernopendata files location local var/data --default
 
-cernopendata fixtures glossary
+if [[ "$@" = *"--skip-glossary"* ]]; then
+    echo "[INFO] Skipping loading of glossary terms."
+else
+    cernopendata fixtures glossary --mode insert
+fi
 
 if [[ "$@" = *"--skip-docs"* ]]; then
-    echo "[INFO] Skipping loading of records."
+    echo "[INFO] Skipping loading of docs."
 else
     cernopendata fixtures docs --mode insert
 fi


### PR DESCRIPTION
Adds CLI options `--file` and `--mode` when loading glossary terms.
Allows to update selectively some terms without touching others. Useful
for fast production updates. This change makes the glossary term loading
process on par with docs loading and record loading.