### PR TITLE
nginx: 1.22-perl

### DIFF
--- a/elasticsearch-proxy/Dockerfile
+++ b/elasticsearch-proxy/Dockerfile
@@ -1,7 +1,7 @@
 # -*- coding: utf-8 -*-
 #
 # This file is part of CERN Open Data Portal.
-# Copyright (C) 2017 CERN.
+# Copyright (C) 2017, 2022 CERN.
 #
 # CERN Open Data Portal is free software; you can redistribute it
 # and/or modify it under the terms of the GNU General Public License as
@@ -22,7 +22,7 @@
 # waive the privileges and immunities granted to it by virtue of its status
 # as an Intergovernmental Organization or submit itself to any jurisdiction.
 
-FROM nginx
+FROM nginx:1.22
 
 RUN rm /etc/nginx/conf.d/default.conf
 ADD nginx.conf /etc/nginx/conf.d/

--- a/nginx/Dockerfile
+++ b/nginx/Dockerfile
@@ -1,7 +1,7 @@
 # -*- coding: utf-8 -*-
 #
 # This file is part of CERN Open Data Portal.
-# Copyright (C) 2016 CERN.
+# Copyright (C) 2016, 2022 CERN.
 #
 # CERN Open Data Portal is free software; you can redistribute it
 # and/or modify it under the terms of the GNU General Public License as
@@ -22,7 +22,7 @@
 # waive the privileges and immunities granted to it by virtue of its status
 # as an Intergovernmental Organization or submit itself to any jurisdiction.
 
-FROM nginx:perl
+FROM nginx:1.22-perl
 
 RUN rm /etc/nginx/conf.d/default.conf
 ADD cernopendata.conf /etc/nginx/conf.d/


### PR DESCRIPTION
Pins nginx perl version to an older release, fixing some reverse-proxy file streaming issues, such as upstream sending invalid "Content-Length: None" response.