### PR TITLE
docs: add missing author

### DIFF
--- a/AUTHORS.rst
+++ b/AUTHORS.rst
@@ -15,6 +15,7 @@ The list of contributors in alphabetical order:
 - `Arturo Sanchez <https://github.com/artfisica>`_
 - `Audrius Mecionis <https://orcid.org/0000-0002-3759-1663>`_
 - `Clemens Lange <https://github.com/clelange>`_
+- `Daan Rosendal <https://github.com/DaanRosendal>`_
 - `Diego Rodriguez <https://orcid.org/0000-0003-0649-2002>`_
 - `Edgar Carrera <https://github.com/caredg>`_
 - `Eric Engestrom <https://github.com/1ace>`_


### PR DESCRIPTION
Adds my name to the `AUTHORS.rst` file.