### PR TITLE
records: LHCb 2011 2012 file index updates

### DIFF
--- a/cernopendata/modules/fixtures/data/records/LHCb_2011_Beam3500GeV_VeloClosed_MagDown_RealData_Reco14_Stripping21r1_EW_DST.json
+++ b/cernopendata/modules/fixtures/data/records/LHCb_2011_Beam3500GeV_VeloClosed_MagDown_RealData_Reco14_Stripping21r1_EW_DST.json
@@ -36,14 +36,14 @@
         "uri": "root://eospublic.cern.ch//eos/opendata/lhcb/Collision11/EW/LHCb_2011_Beam3500GeV_VeloClosed_MagDown_RealData_Reco14_Stripping21r1_EW_DST/file-indexes/LHCb_2011_Beam3500GeV_VeloClosed_MagDown_RealData_Reco14_Stripping21r1_EW_DST_LFNS.txt"
       },
       {
-        "checksum": "adler32:45f79ff9",
-        "size": 278235,
+        "checksum": "adler32:46865581",
+        "size": 1367040,
         "type": "index.json",
         "uri": "root://eospublic.cern.ch//eos/opendata/lhcb/Collision11/EW/LHCb_2011_Beam3500GeV_VeloClosed_MagDown_RealData_Reco14_Stripping21r1_EW_DST/file-indexes/LHCb_2011_Beam3500GeV_VeloClosed_MagDown_RealData_Reco14_Stripping21r1_EW_DST_file_index.json"
       },
       {
-        "checksum": "adler32:936dbd78",
-        "size": 162158,
+        "checksum": "adler32:a8f0e165",
+        "size": 797796,
         "type": "index.txt",
         "uri": "root://eospublic.cern.ch//eos/opendata/lhcb/Collision11/EW/LHCb_2011_Beam3500GeV_VeloClosed_MagDown_RealData_Reco14_Stripping21r1_EW_DST/file-indexes/LHCb_2011_Beam3500GeV_VeloClosed_MagDown_RealData_Reco14_Stripping21r1_EW_DST_file_index.txt"
       }

--- a/cernopendata/modules/fixtures/data/records/LHCb_2011_Beam3500GeV_VeloClosed_MagDown_RealData_Reco14_Stripping21r1_LEPTONIC_MDST.json
+++ b/cernopendata/modules/fixtures/data/records/LHCb_2011_Beam3500GeV_VeloClosed_MagDown_RealData_Reco14_Stripping21r1_LEPTONIC_MDST.json
@@ -36,14 +36,14 @@
         "uri": "root://eospublic.cern.ch//eos/opendata/lhcb/Collision11/LEPTONIC/LHCb_2011_Beam3500GeV_VeloClosed_MagDown_RealData_Reco14_Stripping21r1_LEPTONIC_MDST/file-indexes/LHCb_2011_Beam3500GeV_VeloClosed_MagDown_RealData_Reco14_Stripping21r1_LEPTONIC_MDST_LFNS.txt"
       },
       {
-        "checksum": "adler32:c9967693",
-        "size": 294418,
+        "checksum": "adler32:69d42ff8",
+        "size": 1432190,
         "type": "index.json",
         "uri": "root://eospublic.cern.ch//eos/opendata/lhcb/Collision11/LEPTONIC/LHCb_2011_Beam3500GeV_VeloClosed_MagDown_RealData_Reco14_Stripping21r1_LEPTONIC_MDST/file-indexes/LHCb_2011_Beam3500GeV_VeloClosed_MagDown_RealData_Reco14_Stripping21r1_LEPTONIC_MDST_file_index.json"
       },
       {
-        "checksum": "adler32:17a98b55",
-        "size": 175428,
+        "checksum": "adler32:18d585cd",
+        "size": 854370,
         "type": "index.txt",
         "uri": "root://eospublic.cern.ch//eos/opendata/lhcb/Collision11/LEPTONIC/LHCb_2011_Beam3500GeV_VeloClosed_MagDown_RealData_Reco14_Stripping21r1_LEPTONIC_MDST/file-indexes/LHCb_2011_Beam3500GeV_VeloClosed_MagDown_RealData_Reco14_Stripping21r1_LEPTONIC_MDST_file_index.txt"
       }

--- a/cernopendata/modules/fixtures/data/records/LHCb_2011_Beam3500GeV_VeloClosed_MagDown_RealData_Reco14_Stripping21r1_RADIATIVE_DST.json
+++ b/cernopendata/modules/fixtures/data/records/LHCb_2011_Beam3500GeV_VeloClosed_MagDown_RealData_Reco14_Stripping21r1_RADIATIVE_DST.json
@@ -36,14 +36,14 @@
         "uri": "root://eospublic.cern.ch//eos/opendata/lhcb/Collision11/RADIATIVE/LHCb_2011_Beam3500GeV_VeloClosed_MagDown_RealData_Reco14_Stripping21r1_RADIATIVE_DST/file-indexes/LHCb_2011_Beam3500GeV_VeloClosed_MagDown_RealData_Reco14_Stripping21r1_RADIATIVE_DST_LFNS.txt"
       },
       {
-        "checksum": "adler32:278e2d0a",
-        "size": 213277,
+        "checksum": "adler32:18a77063",
+        "size": 1089777,
         "type": "index.json",
         "uri": "root://eospublic.cern.ch//eos/opendata/lhcb/Collision11/RADIATIVE/LHCb_2011_Beam3500GeV_VeloClosed_MagDown_RealData_Reco14_Stripping21r1_RADIATIVE_DST/file-indexes/LHCb_2011_Beam3500GeV_VeloClosed_MagDown_RealData_Reco14_Stripping21r1_RADIATIVE_DST_file_index.json"
       },
       {
-        "checksum": "adler32:bf85c728",
-        "size": 127559,
+        "checksum": "adler32:9f6c733f",
+        "size": 652322,
         "type": "index.txt",
         "uri": "root://eospublic.cern.ch//eos/opendata/lhcb/Collision11/RADIATIVE/LHCb_2011_Beam3500GeV_VeloClosed_MagDown_RealData_Reco14_Stripping21r1_RADIATIVE_DST/file-indexes/LHCb_2011_Beam3500GeV_VeloClosed_MagDown_RealData_Reco14_Stripping21r1_RADIATIVE_DST_file_index.txt"
       }

--- a/cernopendata/modules/fixtures/data/records/LHCb_2011_Beam3500GeV_VeloClosed_MagDown_RealData_Reco14_Stripping21r1p1a_EW_DST.json
+++ b/cernopendata/modules/fixtures/data/records/LHCb_2011_Beam3500GeV_VeloClosed_MagDown_RealData_Reco14_Stripping21r1p1a_EW_DST.json
@@ -36,14 +36,14 @@
         "uri": "root://eospublic.cern.ch//eos/opendata/lhcb/Collision11/EW/LHCb_2011_Beam3500GeV_VeloClosed_MagDown_RealData_Reco14_Stripping21r1p1a_EW_DST/file-indexes/LHCb_2011_Beam3500GeV_VeloClosed_MagDown_RealData_Reco14_Stripping21r1p1a_EW_DST_LFNS.txt"
       },
       {
-        "checksum": "adler32:a966e7ec",
-        "size": 208239,
+        "checksum": "adler32:e978ac4a",
+        "size": 444860,
         "type": "index.json",
         "uri": "root://eospublic.cern.ch//eos/opendata/lhcb/Collision11/EW/LHCb_2011_Beam3500GeV_VeloClosed_MagDown_RealData_Reco14_Stripping21r1p1a_EW_DST/file-indexes/LHCb_2011_Beam3500GeV_VeloClosed_MagDown_RealData_Reco14_Stripping21r1p1a_EW_DST_file_index.json"
       },
       {
-        "checksum": "adler32:7787936e",
-        "size": 122718,
+        "checksum": "adler32:8ab5ccd0",
+        "size": 261907,
         "type": "index.txt",
         "uri": "root://eospublic.cern.ch//eos/opendata/lhcb/Collision11/EW/LHCb_2011_Beam3500GeV_VeloClosed_MagDown_RealData_Reco14_Stripping21r1p1a_EW_DST/file-indexes/LHCb_2011_Beam3500GeV_VeloClosed_MagDown_RealData_Reco14_Stripping21r1p1a_EW_DST_file_index.txt"
       }

--- a/cernopendata/modules/fixtures/data/records/LHCb_2011_Beam3500GeV_VeloClosed_MagDown_RealData_Reco14_Stripping21r1p1a_LEPTONIC_MDST.json
+++ b/cernopendata/modules/fixtures/data/records/LHCb_2011_Beam3500GeV_VeloClosed_MagDown_RealData_Reco14_Stripping21r1p1a_LEPTONIC_MDST.json
@@ -36,14 +36,14 @@
         "uri": "root://eospublic.cern.ch//eos/opendata/lhcb/Collision11/LEPTONIC/LHCb_2011_Beam3500GeV_VeloClosed_MagDown_RealData_Reco14_Stripping21r1p1a_LEPTONIC_MDST/file-indexes/LHCb_2011_Beam3500GeV_VeloClosed_MagDown_RealData_Reco14_Stripping21r1p1a_LEPTONIC_MDST_LFNS.txt"
       },
       {
-        "checksum": "adler32:39995263",
-        "size": 210776,
+        "checksum": "adler32:559e5195",
+        "size": 697312,
         "type": "index.json",
         "uri": "root://eospublic.cern.ch//eos/opendata/lhcb/Collision11/LEPTONIC/LHCb_2011_Beam3500GeV_VeloClosed_MagDown_RealData_Reco14_Stripping21r1p1a_LEPTONIC_MDST/file-indexes/LHCb_2011_Beam3500GeV_VeloClosed_MagDown_RealData_Reco14_Stripping21r1p1a_LEPTONIC_MDST_file_index.json"
       },
       {
-        "checksum": "adler32:29820fa9",
-        "size": 126429,
+        "checksum": "adler32:e76e0f55",
+        "size": 418080,
         "type": "index.txt",
         "uri": "root://eospublic.cern.ch//eos/opendata/lhcb/Collision11/LEPTONIC/LHCb_2011_Beam3500GeV_VeloClosed_MagDown_RealData_Reco14_Stripping21r1p1a_LEPTONIC_MDST/file-indexes/LHCb_2011_Beam3500GeV_VeloClosed_MagDown_RealData_Reco14_Stripping21r1p1a_LEPTONIC_MDST_file_index.txt"
       }

--- a/cernopendata/modules/fixtures/data/records/LHCb_2011_Beam3500GeV_VeloClosed_MagDown_RealData_Reco14_Stripping21r1p2_EW_DST.json
+++ b/cernopendata/modules/fixtures/data/records/LHCb_2011_Beam3500GeV_VeloClosed_MagDown_RealData_Reco14_Stripping21r1p2_EW_DST.json
@@ -36,14 +36,14 @@
         "uri": "root://eospublic.cern.ch//eos/opendata/lhcb/Collision11/EW/LHCb_2011_Beam3500GeV_VeloClosed_MagDown_RealData_Reco14_Stripping21r1p2_EW_DST/file-indexes/LHCb_2011_Beam3500GeV_VeloClosed_MagDown_RealData_Reco14_Stripping21r1p2_EW_DST_LFNS.txt"
       },
       {
-        "checksum": "adler32:2d46a13f",
-        "size": 158188,
+        "checksum": "adler32:cbc93cc0",
+        "size": 685684,
         "type": "index.json",
         "uri": "root://eospublic.cern.ch//eos/opendata/lhcb/Collision11/EW/LHCb_2011_Beam3500GeV_VeloClosed_MagDown_RealData_Reco14_Stripping21r1p2_EW_DST/file-indexes/LHCb_2011_Beam3500GeV_VeloClosed_MagDown_RealData_Reco14_Stripping21r1p2_EW_DST_file_index.json"
       },
       {
-        "checksum": "adler32:c89417a6",
-        "size": 92700,
+        "checksum": "adler32:a9567b0e",
+        "size": 401940,
         "type": "index.txt",
         "uri": "root://eospublic.cern.ch//eos/opendata/lhcb/Collision11/EW/LHCb_2011_Beam3500GeV_VeloClosed_MagDown_RealData_Reco14_Stripping21r1p2_EW_DST/file-indexes/LHCb_2011_Beam3500GeV_VeloClosed_MagDown_RealData_Reco14_Stripping21r1p2_EW_DST_file_index.txt"
       }

--- a/cernopendata/modules/fixtures/data/records/LHCb_2011_Beam3500GeV_VeloClosed_MagDown_RealData_Reco14_Stripping21r1p2_LEPTONIC_MDST.json
+++ b/cernopendata/modules/fixtures/data/records/LHCb_2011_Beam3500GeV_VeloClosed_MagDown_RealData_Reco14_Stripping21r1p2_LEPTONIC_MDST.json
@@ -36,14 +36,14 @@
         "uri": "root://eospublic.cern.ch//eos/opendata/lhcb/Collision11/LEPTONIC/LHCb_2011_Beam3500GeV_VeloClosed_MagDown_RealData_Reco14_Stripping21r1p2_LEPTONIC_MDST/file-indexes/LHCb_2011_Beam3500GeV_VeloClosed_MagDown_RealData_Reco14_Stripping21r1p2_LEPTONIC_MDST_LFNS.txt"
       },
       {
-        "checksum": "adler32:79fc64e2",
-        "size": 218619,
+        "checksum": "adler32:a197f750",
+        "size": 779482,
         "type": "index.json",
         "uri": "root://eospublic.cern.ch//eos/opendata/lhcb/Collision11/LEPTONIC/LHCb_2011_Beam3500GeV_VeloClosed_MagDown_RealData_Reco14_Stripping21r1p2_LEPTONIC_MDST/file-indexes/LHCb_2011_Beam3500GeV_VeloClosed_MagDown_RealData_Reco14_Stripping21r1p2_LEPTONIC_MDST_file_index.json"
       },
       {
-        "checksum": "adler32:3552ae99",
-        "size": 130800,
+        "checksum": "adler32:41324ebb",
+        "size": 466400,
         "type": "index.txt",
         "uri": "root://eospublic.cern.ch//eos/opendata/lhcb/Collision11/LEPTONIC/LHCb_2011_Beam3500GeV_VeloClosed_MagDown_RealData_Reco14_Stripping21r1p2_LEPTONIC_MDST/file-indexes/LHCb_2011_Beam3500GeV_VeloClosed_MagDown_RealData_Reco14_Stripping21r1p2_LEPTONIC_MDST_file_index.txt"
       }

--- a/cernopendata/modules/fixtures/data/records/LHCb_2011_Beam3500GeV_VeloClosed_MagUp_RealData_Reco14_Stripping21r1_EW_DST.json
+++ b/cernopendata/modules/fixtures/data/records/LHCb_2011_Beam3500GeV_VeloClosed_MagUp_RealData_Reco14_Stripping21r1_EW_DST.json
@@ -36,14 +36,14 @@
         "uri": "root://eospublic.cern.ch//eos/opendata/lhcb/Collision11/EW/LHCb_2011_Beam3500GeV_VeloClosed_MagUp_RealData_Reco14_Stripping21r1_EW_DST/file-indexes/LHCb_2011_Beam3500GeV_VeloClosed_MagUp_RealData_Reco14_Stripping21r1_EW_DST_LFNS.txt"
       },
       {
-        "checksum": "adler32:09374799",
-        "size": 292689,
+        "checksum": "adler32:762887a6",
+        "size": 1147218,
         "type": "index.json",
         "uri": "root://eospublic.cern.ch//eos/opendata/lhcb/Collision11/EW/LHCb_2011_Beam3500GeV_VeloClosed_MagUp_RealData_Reco14_Stripping21r1_EW_DST/file-indexes/LHCb_2011_Beam3500GeV_VeloClosed_MagUp_RealData_Reco14_Stripping21r1_EW_DST_file_index.json"
       },
       {
-        "checksum": "adler32:5e29129d",
-        "size": 170016,
+        "checksum": "adler32:5cccea37",
+        "size": 666688,
         "type": "index.txt",
         "uri": "root://eospublic.cern.ch//eos/opendata/lhcb/Collision11/EW/LHCb_2011_Beam3500GeV_VeloClosed_MagUp_RealData_Reco14_Stripping21r1_EW_DST/file-indexes/LHCb_2011_Beam3500GeV_VeloClosed_MagUp_RealData_Reco14_Stripping21r1_EW_DST_file_index.txt"
       }

--- a/cernopendata/modules/fixtures/data/records/LHCb_2011_Beam3500GeV_VeloClosed_MagUp_RealData_Reco14_Stripping21r1_LEPTONIC_MDST.json
+++ b/cernopendata/modules/fixtures/data/records/LHCb_2011_Beam3500GeV_VeloClosed_MagUp_RealData_Reco14_Stripping21r1_LEPTONIC_MDST.json
@@ -36,14 +36,14 @@
         "uri": "root://eospublic.cern.ch//eos/opendata/lhcb/Collision11/LEPTONIC/LHCb_2011_Beam3500GeV_VeloClosed_MagUp_RealData_Reco14_Stripping21r1_LEPTONIC_MDST/file-indexes/LHCb_2011_Beam3500GeV_VeloClosed_MagUp_RealData_Reco14_Stripping21r1_LEPTONIC_MDST_LFNS.txt"
       },
       {
-        "checksum": "adler32:4730f61c",
-        "size": 340725,
+        "checksum": "adler32:bcad584a",
+        "size": 1166559,
         "type": "index.json",
         "uri": "root://eospublic.cern.ch//eos/opendata/lhcb/Collision11/LEPTONIC/LHCb_2011_Beam3500GeV_VeloClosed_MagUp_RealData_Reco14_Stripping21r1_LEPTONIC_MDST/file-indexes/LHCb_2011_Beam3500GeV_VeloClosed_MagUp_RealData_Reco14_Stripping21r1_LEPTONIC_MDST_file_index.json"
       },
       {
-        "checksum": "adler32:ecd808dd",
-        "size": 202468,
+        "checksum": "adler32:1fbc51fc",
+        "size": 693448,
         "type": "index.txt",
         "uri": "root://eospublic.cern.ch//eos/opendata/lhcb/Collision11/LEPTONIC/LHCb_2011_Beam3500GeV_VeloClosed_MagUp_RealData_Reco14_Stripping21r1_LEPTONIC_MDST/file-indexes/LHCb_2011_Beam3500GeV_VeloClosed_MagUp_RealData_Reco14_Stripping21r1_LEPTONIC_MDST_file_index.txt"
       }

--- a/cernopendata/modules/fixtures/data/records/LHCb_2011_Beam3500GeV_VeloClosed_MagUp_RealData_Reco14_Stripping21r1p1a_EW_DST.json
+++ b/cernopendata/modules/fixtures/data/records/LHCb_2011_Beam3500GeV_VeloClosed_MagUp_RealData_Reco14_Stripping21r1p1a_EW_DST.json
@@ -36,14 +36,14 @@
         "uri": "root://eospublic.cern.ch//eos/opendata/lhcb/Collision11/EW/LHCb_2011_Beam3500GeV_VeloClosed_MagUp_RealData_Reco14_Stripping21r1p1a_EW_DST/file-indexes/LHCb_2011_Beam3500GeV_VeloClosed_MagUp_RealData_Reco14_Stripping21r1p1a_EW_DST_LFNS.txt"
       },
       {
-        "checksum": "adler32:6e2074d9",
-        "size": 143068,
+        "checksum": "adler32:4a4b8ef8",
+        "size": 348239,
         "type": "index.json",
         "uri": "root://eospublic.cern.ch//eos/opendata/lhcb/Collision11/EW/LHCb_2011_Beam3500GeV_VeloClosed_MagUp_RealData_Reco14_Stripping21r1p1a_EW_DST/file-indexes/LHCb_2011_Beam3500GeV_VeloClosed_MagUp_RealData_Reco14_Stripping21r1p1a_EW_DST_file_index.json"
       },
       {
-        "checksum": "adler32:cb3cdacb",
-        "size": 83951,
+        "checksum": "adler32:ec5a1fde",
+        "size": 204239,
         "type": "index.txt",
         "uri": "root://eospublic.cern.ch//eos/opendata/lhcb/Collision11/EW/LHCb_2011_Beam3500GeV_VeloClosed_MagUp_RealData_Reco14_Stripping21r1p1a_EW_DST/file-indexes/LHCb_2011_Beam3500GeV_VeloClosed_MagUp_RealData_Reco14_Stripping21r1p1a_EW_DST_file_index.txt"
       }

--- a/cernopendata/modules/fixtures/data/records/LHCb_2011_Beam3500GeV_VeloClosed_MagUp_RealData_Reco14_Stripping21r1p1a_LEPTONIC_MDST.json
+++ b/cernopendata/modules/fixtures/data/records/LHCb_2011_Beam3500GeV_VeloClosed_MagUp_RealData_Reco14_Stripping21r1p1a_LEPTONIC_MDST.json
@@ -36,14 +36,14 @@
         "uri": "root://eospublic.cern.ch//eos/opendata/lhcb/Collision11/LEPTONIC/LHCb_2011_Beam3500GeV_VeloClosed_MagUp_RealData_Reco14_Stripping21r1p1a_LEPTONIC_MDST/file-indexes/LHCb_2011_Beam3500GeV_VeloClosed_MagUp_RealData_Reco14_Stripping21r1p1a_LEPTONIC_MDST_LFNS.txt"
       },
       {
-        "checksum": "adler32:d13c1162",
-        "size": 143532,
+        "checksum": "adler32:3d9644aa",
+        "size": 500440,
         "type": "index.json",
         "uri": "root://eospublic.cern.ch//eos/opendata/lhcb/Collision11/LEPTONIC/LHCb_2011_Beam3500GeV_VeloClosed_MagUp_RealData_Reco14_Stripping21r1p1a_LEPTONIC_MDST/file-indexes/LHCb_2011_Beam3500GeV_VeloClosed_MagUp_RealData_Reco14_Stripping21r1p1a_LEPTONIC_MDST_file_index.json"
       },
       {
-        "checksum": "adler32:aeabb721",
-        "size": 85769,
+        "checksum": "adler32:bd6cb2ae",
+        "size": 299097,
         "type": "index.txt",
         "uri": "root://eospublic.cern.ch//eos/opendata/lhcb/Collision11/LEPTONIC/LHCb_2011_Beam3500GeV_VeloClosed_MagUp_RealData_Reco14_Stripping21r1p1a_LEPTONIC_MDST/file-indexes/LHCb_2011_Beam3500GeV_VeloClosed_MagUp_RealData_Reco14_Stripping21r1p1a_LEPTONIC_MDST_file_index.txt"
       }

--- a/cernopendata/modules/fixtures/data/records/LHCb_2011_Beam3500GeV_VeloClosed_MagUp_RealData_Reco14_Stripping21r1p2_EW_DST.json
+++ b/cernopendata/modules/fixtures/data/records/LHCb_2011_Beam3500GeV_VeloClosed_MagUp_RealData_Reco14_Stripping21r1p2_EW_DST.json
@@ -36,14 +36,14 @@
         "uri": "root://eospublic.cern.ch//eos/opendata/lhcb/Collision11/EW/LHCb_2011_Beam3500GeV_VeloClosed_MagUp_RealData_Reco14_Stripping21r1p2_EW_DST/file-indexes/LHCb_2011_Beam3500GeV_VeloClosed_MagUp_RealData_Reco14_Stripping21r1p2_EW_DST_LFNS.txt"
       },
       {
-        "checksum": "adler32:f333674b",
-        "size": 114686,
+        "checksum": "adler32:63e6715b",
+        "size": 528868,
         "type": "index.json",
         "uri": "root://eospublic.cern.ch//eos/opendata/lhcb/Collision11/EW/LHCb_2011_Beam3500GeV_VeloClosed_MagUp_RealData_Reco14_Stripping21r1p2_EW_DST/file-indexes/LHCb_2011_Beam3500GeV_VeloClosed_MagUp_RealData_Reco14_Stripping21r1p2_EW_DST_file_index.json"
       },
       {
-        "checksum": "adler32:924f87ae",
-        "size": 66928,
+        "checksum": "adler32:90498ca3",
+        "size": 308830,
         "type": "index.txt",
         "uri": "root://eospublic.cern.ch//eos/opendata/lhcb/Collision11/EW/LHCb_2011_Beam3500GeV_VeloClosed_MagUp_RealData_Reco14_Stripping21r1p2_EW_DST/file-indexes/LHCb_2011_Beam3500GeV_VeloClosed_MagUp_RealData_Reco14_Stripping21r1p2_EW_DST_file_index.txt"
       }

--- a/cernopendata/modules/fixtures/data/records/LHCb_2011_Beam3500GeV_VeloClosed_MagUp_RealData_Reco14_Stripping21r1p2_LEPTONIC_MDST.json
+++ b/cernopendata/modules/fixtures/data/records/LHCb_2011_Beam3500GeV_VeloClosed_MagUp_RealData_Reco14_Stripping21r1p2_LEPTONIC_MDST.json
@@ -36,14 +36,14 @@
         "uri": "root://eospublic.cern.ch//eos/opendata/lhcb/Collision11/LEPTONIC/LHCb_2011_Beam3500GeV_VeloClosed_MagUp_RealData_Reco14_Stripping21r1p2_LEPTONIC_MDST/file-indexes/LHCb_2011_Beam3500GeV_VeloClosed_MagUp_RealData_Reco14_Stripping21r1p2_LEPTONIC_MDST_LFNS.txt"
       },
       {
-        "checksum": "adler32:cf23df8e",
-        "size": 160066,
+        "checksum": "adler32:f6af19c7",
+        "size": 591587,
         "type": "index.json",
         "uri": "root://eospublic.cern.ch//eos/opendata/lhcb/Collision11/LEPTONIC/LHCb_2011_Beam3500GeV_VeloClosed_MagUp_RealData_Reco14_Stripping21r1p2_LEPTONIC_MDST/file-indexes/LHCb_2011_Beam3500GeV_VeloClosed_MagUp_RealData_Reco14_Stripping21r1p2_LEPTONIC_MDST_file_index.json"
       },
       {
-        "checksum": "adler32:3fe2cb3f",
-        "size": 95436,
+        "checksum": "adler32:d767fe37",
+        "size": 352836,
         "type": "index.txt",
         "uri": "root://eospublic.cern.ch//eos/opendata/lhcb/Collision11/LEPTONIC/LHCb_2011_Beam3500GeV_VeloClosed_MagUp_RealData_Reco14_Stripping21r1p2_LEPTONIC_MDST/file-indexes/LHCb_2011_Beam3500GeV_VeloClosed_MagUp_RealData_Reco14_Stripping21r1p2_LEPTONIC_MDST_file_index.txt"
       }

--- a/cernopendata/modules/fixtures/data/records/LHCb_2012_Beam4000GeV_VeloClosed_MagDown_RealData_Reco14_Stripping21_EW_DST.json
+++ b/cernopendata/modules/fixtures/data/records/LHCb_2012_Beam4000GeV_VeloClosed_MagDown_RealData_Reco14_Stripping21_EW_DST.json
@@ -36,14 +36,14 @@
         "uri": "root://eospublic.cern.ch//eos/opendata/lhcb/Collision12/EW/LHCb_2012_Beam4000GeV_VeloClosed_MagDown_RealData_Reco14_Stripping21_EW_DST/file-indexes/LHCb_2012_Beam4000GeV_VeloClosed_MagDown_RealData_Reco14_Stripping21_EW_DST_LFNS.txt"
       },
       {
-        "checksum": "adler32:e7f79f02",
-        "size": 432009,
+        "checksum": "adler32:41b3f944",
+        "size": 1764992,
         "type": "index.json",
         "uri": "root://eospublic.cern.ch//eos/opendata/lhcb/Collision12/EW/LHCb_2012_Beam4000GeV_VeloClosed_MagDown_RealData_Reco14_Stripping21_EW_DST/file-indexes/LHCb_2012_Beam4000GeV_VeloClosed_MagDown_RealData_Reco14_Stripping21_EW_DST_file_index.json"
       },
       {
-        "checksum": "adler32:885d20af",
-        "size": 250272,
+        "checksum": "adler32:00334371",
+        "size": 1022736,
         "type": "index.txt",
         "uri": "root://eospublic.cern.ch//eos/opendata/lhcb/Collision12/EW/LHCb_2012_Beam4000GeV_VeloClosed_MagDown_RealData_Reco14_Stripping21_EW_DST/file-indexes/LHCb_2012_Beam4000GeV_VeloClosed_MagDown_RealData_Reco14_Stripping21_EW_DST_file_index.txt"
       }

--- a/cernopendata/modules/fixtures/data/records/LHCb_2012_Beam4000GeV_VeloClosed_MagDown_RealData_Reco14_Stripping21_LEPTONIC_MDST.json
+++ b/cernopendata/modules/fixtures/data/records/LHCb_2012_Beam4000GeV_VeloClosed_MagDown_RealData_Reco14_Stripping21_LEPTONIC_MDST.json
@@ -36,14 +36,14 @@
         "uri": "root://eospublic.cern.ch//eos/opendata/lhcb/Collision12/LEPTONIC/LHCb_2012_Beam4000GeV_VeloClosed_MagDown_RealData_Reco14_Stripping21_LEPTONIC_MDST/file-indexes/LHCb_2012_Beam4000GeV_VeloClosed_MagDown_RealData_Reco14_Stripping21_LEPTONIC_MDST_LFNS.txt"
       },
       {
-        "checksum": "adler32:e9161eee",
-        "size": 408841,
+        "checksum": "adler32:99c35999",
+        "size": 1777851,
         "type": "index.json",
         "uri": "root://eospublic.cern.ch//eos/opendata/lhcb/Collision12/LEPTONIC/LHCb_2012_Beam4000GeV_VeloClosed_MagDown_RealData_Reco14_Stripping21_LEPTONIC_MDST/file-indexes/LHCb_2012_Beam4000GeV_VeloClosed_MagDown_RealData_Reco14_Stripping21_LEPTONIC_MDST_file_index.json"
       },
       {
-        "checksum": "adler32:570ac55e",
-        "size": 242256,
+        "checksum": "adler32:af083773",
+        "size": 1053696,
         "type": "index.txt",
         "uri": "root://eospublic.cern.ch//eos/opendata/lhcb/Collision12/LEPTONIC/LHCb_2012_Beam4000GeV_VeloClosed_MagDown_RealData_Reco14_Stripping21_LEPTONIC_MDST/file-indexes/LHCb_2012_Beam4000GeV_VeloClosed_MagDown_RealData_Reco14_Stripping21_LEPTONIC_MDST_file_index.txt"
       }

--- a/cernopendata/modules/fixtures/data/records/LHCb_2012_Beam4000GeV_VeloClosed_MagDown_RealData_Reco14_Stripping21_RADIATIVE_DST.json
+++ b/cernopendata/modules/fixtures/data/records/LHCb_2012_Beam4000GeV_VeloClosed_MagDown_RealData_Reco14_Stripping21_RADIATIVE_DST.json
@@ -36,14 +36,14 @@
         "uri": "root://eospublic.cern.ch//eos/opendata/lhcb/Collision12/RADIATIVE/LHCb_2012_Beam4000GeV_VeloClosed_MagDown_RealData_Reco14_Stripping21_RADIATIVE_DST/file-indexes/LHCb_2012_Beam4000GeV_VeloClosed_MagDown_RealData_Reco14_Stripping21_RADIATIVE_DST_LFNS.txt"
       },
       {
-        "checksum": "adler32:f3632b64",
-        "size": 244961,
+        "checksum": "adler32:ca75b515",
+        "size": 1157386,
         "type": "index.json",
         "uri": "root://eospublic.cern.ch//eos/opendata/lhcb/Collision12/RADIATIVE/LHCb_2012_Beam4000GeV_VeloClosed_MagDown_RealData_Reco14_Stripping21_RADIATIVE_DST/file-indexes/LHCb_2012_Beam4000GeV_VeloClosed_MagDown_RealData_Reco14_Stripping21_RADIATIVE_DST_file_index.json"
       },
       {
-        "checksum": "adler32:2e757b37",
-        "size": 145583,
+        "checksum": "adler32:bc73b474",
+        "size": 687924,
         "type": "index.txt",
         "uri": "root://eospublic.cern.ch//eos/opendata/lhcb/Collision12/RADIATIVE/LHCb_2012_Beam4000GeV_VeloClosed_MagDown_RealData_Reco14_Stripping21_RADIATIVE_DST/file-indexes/LHCb_2012_Beam4000GeV_VeloClosed_MagDown_RealData_Reco14_Stripping21_RADIATIVE_DST_file_index.txt"
       }

--- a/cernopendata/modules/fixtures/data/records/LHCb_2012_Beam4000GeV_VeloClosed_MagDown_RealData_Reco14_Stripping21r0p1a_EW_DST.json
+++ b/cernopendata/modules/fixtures/data/records/LHCb_2012_Beam4000GeV_VeloClosed_MagDown_RealData_Reco14_Stripping21r0p1a_EW_DST.json
@@ -36,14 +36,14 @@
         "uri": "root://eospublic.cern.ch//eos/opendata/lhcb/Collision12/EW/LHCb_2012_Beam4000GeV_VeloClosed_MagDown_RealData_Reco14_Stripping21r0p1a_EW_DST/file-indexes/LHCb_2012_Beam4000GeV_VeloClosed_MagDown_RealData_Reco14_Stripping21r0p1a_EW_DST_LFNS.txt"
       },
       {
-        "checksum": "adler32:d423d190",
-        "size": 201802,
+        "checksum": "adler32:2489c312",
+        "size": 612322,
         "type": "index.json",
         "uri": "root://eospublic.cern.ch//eos/opendata/lhcb/Collision12/EW/LHCb_2012_Beam4000GeV_VeloClosed_MagDown_RealData_Reco14_Stripping21r0p1a_EW_DST/file-indexes/LHCb_2012_Beam4000GeV_VeloClosed_MagDown_RealData_Reco14_Stripping21r0p1a_EW_DST_file_index.json"
       },
       {
-        "checksum": "adler32:c193b61a",
-        "size": 118736,
+        "checksum": "adler32:b3681035",
+        "size": 360371,
         "type": "index.txt",
         "uri": "root://eospublic.cern.ch//eos/opendata/lhcb/Collision12/EW/LHCb_2012_Beam4000GeV_VeloClosed_MagDown_RealData_Reco14_Stripping21r0p1a_EW_DST/file-indexes/LHCb_2012_Beam4000GeV_VeloClosed_MagDown_RealData_Reco14_Stripping21r0p1a_EW_DST_file_index.txt"
       }

--- a/cernopendata/modules/fixtures/data/records/LHCb_2012_Beam4000GeV_VeloClosed_MagDown_RealData_Reco14_Stripping21r0p1a_LEPTONIC_MDST.json
+++ b/cernopendata/modules/fixtures/data/records/LHCb_2012_Beam4000GeV_VeloClosed_MagDown_RealData_Reco14_Stripping21r0p1a_LEPTONIC_MDST.json
@@ -36,14 +36,14 @@
         "uri": "root://eospublic.cern.ch//eos/opendata/lhcb/Collision12/LEPTONIC/LHCb_2012_Beam4000GeV_VeloClosed_MagDown_RealData_Reco14_Stripping21r0p1a_LEPTONIC_MDST/file-indexes/LHCb_2012_Beam4000GeV_VeloClosed_MagDown_RealData_Reco14_Stripping21r0p1a_LEPTONIC_MDST_LFNS.txt"
       },
       {
-        "checksum": "adler32:4ccd62f0",
-        "size": 351447,
+        "checksum": "adler32:333e2697",
+        "size": 1408505,
         "type": "index.json",
         "uri": "root://eospublic.cern.ch//eos/opendata/lhcb/Collision12/LEPTONIC/LHCb_2012_Beam4000GeV_VeloClosed_MagDown_RealData_Reco14_Stripping21r0p1a_LEPTONIC_MDST/file-indexes/LHCb_2012_Beam4000GeV_VeloClosed_MagDown_RealData_Reco14_Stripping21r0p1a_LEPTONIC_MDST_file_index.json"
       },
       {
-        "checksum": "adler32:9df3f380",
-        "size": 210447,
+        "checksum": "adler32:da67f6fc",
+        "size": 843999,
         "type": "index.txt",
         "uri": "root://eospublic.cern.ch//eos/opendata/lhcb/Collision12/LEPTONIC/LHCb_2012_Beam4000GeV_VeloClosed_MagDown_RealData_Reco14_Stripping21r0p1a_LEPTONIC_MDST/file-indexes/LHCb_2012_Beam4000GeV_VeloClosed_MagDown_RealData_Reco14_Stripping21r0p1a_LEPTONIC_MDST_file_index.txt"
       }

--- a/cernopendata/modules/fixtures/data/records/LHCb_2012_Beam4000GeV_VeloClosed_MagDown_RealData_Reco14_Stripping21r0p2_EW_DST.json
+++ b/cernopendata/modules/fixtures/data/records/LHCb_2012_Beam4000GeV_VeloClosed_MagDown_RealData_Reco14_Stripping21r0p2_EW_DST.json
@@ -36,14 +36,14 @@
         "uri": "root://eospublic.cern.ch//eos/opendata/lhcb/Collision12/EW/LHCb_2012_Beam4000GeV_VeloClosed_MagDown_RealData_Reco14_Stripping21r0p2_EW_DST/file-indexes/LHCb_2012_Beam4000GeV_VeloClosed_MagDown_RealData_Reco14_Stripping21r0p2_EW_DST_LFNS.txt"
       },
       {
-        "checksum": "adler32:a5174f30",
-        "size": 350848,
+        "checksum": "adler32:d7823f3a",
+        "size": 1279874,
         "type": "index.json",
         "uri": "root://eospublic.cern.ch//eos/opendata/lhcb/Collision12/EW/LHCb_2012_Beam4000GeV_VeloClosed_MagDown_RealData_Reco14_Stripping21r0p2_EW_DST/file-indexes/LHCb_2012_Beam4000GeV_VeloClosed_MagDown_RealData_Reco14_Stripping21r0p2_EW_DST_file_index.json"
       },
       {
-        "checksum": "adler32:ee58d678",
-        "size": 205380,
+        "checksum": "adler32:118c50ac",
+        "size": 749700,
         "type": "index.txt",
         "uri": "root://eospublic.cern.ch//eos/opendata/lhcb/Collision12/EW/LHCb_2012_Beam4000GeV_VeloClosed_MagDown_RealData_Reco14_Stripping21r0p2_EW_DST/file-indexes/LHCb_2012_Beam4000GeV_VeloClosed_MagDown_RealData_Reco14_Stripping21r0p2_EW_DST_file_index.txt"
       }

--- a/cernopendata/modules/fixtures/data/records/LHCb_2012_Beam4000GeV_VeloClosed_MagDown_RealData_Reco14_Stripping21r0p2_LEPTONIC_MDST.json
+++ b/cernopendata/modules/fixtures/data/records/LHCb_2012_Beam4000GeV_VeloClosed_MagDown_RealData_Reco14_Stripping21r0p2_LEPTONIC_MDST.json
@@ -36,14 +36,14 @@
         "uri": "root://eospublic.cern.ch//eos/opendata/lhcb/Collision12/LEPTONIC/LHCb_2012_Beam4000GeV_VeloClosed_MagDown_RealData_Reco14_Stripping21r0p2_LEPTONIC_MDST/file-indexes/LHCb_2012_Beam4000GeV_VeloClosed_MagDown_RealData_Reco14_Stripping21r0p2_LEPTONIC_MDST_LFNS.txt"
       },
       {
-        "checksum": "adler32:2a00aa85",
-        "size": 415903,
+        "checksum": "adler32:c3084a65",
+        "size": 1608654,
         "type": "index.json",
         "uri": "root://eospublic.cern.ch//eos/opendata/lhcb/Collision12/LEPTONIC/LHCb_2012_Beam4000GeV_VeloClosed_MagDown_RealData_Reco14_Stripping21r0p2_LEPTONIC_MDST/file-indexes/LHCb_2012_Beam4000GeV_VeloClosed_MagDown_RealData_Reco14_Stripping21r0p2_LEPTONIC_MDST_file_index.json"
       },
       {
-        "checksum": "adler32:b04295a7",
-        "size": 248600,
+        "checksum": "adler32:70a67bc5",
+        "size": 962000,
         "type": "index.txt",
         "uri": "root://eospublic.cern.ch//eos/opendata/lhcb/Collision12/LEPTONIC/LHCb_2012_Beam4000GeV_VeloClosed_MagDown_RealData_Reco14_Stripping21r0p2_LEPTONIC_MDST/file-indexes/LHCb_2012_Beam4000GeV_VeloClosed_MagDown_RealData_Reco14_Stripping21r0p2_LEPTONIC_MDST_file_index.txt"
       }

--- a/cernopendata/modules/fixtures/data/records/LHCb_2012_Beam4000GeV_VeloClosed_MagUp_RealData_Reco14_Stripping21_EW_DST.json
+++ b/cernopendata/modules/fixtures/data/records/LHCb_2012_Beam4000GeV_VeloClosed_MagUp_RealData_Reco14_Stripping21_EW_DST.json
@@ -36,14 +36,14 @@
         "uri": "root://eospublic.cern.ch//eos/opendata/lhcb/Collision12/EW/LHCb_2012_Beam4000GeV_VeloClosed_MagUp_RealData_Reco14_Stripping21_EW_DST/file-indexes/LHCb_2012_Beam4000GeV_VeloClosed_MagUp_RealData_Reco14_Stripping21_EW_DST_LFNS.txt"
       },
       {
-        "checksum": "adler32:faf49e23",
-        "size": 299893,
+        "checksum": "adler32:b02656f9",
+        "size": 1881754,
         "type": "index.json",
         "uri": "root://eospublic.cern.ch//eos/opendata/lhcb/Collision12/EW/LHCb_2012_Beam4000GeV_VeloClosed_MagUp_RealData_Reco14_Stripping21_EW_DST/file-indexes/LHCb_2012_Beam4000GeV_VeloClosed_MagUp_RealData_Reco14_Stripping21_EW_DST_file_index.json"
       },
       {
-        "checksum": "adler32:a790a012",
-        "size": 172956,
+        "checksum": "adler32:d2c61d86",
+        "size": 1085586,
         "type": "index.txt",
         "uri": "root://eospublic.cern.ch//eos/opendata/lhcb/Collision12/EW/LHCb_2012_Beam4000GeV_VeloClosed_MagUp_RealData_Reco14_Stripping21_EW_DST/file-indexes/LHCb_2012_Beam4000GeV_VeloClosed_MagUp_RealData_Reco14_Stripping21_EW_DST_file_index.txt"
       }

--- a/cernopendata/modules/fixtures/data/records/LHCb_2012_Beam4000GeV_VeloClosed_MagUp_RealData_Reco14_Stripping21_LEPTONIC_MDST.json
+++ b/cernopendata/modules/fixtures/data/records/LHCb_2012_Beam4000GeV_VeloClosed_MagUp_RealData_Reco14_Stripping21_LEPTONIC_MDST.json
@@ -36,14 +36,14 @@
         "uri": "root://eospublic.cern.ch//eos/opendata/lhcb/Collision12/LEPTONIC/LHCb_2012_Beam4000GeV_VeloClosed_MagUp_RealData_Reco14_Stripping21_LEPTONIC_MDST/file-indexes/LHCb_2012_Beam4000GeV_VeloClosed_MagUp_RealData_Reco14_Stripping21_LEPTONIC_MDST_LFNS.txt"
       },
       {
-        "checksum": "adler32:2b358945",
-        "size": 434879,
+        "checksum": "adler32:d09fe6ec",
+        "size": 1940816,
         "type": "index.json",
         "uri": "root://eospublic.cern.ch//eos/opendata/lhcb/Collision12/LEPTONIC/LHCb_2012_Beam4000GeV_VeloClosed_MagUp_RealData_Reco14_Stripping21_LEPTONIC_MDST/file-indexes/LHCb_2012_Beam4000GeV_VeloClosed_MagUp_RealData_Reco14_Stripping21_LEPTONIC_MDST_file_index.json"
       },
       {
-        "checksum": "adler32:ff50dfea",
-        "size": 256662,
+        "checksum": "adler32:d5a7d180",
+        "size": 1145958,
         "type": "index.txt",
         "uri": "root://eospublic.cern.ch//eos/opendata/lhcb/Collision12/LEPTONIC/LHCb_2012_Beam4000GeV_VeloClosed_MagUp_RealData_Reco14_Stripping21_LEPTONIC_MDST/file-indexes/LHCb_2012_Beam4000GeV_VeloClosed_MagUp_RealData_Reco14_Stripping21_LEPTONIC_MDST_file_index.txt"
       }

--- a/cernopendata/modules/fixtures/data/records/LHCb_2012_Beam4000GeV_VeloClosed_MagUp_RealData_Reco14_Stripping21_RADIATIVE_DST.json
+++ b/cernopendata/modules/fixtures/data/records/LHCb_2012_Beam4000GeV_VeloClosed_MagUp_RealData_Reco14_Stripping21_RADIATIVE_DST.json
@@ -36,14 +36,14 @@
         "uri": "root://eospublic.cern.ch//eos/opendata/lhcb/Collision12/RADIATIVE/LHCb_2012_Beam4000GeV_VeloClosed_MagUp_RealData_Reco14_Stripping21_RADIATIVE_DST/file-indexes/LHCb_2012_Beam4000GeV_VeloClosed_MagUp_RealData_Reco14_Stripping21_RADIATIVE_DST_LFNS.txt"
       },
       {
-        "checksum": "adler32:70c16d15",
-        "size": 316175,
+        "checksum": "adler32:c0a2682c",
+        "size": 1349222,
         "type": "index.json",
         "uri": "root://eospublic.cern.ch//eos/opendata/lhcb/Collision12/RADIATIVE/LHCb_2012_Beam4000GeV_VeloClosed_MagUp_RealData_Reco14_Stripping21_RADIATIVE_DST/file-indexes/LHCb_2012_Beam4000GeV_VeloClosed_MagUp_RealData_Reco14_Stripping21_RADIATIVE_DST_file_index.json"
       },
       {
-        "checksum": "adler32:001fe9ec",
-        "size": 187200,
+        "checksum": "adler32:87f2f22a",
+        "size": 799110,
         "type": "index.txt",
         "uri": "root://eospublic.cern.ch//eos/opendata/lhcb/Collision12/RADIATIVE/LHCb_2012_Beam4000GeV_VeloClosed_MagUp_RealData_Reco14_Stripping21_RADIATIVE_DST/file-indexes/LHCb_2012_Beam4000GeV_VeloClosed_MagUp_RealData_Reco14_Stripping21_RADIATIVE_DST_file_index.txt"
       }

--- a/cernopendata/modules/fixtures/data/records/LHCb_2012_Beam4000GeV_VeloClosed_MagUp_RealData_Reco14_Stripping21r0p1a_EW_DST.json
+++ b/cernopendata/modules/fixtures/data/records/LHCb_2012_Beam4000GeV_VeloClosed_MagUp_RealData_Reco14_Stripping21r0p1a_EW_DST.json
@@ -36,14 +36,14 @@
         "uri": "root://eospublic.cern.ch//eos/opendata/lhcb/Collision12/EW/LHCb_2012_Beam4000GeV_VeloClosed_MagUp_RealData_Reco14_Stripping21r0p1a_EW_DST/file-indexes/LHCb_2012_Beam4000GeV_VeloClosed_MagUp_RealData_Reco14_Stripping21r0p1a_EW_DST_LFNS.txt"
       },
       {
-        "checksum": "adler32:23657c46",
-        "size": 201388,
+        "checksum": "adler32:8f69711e",
+        "size": 557621,
         "type": "index.json",
         "uri": "root://eospublic.cern.ch//eos/opendata/lhcb/Collision12/EW/LHCb_2012_Beam4000GeV_VeloClosed_MagUp_RealData_Reco14_Stripping21r0p1a_EW_DST/file-indexes/LHCb_2012_Beam4000GeV_VeloClosed_MagUp_RealData_Reco14_Stripping21r0p1a_EW_DST_file_index.json"
       },
       {
-        "checksum": "adler32:be70231d",
-        "size": 117961,
+        "checksum": "adler32:278164c1",
+        "size": 326496,
         "type": "index.txt",
         "uri": "root://eospublic.cern.ch//eos/opendata/lhcb/Collision12/EW/LHCb_2012_Beam4000GeV_VeloClosed_MagUp_RealData_Reco14_Stripping21r0p1a_EW_DST/file-indexes/LHCb_2012_Beam4000GeV_VeloClosed_MagUp_RealData_Reco14_Stripping21r0p1a_EW_DST_file_index.txt"
       }

--- a/cernopendata/modules/fixtures/data/records/LHCb_2012_Beam4000GeV_VeloClosed_MagUp_RealData_Reco14_Stripping21r0p1a_LEPTONIC_MDST.json
+++ b/cernopendata/modules/fixtures/data/records/LHCb_2012_Beam4000GeV_VeloClosed_MagUp_RealData_Reco14_Stripping21r0p1a_LEPTONIC_MDST.json
@@ -36,14 +36,14 @@
         "uri": "root://eospublic.cern.ch//eos/opendata/lhcb/Collision12/LEPTONIC/LHCb_2012_Beam4000GeV_VeloClosed_MagUp_RealData_Reco14_Stripping21r0p1a_LEPTONIC_MDST/file-indexes/LHCb_2012_Beam4000GeV_VeloClosed_MagUp_RealData_Reco14_Stripping21r0p1a_LEPTONIC_MDST_LFNS.txt"
       },
       {
-        "checksum": "adler32:81341f01",
-        "size": 338308,
+        "checksum": "adler32:8296232e",
+        "size": 1342695,
         "type": "index.json",
         "uri": "root://eospublic.cern.ch//eos/opendata/lhcb/Collision12/LEPTONIC/LHCb_2012_Beam4000GeV_VeloClosed_MagUp_RealData_Reco14_Stripping21r0p1a_LEPTONIC_MDST/file-indexes/LHCb_2012_Beam4000GeV_VeloClosed_MagUp_RealData_Reco14_Stripping21r0p1a_LEPTONIC_MDST_file_index.json"
       },
       {
-        "checksum": "adler32:aa4a1d44",
-        "size": 201786,
+        "checksum": "adler32:6fc427c7",
+        "size": 800975,
         "type": "index.txt",
         "uri": "root://eospublic.cern.ch//eos/opendata/lhcb/Collision12/LEPTONIC/LHCb_2012_Beam4000GeV_VeloClosed_MagUp_RealData_Reco14_Stripping21r0p1a_LEPTONIC_MDST/file-indexes/LHCb_2012_Beam4000GeV_VeloClosed_MagUp_RealData_Reco14_Stripping21r0p1a_LEPTONIC_MDST_file_index.txt"
       }

--- a/cernopendata/modules/fixtures/data/records/LHCb_2012_Beam4000GeV_VeloClosed_MagUp_RealData_Reco14_Stripping21r0p2_EW_DST.json
+++ b/cernopendata/modules/fixtures/data/records/LHCb_2012_Beam4000GeV_VeloClosed_MagUp_RealData_Reco14_Stripping21r0p2_EW_DST.json
@@ -36,14 +36,14 @@
         "uri": "root://eospublic.cern.ch//eos/opendata/lhcb/Collision12/EW/LHCb_2012_Beam4000GeV_VeloClosed_MagUp_RealData_Reco14_Stripping21r0p2_EW_DST/file-indexes/LHCb_2012_Beam4000GeV_VeloClosed_MagUp_RealData_Reco14_Stripping21r0p2_EW_DST_LFNS.txt"
       },
       {
-        "checksum": "adler32:e3875945",
-        "size": 409150,
+        "checksum": "adler32:a007951e",
+        "size": 1256166,
         "type": "index.json",
         "uri": "root://eospublic.cern.ch//eos/opendata/lhcb/Collision12/EW/LHCb_2012_Beam4000GeV_VeloClosed_MagUp_RealData_Reco14_Stripping21r0p2_EW_DST/file-indexes/LHCb_2012_Beam4000GeV_VeloClosed_MagUp_RealData_Reco14_Stripping21r0p2_EW_DST_file_index.json"
       },
       {
-        "checksum": "adler32:af293d86",
-        "size": 238520,
+        "checksum": "adler32:0210b42a",
+        "size": 732114,
         "type": "index.txt",
         "uri": "root://eospublic.cern.ch//eos/opendata/lhcb/Collision12/EW/LHCb_2012_Beam4000GeV_VeloClosed_MagUp_RealData_Reco14_Stripping21r0p2_EW_DST/file-indexes/LHCb_2012_Beam4000GeV_VeloClosed_MagUp_RealData_Reco14_Stripping21r0p2_EW_DST_file_index.txt"
       }

--- a/cernopendata/modules/fixtures/data/records/LHCb_2012_Beam4000GeV_VeloClosed_MagUp_RealData_Reco14_Stripping21r0p2_LEPTONIC_MDST.json
+++ b/cernopendata/modules/fixtures/data/records/LHCb_2012_Beam4000GeV_VeloClosed_MagUp_RealData_Reco14_Stripping21r0p2_LEPTONIC_MDST.json
@@ -36,14 +36,14 @@
         "uri": "root://eospublic.cern.ch//eos/opendata/lhcb/Collision12/LEPTONIC/LHCb_2012_Beam4000GeV_VeloClosed_MagUp_RealData_Reco14_Stripping21r0p2_LEPTONIC_MDST/file-indexes/LHCb_2012_Beam4000GeV_VeloClosed_MagUp_RealData_Reco14_Stripping21r0p2_LEPTONIC_MDST_LFNS.txt"
       },
       {
-        "checksum": "adler32:91d8af1b",
-        "size": 482827,
+        "checksum": "adler32:2e744a77",
+        "size": 1601651,
         "type": "index.json",
         "uri": "root://eospublic.cern.ch//eos/opendata/lhcb/Collision12/LEPTONIC/LHCb_2012_Beam4000GeV_VeloClosed_MagUp_RealData_Reco14_Stripping21r0p2_LEPTONIC_MDST/file-indexes/LHCb_2012_Beam4000GeV_VeloClosed_MagUp_RealData_Reco14_Stripping21r0p2_LEPTONIC_MDST_file_index.json"
       },
       {
-        "checksum": "adler32:99dc60a7",
-        "size": 287496,
+        "checksum": "adler32:7a34bb77",
+        "size": 953568,
         "type": "index.txt",
         "uri": "root://eospublic.cern.ch//eos/opendata/lhcb/Collision12/LEPTONIC/LHCb_2012_Beam4000GeV_VeloClosed_MagUp_RealData_Reco14_Stripping21r0p2_LEPTONIC_MDST/file-indexes/LHCb_2012_Beam4000GeV_VeloClosed_MagUp_RealData_Reco14_Stripping21r0p2_LEPTONIC_MDST_file_index.txt"
       }


### PR DESCRIPTION
Updates LHCb 2011 2012 dataset file indexes after all the files were transferred for the public release.