### PR TITLE
docs: developing guide using docker compose v2

### DIFF
--- a/DEVELOPING.rst
+++ b/DEVELOPING.rst
@@ -17,11 +17,11 @@ integration purposes. A usage example:
 .. code-block:: console
 
    $ ./scripts/generate-localhost-certificate.sh
-   $ docker-compose -f docker-compose-dev.yml build
-   $ docker-compose -f docker-compose-dev.yml up
-   $ docker exec -i -t opendatacernch_web_1 /code/scripts/populate-instance.sh --skip-files
+   $ docker compose -f docker-compose-dev.yml build
+   $ docker compose -f docker-compose-dev.yml up
+   $ docker exec -i -t opendatacernch-web-1 /code/scripts/populate-instance.sh --skip-files
    $ firefox http://0.0.0.0:5000/
-   $ docker-compose -f docker-compose-dev.yml down
+   $ docker compose -f docker-compose-dev.yml down
 
 If you want to use production-like conditions locally, you can use Docker with
 ``docker-compose.yml`` configuration. This is useful for tuning overall system
@@ -31,11 +31,11 @@ mounted in the container in this case. A usage example:
 .. code-block:: console
 
    $ ./scripts/generate-localhost-certificate.sh
-   $ docker-compose build
-   $ docker-compose up
-   $ docker exec -i -t opendatacernch_web_1 /code/scripts/populate-instance.sh
+   $ docker compose build
+   $ docker compose up
+   $ docker exec -i -t opendatacernch-web-1 /code/scripts/populate-instance.sh
    $ firefox http://0.0.0.0/
-   $ docker-compose down -v
+   $ docker compose down -v
 
 Development tips
 ================
@@ -83,8 +83,8 @@ can re-upload all the docs by cleaning the instance first:
 
 .. code-block:: console
 
-   $ docker exec -i -t opendatacernch_web_1 /code/scripts/clean-instance.sh
-   $ docker exec -i -t opendatacernch_web_1 /code/scripts/populate-instance.sh --skip-records
+   $ docker exec -i -t opendatacernch-web-1 /code/scripts/clean-instance.sh
+   $ docker exec -i -t opendatacernch-web-1 /code/scripts/populate-instance.sh --skip-records
 
 Working with records
 --------------------
@@ -96,20 +96,20 @@ wish by doing:
 
 .. code-block:: console
 
-   $ docker exec -i -t opendatacernch_web_1 /code/scripts/populate-instance.sh --skip-records
-   $ docker exec -i -t opendatacernch_web_1 cernopendata fixtures records -f /code/cernopendata/modules/fixtures/data/records/opera-author-list-multiplicity.json --mode insert
-   $ docker exec -i -t opendatacernch_web_1 cernopendata fixtures records -f /code/cernopendata/modules/fixtures/data/records/opera-author-list-tau.json --mode insert
-   $ docker exec -i -t opendatacernch_web_1 cernopendata fixtures records -f /code/cernopendata/modules/fixtures/data/records/opera-detector-events-multiplicity.json --mode insert
-   $ docker exec -i -t opendatacernch_web_1 cernopendata fixtures records -f /code/cernopendata/modules/fixtures/data/records/opera-detector-events-tau.json --mode insert
-   $ docker exec -i -t opendatacernch_web_1 cernopendata fixtures records -f /code/cernopendata/modules/fixtures/data/records/opera-ecc-datasets.json --mode insert
-   $ docker exec -i -t opendatacernch_web_1 cernopendata fixtures records -f /code/cernopendata/modules/fixtures/data/records/opera-ed-datasets.json --mode insert
+   $ docker exec -i -t opendatacernch-web-1 /code/scripts/populate-instance.sh --skip-records
+   $ docker exec -i -t opendatacernch-web-1 cernopendata fixtures records -f /code/cernopendata/modules/fixtures/data/records/opera-author-list-multiplicity.json --mode insert
+   $ docker exec -i -t opendatacernch-web-1 cernopendata fixtures records -f /code/cernopendata/modules/fixtures/data/records/opera-author-list-tau.json --mode insert
+   $ docker exec -i -t opendatacernch-web-1 cernopendata fixtures records -f /code/cernopendata/modules/fixtures/data/records/opera-detector-events-multiplicity.json --mode insert
+   $ docker exec -i -t opendatacernch-web-1 cernopendata fixtures records -f /code/cernopendata/modules/fixtures/data/records/opera-detector-events-tau.json --mode insert
+   $ docker exec -i -t opendatacernch-web-1 cernopendata fixtures records -f /code/cernopendata/modules/fixtures/data/records/opera-ecc-datasets.json --mode insert
+   $ docker exec -i -t opendatacernch-web-1 cernopendata fixtures records -f /code/cernopendata/modules/fixtures/data/records/opera-ed-datasets.json --mode insert
 
 If you alter one of the fixture files, you can upload your changes by using the
 ``replace`` mode:
 
 .. code-block:: console
 
-   $ docker exec -i -t opendatacernch_web_1 cernopendata fixtures records -f /code/cernopendata/modules/fixtures/data/records/opera-ed-datasets.json --mode replace
+   $ docker exec -i -t opendatacernch-web-1 cernopendata fixtures records -f /code/cernopendata/modules/fixtures/data/records/opera-ed-datasets.json --mode replace
 
 Working with files
 ------------------
@@ -121,7 +121,7 @@ your laptop from the deep sleep. In this case it may be necessary to restart the
 
 .. code-block:: console
 
-   $ docker-compose -f docker-compose-dev.yml restart web web-files
+   $ docker compose -f docker-compose-dev.yml restart web web-files
 
 Working with proxy
 ------------------
@@ -131,7 +131,7 @@ cache content, you can run:
 
 .. code-block:: console
 
-   $ docker exec opendatacernch_nginx_1 find /var/cache/nginx -type f -delete
+   $ docker exec opendatacernch-nginx-1 find /var/cache/nginx -type f -delete
 
 Switching between PROD and DEV contexts
 ---------------------------------------
@@ -146,37 +146,37 @@ can do:
 
 .. code-block:: shell
 
-   docker-compose down -v
-   docker-compose -f docker-compose-dev.yml down -v
-   docker-compose build
-   docker-compose up -d
+   docker compose down -v
+   docker compose -f docker-compose-dev.yml down -v
+   docker compose build
+   docker compose up -d
    sleep 20
-   docker exec -i -t opendatacernch_web_1 /code/scripts/populate-instance.sh --skip-records
-   docker exec -i -t opendatacernch_web_1 cernopendata fixtures records -f /code/cernopendata/modules/fixtures/data/records/opera-author-list-multiplicity.json --mode insert
-   docker exec -i -t opendatacernch_web_1 cernopendata fixtures records -f /code/cernopendata/modules/fixtures/data/records/opera-author-list-tau.json --mode insert
-   docker exec -i -t opendatacernch_web_1 cernopendata fixtures records -f /code/cernopendata/modules/fixtures/data/records/opera-detector-events-multiplicity.json --mode insert
-   docker exec -i -t opendatacernch_web_1 cernopendata fixtures records -f /code/cernopendata/modules/fixtures/data/records/opera-detector-events-tau.json --mode insert
-   docker exec -i -t opendatacernch_web_1 cernopendata fixtures records -f /code/cernopendata/modules/fixtures/data/records/opera-ecc-datasets.json --mode insert
-   docker exec -i -t opendatacernch_web_1 cernopendata fixtures records -f /code/cernopendata/modules/fixtures/data/records/opera-ed-datasets.json --mode insert
+   docker exec -i -t opendatacernch-web-1 /code/scripts/populate-instance.sh --skip-records
+   docker exec -i -t opendatacernch-web-1 cernopendata fixtures records -f /code/cernopendata/modules/fixtures/data/records/opera-author-list-multiplicity.json --mode insert
+   docker exec -i -t opendatacernch-web-1 cernopendata fixtures records -f /code/cernopendata/modules/fixtures/data/records/opera-author-list-tau.json --mode insert
+   docker exec -i -t opendatacernch-web-1 cernopendata fixtures records -f /code/cernopendata/modules/fixtures/data/records/opera-detector-events-multiplicity.json --mode insert
+   docker exec -i -t opendatacernch-web-1 cernopendata fixtures records -f /code/cernopendata/modules/fixtures/data/records/opera-detector-events-tau.json --mode insert
+   docker exec -i -t opendatacernch-web-1 cernopendata fixtures records -f /code/cernopendata/modules/fixtures/data/records/opera-ecc-datasets.json --mode insert
+   docker exec -i -t opendatacernch-web-1 cernopendata fixtures records -f /code/cernopendata/modules/fixtures/data/records/opera-ed-datasets.json --mode insert
 
 For switching from any mode to the development mode working on OPERA records,
 you can do:
 
 .. code-block:: shell
 
-   docker-compose down -v
-   docker-compose -f docker-compose-dev.yml down -v
-   docker-compose -f docker-compose-dev.yml build
-   docker-compose -f docker-compose-dev.yml up -d
+   docker compose down -v
+   docker compose -f docker-compose-dev.yml down -v
+   docker compose -f docker-compose-dev.yml build
+   docker compose -f docker-compose-dev.yml up -d
    sleep 20
-   docker exec -i -t opendatacernch_web_1 /code/scripts/populate-instance.sh --skip-records
-   docker exec -i -t opendatacernch_web_1 cernopendata fixtures records -f /code/cernopendata/modules/fixtures/data/records/cms-derived-csv-Run2011A.json --mode insert
-   docker exec -i -t opendatacernch_web_1 cernopendata fixtures records -f /code/cernopendata/modules/fixtures/data/records/opera-author-list-multiplicity.json --mode insert
-   docker exec -i -t opendatacernch_web_1 cernopendata fixtures records -f /code/cernopendata/modules/fixtures/data/records/opera-author-list-tau.json --mode insert
-   docker exec -i -t opendatacernch_web_1 cernopendata fixtures records -f /code/cernopendata/modules/fixtures/data/records/opera-detector-events-multiplicity.json --mode insert
-   docker exec -i -t opendatacernch_web_1 cernopendata fixtures records -f /code/cernopendata/modules/fixtures/data/records/opera-detector-events-tau.json --mode insert
-   docker exec -i -t opendatacernch_web_1 cernopendata fixtures records -f /code/cernopendata/modules/fixtures/data/records/opera-ecc-datasets.json --mode insert
-   docker exec -i -t opendatacernch_web_1 cernopendata fixtures records -f /code/cernopendata/modules/fixtures/data/records/opera-ed-datasets.json --mode insert
+   docker exec -i -t opendatacernch-web-1 /code/scripts/populate-instance.sh --skip-records
+   docker exec -i -t opendatacernch-web-1 cernopendata fixtures records -f /code/cernopendata/modules/fixtures/data/records/cms-derived-csv-Run2011A.json --mode insert
+   docker exec -i -t opendatacernch-web-1 cernopendata fixtures records -f /code/cernopendata/modules/fixtures/data/records/opera-author-list-multiplicity.json --mode insert
+   docker exec -i -t opendatacernch-web-1 cernopendata fixtures records -f /code/cernopendata/modules/fixtures/data/records/opera-author-list-tau.json --mode insert
+   docker exec -i -t opendatacernch-web-1 cernopendata fixtures records -f /code/cernopendata/modules/fixtures/data/records/opera-detector-events-multiplicity.json --mode insert
+   docker exec -i -t opendatacernch-web-1 cernopendata fixtures records -f /code/cernopendata/modules/fixtures/data/records/opera-detector-events-tau.json --mode insert
+   docker exec -i -t opendatacernch-web-1 cernopendata fixtures records -f /code/cernopendata/modules/fixtures/data/records/opera-ecc-datasets.json --mode insert
+   docker exec -i -t opendatacernch-web-1 cernopendata fixtures records -f /code/cernopendata/modules/fixtures/data/records/opera-ed-datasets.json --mode insert
 
 Appendix: Git workflow
 ======================


### PR DESCRIPTION
Closes [#3388](https://github.com/cernopendata/opendata.cern.ch/issues/3388)
updates developing guide to indicate use of docker compose v2 everywhere