### PR TITLE
fixes filter event_number auto hide closes #3263

### DIFF
--- a/AUTHORS.rst
+++ b/AUTHORS.rst
@@ -41,6 +41,7 @@ The list of contributors in alphabetical order:
 - `Sergey Dmitrievsky <https://github.com/dmitr25>`_
 - `Silvia Amerio <https://github.com/samerio>`_
 - `Stefan Wunsch <https://github.com/stwunsch>`_
+- `Suchith Krishna S Donni <https://github.com/sksDonni>`_
 - `Thomas McCauley <https://github.com/tpmccauley>`_
 - `Tibor Šimko <https://orcid.org/0000-0001-7202-5803>`_
 - `Tim Smith <https://github.com/TimSmithCH>`_

--- a/cernopendata/modules/records/serializers/basic_json.py
+++ b/cernopendata/modules/records/serializers/basic_json.py
@@ -1,7 +1,7 @@
 # -*- coding: utf-8 -*-
 #
 # This file is part of CERN Open Data Portal.
-# Copyright (C) 2017 CERN.
+# Copyright (C) 2017, 2022 CERN.
 #
 # CERN Open Data Portal is free software; you can redistribute it
 # and/or modify it under the terms of the GNU General Public License as
@@ -74,6 +74,15 @@ class CODJSONSerializer(JSONSerializer):
                     agg.pop('filtered')
 
         aggregations = aggregations[0]
+
+        # Remove empty buckets in event_numbers facet
+        if "event_number" in aggregations.keys():
+            new_event_list = []
+            for bucket in aggregations["event_number"]["buckets"]:
+                if bucket["doc_count"] != 0:
+                    new_event_list.append(bucket)
+            aggregations["event_number"]["buckets"] = new_event_list
+
         return json.dumps(
             dict(
                 hits=dict(


### PR DESCRIPTION
Added a conditional to check and remove empty buckets in the event_number dictionary of the aggregations part of search results.