### PR TITLE
added spaces between badges in news and updates closes #3232

### DIFF
--- a/cernopendata/modules/theme/static/scss/frontpage.scss
+++ b/cernopendata/modules/theme/static/scss/frontpage.scss
@@ -444,6 +444,7 @@ $break-md: 768px;
     border: 1px solid $dark_blue;
     border-radius: 2px;
     margin-bottom: 25px;
+    width: 100%;
 
     h4 {
       a {

--- a/cernopendata/templates/cernopendata_pages/front/news.html
+++ b/cernopendata/templates/cernopendata_pages/front/news.html
@@ -7,18 +7,18 @@
             {% for article in featured_articles %}
             {% set article = article._source %}
             <div class="news-item align-content-stretch col-sm-6 col-md-4">
-                <div class="news-card container-fluid">
+                <div class="news-card">
                     <div class="card-body">
-                        <p class="row date-author-small">
+                        <p class="date-author-small">
                             {{ article.created or '-' }} by
                             {{ article.author or 'Open Data Portal team'}}
                         </p>
-                        <div class="row">
+                        <div class="">
                             <h4>
                                 <a href="/docs/{{article.control_number}}">{{article.title}}</a>
                             </h4>
                         </div>
-                        <div class="tags-box row align-self-end">
+                        <div class="badges-box align-self-end">
                             <a href="/search?type={{article.type.primary}}" class="badge  badge-success custom-badge-success">
                                 {{article.type.primary }}
                             </a>


### PR DESCRIPTION
Added spaces between badges in the news and updates section to keep in line with the general site theme.
Requesting a PR directly into production as the master branch has a lot of diff with the production branch