### PR TITLE
records: CMS 2010 2.76 TeV energy fix

### DIFF
--- a/cernopendata/modules/fixtures/data/records/cms-simulated-datasets-2010-commissioning.json
+++ b/cernopendata/modules/fixtures/data/records/cms-simulated-datasets-2010-commissioning.json
@@ -121,7 +121,7 @@
   },
   {
     "abstract": {
-      "description": "<p>Simulated dataset MinBias_TuneZ2_2760GeV_pythia6_cff_py_GEN_SIM_START311_V2_Dec11_v2 in GEN-SIM-RECO format (see <a href=\"/docs/cms-mc-production-overview\">CMS Monte Carlo production overview</a>) format for Run2011A data at 2.76 GeV. </p><p>See the description of the simulated dataset names in: <a href=\"/about/CMS-Simulated-Dataset-Names\">About CMS simulated dataset names</a>.</p> <p>These simulated data correspond to the collision data that were collected by the CMS experiment during Run2011A and contain the simulation of <a href=\"http://inspirehep.net/record/1227802/\">the CASTOR calorimeter</a>.</p>"
+      "description": "<p>Simulated dataset MinBias_TuneZ2_2760GeV_pythia6_cff_py_GEN_SIM_START311_V2_Dec11_v2 in GEN-SIM-RECO format (see <a href=\"/docs/cms-mc-production-overview\">CMS Monte Carlo production overview</a>) format for Run2011A data at 2.76 TeV. </p><p>See the description of the simulated dataset names in: <a href=\"/about/CMS-Simulated-Dataset-Names\">About CMS simulated dataset names</a>.</p> <p>These simulated data correspond to the collision data that were collected by the CMS experiment during Run2011A and contain the simulation of <a href=\"http://inspirehep.net/record/1227802/\">the CASTOR calorimeter</a>.</p>"
     },
     "accelerator": "CERN-LHC",
     "categories": {
@@ -481,7 +481,7 @@
   },
   {
     "abstract": {
-      "description": "<p>Simulated dataset MinBias_Tune4C_2760GeV_pythia8_cff_py_GEN_SIM_START311_V2_Dec11_v1 in GEN-SIM-RECO format (see <a href=\"/docs/cms-mc-production-overview\">CMS Monte Carlo production overview</a>) format for Run2011A data at 2.76 GeV. </p><p>See the description of the simulated dataset names in: <a href=\"/about/CMS-Simulated-Dataset-Names\">About CMS simulated dataset names</a>.</p> <p>These simulated data correspond to the collision data that were collected by the CMS experiment during Run2011A and contain the simulation of <a href=\"http://inspirehep.net/record/1227802/\">the CASTOR calorimeter</a>.</p>"
+      "description": "<p>Simulated dataset MinBias_Tune4C_2760GeV_pythia8_cff_py_GEN_SIM_START311_V2_Dec11_v1 in GEN-SIM-RECO format (see <a href=\"/docs/cms-mc-production-overview\">CMS Monte Carlo production overview</a>) format for Run2011A data at 2.76 TeV. </p><p>See the description of the simulated dataset names in: <a href=\"/about/CMS-Simulated-Dataset-Names\">About CMS simulated dataset names</a>.</p> <p>These simulated data correspond to the collision data that were collected by the CMS experiment during Run2011A and contain the simulation of <a href=\"http://inspirehep.net/record/1227802/\">the CASTOR calorimeter</a>.</p>"
     },
     "accelerator": "CERN-LHC",
     "categories": {


### PR DESCRIPTION
Fixes energy units in 2010 simulated datasets. Closes #3364.