### PR TITLE
docs: update CMS internal OD usage link

### DIFF
--- a/cernopendata/modules/fixtures/data/docs/cms-about/cms-about.md
+++ b/cernopendata/modules/fixtures/data/docs/cms-about/cms-about.md
@@ -76,4 +76,4 @@ The following are provided through this portal:
 ## <a name="policies">Policies</a>
 
 * [Data preservation and open access policy](/record/415)
-* [Papers by CMS members using public data [internal]](https://cms-docdb.cern.ch/cgi-bin/DocDB/ShowDocument?docid=12242)
+* [Papers by CMS members using public data [internal]](https://cms-docdb.cern.ch/cgi-bin/DocDB/ShowDocument?docid=14372)


### PR DESCRIPTION
(closes #3350)

Updates the link to the limited authorship document