### PR TITLE
docker: clean `pip check` friendly setup

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -1,5 +1,5 @@
 # This file is part of CERN Open Data Portal.
-# Copyright (C) 2020 CERN.
+# Copyright (C) 2020, 2023 CERN.
 #
 # CERN Open Data Portal is free software; you can redistribute it
 # and/or modify it under the terms of the GNU General Public License as
@@ -26,7 +26,7 @@ on: [push, pull_request]
 
 jobs:
   lint-shellcheck:
-    runs-on: ubuntu-latest
+    runs-on: ubuntu-20.04
     steps:
       - name: Checkout
         uses: actions/checkout@v2
@@ -37,7 +37,7 @@ jobs:
           ./run-tests.sh --check-shellscript
 
   lint-pycodestyle:
-    runs-on: ubuntu-latest
+    runs-on: ubuntu-20.04
     steps:
       - name: Checkout
         uses: actions/checkout@v2
@@ -54,7 +54,7 @@ jobs:
           ./run-tests.sh --check-pycodestyle
 
   lint-pydocstyle:
-    runs-on: ubuntu-latest
+    runs-on: ubuntu-20.04
     steps:
       - name: Checkout
         uses: actions/checkout@v2
@@ -71,7 +71,7 @@ jobs:
           ./run-tests.sh --check-pydocstyle
 
   lint-check-manifest:
-    runs-on: ubuntu-latest
+    runs-on: ubuntu-20.04
     steps:
       - name: Checkout
         uses: actions/checkout@v2
@@ -88,7 +88,7 @@ jobs:
           ./run-tests.sh --check-manifest
 
   check-fixtures:
-    runs-on: ubuntu-latest
+    runs-on: ubuntu-20.04
     steps:
       - name: Checkout
         uses: actions/checkout@v2
@@ -105,7 +105,7 @@ jobs:
         run: ./run-tests.sh --check-fixtures
 
   check-isort:
-    runs-on: ubuntu-latest
+    runs-on: ubuntu-20.04
     steps:
       - name: Checkout
         uses: actions/checkout@v2
@@ -122,7 +122,7 @@ jobs:
           ./run-tests.sh --check-isort
 
   docker-build:
-    runs-on: ubuntu-latest
+    runs-on: ubuntu-20.04
     steps:
       - name: Checkout
         uses: actions/checkout@v2

--- a/Dockerfile
+++ b/Dockerfile
@@ -78,8 +78,11 @@ RUN pip install --user xrootd==${XROOTD_VERSION} xrootdpyfs==0.2.2
 # Install requirements
 COPY requirements-production-local-forks.txt /tmp
 COPY requirements-production.txt /tmp
-RUN pip install --user -r /tmp/requirements-production-local-forks.txt
+RUN pip install --user --no-deps -r /tmp/requirements-production-local-forks.txt
 RUN pip install --user -r /tmp/requirements-production.txt
+
+# Check for any broken Python dependencies
+RUN pip check
 
 # Add CERN Open Data Portal sources to `code` and work there
 WORKDIR ${CODE_DIR}
@@ -92,8 +95,9 @@ USER ${INVENIO_USER_ID}
 ARG DEBUG=""
 ENV DEBUG=${DEBUG:-""}
 
+# Install CERN Open Data Portal sources
 # hadolint ignore=DL3013
-RUN if [ "$DEBUG" ]; then pip install --user -e ".[all]"; else pip install --user ".[all]"; fi;
+RUN if [ "$DEBUG" ]; then pip install --user -e ".[all]" && pip check; else pip install --user ".[all]" && pip check; fi;
 
 # Create instance
 RUN scripts/create-instance.sh
@@ -117,7 +121,7 @@ ARG UWSGI_WSGI_MODULE=cernopendata.wsgi:application
 ENV UWSGI_WSGI_MODULE ${UWSGI_WSGI_MODULE:-cernopendata.wsgi:application}
 
 # Install Python packages needed for development
-RUN if [ "$DEBUG" ]; then pip install --user -r requirements-dev.txt; fi;
+RUN if [ "$DEBUG" ]; then pip install --user -r requirements-dev.txt && pip check; fi;
 
 # Start the CERN Open Data Portal application
 # hadolint ignore=DL3025

--- a/requirements-production.txt
+++ b/requirements-production.txt
@@ -420,7 +420,7 @@ packaging==20.9
     # via bleach
 pandocfilters==1.4.3
     # via nbconvert
-parso==0.8.2
+parso==0.7.1
     # via jedi
 passlib==1.7.4
     # via

--- a/requirements-production.txt
+++ b/requirements-production.txt
@@ -324,7 +324,7 @@ invenio-theme==1.3.6
     #   invenio-accounts
 invenio-xrootd==1.0.0a6
     # via cernopendata (setup.py)
-ipython==7.16.1
+ipython==7.16.3
     # via
     #   flask-shell-ipython
     #   invenio-previewer
@@ -340,7 +340,7 @@ itsdangerous==1.1.0
     #   flask-kvsession-invenio
     #   flask-security
     #   flask-wtf
-jedi==0.18.0
+jedi==0.17.2
     # via ipython
 jinja2==2.11.3
     # via

--- a/setup.py
+++ b/setup.py
@@ -41,7 +41,7 @@ tests_require = [
     'check-manifest>=0.25',
     'coverage>=4.0',
     'isort>=4.2.2',
-    'locustio>=0.8,<0.14',
+    'locustio>=0.8,<0.13',
     'mock>=1.3.0',
     'pydocstyle>=1.0.0',
     'pycodestyle>=2.4.0',
@@ -52,7 +52,7 @@ tests_require = [
 
 extras_require = {
     'docs': [
-        'Sphinx>=1.4.2',
+        'Sphinx>=1.4.2,<5.0.0',
     ],
     'tests': tests_require,
 }
@@ -72,6 +72,7 @@ install_requires = [
     'invenio-config==1.0.3',
     # Custom Invenio `base` bundle
     'invenio-assets==1.2.7',
+    'invenio-accounts==1.4.5',
     'invenio-logging[sentry]==1.3.0',
     'invenio-rest==1.2.1',
     'invenio-theme==1.3.6',
@@ -112,10 +113,8 @@ install_requires = [
     'celery==5.0.4',
     # Pin XRootD consistently with Dockerfile
     'xrootd==4.12.7',
-    # Pin Flask/Jinja/importlib/gevent/greenlet/raven to make master work again
+    # Pin Flask/gevent/greenlet/raven to make master work again
     'Flask<1.2',
-    'Flask<2.12',
-    "importlib-metadata<5.0.0 ; python_version<'3.8'",
     'gevent<1.6',
     'greenlet<1.2',
     'raven<6.11',


### PR DESCRIPTION
Upgrades ipython and downgrades jedi, fixing development setup. Closes #3339.

Solves remaining `pip check` warnings and introduces several `pip check` commands alongside the container image building process in order to catch any possible Python dependency troubles early.