### PR TITLE
records: CMS HLT 2011 2012 trigger path updates

### DIFF
--- a/cernopendata/modules/fixtures/data/records/cms-hlt-trigger-paths-2012.json
+++ b/cernopendata/modules/fixtures/data/records/cms-hlt-trigger-paths-2012.json
@@ -11,10 +11,6 @@
     "collections": [
       "CMS-Trigger-Information"
     ],
-    "collision_information": {
-      "energy": "8TeV",
-      "type": "pp"
-    },
     "date_created": [
       "2012"
     ],
@@ -22,10 +18,6 @@
     "experiment": "CMS",
     "publisher": "CERN Open Data Portal",
     "recid": "6200",
-    "run_period": [
-      "Run2012B",
-      "Run2012C"
-    ],
     "title": "High-Level Trigger path information ACoreOutput",
     "type": {
       "primary": "Supplementaries",
@@ -46,10 +38,6 @@
     "collections": [
       "CMS-Trigger-Information"
     ],
-    "collision_information": {
-      "energy": "8TeV",
-      "type": "pp"
-    },
     "date_created": [
       "2012"
     ],
@@ -57,10 +45,6 @@
     "experiment": "CMS",
     "publisher": "CERN Open Data Portal",
     "recid": "6201",
-    "run_period": [
-      "Run2012B",
-      "Run2012C"
-    ],
     "title": "High-Level Trigger path information ALCALUMIPIXELSOutput",
     "type": {
       "primary": "Supplementaries",
@@ -81,10 +65,6 @@
     "collections": [
       "CMS-Trigger-Information"
     ],
-    "collision_information": {
-      "energy": "8TeV",
-      "type": "pp"
-    },
     "date_created": [
       "2012"
     ],
@@ -92,10 +72,6 @@
     "experiment": "CMS",
     "publisher": "CERN Open Data Portal",
     "recid": "6202",
-    "run_period": [
-      "Run2012B",
-      "Run2012C"
-    ],
     "title": "High-Level Trigger path information ALCAP0Output",
     "type": {
       "primary": "Supplementaries",
@@ -116,10 +92,6 @@
     "collections": [
       "CMS-Trigger-Information"
     ],
-    "collision_information": {
-      "energy": "8TeV",
-      "type": "pp"
-    },
     "date_created": [
       "2012"
     ],
@@ -127,10 +99,6 @@
     "experiment": "CMS",
     "publisher": "CERN Open Data Portal",
     "recid": "6203",
-    "run_period": [
-      "Run2012B",
-      "Run2012C"
-    ],
     "title": "High-Level Trigger path information ALCAPHISYMOutput",
     "type": {
       "primary": "Supplementaries",
@@ -151,10 +119,6 @@
     "collections": [
       "CMS-Trigger-Information"
     ],
-    "collision_information": {
-      "energy": "8TeV",
-      "type": "pp"
-    },
     "date_created": [
       "2012"
     ],
@@ -162,10 +126,6 @@
     "experiment": "CMS",
     "publisher": "CERN Open Data Portal",
     "recid": "6204",
-    "run_period": [
-      "Run2012B",
-      "Run2012C"
-    ],
     "title": "High-Level Trigger path information AOutput",
     "type": {
       "primary": "Supplementaries",
@@ -186,10 +146,6 @@
     "collections": [
       "CMS-Trigger-Information"
     ],
-    "collision_information": {
-      "energy": "8TeV",
-      "type": "pp"
-    },
     "date_created": [
       "2012"
     ],
@@ -197,10 +153,6 @@
     "experiment": "CMS",
     "publisher": "CERN Open Data Portal",
     "recid": "6205",
-    "run_period": [
-      "Run2012B",
-      "Run2012C"
-    ],
     "title": "High-Level Trigger path information AlCa_EcalEtaEBonly",
     "type": {
       "primary": "Supplementaries",
@@ -221,10 +173,6 @@
     "collections": [
       "CMS-Trigger-Information"
     ],
-    "collision_information": {
-      "energy": "8TeV",
-      "type": "pp"
-    },
     "date_created": [
       "2012"
     ],
@@ -232,10 +180,6 @@
     "experiment": "CMS",
     "publisher": "CERN Open Data Portal",
     "recid": "6206",
-    "run_period": [
-      "Run2012B",
-      "Run2012C"
-    ],
     "title": "High-Level Trigger path information AlCa_EcalEtaEEonly",
     "type": {
       "primary": "Supplementaries",
@@ -256,10 +200,6 @@
     "collections": [
       "CMS-Trigger-Information"
     ],
-    "collision_information": {
-      "energy": "8TeV",
-      "type": "pp"
-    },
     "date_created": [
       "2012"
     ],
@@ -267,10 +207,6 @@
     "experiment": "CMS",
     "publisher": "CERN Open Data Portal",
     "recid": "6207",
-    "run_period": [
-      "Run2012B",
-      "Run2012C"
-    ],
     "title": "High-Level Trigger path information AlCa_EcalPhiSym",
     "type": {
       "primary": "Supplementaries",
@@ -291,10 +227,6 @@
     "collections": [
       "CMS-Trigger-Information"
     ],
-    "collision_information": {
-      "energy": "8TeV",
-      "type": "pp"
-    },
     "date_created": [
       "2012"
     ],
@@ -302,10 +234,6 @@
     "experiment": "CMS",
     "publisher": "CERN Open Data Portal",
     "recid": "6208",
-    "run_period": [
-      "Run2012B",
-      "Run2012C"
-    ],
     "title": "High-Level Trigger path information AlCa_EcalPi0EBonly",
     "type": {
       "primary": "Supplementaries",
@@ -326,10 +254,6 @@
     "collections": [
       "CMS-Trigger-Information"
     ],
-    "collision_information": {
-      "energy": "8TeV",
-      "type": "pp"
-    },
     "date_created": [
       "2012"
     ],
@@ -337,10 +261,6 @@
     "experiment": "CMS",
     "publisher": "CERN Open Data Portal",
     "recid": "6209",
-    "run_period": [
-      "Run2012B",
-      "Run2012C"
-    ],
     "title": "High-Level Trigger path information AlCa_EcalPi0EEonly",
     "type": {
       "primary": "Supplementaries",
@@ -361,10 +281,6 @@
     "collections": [
       "CMS-Trigger-Information"
     ],
-    "collision_information": {
-      "energy": "8TeV",
-      "type": "pp"
-    },
     "date_created": [
       "2012"
     ],
@@ -372,10 +288,6 @@
     "experiment": "CMS",
     "publisher": "CERN Open Data Portal",
     "recid": "6210",
-    "run_period": [
-      "Run2012B",
-      "Run2012C"
-    ],
     "title": "High-Level Trigger path information AlCa_LumiPixels",
     "type": {
       "primary": "Supplementaries",
@@ -396,10 +308,6 @@
     "collections": [
       "CMS-Trigger-Information"
     ],
-    "collision_information": {
-      "energy": "8TeV",
-      "type": "pp"
-    },
     "date_created": [
       "2012"
     ],
@@ -407,10 +315,6 @@
     "experiment": "CMS",
     "publisher": "CERN Open Data Portal",
     "recid": "6211",
-    "run_period": [
-      "Run2012B",
-      "Run2012C"
-    ],
     "title": "High-Level Trigger path information AlCa_LumiPixels_Random",
     "type": {
       "primary": "Supplementaries",
@@ -431,10 +335,6 @@
     "collections": [
       "CMS-Trigger-Information"
     ],
-    "collision_information": {
-      "energy": "8TeV",
-      "type": "pp"
-    },
     "date_created": [
       "2012"
     ],
@@ -442,10 +342,6 @@
     "experiment": "CMS",
     "publisher": "CERN Open Data Portal",
     "recid": "6212",
-    "run_period": [
-      "Run2012B",
-      "Run2012C"
-    ],
     "title": "High-Level Trigger path information AlCa_LumiPixels_ZeroBias",
     "type": {
       "primary": "Supplementaries",
@@ -466,10 +362,6 @@
     "collections": [
       "CMS-Trigger-Information"
     ],
-    "collision_information": {
-      "energy": "8TeV",
-      "type": "pp"
-    },
     "date_created": [
       "2012"
     ],
@@ -477,10 +369,6 @@
     "experiment": "CMS",
     "publisher": "CERN Open Data Portal",
     "recid": "6213",
-    "run_period": [
-      "Run2012B",
-      "Run2012C"
-    ],
     "title": "High-Level Trigger path information AlCa_RPCMuonNoHits",
     "type": {
       "primary": "Supplementaries",
@@ -501,10 +389,6 @@
     "collections": [
       "CMS-Trigger-Information"
     ],
-    "collision_information": {
-      "energy": "8TeV",
-      "type": "pp"
-    },
     "date_created": [
       "2012"
     ],
@@ -512,10 +396,6 @@
     "experiment": "CMS",
     "publisher": "CERN Open Data Portal",
     "recid": "6214",
-    "run_period": [
-      "Run2012B",
-      "Run2012C"
-    ],
     "title": "High-Level Trigger path information AlCa_RPCMuonNoTriggers",
     "type": {
       "primary": "Supplementaries",
@@ -536,10 +416,6 @@
     "collections": [
       "CMS-Trigger-Information"
     ],
-    "collision_information": {
-      "energy": "8TeV",
-      "type": "pp"
-    },
     "date_created": [
       "2012"
     ],
@@ -547,10 +423,6 @@
     "experiment": "CMS",
     "publisher": "CERN Open Data Portal",
     "recid": "6215",
-    "run_period": [
-      "Run2012B",
-      "Run2012C"
-    ],
     "title": "High-Level Trigger path information AlCa_RPCMuonNormalisation",
     "type": {
       "primary": "Supplementaries",
@@ -571,10 +443,6 @@
     "collections": [
       "CMS-Trigger-Information"
     ],
-    "collision_information": {
-      "energy": "8TeV",
-      "type": "pp"
-    },
     "date_created": [
       "2012"
     ],
@@ -582,10 +450,6 @@
     "experiment": "CMS",
     "publisher": "CERN Open Data Portal",
     "recid": "6216",
-    "run_period": [
-      "Run2012B",
-      "Run2012C"
-    ],
     "title": "High-Level Trigger path information BOutput",
     "type": {
       "primary": "Supplementaries",
@@ -606,10 +470,6 @@
     "collections": [
       "CMS-Trigger-Information"
     ],
-    "collision_information": {
-      "energy": "8TeV",
-      "type": "pp"
-    },
     "date_created": [
       "2012"
     ],
@@ -617,10 +477,6 @@
     "experiment": "CMS",
     "publisher": "CERN Open Data Portal",
     "recid": "6217",
-    "run_period": [
-      "Run2012B",
-      "Run2012C"
-    ],
     "title": "High-Level Trigger path information CalibrationOutput",
     "type": {
       "primary": "Supplementaries",
@@ -641,10 +497,6 @@
     "collections": [
       "CMS-Trigger-Information"
     ],
-    "collision_information": {
-      "energy": "8TeV",
-      "type": "pp"
-    },
     "date_created": [
       "2012"
     ],
@@ -652,10 +504,6 @@
     "experiment": "CMS",
     "publisher": "CERN Open Data Portal",
     "recid": "6218",
-    "run_period": [
-      "Run2012B",
-      "Run2012C"
-    ],
     "title": "High-Level Trigger path information DQMOutput",
     "type": {
       "primary": "Supplementaries",
@@ -676,10 +524,6 @@
     "collections": [
       "CMS-Trigger-Information"
     ],
-    "collision_information": {
-      "energy": "8TeV",
-      "type": "pp"
-    },
     "date_created": [
       "2012"
     ],
@@ -687,10 +531,6 @@
     "experiment": "CMS",
     "publisher": "CERN Open Data Portal",
     "recid": "6219",
-    "run_period": [
-      "Run2012B",
-      "Run2012C"
-    ],
     "title": "High-Level Trigger path information DQM_FEDIntegrity",
     "type": {
       "primary": "Supplementaries",
@@ -711,10 +551,6 @@
     "collections": [
       "CMS-Trigger-Information"
     ],
-    "collision_information": {
-      "energy": "8TeV",
-      "type": "pp"
-    },
     "date_created": [
       "2012"
     ],
@@ -722,10 +558,6 @@
     "experiment": "CMS",
     "publisher": "CERN Open Data Portal",
     "recid": "6220",
-    "run_period": [
-      "Run2012B",
-      "Run2012C"
-    ],
     "title": "High-Level Trigger path information DQM_HcalEmptyEvents",
     "type": {
       "primary": "Supplementaries",
@@ -746,10 +578,6 @@
     "collections": [
       "CMS-Trigger-Information"
     ],
-    "collision_information": {
-      "energy": "8TeV",
-      "type": "pp"
-    },
     "date_created": [
       "2012"
     ],
@@ -757,10 +585,6 @@
     "experiment": "CMS",
     "publisher": "CERN Open Data Portal",
     "recid": "6221",
-    "run_period": [
-      "Run2012B",
-      "Run2012C"
-    ],
     "title": "High-Level Trigger path information DST_Ele8_CaloIdL_CaloIsoVL_TrkIdVL_TrkIsoVL_HT250 (DataScouting dataset)",
     "type": {
       "primary": "Supplementaries",
@@ -781,10 +605,6 @@
     "collections": [
       "CMS-Trigger-Information"
     ],
-    "collision_information": {
-      "energy": "8TeV",
-      "type": "pp"
-    },
     "date_created": [
       "2012"
     ],
@@ -792,10 +612,6 @@
     "experiment": "CMS",
     "publisher": "CERN Open Data Portal",
     "recid": "6222",
-    "run_period": [
-      "Run2012B",
-      "Run2012C"
-    ],
     "title": "High-Level Trigger path information DST_HT250 (DataScouting dataset)",
     "type": {
       "primary": "Supplementaries",
@@ -816,10 +632,6 @@
     "collections": [
       "CMS-Trigger-Information"
     ],
-    "collision_information": {
-      "energy": "8TeV",
-      "type": "pp"
-    },
     "date_created": [
       "2012"
     ],
@@ -827,10 +639,6 @@
     "experiment": "CMS",
     "publisher": "CERN Open Data Portal",
     "recid": "6223",
-    "run_period": [
-      "Run2012B",
-      "Run2012C"
-    ],
     "title": "High-Level Trigger path information DST_L1HTT_Or_L1MultiJet (DataScouting dataset)",
     "type": {
       "primary": "Supplementaries",
@@ -851,10 +659,6 @@
     "collections": [
       "CMS-Trigger-Information"
     ],
-    "collision_information": {
-      "energy": "8TeV",
-      "type": "pp"
-    },
     "date_created": [
       "2012"
     ],
@@ -862,10 +666,6 @@
     "experiment": "CMS",
     "publisher": "CERN Open Data Portal",
     "recid": "6224",
-    "run_period": [
-      "Run2012B",
-      "Run2012C"
-    ],
     "title": "High-Level Trigger path information DST_Mu5_HT250 (DataScouting dataset)",
     "type": {
       "primary": "Supplementaries",
@@ -886,10 +686,6 @@
     "collections": [
       "CMS-Trigger-Information"
     ],
-    "collision_information": {
-      "energy": "8TeV",
-      "type": "pp"
-    },
     "date_created": [
       "2012"
     ],
@@ -897,10 +693,6 @@
     "experiment": "CMS",
     "publisher": "CERN Open Data Portal",
     "recid": "6225",
-    "run_period": [
-      "Run2012B",
-      "Run2012C"
-    ],
     "title": "High-Level Trigger path information DST_Physics",
     "type": {
       "primary": "Supplementaries",
@@ -921,10 +713,6 @@
     "collections": [
       "CMS-Trigger-Information"
     ],
-    "collision_information": {
-      "energy": "8TeV",
-      "type": "pp"
-    },
     "date_created": [
       "2012"
     ],
@@ -932,10 +720,6 @@
     "experiment": "CMS",
     "publisher": "CERN Open Data Portal",
     "recid": "6226",
-    "run_period": [
-      "Run2012B",
-      "Run2012C"
-    ],
     "title": "High-Level Trigger path information EcalCalibrationOutput",
     "type": {
       "primary": "Supplementaries",
@@ -956,10 +740,6 @@
     "collections": [
       "CMS-Trigger-Information"
     ],
-    "collision_information": {
-      "energy": "8TeV",
-      "type": "pp"
-    },
     "date_created": [
       "2012"
     ],
@@ -967,10 +747,6 @@
     "experiment": "CMS",
     "publisher": "CERN Open Data Portal",
     "recid": "6227",
-    "run_period": [
-      "Run2012B",
-      "Run2012C"
-    ],
     "title": "High-Level Trigger path information ExpressOutput",
     "type": {
       "primary": "Supplementaries",
@@ -991,10 +767,6 @@
     "collections": [
       "CMS-Trigger-Information"
     ],
-    "collision_information": {
-      "energy": "8TeV",
-      "type": "pp"
-    },
     "date_created": [
       "2012"
     ],
@@ -1002,10 +774,6 @@
     "experiment": "CMS",
     "publisher": "CERN Open Data Portal",
     "recid": "6228",
-    "run_period": [
-      "Run2012B",
-      "Run2012C"
-    ],
     "title": "High-Level Trigger path information HLTDQMOutput",
     "type": {
       "primary": "Supplementaries",
@@ -1026,10 +794,6 @@
     "collections": [
       "CMS-Trigger-Information"
     ],
-    "collision_information": {
-      "energy": "8TeV",
-      "type": "pp"
-    },
     "date_created": [
       "2012"
     ],
@@ -1037,10 +801,6 @@
     "experiment": "CMS",
     "publisher": "CERN Open Data Portal",
     "recid": "6229",
-    "run_period": [
-      "Run2012B",
-      "Run2012C"
-    ],
     "title": "High-Level Trigger path information HLTDQMResultsOutput",
     "type": {
       "primary": "Supplementaries",
@@ -1061,10 +821,6 @@
     "collections": [
       "CMS-Trigger-Information"
     ],
-    "collision_information": {
-      "energy": "8TeV",
-      "type": "pp"
-    },
     "date_created": [
       "2012"
     ],
@@ -1072,10 +828,6 @@
     "experiment": "CMS",
     "publisher": "CERN Open Data Portal",
     "recid": "6230",
-    "run_period": [
-      "Run2012B",
-      "Run2012C"
-    ],
     "title": "High-Level Trigger path information HLTMONOutput",
     "type": {
       "primary": "Supplementaries",
@@ -1096,10 +848,6 @@
     "collections": [
       "CMS-Trigger-Information"
     ],
-    "collision_information": {
-      "energy": "8TeV",
-      "type": "pp"
-    },
     "date_created": [
       "2012"
     ],
@@ -1107,10 +855,6 @@
     "experiment": "CMS",
     "publisher": "CERN Open Data Portal",
     "recid": "6231",
-    "run_period": [
-      "Run2012B",
-      "Run2012C"
-    ],
     "title": "High-Level Trigger path information HLT_Activity_Ecal_2SC7 (Commissioning dataset)",
     "type": {
       "primary": "Supplementaries",
@@ -1131,10 +875,6 @@
     "collections": [
       "CMS-Trigger-Information"
     ],
-    "collision_information": {
-      "energy": "8TeV",
-      "type": "pp"
-    },
     "date_created": [
       "2012"
     ],
@@ -1142,10 +882,6 @@
     "experiment": "CMS",
     "publisher": "CERN Open Data Portal",
     "recid": "6232",
-    "run_period": [
-      "Run2012B",
-      "Run2012C"
-    ],
     "title": "High-Level Trigger path information HLT_Activity_Ecal_SC7 (Commissioning dataset)",
     "type": {
       "primary": "Supplementaries",
@@ -1166,10 +902,6 @@
     "collections": [
       "CMS-Trigger-Information"
     ],
-    "collision_information": {
-      "energy": "8TeV",
-      "type": "pp"
-    },
     "date_created": [
       "2012"
     ],
@@ -1177,10 +909,6 @@
     "experiment": "CMS",
     "publisher": "CERN Open Data Portal",
     "recid": "6233",
-    "run_period": [
-      "Run2012B",
-      "Run2012C"
-    ],
     "title": "High-Level Trigger path information HLT_BTagMu_DiJet110_Mu5 (BTag dataset)",
     "type": {
       "primary": "Supplementaries",
@@ -1201,10 +929,6 @@
     "collections": [
       "CMS-Trigger-Information"
     ],
-    "collision_information": {
-      "energy": "8TeV",
-      "type": "pp"
-    },
     "date_created": [
       "2012"
     ],
@@ -1212,10 +936,6 @@
     "experiment": "CMS",
     "publisher": "CERN Open Data Portal",
     "recid": "6234",
-    "run_period": [
-      "Run2012B",
-      "Run2012C"
-    ],
     "title": "High-Level Trigger path information HLT_BTagMu_DiJet20_Mu5 (BTag dataset)",
     "type": {
       "primary": "Supplementaries",
@@ -1236,10 +956,6 @@
     "collections": [
       "CMS-Trigger-Information"
     ],
-    "collision_information": {
-      "energy": "8TeV",
-      "type": "pp"
-    },
     "date_created": [
       "2012"
     ],
@@ -1247,10 +963,6 @@
     "experiment": "CMS",
     "publisher": "CERN Open Data Portal",
     "recid": "6235",
-    "run_period": [
-      "Run2012B",
-      "Run2012C"
-    ],
     "title": "High-Level Trigger path information HLT_BTagMu_DiJet40_Mu5 (BTag dataset)",
     "type": {
       "primary": "Supplementaries",
@@ -1271,10 +983,6 @@
     "collections": [
       "CMS-Trigger-Information"
     ],
-    "collision_information": {
-      "energy": "8TeV",
-      "type": "pp"
-    },
     "date_created": [
       "2012"
     ],
@@ -1282,10 +990,6 @@
     "experiment": "CMS",
     "publisher": "CERN Open Data Portal",
     "recid": "6236",
-    "run_period": [
-      "Run2012B",
-      "Run2012C"
-    ],
     "title": "High-Level Trigger path information HLT_BTagMu_DiJet70_Mu5 (BTag dataset)",
     "type": {
       "primary": "Supplementaries",
@@ -1306,10 +1010,6 @@
     "collections": [
       "CMS-Trigger-Information"
     ],
-    "collision_information": {
-      "energy": "8TeV",
-      "type": "pp"
-    },
     "date_created": [
       "2012"
     ],
@@ -1317,10 +1017,6 @@
     "experiment": "CMS",
     "publisher": "CERN Open Data Portal",
     "recid": "6237",
-    "run_period": [
-      "Run2012B",
-      "Run2012C"
-    ],
     "title": "High-Level Trigger path information HLT_BTagMu_Jet20_Mu4 (MuOniaParked dataset)",
     "type": {
       "primary": "Supplementaries",
@@ -1341,10 +1037,6 @@
     "collections": [
       "CMS-Trigger-Information"
     ],
-    "collision_information": {
-      "energy": "8TeV",
-      "type": "pp"
-    },
     "date_created": [
       "2012"
     ],
@@ -1352,10 +1044,6 @@
     "experiment": "CMS",
     "publisher": "CERN Open Data Portal",
     "recid": "6238",
-    "run_period": [
-      "Run2012B",
-      "Run2012C"
-    ],
     "title": "High-Level Trigger path information HLT_BTagMu_Jet300_Mu5 (BTag dataset)",
     "type": {
       "primary": "Supplementaries",
@@ -1376,10 +1064,6 @@
     "collections": [
       "CMS-Trigger-Information"
     ],
-    "collision_information": {
-      "energy": "8TeV",
-      "type": "pp"
-    },
     "date_created": [
       "2012"
     ],
@@ -1387,10 +1071,6 @@
     "experiment": "CMS",
     "publisher": "CERN Open Data Portal",
     "recid": "6239",
-    "run_period": [
-      "Run2012B",
-      "Run2012C"
-    ],
     "title": "High-Level Trigger path information HLT_BTagMu_Jet60_Mu4 (MuOniaParked dataset)",
     "type": {
       "primary": "Supplementaries",
@@ -1411,10 +1091,6 @@
     "collections": [
       "CMS-Trigger-Information"
     ],
-    "collision_information": {
-      "energy": "8TeV",
-      "type": "pp"
-    },
     "date_created": [
       "2012"
     ],
@@ -1422,10 +1098,6 @@
     "experiment": "CMS",
     "publisher": "CERN Open Data Portal",
     "recid": "6240",
-    "run_period": [
-      "Run2012B",
-      "Run2012C"
-    ],
     "title": "High-Level Trigger path information HLT_BeamGas_HF_Beam1 (Commissioning dataset)",
     "type": {
       "primary": "Supplementaries",
@@ -1446,10 +1118,6 @@
     "collections": [
       "CMS-Trigger-Information"
     ],
-    "collision_information": {
-      "energy": "8TeV",
-      "type": "pp"
-    },
     "date_created": [
       "2012"
     ],
@@ -1457,10 +1125,6 @@
     "experiment": "CMS",
     "publisher": "CERN Open Data Portal",
     "recid": "6241",
-    "run_period": [
-      "Run2012B",
-      "Run2012C"
-    ],
     "title": "High-Level Trigger path information HLT_BeamGas_HF_Beam2 (Commissioning dataset)",
     "type": {
       "primary": "Supplementaries",
@@ -1481,10 +1145,6 @@
     "collections": [
       "CMS-Trigger-Information"
     ],
-    "collision_information": {
-      "energy": "8TeV",
-      "type": "pp"
-    },
     "date_created": [
       "2012"
     ],
@@ -1492,10 +1152,6 @@
     "experiment": "CMS",
     "publisher": "CERN Open Data Portal",
     "recid": "6242",
-    "run_period": [
-      "Run2012B",
-      "Run2012C"
-    ],
     "title": "High-Level Trigger path information HLT_BeamHalo (Cosmics dataset)",
     "type": {
       "primary": "Supplementaries",
@@ -1516,10 +1172,6 @@
     "collections": [
       "CMS-Trigger-Information"
     ],
-    "collision_information": {
-      "energy": "8TeV",
-      "type": "pp"
-    },
     "date_created": [
       "2012"
     ],
@@ -1527,10 +1179,6 @@
     "experiment": "CMS",
     "publisher": "CERN Open Data Portal",
     "recid": "6243",
-    "run_period": [
-      "Run2012B",
-      "Run2012C"
-    ],
     "title": "High-Level Trigger path information HLT_CentralPFJet80_CaloMET50_dPhi1_PFMHT80_HBHENoiseFiltered (MET dataset)",
     "type": {
       "primary": "Supplementaries",
@@ -1551,10 +1199,6 @@
     "collections": [
       "CMS-Trigger-Information"
     ],
-    "collision_information": {
-      "energy": "8TeV",
-      "type": "pp"
-    },
     "date_created": [
       "2012"
     ],
@@ -1562,10 +1206,6 @@
     "experiment": "CMS",
     "publisher": "CERN Open Data Portal",
     "recid": "6244",
-    "run_period": [
-      "Run2012B",
-      "Run2012C"
-    ],
     "title": "High-Level Trigger path information HLT_CleanPFHT300_Ele15_CaloIdT_CaloIsoVL_TrkIdT_TrkIsoVL_PFMET45 (ElectronHad, HT datasets)",
     "type": {
       "primary": "Supplementaries",
@@ -1586,10 +1226,6 @@
     "collections": [
       "CMS-Trigger-Information"
     ],
-    "collision_information": {
-      "energy": "8TeV",
-      "type": "pp"
-    },
     "date_created": [
       "2012"
     ],
@@ -1597,10 +1233,6 @@
     "experiment": "CMS",
     "publisher": "CERN Open Data Portal",
     "recid": "6245",
-    "run_period": [
-      "Run2012B",
-      "Run2012C"
-    ],
     "title": "High-Level Trigger path information HLT_CleanPFHT300_Ele15_CaloIdT_CaloIsoVL_TrkIdT_TrkIsoVL_PFMET50 (ElectronHad, HT datasets)",
     "type": {
       "primary": "Supplementaries",
@@ -1621,10 +1253,6 @@
     "collections": [
       "CMS-Trigger-Information"
     ],
-    "collision_information": {
-      "energy": "8TeV",
-      "type": "pp"
-    },
     "date_created": [
       "2012"
     ],
@@ -1632,10 +1260,6 @@
     "experiment": "CMS",
     "publisher": "CERN Open Data Portal",
     "recid": "6246",
-    "run_period": [
-      "Run2012B",
-      "Run2012C"
-    ],
     "title": "High-Level Trigger path information HLT_CleanPFHT300_Ele40_CaloIdVT_TrkIdT (ElectronHad, HT datasets)",
     "type": {
       "primary": "Supplementaries",
@@ -1656,10 +1280,6 @@
     "collections": [
       "CMS-Trigger-Information"
     ],
-    "collision_information": {
-      "energy": "8TeV",
-      "type": "pp"
-    },
     "date_created": [
       "2012"
     ],
@@ -1667,10 +1287,6 @@
     "experiment": "CMS",
     "publisher": "CERN Open Data Portal",
     "recid": "6247",
-    "run_period": [
-      "Run2012B",
-      "Run2012C"
-    ],
     "title": "High-Level Trigger path information HLT_CleanPFHT300_Ele60_CaloIdVT_TrkIdT (ElectronHad, HT datasets)",
     "type": {
       "primary": "Supplementaries",
@@ -1691,10 +1307,6 @@
     "collections": [
       "CMS-Trigger-Information"
     ],
-    "collision_information": {
-      "energy": "8TeV",
-      "type": "pp"
-    },
     "date_created": [
       "2012"
     ],
@@ -1702,10 +1314,6 @@
     "experiment": "CMS",
     "publisher": "CERN Open Data Portal",
     "recid": "6248",
-    "run_period": [
-      "Run2012B",
-      "Run2012C"
-    ],
     "title": "High-Level Trigger path information HLT_CleanPFHT350_Ele5_CaloIdT_CaloIsoVL_TrkIdT_TrkIsoVL_PFMET45 (ElectronHad, HT datasets)",
     "type": {
       "primary": "Supplementaries",
@@ -1726,10 +1334,6 @@
     "collections": [
       "CMS-Trigger-Information"
     ],
-    "collision_information": {
-      "energy": "8TeV",
-      "type": "pp"
-    },
     "date_created": [
       "2012"
     ],
@@ -1737,10 +1341,6 @@
     "experiment": "CMS",
     "publisher": "CERN Open Data Portal",
     "recid": "6249",
-    "run_period": [
-      "Run2012B",
-      "Run2012C"
-    ],
     "title": "High-Level Trigger path information HLT_CleanPFHT350_Ele5_CaloIdT_CaloIsoVL_TrkIdT_TrkIsoVL_PFMET50 (ElectronHad, HT datasets)",
     "type": {
       "primary": "Supplementaries",
@@ -1761,10 +1361,6 @@
     "collections": [
       "CMS-Trigger-Information"
     ],
-    "collision_information": {
-      "energy": "8TeV",
-      "type": "pp"
-    },
     "date_created": [
       "2012"
     ],
@@ -1772,10 +1368,6 @@
     "experiment": "CMS",
     "publisher": "CERN Open Data Portal",
     "recid": "6250",
-    "run_period": [
-      "Run2012B",
-      "Run2012C"
-    ],
     "title": "High-Level Trigger path information HLT_CleanPFNoPUHT300_Ele15_CaloIdT_CaloIsoVL_TrkIdT_TrkIsoVL_PFMET45 (ElectronHad dataset)",
     "type": {
       "primary": "Supplementaries",
@@ -1796,10 +1388,6 @@
     "collections": [
       "CMS-Trigger-Information"
     ],
-    "collision_information": {
-      "energy": "8TeV",
-      "type": "pp"
-    },
     "date_created": [
       "2012"
     ],
@@ -1807,10 +1395,6 @@
     "experiment": "CMS",
     "publisher": "CERN Open Data Portal",
     "recid": "6251",
-    "run_period": [
-      "Run2012B",
-      "Run2012C"
-    ],
     "title": "High-Level Trigger path information HLT_CleanPFNoPUHT300_Ele15_CaloIdT_CaloIsoVL_TrkIdT_TrkIsoVL_PFMET50 (ElectronHad dataset)",
     "type": {
       "primary": "Supplementaries",
@@ -1831,10 +1415,6 @@
     "collections": [
       "CMS-Trigger-Information"
     ],
-    "collision_information": {
-      "energy": "8TeV",
-      "type": "pp"
-    },
     "date_created": [
       "2012"
     ],
@@ -1842,10 +1422,6 @@
     "experiment": "CMS",
     "publisher": "CERN Open Data Portal",
     "recid": "6252",
-    "run_period": [
-      "Run2012B",
-      "Run2012C"
-    ],
     "title": "High-Level Trigger path information HLT_CleanPFNoPUHT300_Ele40_CaloIdVT_TrkIdT (ElectronHad dataset)",
     "type": {
       "primary": "Supplementaries",
@@ -1866,10 +1442,6 @@
     "collections": [
       "CMS-Trigger-Information"
     ],
-    "collision_information": {
-      "energy": "8TeV",
-      "type": "pp"
-    },
     "date_created": [
       "2012"
     ],
@@ -1877,10 +1449,6 @@
     "experiment": "CMS",
     "publisher": "CERN Open Data Portal",
     "recid": "6253",
-    "run_period": [
-      "Run2012B",
-      "Run2012C"
-    ],
     "title": "High-Level Trigger path information HLT_CleanPFNoPUHT300_Ele60_CaloIdVT_TrkIdT (ElectronHad dataset)",
     "type": {
       "primary": "Supplementaries",
@@ -1901,10 +1469,6 @@
     "collections": [
       "CMS-Trigger-Information"
     ],
-    "collision_information": {
-      "energy": "8TeV",
-      "type": "pp"
-    },
     "date_created": [
       "2012"
     ],
@@ -1912,10 +1476,6 @@
     "experiment": "CMS",
     "publisher": "CERN Open Data Portal",
     "recid": "6254",
-    "run_period": [
-      "Run2012B",
-      "Run2012C"
-    ],
     "title": "High-Level Trigger path information HLT_CleanPFNoPUHT350_Ele5_CaloIdT_CaloIsoVL_TrkIdT_TrkIsoVL_PFMET45 (ElectronHad dataset)",
     "type": {
       "primary": "Supplementaries",
@@ -1936,10 +1496,6 @@
     "collections": [
       "CMS-Trigger-Information"
     ],
-    "collision_information": {
-      "energy": "8TeV",
-      "type": "pp"
-    },
     "date_created": [
       "2012"
     ],
@@ -1947,10 +1503,6 @@
     "experiment": "CMS",
     "publisher": "CERN Open Data Portal",
     "recid": "6255",
-    "run_period": [
-      "Run2012B",
-      "Run2012C"
-    ],
     "title": "High-Level Trigger path information HLT_CleanPFNoPUHT350_Ele5_CaloIdT_CaloIsoVL_TrkIdT_TrkIsoVL_PFMET50 (ElectronHad dataset)",
     "type": {
       "primary": "Supplementaries",
@@ -1971,10 +1523,6 @@
     "collections": [
       "CMS-Trigger-Information"
     ],
-    "collision_information": {
-      "energy": "8TeV",
-      "type": "pp"
-    },
     "date_created": [
       "2012"
     ],
@@ -1982,10 +1530,6 @@
     "experiment": "CMS",
     "publisher": "CERN Open Data Portal",
     "recid": "6256",
-    "run_period": [
-      "Run2012B",
-      "Run2012C"
-    ],
     "title": "High-Level Trigger path information HLT_DTCalibration",
     "type": {
       "primary": "Supplementaries",
@@ -2006,10 +1550,6 @@
     "collections": [
       "CMS-Trigger-Information"
     ],
-    "collision_information": {
-      "energy": "8TeV",
-      "type": "pp"
-    },
     "date_created": [
       "2012"
     ],
@@ -2017,10 +1557,6 @@
     "experiment": "CMS",
     "publisher": "CERN Open Data Portal",
     "recid": "6257",
-    "run_period": [
-      "Run2012B",
-      "Run2012C"
-    ],
     "title": "High-Level Trigger path information HLT_DTErrors (FEDMonitor dataset)",
     "type": {
       "primary": "Supplementaries",
@@ -2041,10 +1577,6 @@
     "collections": [
       "CMS-Trigger-Information"
     ],
-    "collision_information": {
-      "energy": "8TeV",
-      "type": "pp"
-    },
     "date_created": [
       "2012"
     ],
@@ -2052,10 +1584,6 @@
     "experiment": "CMS",
     "publisher": "CERN Open Data Portal",
     "recid": "6258",
-    "run_period": [
-      "Run2012B",
-      "Run2012C"
-    ],
     "title": "High-Level Trigger path information HLT_DiCentralJet20_BTagIP_MET65_HBHENoiseFiltered_dPhi1 (MET dataset)",
     "type": {
       "primary": "Supplementaries",
@@ -2076,10 +1604,6 @@
     "collections": [
       "CMS-Trigger-Information"
     ],
-    "collision_information": {
-      "energy": "8TeV",
-      "type": "pp"
-    },
     "date_created": [
       "2012"
     ],
@@ -2087,10 +1611,6 @@
     "experiment": "CMS",
     "publisher": "CERN Open Data Portal",
     "recid": "6259",
-    "run_period": [
-      "Run2012B",
-      "Run2012C"
-    ],
     "title": "High-Level Trigger path information HLT_DiCentralJet20_CaloMET65_BTagCSV07_PFMHT80 (MET dataset)",
     "type": {
       "primary": "Supplementaries",
@@ -2111,10 +1631,6 @@
     "collections": [
       "CMS-Trigger-Information"
     ],
-    "collision_information": {
-      "energy": "8TeV",
-      "type": "pp"
-    },
     "date_created": [
       "2012"
     ],
@@ -2122,10 +1638,6 @@
     "experiment": "CMS",
     "publisher": "CERN Open Data Portal",
     "recid": "6260",
-    "run_period": [
-      "Run2012B",
-      "Run2012C"
-    ],
     "title": "High-Level Trigger path information HLT_DiCentralJetSumpT100_dPhi05_DiCentralPFJet60_25_PFMET100_HBHENoiseCleaned (MET dataset)",
     "type": {
       "primary": "Supplementaries",
@@ -2146,10 +1658,6 @@
     "collections": [
       "CMS-Trigger-Information"
     ],
-    "collision_information": {
-      "energy": "8TeV",
-      "type": "pp"
-    },
     "date_created": [
       "2012"
     ],
@@ -2157,10 +1665,6 @@
     "experiment": "CMS",
     "publisher": "CERN Open Data Portal",
     "recid": "6261",
-    "run_period": [
-      "Run2012B",
-      "Run2012C"
-    ],
     "title": "High-Level Trigger path information HLT_DiCentralPFJet30_CaloMET50_dPhi1_PFMHT80_HBHENoiseFiltered (MET dataset)",
     "type": {
       "primary": "Supplementaries",
@@ -2181,10 +1685,6 @@
     "collections": [
       "CMS-Trigger-Information"
     ],
-    "collision_information": {
-      "energy": "8TeV",
-      "type": "pp"
-    },
     "date_created": [
       "2012"
     ],
@@ -2192,10 +1692,6 @@
     "experiment": "CMS",
     "publisher": "CERN Open Data Portal",
     "recid": "6262",
-    "run_period": [
-      "Run2012B",
-      "Run2012C"
-    ],
     "title": "High-Level Trigger path information HLT_DiCentralPFJet30_PFMET80 (MET dataset)",
     "type": {
       "primary": "Supplementaries",
@@ -2216,10 +1712,6 @@
     "collections": [
       "CMS-Trigger-Information"
     ],
-    "collision_information": {
-      "energy": "8TeV",
-      "type": "pp"
-    },
     "date_created": [
       "2012"
     ],
@@ -2227,10 +1719,6 @@
     "experiment": "CMS",
     "publisher": "CERN Open Data Portal",
     "recid": "6263",
-    "run_period": [
-      "Run2012B",
-      "Run2012C"
-    ],
     "title": "High-Level Trigger path information HLT_DiCentralPFJet30_PFMET80_BTagCSV07 (MET dataset)",
     "type": {
       "primary": "Supplementaries",
@@ -2251,10 +1739,6 @@
     "collections": [
       "CMS-Trigger-Information"
     ],
-    "collision_information": {
-      "energy": "8TeV",
-      "type": "pp"
-    },
     "date_created": [
       "2012"
     ],
@@ -2262,10 +1746,6 @@
     "experiment": "CMS",
     "publisher": "CERN Open Data Portal",
     "recid": "6264",
-    "run_period": [
-      "Run2012B",
-      "Run2012C"
-    ],
     "title": "High-Level Trigger path information HLT_DiCentralPFJet30_PFMHT80 (MET dataset)",
     "type": {
       "primary": "Supplementaries",
@@ -2286,10 +1766,6 @@
     "collections": [
       "CMS-Trigger-Information"
     ],
-    "collision_information": {
-      "energy": "8TeV",
-      "type": "pp"
-    },
     "date_created": [
       "2012"
     ],
@@ -2297,10 +1773,6 @@
     "experiment": "CMS",
     "publisher": "CERN Open Data Portal",
     "recid": "6265",
-    "run_period": [
-      "Run2012B",
-      "Run2012C"
-    ],
     "title": "High-Level Trigger path information HLT_DiCentralPFJet50_PFMET80 (MET dataset)",
     "type": {
       "primary": "Supplementaries",
@@ -2321,10 +1793,6 @@
     "collections": [
       "CMS-Trigger-Information"
     ],
-    "collision_information": {
-      "energy": "8TeV",
-      "type": "pp"
-    },
     "date_created": [
       "2012"
     ],
@@ -2332,10 +1800,6 @@
     "experiment": "CMS",
     "publisher": "CERN Open Data Portal",
     "recid": "6266",
-    "run_period": [
-      "Run2012B",
-      "Run2012C"
-    ],
     "title": "High-Level Trigger path information HLT_DiCentralPFNoPUJet50_PFMETORPFMETNoMu80 (MET dataset)",
     "type": {
       "primary": "Supplementaries",
@@ -2356,10 +1820,6 @@
     "collections": [
       "CMS-Trigger-Information"
     ],
-    "collision_information": {
-      "energy": "8TeV",
-      "type": "pp"
-    },
     "date_created": [
       "2012"
     ],
@@ -2367,10 +1827,6 @@
     "experiment": "CMS",
     "publisher": "CERN Open Data Portal",
     "recid": "6267",
-    "run_period": [
-      "Run2012B",
-      "Run2012C"
-    ],
     "title": "High-Level Trigger path information HLT_DiJet20_MJJ650_AllJets_DEta3p5_HT120_VBF (VBF1Parked dataset)",
     "type": {
       "primary": "Supplementaries",
@@ -2391,10 +1847,6 @@
     "collections": [
       "CMS-Trigger-Information"
     ],
-    "collision_information": {
-      "energy": "8TeV",
-      "type": "pp"
-    },
     "date_created": [
       "2012"
     ],
@@ -2402,10 +1854,6 @@
     "experiment": "CMS",
     "publisher": "CERN Open Data Portal",
     "recid": "6268",
-    "run_period": [
-      "Run2012B",
-      "Run2012C"
-    ],
     "title": "High-Level Trigger path information HLT_DiJet30_MJJ700_AllJets_DEta3p5_VBF (VBF1Parked dataset)",
     "type": {
       "primary": "Supplementaries",
@@ -2426,10 +1874,6 @@
     "collections": [
       "CMS-Trigger-Information"
     ],
-    "collision_information": {
-      "energy": "8TeV",
-      "type": "pp"
-    },
     "date_created": [
       "2012"
     ],
@@ -2437,10 +1881,6 @@
     "experiment": "CMS",
     "publisher": "CERN Open Data Portal",
     "recid": "6269",
-    "run_period": [
-      "Run2012B",
-      "Run2012C"
-    ],
     "title": "High-Level Trigger path information HLT_DiJet35_MJJ650_AllJets_DEta3p5_VBF (VBF1Parked dataset)",
     "type": {
       "primary": "Supplementaries",
@@ -2461,10 +1901,6 @@
     "collections": [
       "CMS-Trigger-Information"
     ],
-    "collision_information": {
-      "energy": "8TeV",
-      "type": "pp"
-    },
     "date_created": [
       "2012"
     ],
@@ -2472,10 +1908,6 @@
     "experiment": "CMS",
     "publisher": "CERN Open Data Portal",
     "recid": "6270",
-    "run_period": [
-      "Run2012B",
-      "Run2012C"
-    ],
     "title": "High-Level Trigger path information HLT_DiJet35_MJJ700_AllJets_DEta3p5_VBF (VBF1Parked dataset)",
     "type": {
       "primary": "Supplementaries",
@@ -2496,10 +1928,6 @@
     "collections": [
       "CMS-Trigger-Information"
     ],
-    "collision_information": {
-      "energy": "8TeV",
-      "type": "pp"
-    },
     "date_created": [
       "2012"
     ],
@@ -2507,10 +1935,6 @@
     "experiment": "CMS",
     "publisher": "CERN Open Data Portal",
     "recid": "6271",
-    "run_period": [
-      "Run2012B",
-      "Run2012C"
-    ],
     "title": "High-Level Trigger path information HLT_DiJet35_MJJ750_AllJets_DEta3p5_VBF (VBF1Parked dataset)",
     "type": {
       "primary": "Supplementaries",
@@ -2531,10 +1955,6 @@
     "collections": [
       "CMS-Trigger-Information"
     ],
-    "collision_information": {
-      "energy": "8TeV",
-      "type": "pp"
-    },
     "date_created": [
       "2012"
     ],
@@ -2542,10 +1962,6 @@
     "experiment": "CMS",
     "publisher": "CERN Open Data Portal",
     "recid": "6272",
-    "run_period": [
-      "Run2012B",
-      "Run2012C"
-    ],
     "title": "High-Level Trigger path information HLT_DiJet40Eta2p6_BTagIP3D (MultiJet dataset)",
     "type": {
       "primary": "Supplementaries",
@@ -2566,10 +1982,6 @@
     "collections": [
       "CMS-Trigger-Information"
     ],
-    "collision_information": {
-      "energy": "8TeV",
-      "type": "pp"
-    },
     "date_created": [
       "2012"
     ],
@@ -2577,10 +1989,6 @@
     "experiment": "CMS",
     "publisher": "CERN Open Data Portal",
     "recid": "6273",
-    "run_period": [
-      "Run2012B",
-      "Run2012C"
-    ],
     "title": "High-Level Trigger path information HLT_DiJet40Eta2p6_BTagIP3DFastPV (BJetPlusX, MultiJet datasets)",
     "type": {
       "primary": "Supplementaries",
@@ -2601,10 +2009,6 @@
     "collections": [
       "CMS-Trigger-Information"
     ],
-    "collision_information": {
-      "energy": "8TeV",
-      "type": "pp"
-    },
     "date_created": [
       "2012"
     ],
@@ -2612,10 +2016,6 @@
     "experiment": "CMS",
     "publisher": "CERN Open Data Portal",
     "recid": "6274",
-    "run_period": [
-      "Run2012B",
-      "Run2012C"
-    ],
     "title": "High-Level Trigger path information HLT_DiJet80Eta2p6_BTagIP3DFastPVLoose (BJetPlusX, MultiJet datasets)",
     "type": {
       "primary": "Supplementaries",
@@ -2636,10 +2036,6 @@
     "collections": [
       "CMS-Trigger-Information"
     ],
-    "collision_information": {
-      "energy": "8TeV",
-      "type": "pp"
-    },
     "date_created": [
       "2012"
     ],
@@ -2647,10 +2043,6 @@
     "experiment": "CMS",
     "publisher": "CERN Open Data Portal",
     "recid": "6275",
-    "run_period": [
-      "Run2012B",
-      "Run2012C"
-    ],
     "title": "High-Level Trigger path information HLT_DiJet80Eta2p6_BTagIP3DLoose (MultiJet dataset)",
     "type": {
       "primary": "Supplementaries",
@@ -2671,10 +2063,6 @@
     "collections": [
       "CMS-Trigger-Information"
     ],
-    "collision_information": {
-      "energy": "8TeV",
-      "type": "pp"
-    },
     "date_created": [
       "2012"
     ],
@@ -2682,10 +2070,6 @@
     "experiment": "CMS",
     "publisher": "CERN Open Data Portal",
     "recid": "6276",
-    "run_period": [
-      "Run2012B",
-      "Run2012C"
-    ],
     "title": "High-Level Trigger path information HLT_DiJet80_DiJet60_DiJet20 (MultiJet, MultiJet1Parked datasets)",
     "type": {
       "primary": "Supplementaries",
@@ -2706,10 +2090,6 @@
     "collections": [
       "CMS-Trigger-Information"
     ],
-    "collision_information": {
-      "energy": "8TeV",
-      "type": "pp"
-    },
     "date_created": [
       "2012"
     ],
@@ -2717,10 +2097,6 @@
     "experiment": "CMS",
     "publisher": "CERN Open Data Portal",
     "recid": "6277",
-    "run_period": [
-      "Run2012B",
-      "Run2012C"
-    ],
     "title": "High-Level Trigger path information HLT_DiPFJet40_PFMETnoMu65_MJJ600VBF_LeadingJets (MET dataset)",
     "type": {
       "primary": "Supplementaries",
@@ -2741,10 +2117,6 @@
     "collections": [
       "CMS-Trigger-Information"
     ],
-    "collision_information": {
-      "energy": "8TeV",
-      "type": "pp"
-    },
     "date_created": [
       "2012"
     ],
@@ -2752,10 +2124,6 @@
     "experiment": "CMS",
     "publisher": "CERN Open Data Portal",
     "recid": "6278",
-    "run_period": [
-      "Run2012B",
-      "Run2012C"
-    ],
     "title": "High-Level Trigger path information HLT_DiPFJet40_PFMETnoMu65_MJJ800VBF_AllJets (MET dataset)",
     "type": {
       "primary": "Supplementaries",
@@ -2776,10 +2144,6 @@
     "collections": [
       "CMS-Trigger-Information"
     ],
-    "collision_information": {
-      "energy": "8TeV",
-      "type": "pp"
-    },
     "date_created": [
       "2012"
     ],
@@ -2787,10 +2151,6 @@
     "experiment": "CMS",
     "publisher": "CERN Open Data Portal",
     "recid": "6279",
-    "run_period": [
-      "Run2012B",
-      "Run2012C"
-    ],
     "title": "High-Level Trigger path information HLT_DiPFJet80_DiPFJet30_BTagCSVd07d05 (BJetPlusX dataset)",
     "type": {
       "primary": "Supplementaries",
@@ -2811,10 +2171,6 @@
     "collections": [
       "CMS-Trigger-Information"
     ],
-    "collision_information": {
-      "energy": "8TeV",
-      "type": "pp"
-    },
     "date_created": [
       "2012"
     ],
@@ -2822,10 +2178,6 @@
     "experiment": "CMS",
     "publisher": "CERN Open Data Portal",
     "recid": "6280",
-    "run_period": [
-      "Run2012B",
-      "Run2012C"
-    ],
     "title": "High-Level Trigger path information HLT_DiPFJet80_DiPFJet30_BTagCSVd07d05d03 (BJetPlusX dataset)",
     "type": {
       "primary": "Supplementaries",
@@ -2846,10 +2198,6 @@
     "collections": [
       "CMS-Trigger-Information"
     ],
-    "collision_information": {
-      "energy": "8TeV",
-      "type": "pp"
-    },
     "date_created": [
       "2012"
     ],
@@ -2857,10 +2205,6 @@
     "experiment": "CMS",
     "publisher": "CERN Open Data Portal",
     "recid": "6281",
-    "run_period": [
-      "Run2012B",
-      "Run2012C"
-    ],
     "title": "High-Level Trigger path information HLT_DiPFJet80_DiPFJet30_BTagCSVd07d05d03_PFDiJetPt120 (BJetPlusX dataset)",
     "type": {
       "primary": "Supplementaries",
@@ -2881,10 +2225,6 @@
     "collections": [
       "CMS-Trigger-Information"
     ],
-    "collision_information": {
-      "energy": "8TeV",
-      "type": "pp"
-    },
     "date_created": [
       "2012"
     ],
@@ -2892,10 +2232,6 @@
     "experiment": "CMS",
     "publisher": "CERN Open Data Portal",
     "recid": "6282",
-    "run_period": [
-      "Run2012B",
-      "Run2012C"
-    ],
     "title": "High-Level Trigger path information HLT_DiPFJet80_DiPFJet30_BTagCSVd07d05d05 (BJetPlusX dataset)",
     "type": {
       "primary": "Supplementaries",
@@ -2916,10 +2252,6 @@
     "collections": [
       "CMS-Trigger-Information"
     ],
-    "collision_information": {
-      "energy": "8TeV",
-      "type": "pp"
-    },
     "date_created": [
       "2012"
     ],
@@ -2927,10 +2259,6 @@
     "experiment": "CMS",
     "publisher": "CERN Open Data Portal",
     "recid": "6283",
-    "run_period": [
-      "Run2012B",
-      "Run2012C"
-    ],
     "title": "High-Level Trigger path information HLT_DiPFJetAve140 (Jet, JetMon datasets)",
     "type": {
       "primary": "Supplementaries",
@@ -2951,10 +2279,6 @@
     "collections": [
       "CMS-Trigger-Information"
     ],
-    "collision_information": {
-      "energy": "8TeV",
-      "type": "pp"
-    },
     "date_created": [
       "2012"
     ],
@@ -2962,10 +2286,6 @@
     "experiment": "CMS",
     "publisher": "CERN Open Data Portal",
     "recid": "6284",
-    "run_period": [
-      "Run2012B",
-      "Run2012C"
-    ],
     "title": "High-Level Trigger path information HLT_DiPFJetAve200 (Jet, JetMon datasets)",
     "type": {
       "primary": "Supplementaries",
@@ -2986,10 +2306,6 @@
     "collections": [
       "CMS-Trigger-Information"
     ],
-    "collision_information": {
-      "energy": "8TeV",
-      "type": "pp"
-    },
     "date_created": [
       "2012"
     ],
@@ -2997,10 +2313,6 @@
     "experiment": "CMS",
     "publisher": "CERN Open Data Portal",
     "recid": "6285",
-    "run_period": [
-      "Run2012B",
-      "Run2012C"
-    ],
     "title": "High-Level Trigger path information HLT_DiPFJetAve260 (Jet, JetMon datasets)",
     "type": {
       "primary": "Supplementaries",
@@ -3021,10 +2333,6 @@
     "collections": [
       "CMS-Trigger-Information"
     ],
-    "collision_information": {
-      "energy": "8TeV",
-      "type": "pp"
-    },
     "date_created": [
       "2012"
     ],
@@ -3032,10 +2340,6 @@
     "experiment": "CMS",
     "publisher": "CERN Open Data Portal",
     "recid": "6286",
-    "run_period": [
-      "Run2012B",
-      "Run2012C"
-    ],
     "title": "High-Level Trigger path information HLT_DiPFJetAve320 (Jet, JetHT datasets)",
     "type": {
       "primary": "Supplementaries",
@@ -3056,10 +2360,6 @@
     "collections": [
       "CMS-Trigger-Information"
     ],
-    "collision_information": {
-      "energy": "8TeV",
-      "type": "pp"
-    },
     "date_created": [
       "2012"
     ],
@@ -3067,10 +2367,6 @@
     "experiment": "CMS",
     "publisher": "CERN Open Data Portal",
     "recid": "6287",
-    "run_period": [
-      "Run2012B",
-      "Run2012C"
-    ],
     "title": "High-Level Trigger path information HLT_DiPFJetAve40 (Jet, JetMon datasets)",
     "type": {
       "primary": "Supplementaries",
@@ -3091,10 +2387,6 @@
     "collections": [
       "CMS-Trigger-Information"
     ],
-    "collision_information": {
-      "energy": "8TeV",
-      "type": "pp"
-    },
     "date_created": [
       "2012"
     ],
@@ -3102,10 +2394,6 @@
     "experiment": "CMS",
     "publisher": "CERN Open Data Portal",
     "recid": "6288",
-    "run_period": [
-      "Run2012B",
-      "Run2012C"
-    ],
     "title": "High-Level Trigger path information HLT_DiPFJetAve400 (Jet, JetHT datasets)",
     "type": {
       "primary": "Supplementaries",
@@ -3126,10 +2414,6 @@
     "collections": [
       "CMS-Trigger-Information"
     ],
-    "collision_information": {
-      "energy": "8TeV",
-      "type": "pp"
-    },
     "date_created": [
       "2012"
     ],
@@ -3137,10 +2421,6 @@
     "experiment": "CMS",
     "publisher": "CERN Open Data Portal",
     "recid": "6289",
-    "run_period": [
-      "Run2012B",
-      "Run2012C"
-    ],
     "title": "High-Level Trigger path information HLT_DiPFJetAve80 (Jet, JetMon datasets)",
     "type": {
       "primary": "Supplementaries",
@@ -3161,10 +2441,6 @@
     "collections": [
       "CMS-Trigger-Information"
     ],
-    "collision_information": {
-      "energy": "8TeV",
-      "type": "pp"
-    },
     "date_created": [
       "2012"
     ],
@@ -3172,10 +2448,6 @@
     "experiment": "CMS",
     "publisher": "CERN Open Data Portal",
     "recid": "6290",
-    "run_period": [
-      "Run2012B",
-      "Run2012C"
-    ],
     "title": "High-Level Trigger path information HLT_Dimuon0_Jpsi (MuOnia dataset)",
     "type": {
       "primary": "Supplementaries",
@@ -3196,10 +2468,6 @@
     "collections": [
       "CMS-Trigger-Information"
     ],
-    "collision_information": {
-      "energy": "8TeV",
-      "type": "pp"
-    },
     "date_created": [
       "2012"
     ],
@@ -3207,10 +2475,6 @@
     "experiment": "CMS",
     "publisher": "CERN Open Data Portal",
     "recid": "6291",
-    "run_period": [
-      "Run2012B",
-      "Run2012C"
-    ],
     "title": "High-Level Trigger path information HLT_Dimuon0_Jpsi_Muon (MuOnia dataset)",
     "type": {
       "primary": "Supplementaries",
@@ -3231,10 +2495,6 @@
     "collections": [
       "CMS-Trigger-Information"
     ],
-    "collision_information": {
-      "energy": "8TeV",
-      "type": "pp"
-    },
     "date_created": [
       "2012"
     ],
@@ -3242,10 +2502,6 @@
     "experiment": "CMS",
     "publisher": "CERN Open Data Portal",
     "recid": "6292",
-    "run_period": [
-      "Run2012B",
-      "Run2012C"
-    ],
     "title": "High-Level Trigger path information HLT_Dimuon0_Jpsi_NoVertexing (MuOnia dataset)",
     "type": {
       "primary": "Supplementaries",
@@ -3266,10 +2522,6 @@
     "collections": [
       "CMS-Trigger-Information"
     ],
-    "collision_information": {
-      "energy": "8TeV",
-      "type": "pp"
-    },
     "date_created": [
       "2012"
     ],
@@ -3277,10 +2529,6 @@
     "experiment": "CMS",
     "publisher": "CERN Open Data Portal",
     "recid": "6293",
-    "run_period": [
-      "Run2012B",
-      "Run2012C"
-    ],
     "title": "High-Level Trigger path information HLT_Dimuon0_PsiPrime (MuOnia dataset)",
     "type": {
       "primary": "Supplementaries",
@@ -3301,10 +2549,6 @@
     "collections": [
       "CMS-Trigger-Information"
     ],
-    "collision_information": {
-      "energy": "8TeV",
-      "type": "pp"
-    },
     "date_created": [
       "2012"
     ],
@@ -3312,10 +2556,6 @@
     "experiment": "CMS",
     "publisher": "CERN Open Data Portal",
     "recid": "6294",
-    "run_period": [
-      "Run2012B",
-      "Run2012C"
-    ],
     "title": "High-Level Trigger path information HLT_Dimuon0_Upsilon (MuOnia dataset)",
     "type": {
       "primary": "Supplementaries",
@@ -3336,10 +2576,6 @@
     "collections": [
       "CMS-Trigger-Information"
     ],
-    "collision_information": {
-      "energy": "8TeV",
-      "type": "pp"
-    },
     "date_created": [
       "2012"
     ],
@@ -3347,10 +2583,6 @@
     "experiment": "CMS",
     "publisher": "CERN Open Data Portal",
     "recid": "6295",
-    "run_period": [
-      "Run2012B",
-      "Run2012C"
-    ],
     "title": "High-Level Trigger path information HLT_Dimuon0_Upsilon_Muon (MuOnia dataset)",
     "type": {
       "primary": "Supplementaries",
@@ -3371,10 +2603,6 @@
     "collections": [
       "CMS-Trigger-Information"
     ],
-    "collision_information": {
-      "energy": "8TeV",
-      "type": "pp"
-    },
     "date_created": [
       "2012"
     ],
@@ -3382,10 +2610,6 @@
     "experiment": "CMS",
     "publisher": "CERN Open Data Portal",
     "recid": "6296",
-    "run_period": [
-      "Run2012B",
-      "Run2012C"
-    ],
     "title": "High-Level Trigger path information HLT_Dimuon10_Jpsi (DoubleMuParked, MuOniaParked datasets)",
     "type": {
       "primary": "Supplementaries",
@@ -3406,10 +2630,6 @@
     "collections": [
       "CMS-Trigger-Information"
     ],
-    "collision_information": {
-      "energy": "8TeV",
-      "type": "pp"
-    },
     "date_created": [
       "2012"
     ],
@@ -3417,10 +2637,6 @@
     "experiment": "CMS",
     "publisher": "CERN Open Data Portal",
     "recid": "6297",
-    "run_period": [
-      "Run2012B",
-      "Run2012C"
-    ],
     "title": "High-Level Trigger path information HLT_Dimuon11_Upsilon (MuOnia dataset)",
     "type": {
       "primary": "Supplementaries",
@@ -3441,10 +2657,6 @@
     "collections": [
       "CMS-Trigger-Information"
     ],
-    "collision_information": {
-      "energy": "8TeV",
-      "type": "pp"
-    },
     "date_created": [
       "2012"
     ],
@@ -3452,10 +2664,6 @@
     "experiment": "CMS",
     "publisher": "CERN Open Data Portal",
     "recid": "6298",
-    "run_period": [
-      "Run2012B",
-      "Run2012C"
-    ],
     "title": "High-Level Trigger path information HLT_Dimuon3p5_SameSign (MuOnia dataset)",
     "type": {
       "primary": "Supplementaries",
@@ -3476,10 +2684,6 @@
     "collections": [
       "CMS-Trigger-Information"
     ],
-    "collision_information": {
-      "energy": "8TeV",
-      "type": "pp"
-    },
     "date_created": [
       "2012"
     ],
@@ -3487,10 +2691,6 @@
     "experiment": "CMS",
     "publisher": "CERN Open Data Portal",
     "recid": "6299",
-    "run_period": [
-      "Run2012B",
-      "Run2012C"
-    ],
     "title": "High-Level Trigger path information HLT_Dimuon5_PsiPrime (DoubleMuParked, MuOniaParked datasets)",
     "type": {
       "primary": "Supplementaries",
@@ -3511,10 +2711,6 @@
     "collections": [
       "CMS-Trigger-Information"
     ],
-    "collision_information": {
-      "energy": "8TeV",
-      "type": "pp"
-    },
     "date_created": [
       "2012"
     ],
@@ -3522,10 +2718,6 @@
     "experiment": "CMS",
     "publisher": "CERN Open Data Portal",
     "recid": "6300",
-    "run_period": [
-      "Run2012B",
-      "Run2012C"
-    ],
     "title": "High-Level Trigger path information HLT_Dimuon5_Upsilon (MuOnia, MuOniaParked datasets)",
     "type": {
       "primary": "Supplementaries",
@@ -3546,10 +2738,6 @@
     "collections": [
       "CMS-Trigger-Information"
     ],
-    "collision_information": {
-      "energy": "8TeV",
-      "type": "pp"
-    },
     "date_created": [
       "2012"
     ],
@@ -3557,10 +2745,6 @@
     "experiment": "CMS",
     "publisher": "CERN Open Data Portal",
     "recid": "6301",
-    "run_period": [
-      "Run2012B",
-      "Run2012C"
-    ],
     "title": "High-Level Trigger path information HLT_Dimuon7_PsiPrime (MuOniaParked dataset)",
     "type": {
       "primary": "Supplementaries",
@@ -3581,10 +2765,6 @@
     "collections": [
       "CMS-Trigger-Information"
     ],
-    "collision_information": {
-      "energy": "8TeV",
-      "type": "pp"
-    },
     "date_created": [
       "2012"
     ],
@@ -3592,10 +2772,6 @@
     "experiment": "CMS",
     "publisher": "CERN Open Data Portal",
     "recid": "6302",
-    "run_period": [
-      "Run2012B",
-      "Run2012C"
-    ],
     "title": "High-Level Trigger path information HLT_Dimuon7_Upsilon (MuOnia dataset)",
     "type": {
       "primary": "Supplementaries",
@@ -3616,10 +2792,6 @@
     "collections": [
       "CMS-Trigger-Information"
     ],
-    "collision_information": {
-      "energy": "8TeV",
-      "type": "pp"
-    },
     "date_created": [
       "2012"
     ],
@@ -3627,10 +2799,6 @@
     "experiment": "CMS",
     "publisher": "CERN Open Data Portal",
     "recid": "6303",
-    "run_period": [
-      "Run2012B",
-      "Run2012C"
-    ],
     "title": "High-Level Trigger path information HLT_Dimuon8_Jpsi (DoubleMuParked, MuOniaParked datasets)",
     "type": {
       "primary": "Supplementaries",
@@ -3651,10 +2819,6 @@
     "collections": [
       "CMS-Trigger-Information"
     ],
-    "collision_information": {
-      "energy": "8TeV",
-      "type": "pp"
-    },
     "date_created": [
       "2012"
     ],
@@ -3662,10 +2826,6 @@
     "experiment": "CMS",
     "publisher": "CERN Open Data Portal",
     "recid": "6304",
-    "run_period": [
-      "Run2012B",
-      "Run2012C"
-    ],
     "title": "High-Level Trigger path information HLT_Dimuon8_Upsilon (MuOnia, MuOniaParked datasets)",
     "type": {
       "primary": "Supplementaries",
@@ -3686,10 +2846,6 @@
     "collections": [
       "CMS-Trigger-Information"
     ],
-    "collision_information": {
-      "energy": "8TeV",
-      "type": "pp"
-    },
     "date_created": [
       "2012"
     ],
@@ -3697,10 +2853,6 @@
     "experiment": "CMS",
     "publisher": "CERN Open Data Portal",
     "recid": "6305",
-    "run_period": [
-      "Run2012B",
-      "Run2012C"
-    ],
     "title": "High-Level Trigger path information HLT_Dimuon9_PsiPrime (DoubleMuParked dataset)",
     "type": {
       "primary": "Supplementaries",
@@ -3721,10 +2873,6 @@
     "collections": [
       "CMS-Trigger-Information"
     ],
-    "collision_information": {
-      "energy": "8TeV",
-      "type": "pp"
-    },
     "date_created": [
       "2012"
     ],
@@ -3732,10 +2880,6 @@
     "experiment": "CMS",
     "publisher": "CERN Open Data Portal",
     "recid": "6306",
-    "run_period": [
-      "Run2012B",
-      "Run2012C"
-    ],
     "title": "High-Level Trigger path information HLT_DisplacedPhoton65EBOnly_CaloIdVL_IsoL_PFMET30 (SinglePhoton dataset)",
     "type": {
       "primary": "Supplementaries",
@@ -3756,10 +2900,6 @@
     "collections": [
       "CMS-Trigger-Information"
     ],
-    "collision_information": {
-      "energy": "8TeV",
-      "type": "pp"
-    },
     "date_created": [
       "2012"
     ],
@@ -3767,10 +2907,6 @@
     "experiment": "CMS",
     "publisher": "CERN Open Data Portal",
     "recid": "6307",
-    "run_period": [
-      "Run2012B",
-      "Run2012C"
-    ],
     "title": "High-Level Trigger path information HLT_DisplacedPhoton65_CaloIdVL_IsoL_PFMET25 (SinglePhoton dataset)",
     "type": {
       "primary": "Supplementaries",
@@ -3791,10 +2927,6 @@
     "collections": [
       "CMS-Trigger-Information"
     ],
-    "collision_information": {
-      "energy": "8TeV",
-      "type": "pp"
-    },
     "date_created": [
       "2012"
     ],
@@ -3802,10 +2934,6 @@
     "experiment": "CMS",
     "publisher": "CERN Open Data Portal",
     "recid": "6308",
-    "run_period": [
-      "Run2012B",
-      "Run2012C"
-    ],
     "title": "High-Level Trigger path information HLT_DoubleDisplacedMu4_DiPFJet40Neutral (MuHad dataset)",
     "type": {
       "primary": "Supplementaries",
@@ -3826,10 +2954,6 @@
     "collections": [
       "CMS-Trigger-Information"
     ],
-    "collision_information": {
-      "energy": "8TeV",
-      "type": "pp"
-    },
     "date_created": [
       "2012"
     ],
@@ -3837,10 +2961,6 @@
     "experiment": "CMS",
     "publisher": "CERN Open Data Portal",
     "recid": "6309",
-    "run_period": [
-      "Run2012B",
-      "Run2012C"
-    ],
     "title": "High-Level Trigger path information HLT_DoubleEle10_CaloIdL_TrkIdVL_Ele10_CaloIdT_TrkIdVL (DoubleElectron dataset)",
     "type": {
       "primary": "Supplementaries",
@@ -3861,10 +2981,6 @@
     "collections": [
       "CMS-Trigger-Information"
     ],
-    "collision_information": {
-      "energy": "8TeV",
-      "type": "pp"
-    },
     "date_created": [
       "2012"
     ],
@@ -3872,10 +2988,6 @@
     "experiment": "CMS",
     "publisher": "CERN Open Data Portal",
     "recid": "6310",
-    "run_period": [
-      "Run2012B",
-      "Run2012C"
-    ],
     "title": "High-Level Trigger path information HLT_DoubleEle14_CaloIdT_TrkIdVL_Mass8_PFMET40 (ElectronHad dataset)",
     "type": {
       "primary": "Supplementaries",
@@ -3896,10 +3008,6 @@
     "collections": [
       "CMS-Trigger-Information"
     ],
-    "collision_information": {
-      "energy": "8TeV",
-      "type": "pp"
-    },
     "date_created": [
       "2012"
     ],
@@ -3907,10 +3015,6 @@
     "experiment": "CMS",
     "publisher": "CERN Open Data Portal",
     "recid": "6311",
-    "run_period": [
-      "Run2012B",
-      "Run2012C"
-    ],
     "title": "High-Level Trigger path information HLT_DoubleEle14_CaloIdT_TrkIdVL_Mass8_PFMET50 (ElectronHad dataset)",
     "type": {
       "primary": "Supplementaries",
@@ -3931,10 +3035,6 @@
     "collections": [
       "CMS-Trigger-Information"
     ],
-    "collision_information": {
-      "energy": "8TeV",
-      "type": "pp"
-    },
     "date_created": [
       "2012"
     ],
@@ -3942,10 +3042,6 @@
     "experiment": "CMS",
     "publisher": "CERN Open Data Portal",
     "recid": "6312",
-    "run_period": [
-      "Run2012B",
-      "Run2012C"
-    ],
     "title": "High-Level Trigger path information HLT_DoubleEle33_CaloIdL (DoublePhotonHighPt, Photon datasets)",
     "type": {
       "primary": "Supplementaries",
@@ -3966,10 +3062,6 @@
     "collections": [
       "CMS-Trigger-Information"
     ],
-    "collision_information": {
-      "energy": "8TeV",
-      "type": "pp"
-    },
     "date_created": [
       "2012"
     ],
@@ -3977,10 +3069,6 @@
     "experiment": "CMS",
     "publisher": "CERN Open Data Portal",
     "recid": "6313",
-    "run_period": [
-      "Run2012B",
-      "Run2012C"
-    ],
     "title": "High-Level Trigger path information HLT_DoubleEle33_CaloIdL_GsfTrkIdVL (DoublePhotonHighPt, Photon datasets)",
     "type": {
       "primary": "Supplementaries",
@@ -4001,10 +3089,6 @@
     "collections": [
       "CMS-Trigger-Information"
     ],
-    "collision_information": {
-      "energy": "8TeV",
-      "type": "pp"
-    },
     "date_created": [
       "2012"
     ],
@@ -4012,10 +3096,6 @@
     "experiment": "CMS",
     "publisher": "CERN Open Data Portal",
     "recid": "6314",
-    "run_period": [
-      "Run2012B",
-      "Run2012C"
-    ],
     "title": "High-Level Trigger path information HLT_DoubleEle33_CaloIdT (DoublePhotonHighPt, Photon datasets)",
     "type": {
       "primary": "Supplementaries",
@@ -4036,10 +3116,6 @@
     "collections": [
       "CMS-Trigger-Information"
     ],
-    "collision_information": {
-      "energy": "8TeV",
-      "type": "pp"
-    },
     "date_created": [
       "2012"
     ],
@@ -4047,10 +3123,6 @@
     "experiment": "CMS",
     "publisher": "CERN Open Data Portal",
     "recid": "6315",
-    "run_period": [
-      "Run2012B",
-      "Run2012C"
-    ],
     "title": "High-Level Trigger path information HLT_DoubleEle8_CaloIdT_TrkIdVL (ElectronHad dataset)",
     "type": {
       "primary": "Supplementaries",
@@ -4071,10 +3143,6 @@
     "collections": [
       "CMS-Trigger-Information"
     ],
-    "collision_information": {
-      "energy": "8TeV",
-      "type": "pp"
-    },
     "date_created": [
       "2012"
     ],
@@ -4082,10 +3150,6 @@
     "experiment": "CMS",
     "publisher": "CERN Open Data Portal",
     "recid": "6316",
-    "run_period": [
-      "Run2012B",
-      "Run2012C"
-    ],
     "title": "High-Level Trigger path information HLT_DoubleEle8_CaloIdT_TrkIdVL_Mass8_PFHT175 (ElectronHad dataset)",
     "type": {
       "primary": "Supplementaries",
@@ -4106,10 +3170,6 @@
     "collections": [
       "CMS-Trigger-Information"
     ],
-    "collision_information": {
-      "energy": "8TeV",
-      "type": "pp"
-    },
     "date_created": [
       "2012"
     ],
@@ -4117,10 +3177,6 @@
     "experiment": "CMS",
     "publisher": "CERN Open Data Portal",
     "recid": "6317",
-    "run_period": [
-      "Run2012B",
-      "Run2012C"
-    ],
     "title": "High-Level Trigger path information HLT_DoubleEle8_CaloIdT_TrkIdVL_Mass8_PFHT225 (ElectronHad dataset)",
     "type": {
       "primary": "Supplementaries",
@@ -4141,10 +3197,6 @@
     "collections": [
       "CMS-Trigger-Information"
     ],
-    "collision_information": {
-      "energy": "8TeV",
-      "type": "pp"
-    },
     "date_created": [
       "2012"
     ],
@@ -4152,10 +3204,6 @@
     "experiment": "CMS",
     "publisher": "CERN Open Data Portal",
     "recid": "6318",
-    "run_period": [
-      "Run2012B",
-      "Run2012C"
-    ],
     "title": "High-Level Trigger path information HLT_DoubleEle8_CaloIdT_TrkIdVL_Mass8_PFNoPUHT175 (ElectronHad dataset)",
     "type": {
       "primary": "Supplementaries",
@@ -4176,10 +3224,6 @@
     "collections": [
       "CMS-Trigger-Information"
     ],
-    "collision_information": {
-      "energy": "8TeV",
-      "type": "pp"
-    },
     "date_created": [
       "2012"
     ],
@@ -4187,10 +3231,6 @@
     "experiment": "CMS",
     "publisher": "CERN Open Data Portal",
     "recid": "6319",
-    "run_period": [
-      "Run2012B",
-      "Run2012C"
-    ],
     "title": "High-Level Trigger path information HLT_DoubleEle8_CaloIdT_TrkIdVL_Mass8_PFNoPUHT225 (ElectronHad dataset)",
     "type": {
       "primary": "Supplementaries",
@@ -4211,10 +3251,6 @@
     "collections": [
       "CMS-Trigger-Information"
     ],
-    "collision_information": {
-      "energy": "8TeV",
-      "type": "pp"
-    },
     "date_created": [
       "2012"
     ],
@@ -4222,10 +3258,6 @@
     "experiment": "CMS",
     "publisher": "CERN Open Data Portal",
     "recid": "6320",
-    "run_period": [
-      "Run2012B",
-      "Run2012C"
-    ],
     "title": "High-Level Trigger path information HLT_DoubleIsoL2Tau30_eta2p1 (Tau, TauParked datasets)",
     "type": {
       "primary": "Supplementaries",
@@ -4246,10 +3278,6 @@
     "collections": [
       "CMS-Trigger-Information"
     ],
-    "collision_information": {
-      "energy": "8TeV",
-      "type": "pp"
-    },
     "date_created": [
       "2012"
     ],
@@ -4257,10 +3285,6 @@
     "experiment": "CMS",
     "publisher": "CERN Open Data Portal",
     "recid": "6321",
-    "run_period": [
-      "Run2012B",
-      "Run2012C"
-    ],
     "title": "High-Level Trigger path information HLT_DoubleJet20_ForwardBackward (MultiJet, MultiJet1Parked datasets)",
     "type": {
       "primary": "Supplementaries",
@@ -4281,10 +3305,6 @@
     "collections": [
       "CMS-Trigger-Information"
     ],
-    "collision_information": {
-      "energy": "8TeV",
-      "type": "pp"
-    },
     "date_created": [
       "2012"
     ],
@@ -4292,10 +3312,6 @@
     "experiment": "CMS",
     "publisher": "CERN Open Data Portal",
     "recid": "6322",
-    "run_period": [
-      "Run2012B",
-      "Run2012C"
-    ],
     "title": "High-Level Trigger path information HLT_DoubleMediumIsoPFTau25_Trk5_eta2p1_Jet30 (Tau dataset)",
     "type": {
       "primary": "Supplementaries",
@@ -4316,10 +3332,6 @@
     "collections": [
       "CMS-Trigger-Information"
     ],
-    "collision_information": {
-      "energy": "8TeV",
-      "type": "pp"
-    },
     "date_created": [
       "2012"
     ],
@@ -4327,10 +3339,6 @@
     "experiment": "CMS",
     "publisher": "CERN Open Data Portal",
     "recid": "6323",
-    "run_period": [
-      "Run2012B",
-      "Run2012C"
-    ],
     "title": "High-Level Trigger path information HLT_DoubleMediumIsoPFTau30_Trk1_eta2p1 (Tau, TauParked datasets)",
     "type": {
       "primary": "Supplementaries",
@@ -4351,10 +3359,6 @@
     "collections": [
       "CMS-Trigger-Information"
     ],
-    "collision_information": {
-      "energy": "8TeV",
-      "type": "pp"
-    },
     "date_created": [
       "2012"
     ],
@@ -4362,10 +3366,6 @@
     "experiment": "CMS",
     "publisher": "CERN Open Data Portal",
     "recid": "6324",
-    "run_period": [
-      "Run2012B",
-      "Run2012C"
-    ],
     "title": "High-Level Trigger path information HLT_DoubleMediumIsoPFTau30_Trk1_eta2p1_Jet30 (Tau, TauParked datasets)",
     "type": {
       "primary": "Supplementaries",
@@ -4386,10 +3386,6 @@
     "collections": [
       "CMS-Trigger-Information"
     ],
-    "collision_information": {
-      "energy": "8TeV",
-      "type": "pp"
-    },
     "date_created": [
       "2012"
     ],
@@ -4397,10 +3393,6 @@
     "experiment": "CMS",
     "publisher": "CERN Open Data Portal",
     "recid": "6325",
-    "run_period": [
-      "Run2012B",
-      "Run2012C"
-    ],
     "title": "High-Level Trigger path information HLT_DoubleMediumIsoPFTau30_Trk1_eta2p1_Reg (Tau, TauParked datasets)",
     "type": {
       "primary": "Supplementaries",
@@ -4421,10 +3413,6 @@
     "collections": [
       "CMS-Trigger-Information"
     ],
-    "collision_information": {
-      "energy": "8TeV",
-      "type": "pp"
-    },
     "date_created": [
       "2012"
     ],
@@ -4432,10 +3420,6 @@
     "experiment": "CMS",
     "publisher": "CERN Open Data Portal",
     "recid": "6326",
-    "run_period": [
-      "Run2012B",
-      "Run2012C"
-    ],
     "title": "High-Level Trigger path information HLT_DoubleMediumIsoPFTau30_Trk1_eta2p1_Reg_Jet30 (Tau, TauParked datasets)",
     "type": {
       "primary": "Supplementaries",
@@ -4456,10 +3440,6 @@
     "collections": [
       "CMS-Trigger-Information"
     ],
-    "collision_information": {
-      "energy": "8TeV",
-      "type": "pp"
-    },
     "date_created": [
       "2012"
     ],
@@ -4467,10 +3447,6 @@
     "experiment": "CMS",
     "publisher": "CERN Open Data Portal",
     "recid": "6327",
-    "run_period": [
-      "Run2012B",
-      "Run2012C"
-    ],
     "title": "High-Level Trigger path information HLT_DoubleMediumIsoPFTau30_Trk5_eta2p1 (Tau, TauParked datasets)",
     "type": {
       "primary": "Supplementaries",
@@ -4491,10 +3467,6 @@
     "collections": [
       "CMS-Trigger-Information"
     ],
-    "collision_information": {
-      "energy": "8TeV",
-      "type": "pp"
-    },
     "date_created": [
       "2012"
     ],
@@ -4502,10 +3474,6 @@
     "experiment": "CMS",
     "publisher": "CERN Open Data Portal",
     "recid": "6328",
-    "run_period": [
-      "Run2012B",
-      "Run2012C"
-    ],
     "title": "High-Level Trigger path information HLT_DoubleMediumIsoPFTau30_Trk5_eta2p1_Jet30 (Tau, TauParked datasets)",
     "type": {
       "primary": "Supplementaries",
@@ -4526,10 +3494,6 @@
     "collections": [
       "CMS-Trigger-Information"
     ],
-    "collision_information": {
-      "energy": "8TeV",
-      "type": "pp"
-    },
     "date_created": [
       "2012"
     ],
@@ -4537,10 +3501,6 @@
     "experiment": "CMS",
     "publisher": "CERN Open Data Portal",
     "recid": "6329",
-    "run_period": [
-      "Run2012B",
-      "Run2012C"
-    ],
     "title": "High-Level Trigger path information HLT_DoubleMediumIsoPFTau35_Trk1_eta2p1 (TauParked dataset)",
     "type": {
       "primary": "Supplementaries",
@@ -4561,10 +3521,6 @@
     "collections": [
       "CMS-Trigger-Information"
     ],
-    "collision_information": {
-      "energy": "8TeV",
-      "type": "pp"
-    },
     "date_created": [
       "2012"
     ],
@@ -4572,10 +3528,6 @@
     "experiment": "CMS",
     "publisher": "CERN Open Data Portal",
     "recid": "6330",
-    "run_period": [
-      "Run2012B",
-      "Run2012C"
-    ],
     "title": "High-Level Trigger path information HLT_DoubleMediumIsoPFTau35_Trk1_eta2p1_Prong1 (Tau, TauParked datasets)",
     "type": {
       "primary": "Supplementaries",
@@ -4596,10 +3548,6 @@
     "collections": [
       "CMS-Trigger-Information"
     ],
-    "collision_information": {
-      "energy": "8TeV",
-      "type": "pp"
-    },
     "date_created": [
       "2012"
     ],
@@ -4607,10 +3555,6 @@
     "experiment": "CMS",
     "publisher": "CERN Open Data Portal",
     "recid": "6331",
-    "run_period": [
-      "Run2012B",
-      "Run2012C"
-    ],
     "title": "High-Level Trigger path information HLT_DoubleMediumIsoPFTau35_Trk1_eta2p1_Prong1_Reg (Tau, TauParked datasets)",
     "type": {
       "primary": "Supplementaries",
@@ -4631,10 +3575,6 @@
     "collections": [
       "CMS-Trigger-Information"
     ],
-    "collision_information": {
-      "energy": "8TeV",
-      "type": "pp"
-    },
     "date_created": [
       "2012"
     ],
@@ -4642,10 +3582,6 @@
     "experiment": "CMS",
     "publisher": "CERN Open Data Portal",
     "recid": "6332",
-    "run_period": [
-      "Run2012B",
-      "Run2012C"
-    ],
     "title": "High-Level Trigger path information HLT_DoubleMediumIsoPFTau35_Trk1_eta2p1_Reg (TauParked dataset)",
     "type": {
       "primary": "Supplementaries",
@@ -4666,10 +3602,6 @@
     "collections": [
       "CMS-Trigger-Information"
     ],
-    "collision_information": {
-      "energy": "8TeV",
-      "type": "pp"
-    },
     "date_created": [
       "2012"
     ],
@@ -4677,10 +3609,6 @@
     "experiment": "CMS",
     "publisher": "CERN Open Data Portal",
     "recid": "6333",
-    "run_period": [
-      "Run2012B",
-      "Run2012C"
-    ],
     "title": "High-Level Trigger path information HLT_DoubleMediumIsoPFTau35_Trk5_eta2p1 (Tau, TauParked datasets)",
     "type": {
       "primary": "Supplementaries",
@@ -4701,10 +3629,6 @@
     "collections": [
       "CMS-Trigger-Information"
     ],
-    "collision_information": {
-      "energy": "8TeV",
-      "type": "pp"
-    },
     "date_created": [
       "2012"
     ],
@@ -4712,10 +3636,6 @@
     "experiment": "CMS",
     "publisher": "CERN Open Data Portal",
     "recid": "6334",
-    "run_period": [
-      "Run2012B",
-      "Run2012C"
-    ],
     "title": "High-Level Trigger path information HLT_DoubleMediumIsoPFTau35_Trk5_eta2p1_Prong1 (Tau, TauParked datasets)",
     "type": {
       "primary": "Supplementaries",
@@ -4736,10 +3656,6 @@
     "collections": [
       "CMS-Trigger-Information"
     ],
-    "collision_information": {
-      "energy": "8TeV",
-      "type": "pp"
-    },
     "date_created": [
       "2012"
     ],
@@ -4747,10 +3663,6 @@
     "experiment": "CMS",
     "publisher": "CERN Open Data Portal",
     "recid": "6335",
-    "run_period": [
-      "Run2012B",
-      "Run2012C"
-    ],
     "title": "High-Level Trigger path information HLT_DoubleMu11_Acoplanarity03 (DoubleMu, DoubleMuParked datasets)",
     "type": {
       "primary": "Supplementaries",
@@ -4771,10 +3683,6 @@
     "collections": [
       "CMS-Trigger-Information"
     ],
-    "collision_information": {
-      "energy": "8TeV",
-      "type": "pp"
-    },
     "date_created": [
       "2012"
     ],
@@ -4782,10 +3690,6 @@
     "experiment": "CMS",
     "publisher": "CERN Open Data Portal",
     "recid": "6336",
-    "run_period": [
-      "Run2012B",
-      "Run2012C"
-    ],
     "title": "High-Level Trigger path information HLT_DoubleMu14_Mass8_PFMET40 (MuHad dataset)",
     "type": {
       "primary": "Supplementaries",
@@ -4806,10 +3710,6 @@
     "collections": [
       "CMS-Trigger-Information"
     ],
-    "collision_information": {
-      "energy": "8TeV",
-      "type": "pp"
-    },
     "date_created": [
       "2012"
     ],
@@ -4817,10 +3717,6 @@
     "experiment": "CMS",
     "publisher": "CERN Open Data Portal",
     "recid": "6337",
-    "run_period": [
-      "Run2012B",
-      "Run2012C"
-    ],
     "title": "High-Level Trigger path information HLT_DoubleMu14_Mass8_PFMET50 (MuHad dataset)",
     "type": {
       "primary": "Supplementaries",
@@ -4841,10 +3737,6 @@
     "collections": [
       "CMS-Trigger-Information"
     ],
-    "collision_information": {
-      "energy": "8TeV",
-      "type": "pp"
-    },
     "date_created": [
       "2012"
     ],
@@ -4852,10 +3744,6 @@
     "experiment": "CMS",
     "publisher": "CERN Open Data Portal",
     "recid": "6338",
-    "run_period": [
-      "Run2012B",
-      "Run2012C"
-    ],
     "title": "High-Level Trigger path information HLT_DoubleMu3_4_Dimuon5_Bs_Central (MuOnia dataset)",
     "type": {
       "primary": "Supplementaries",
@@ -4876,10 +3764,6 @@
     "collections": [
       "CMS-Trigger-Information"
     ],
-    "collision_information": {
-      "energy": "8TeV",
-      "type": "pp"
-    },
     "date_created": [
       "2012"
     ],
@@ -4887,10 +3771,6 @@
     "experiment": "CMS",
     "publisher": "CERN Open Data Portal",
     "recid": "6339",
-    "run_period": [
-      "Run2012B",
-      "Run2012C"
-    ],
     "title": "High-Level Trigger path information HLT_DoubleMu3p5_4_Dimuon5_Bs_Central (MuOnia dataset)",
     "type": {
       "primary": "Supplementaries",
@@ -4911,10 +3791,6 @@
     "collections": [
       "CMS-Trigger-Information"
     ],
-    "collision_information": {
-      "energy": "8TeV",
-      "type": "pp"
-    },
     "date_created": [
       "2012"
     ],
@@ -4922,10 +3798,6 @@
     "experiment": "CMS",
     "publisher": "CERN Open Data Portal",
     "recid": "6340",
-    "run_period": [
-      "Run2012B",
-      "Run2012C"
-    ],
     "title": "High-Level Trigger path information HLT_DoubleMu3p5_LowMassNonResonant_Displaced (DoubleMuParked, MuOniaParked datasets)",
     "type": {
       "primary": "Supplementaries",
@@ -4946,10 +3818,6 @@
     "collections": [
       "CMS-Trigger-Information"
     ],
-    "collision_information": {
-      "energy": "8TeV",
-      "type": "pp"
-    },
     "date_created": [
       "2012"
     ],
@@ -4957,10 +3825,6 @@
     "experiment": "CMS",
     "publisher": "CERN Open Data Portal",
     "recid": "6341",
-    "run_period": [
-      "Run2012B",
-      "Run2012C"
-    ],
     "title": "High-Level Trigger path information HLT_DoubleMu3p5_LowMass_Displaced (DoubleMuParked, MuOniaParked datasets)",
     "type": {
       "primary": "Supplementaries",
@@ -4981,10 +3845,6 @@
     "collections": [
       "CMS-Trigger-Information"
     ],
-    "collision_information": {
-      "energy": "8TeV",
-      "type": "pp"
-    },
     "date_created": [
       "2012"
     ],
@@ -4992,10 +3852,6 @@
     "experiment": "CMS",
     "publisher": "CERN Open Data Portal",
     "recid": "6342",
-    "run_period": [
-      "Run2012B",
-      "Run2012C"
-    ],
     "title": "High-Level Trigger path information HLT_DoubleMu4_Acoplanarity03 (DoubleMu, DoubleMuParked datasets)",
     "type": {
       "primary": "Supplementaries",
@@ -5016,10 +3872,6 @@
     "collections": [
       "CMS-Trigger-Information"
     ],
-    "collision_information": {
-      "energy": "8TeV",
-      "type": "pp"
-    },
     "date_created": [
       "2012"
     ],
@@ -5027,10 +3879,6 @@
     "experiment": "CMS",
     "publisher": "CERN Open Data Portal",
     "recid": "6343",
-    "run_period": [
-      "Run2012B",
-      "Run2012C"
-    ],
     "title": "High-Level Trigger path information HLT_DoubleMu4_Dimuon7_Bs_Forward (MuOnia dataset)",
     "type": {
       "primary": "Supplementaries",
@@ -5051,10 +3899,6 @@
     "collections": [
       "CMS-Trigger-Information"
     ],
-    "collision_information": {
-      "energy": "8TeV",
-      "type": "pp"
-    },
     "date_created": [
       "2012"
     ],
@@ -5062,10 +3906,6 @@
     "experiment": "CMS",
     "publisher": "CERN Open Data Portal",
     "recid": "6344",
-    "run_period": [
-      "Run2012B",
-      "Run2012C"
-    ],
     "title": "High-Level Trigger path information HLT_DoubleMu4_JpsiTk_Displaced (MuOnia dataset)",
     "type": {
       "primary": "Supplementaries",
@@ -5086,10 +3926,6 @@
     "collections": [
       "CMS-Trigger-Information"
     ],
-    "collision_information": {
-      "energy": "8TeV",
-      "type": "pp"
-    },
     "date_created": [
       "2012"
     ],
@@ -5097,10 +3933,6 @@
     "experiment": "CMS",
     "publisher": "CERN Open Data Portal",
     "recid": "6345",
-    "run_period": [
-      "Run2012B",
-      "Run2012C"
-    ],
     "title": "High-Level Trigger path information HLT_DoubleMu4_Jpsi_Displaced (MuOnia dataset)",
     "type": {
       "primary": "Supplementaries",
@@ -5121,10 +3953,6 @@
     "collections": [
       "CMS-Trigger-Information"
     ],
-    "collision_information": {
-      "energy": "8TeV",
-      "type": "pp"
-    },
     "date_created": [
       "2012"
     ],
@@ -5132,10 +3960,6 @@
     "experiment": "CMS",
     "publisher": "CERN Open Data Portal",
     "recid": "6346",
-    "run_period": [
-      "Run2012B",
-      "Run2012C"
-    ],
     "title": "High-Level Trigger path information HLT_DoubleMu5_Ele8_CaloIdT_TrkIdVL (MuEG dataset)",
     "type": {
       "primary": "Supplementaries",
@@ -5156,10 +3980,6 @@
     "collections": [
       "CMS-Trigger-Information"
     ],
-    "collision_information": {
-      "energy": "8TeV",
-      "type": "pp"
-    },
     "date_created": [
       "2012"
     ],
@@ -5167,10 +3987,6 @@
     "experiment": "CMS",
     "publisher": "CERN Open Data Portal",
     "recid": "6347",
-    "run_period": [
-      "Run2012B",
-      "Run2012C"
-    ],
     "title": "High-Level Trigger path information HLT_DoubleMu5_IsoMu5 (DoubleMu, DoubleMuParked datasets)",
     "type": {
       "primary": "Supplementaries",
@@ -5191,10 +4007,6 @@
     "collections": [
       "CMS-Trigger-Information"
     ],
-    "collision_information": {
-      "energy": "8TeV",
-      "type": "pp"
-    },
     "date_created": [
       "2012"
     ],
@@ -5202,10 +4014,6 @@
     "experiment": "CMS",
     "publisher": "CERN Open Data Portal",
     "recid": "6348",
-    "run_period": [
-      "Run2012B",
-      "Run2012C"
-    ],
     "title": "High-Level Trigger path information HLT_DoubleMu8_Ele8_CaloIdT_TrkIdVL (MuEG dataset)",
     "type": {
       "primary": "Supplementaries",
@@ -5226,10 +4034,6 @@
     "collections": [
       "CMS-Trigger-Information"
     ],
-    "collision_information": {
-      "energy": "8TeV",
-      "type": "pp"
-    },
     "date_created": [
       "2012"
     ],
@@ -5237,10 +4041,6 @@
     "experiment": "CMS",
     "publisher": "CERN Open Data Portal",
     "recid": "6349",
-    "run_period": [
-      "Run2012B",
-      "Run2012C"
-    ],
     "title": "High-Level Trigger path information HLT_DoubleMu8_Mass8_PFHT175 (MuHad dataset)",
     "type": {
       "primary": "Supplementaries",
@@ -5261,10 +4061,6 @@
     "collections": [
       "CMS-Trigger-Information"
     ],
-    "collision_information": {
-      "energy": "8TeV",
-      "type": "pp"
-    },
     "date_created": [
       "2012"
     ],
@@ -5272,10 +4068,6 @@
     "experiment": "CMS",
     "publisher": "CERN Open Data Portal",
     "recid": "6350",
-    "run_period": [
-      "Run2012B",
-      "Run2012C"
-    ],
     "title": "High-Level Trigger path information HLT_DoubleMu8_Mass8_PFHT225 (MuHad dataset)",
     "type": {
       "primary": "Supplementaries",
@@ -5296,10 +4088,6 @@
     "collections": [
       "CMS-Trigger-Information"
     ],
-    "collision_information": {
-      "energy": "8TeV",
-      "type": "pp"
-    },
     "date_created": [
       "2012"
     ],
@@ -5307,10 +4095,6 @@
     "experiment": "CMS",
     "publisher": "CERN Open Data Portal",
     "recid": "6351",
-    "run_period": [
-      "Run2012B",
-      "Run2012C"
-    ],
     "title": "High-Level Trigger path information HLT_DoubleMu8_Mass8_PFNoPUHT175 (MuHad dataset)",
     "type": {
       "primary": "Supplementaries",
@@ -5331,10 +4115,6 @@
     "collections": [
       "CMS-Trigger-Information"
     ],
-    "collision_information": {
-      "energy": "8TeV",
-      "type": "pp"
-    },
     "date_created": [
       "2012"
     ],
@@ -5342,10 +4122,6 @@
     "experiment": "CMS",
     "publisher": "CERN Open Data Portal",
     "recid": "6352",
-    "run_period": [
-      "Run2012B",
-      "Run2012C"
-    ],
     "title": "High-Level Trigger path information HLT_DoubleMu8_Mass8_PFNoPUHT225 (MuHad dataset)",
     "type": {
       "primary": "Supplementaries",
@@ -5366,10 +4142,6 @@
     "collections": [
       "CMS-Trigger-Information"
     ],
-    "collision_information": {
-      "energy": "8TeV",
-      "type": "pp"
-    },
     "date_created": [
       "2012"
     ],
@@ -5377,10 +4149,6 @@
     "experiment": "CMS",
     "publisher": "CERN Open Data Portal",
     "recid": "6353",
-    "run_period": [
-      "Run2012B",
-      "Run2012C"
-    ],
     "title": "High-Level Trigger path information HLT_DoublePhoton40_CaloIdL_Rsq0p035 (DoublePhotonHighPt, Photon datasets)",
     "type": {
       "primary": "Supplementaries",
@@ -5401,10 +4169,6 @@
     "collections": [
       "CMS-Trigger-Information"
     ],
-    "collision_information": {
-      "energy": "8TeV",
-      "type": "pp"
-    },
     "date_created": [
       "2012"
     ],
@@ -5412,10 +4176,6 @@
     "experiment": "CMS",
     "publisher": "CERN Open Data Portal",
     "recid": "6354",
-    "run_period": [
-      "Run2012B",
-      "Run2012C"
-    ],
     "title": "High-Level Trigger path information HLT_DoublePhoton40_CaloIdL_Rsq0p06 (DoublePhotonHighPt, Photon datasets)",
     "type": {
       "primary": "Supplementaries",
@@ -5436,10 +4196,6 @@
     "collections": [
       "CMS-Trigger-Information"
     ],
-    "collision_information": {
-      "energy": "8TeV",
-      "type": "pp"
-    },
     "date_created": [
       "2012"
     ],
@@ -5447,10 +4203,6 @@
     "experiment": "CMS",
     "publisher": "CERN Open Data Portal",
     "recid": "6355",
-    "run_period": [
-      "Run2012B",
-      "Run2012C"
-    ],
     "title": "High-Level Trigger path information HLT_DoublePhoton43_HEVT (Photon dataset)",
     "type": {
       "primary": "Supplementaries",
@@ -5471,10 +4223,6 @@
     "collections": [
       "CMS-Trigger-Information"
     ],
-    "collision_information": {
-      "energy": "8TeV",
-      "type": "pp"
-    },
     "date_created": [
       "2012"
     ],
@@ -5482,10 +4230,6 @@
     "experiment": "CMS",
     "publisher": "CERN Open Data Portal",
     "recid": "6356",
-    "run_period": [
-      "Run2012B",
-      "Run2012C"
-    ],
     "title": "High-Level Trigger path information HLT_DoublePhoton48_HEVT (DoublePhotonHighPt, Photon datasets)",
     "type": {
       "primary": "Supplementaries",
@@ -5506,10 +4250,6 @@
     "collections": [
       "CMS-Trigger-Information"
     ],
-    "collision_information": {
-      "energy": "8TeV",
-      "type": "pp"
-    },
     "date_created": [
       "2012"
     ],
@@ -5517,10 +4257,6 @@
     "experiment": "CMS",
     "publisher": "CERN Open Data Portal",
     "recid": "6357",
-    "run_period": [
-      "Run2012B",
-      "Run2012C"
-    ],
     "title": "High-Level Trigger path information HLT_DoublePhoton53_HEVT (DoublePhotonHighPt dataset)",
     "type": {
       "primary": "Supplementaries",
@@ -5541,10 +4277,6 @@
     "collections": [
       "CMS-Trigger-Information"
     ],
-    "collision_information": {
-      "energy": "8TeV",
-      "type": "pp"
-    },
     "date_created": [
       "2012"
     ],
@@ -5552,10 +4284,6 @@
     "experiment": "CMS",
     "publisher": "CERN Open Data Portal",
     "recid": "6358",
-    "run_period": [
-      "Run2012B",
-      "Run2012C"
-    ],
     "title": "High-Level Trigger path information HLT_DoublePhoton5_IsoVL_CEP (Photon, SinglePhoton datasets)",
     "type": {
       "primary": "Supplementaries",
@@ -5576,10 +4304,6 @@
     "collections": [
       "CMS-Trigger-Information"
     ],
-    "collision_information": {
-      "energy": "8TeV",
-      "type": "pp"
-    },
     "date_created": [
       "2012"
     ],
@@ -5587,10 +4311,6 @@
     "experiment": "CMS",
     "publisher": "CERN Open Data Portal",
     "recid": "6359",
-    "run_period": [
-      "Run2012B",
-      "Run2012C"
-    ],
     "title": "High-Level Trigger path information HLT_DoublePhoton70 (DoublePhotonHighPt, Photon datasets)",
     "type": {
       "primary": "Supplementaries",
@@ -5611,10 +4331,6 @@
     "collections": [
       "CMS-Trigger-Information"
     ],
-    "collision_information": {
-      "energy": "8TeV",
-      "type": "pp"
-    },
     "date_created": [
       "2012"
     ],
@@ -5622,10 +4338,6 @@
     "experiment": "CMS",
     "publisher": "CERN Open Data Portal",
     "recid": "6360",
-    "run_period": [
-      "Run2012B",
-      "Run2012C"
-    ],
     "title": "High-Level Trigger path information HLT_DoublePhoton80 (DoublePhotonHighPt, Photon datasets)",
     "type": {
       "primary": "Supplementaries",
@@ -5646,10 +4358,6 @@
     "collections": [
       "CMS-Trigger-Information"
     ],
-    "collision_information": {
-      "energy": "8TeV",
-      "type": "pp"
-    },
     "date_created": [
       "2012"
     ],
@@ -5657,10 +4365,6 @@
     "experiment": "CMS",
     "publisher": "CERN Open Data Portal",
     "recid": "6361",
-    "run_period": [
-      "Run2012B",
-      "Run2012C"
-    ],
     "title": "High-Level Trigger path information HLT_DoubleRelIso1p0Mu5_Mass8_PFHT175 (MuHad dataset)",
     "type": {
       "primary": "Supplementaries",
@@ -5681,10 +4385,6 @@
     "collections": [
       "CMS-Trigger-Information"
     ],
-    "collision_information": {
-      "energy": "8TeV",
-      "type": "pp"
-    },
     "date_created": [
       "2012"
     ],
@@ -5692,10 +4392,6 @@
     "experiment": "CMS",
     "publisher": "CERN Open Data Portal",
     "recid": "6362",
-    "run_period": [
-      "Run2012B",
-      "Run2012C"
-    ],
     "title": "High-Level Trigger path information HLT_DoubleRelIso1p0Mu5_Mass8_PFHT225 (MuHad dataset)",
     "type": {
       "primary": "Supplementaries",
@@ -5716,10 +4412,6 @@
     "collections": [
       "CMS-Trigger-Information"
     ],
-    "collision_information": {
-      "energy": "8TeV",
-      "type": "pp"
-    },
     "date_created": [
       "2012"
     ],
@@ -5727,10 +4419,6 @@
     "experiment": "CMS",
     "publisher": "CERN Open Data Portal",
     "recid": "6363",
-    "run_period": [
-      "Run2012B",
-      "Run2012C"
-    ],
     "title": "High-Level Trigger path information HLT_DoubleRelIso1p0Mu5_Mass8_PFNoPUHT175 (MuHad dataset)",
     "type": {
       "primary": "Supplementaries",
@@ -5751,10 +4439,6 @@
     "collections": [
       "CMS-Trigger-Information"
     ],
-    "collision_information": {
-      "energy": "8TeV",
-      "type": "pp"
-    },
     "date_created": [
       "2012"
     ],
@@ -5762,10 +4446,6 @@
     "experiment": "CMS",
     "publisher": "CERN Open Data Portal",
     "recid": "6364",
-    "run_period": [
-      "Run2012B",
-      "Run2012C"
-    ],
     "title": "High-Level Trigger path information HLT_DoubleRelIso1p0Mu5_Mass8_PFNoPUHT225 (MuHad dataset)",
     "type": {
       "primary": "Supplementaries",
@@ -5786,10 +4466,6 @@
     "collections": [
       "CMS-Trigger-Information"
     ],
-    "collision_information": {
-      "energy": "8TeV",
-      "type": "pp"
-    },
     "date_created": [
       "2012"
     ],
@@ -5797,10 +4473,6 @@
     "experiment": "CMS",
     "publisher": "CERN Open Data Portal",
     "recid": "6365",
-    "run_period": [
-      "Run2012B",
-      "Run2012C"
-    ],
     "title": "High-Level Trigger path information HLT_EcalCalibration",
     "type": {
       "primary": "Supplementaries",
@@ -5821,10 +4493,6 @@
     "collections": [
       "CMS-Trigger-Information"
     ],
-    "collision_information": {
-      "energy": "8TeV",
-      "type": "pp"
-    },
     "date_created": [
       "2012"
     ],
@@ -5832,10 +4500,6 @@
     "experiment": "CMS",
     "publisher": "CERN Open Data Portal",
     "recid": "6366",
-    "run_period": [
-      "Run2012B",
-      "Run2012C"
-    ],
     "title": "High-Level Trigger path information HLT_EightJet30_eta3p0 (MultiJet, MultiJet1Parked datasets)",
     "type": {
       "primary": "Supplementaries",
@@ -5856,10 +4520,6 @@
     "collections": [
       "CMS-Trigger-Information"
     ],
-    "collision_information": {
-      "energy": "8TeV",
-      "type": "pp"
-    },
     "date_created": [
       "2012"
     ],
@@ -5867,10 +4527,6 @@
     "experiment": "CMS",
     "publisher": "CERN Open Data Portal",
     "recid": "6367",
-    "run_period": [
-      "Run2012B",
-      "Run2012C"
-    ],
     "title": "High-Level Trigger path information HLT_EightJet35 (MultiJet dataset)",
     "type": {
       "primary": "Supplementaries",
@@ -5891,10 +4547,6 @@
     "collections": [
       "CMS-Trigger-Information"
     ],
-    "collision_information": {
-      "energy": "8TeV",
-      "type": "pp"
-    },
     "date_created": [
       "2012"
     ],
@@ -5902,10 +4554,6 @@
     "experiment": "CMS",
     "publisher": "CERN Open Data Portal",
     "recid": "6368",
-    "run_period": [
-      "Run2012B",
-      "Run2012C"
-    ],
     "title": "High-Level Trigger path information HLT_EightJet35_eta3p0 (MultiJet, MultiJet1Parked datasets)",
     "type": {
       "primary": "Supplementaries",
@@ -5926,10 +4574,6 @@
     "collections": [
       "CMS-Trigger-Information"
     ],
-    "collision_information": {
-      "energy": "8TeV",
-      "type": "pp"
-    },
     "date_created": [
       "2012"
     ],
@@ -5937,10 +4581,6 @@
     "experiment": "CMS",
     "publisher": "CERN Open Data Portal",
     "recid": "6369",
-    "run_period": [
-      "Run2012B",
-      "Run2012C"
-    ],
     "title": "High-Level Trigger path information HLT_EightJet40 (MultiJet dataset)",
     "type": {
       "primary": "Supplementaries",
@@ -5961,10 +4601,6 @@
     "collections": [
       "CMS-Trigger-Information"
     ],
-    "collision_information": {
-      "energy": "8TeV",
-      "type": "pp"
-    },
     "date_created": [
       "2012"
     ],
@@ -5972,10 +4608,6 @@
     "experiment": "CMS",
     "publisher": "CERN Open Data Portal",
     "recid": "6370",
-    "run_period": [
-      "Run2012B",
-      "Run2012C"
-    ],
     "title": "High-Level Trigger path information HLT_Ele100_CaloIdVT_TrkIdT (SingleElectron dataset)",
     "type": {
       "primary": "Supplementaries",
@@ -5996,10 +4628,6 @@
     "collections": [
       "CMS-Trigger-Information"
     ],
-    "collision_information": {
-      "energy": "8TeV",
-      "type": "pp"
-    },
     "date_created": [
       "2012"
     ],
@@ -6007,10 +4635,6 @@
     "experiment": "CMS",
     "publisher": "CERN Open Data Portal",
     "recid": "6371",
-    "run_period": [
-      "Run2012B",
-      "Run2012C"
-    ],
     "title": "High-Level Trigger path information HLT_Ele12_CaloIdL_CaloIsoVL_TrkIdVL_TrkIsoVL_DoubleCentralJet65 (ElectronHad dataset)",
     "type": {
       "primary": "Supplementaries",
@@ -6031,10 +4655,6 @@
     "collections": [
       "CMS-Trigger-Information"
     ],
-    "collision_information": {
-      "energy": "8TeV",
-      "type": "pp"
-    },
     "date_created": [
       "2012"
     ],
@@ -6042,10 +4662,6 @@
     "experiment": "CMS",
     "publisher": "CERN Open Data Portal",
     "recid": "6372",
-    "run_period": [
-      "Run2012B",
-      "Run2012C"
-    ],
     "title": "High-Level Trigger path information HLT_Ele12_CaloIdL_CaloIsoVL_TrkIdVL_TrkIsoVL_RsqMR30_Rsq0p04_MR200 (ElectronHad dataset)",
     "type": {
       "primary": "Supplementaries",
@@ -6066,10 +4682,6 @@
     "collections": [
       "CMS-Trigger-Information"
     ],
-    "collision_information": {
-      "energy": "8TeV",
-      "type": "pp"
-    },
     "date_created": [
       "2012"
     ],
@@ -6077,10 +4689,6 @@
     "experiment": "CMS",
     "publisher": "CERN Open Data Portal",
     "recid": "6373",
-    "run_period": [
-      "Run2012B",
-      "Run2012C"
-    ],
     "title": "High-Level Trigger path information HLT_Ele12_CaloIdL_CaloIsoVL_TrkIdVL_TrkIsoVL_RsqMR40_Rsq0p04_MR200 (ElectronHad dataset)",
     "type": {
       "primary": "Supplementaries",
@@ -6101,10 +4709,6 @@
     "collections": [
       "CMS-Trigger-Information"
     ],
-    "collision_information": {
-      "energy": "8TeV",
-      "type": "pp"
-    },
     "date_created": [
       "2012"
     ],
@@ -6112,10 +4716,6 @@
     "experiment": "CMS",
     "publisher": "CERN Open Data Portal",
     "recid": "6374",
-    "run_period": [
-      "Run2012B",
-      "Run2012C"
-    ],
     "title": "High-Level Trigger path information HLT_Ele12_CaloIdL_CaloIsoVL_TrkIdVL_TrkIsoVL_RsqMR45_Rsq0p04_MR200 (ElectronHad dataset)",
     "type": {
       "primary": "Supplementaries",
@@ -6136,10 +4736,6 @@
     "collections": [
       "CMS-Trigger-Information"
     ],
-    "collision_information": {
-      "energy": "8TeV",
-      "type": "pp"
-    },
     "date_created": [
       "2012"
     ],
@@ -6147,10 +4743,6 @@
     "experiment": "CMS",
     "publisher": "CERN Open Data Portal",
     "recid": "6375",
-    "run_period": [
-      "Run2012B",
-      "Run2012C"
-    ],
     "title": "High-Level Trigger path information HLT_Ele12_CaloIdT_CaloIsoVL_TrkIdVL_TrkIsoVL_DoubleCentralJet65 (ElectronHad dataset)",
     "type": {
       "primary": "Supplementaries",
@@ -6171,10 +4763,6 @@
     "collections": [
       "CMS-Trigger-Information"
     ],
-    "collision_information": {
-      "energy": "8TeV",
-      "type": "pp"
-    },
     "date_created": [
       "2012"
     ],
@@ -6182,10 +4770,6 @@
     "experiment": "CMS",
     "publisher": "CERN Open Data Portal",
     "recid": "6376",
-    "run_period": [
-      "Run2012B",
-      "Run2012C"
-    ],
     "title": "High-Level Trigger path information HLT_Ele12_CaloIdT_CaloIsoVL_TrkIdVL_TrkIsoVL_RsqMR30_Rsq0p04_MR200 (ElectronHad dataset)",
     "type": {
       "primary": "Supplementaries",
@@ -6206,10 +4790,6 @@
     "collections": [
       "CMS-Trigger-Information"
     ],
-    "collision_information": {
-      "energy": "8TeV",
-      "type": "pp"
-    },
     "date_created": [
       "2012"
     ],
@@ -6217,10 +4797,6 @@
     "experiment": "CMS",
     "publisher": "CERN Open Data Portal",
     "recid": "6377",
-    "run_period": [
-      "Run2012B",
-      "Run2012C"
-    ],
     "title": "High-Level Trigger path information HLT_Ele12_CaloIdT_CaloIsoVL_TrkIdVL_TrkIsoVL_RsqMR40_Rsq0p04_MR200 (ElectronHad dataset)",
     "type": {
       "primary": "Supplementaries",
@@ -6241,10 +4817,6 @@
     "collections": [
       "CMS-Trigger-Information"
     ],
-    "collision_information": {
-      "energy": "8TeV",
-      "type": "pp"
-    },
     "date_created": [
       "2012"
     ],
@@ -6252,10 +4824,6 @@
     "experiment": "CMS",
     "publisher": "CERN Open Data Portal",
     "recid": "6378",
-    "run_period": [
-      "Run2012B",
-      "Run2012C"
-    ],
     "title": "High-Level Trigger path information HLT_Ele13_eta2p1_WP90NoIso_LooseIsoPFTau20_L1ETM36 (TauPlusX dataset)",
     "type": {
       "primary": "Supplementaries",
@@ -6276,10 +4844,6 @@
     "collections": [
       "CMS-Trigger-Information"
     ],
-    "collision_information": {
-      "energy": "8TeV",
-      "type": "pp"
-    },
     "date_created": [
       "2012"
     ],
@@ -6287,10 +4851,6 @@
     "experiment": "CMS",
     "publisher": "CERN Open Data Portal",
     "recid": "6379",
-    "run_period": [
-      "Run2012B",
-      "Run2012C"
-    ],
     "title": "High-Level Trigger path information HLT_Ele13_eta2p1_WP90Rho_LooseIsoPFTau20 (TauPlusX dataset)",
     "type": {
       "primary": "Supplementaries",
@@ -6311,10 +4871,6 @@
     "collections": [
       "CMS-Trigger-Information"
     ],
-    "collision_information": {
-      "energy": "8TeV",
-      "type": "pp"
-    },
     "date_created": [
       "2012"
     ],
@@ -6322,10 +4878,6 @@
     "experiment": "CMS",
     "publisher": "CERN Open Data Portal",
     "recid": "6380",
-    "run_period": [
-      "Run2012B",
-      "Run2012C"
-    ],
     "title": "High-Level Trigger path information HLT_Ele13_eta2p1_WP90Rho_LooseIsoPFTau20_L1ETM36 (TauPlusX dataset)",
     "type": {
       "primary": "Supplementaries",
@@ -6346,10 +4898,6 @@
     "collections": [
       "CMS-Trigger-Information"
     ],
-    "collision_information": {
-      "energy": "8TeV",
-      "type": "pp"
-    },
     "date_created": [
       "2012"
     ],
@@ -6357,10 +4905,6 @@
     "experiment": "CMS",
     "publisher": "CERN Open Data Portal",
     "recid": "6381",
-    "run_period": [
-      "Run2012B",
-      "Run2012C"
-    ],
     "title": "High-Level Trigger path information HLT_Ele15_Ele8_Ele5_CaloIdL_TrkIdVL (DoubleElectron dataset)",
     "type": {
       "primary": "Supplementaries",
@@ -6381,10 +4925,6 @@
     "collections": [
       "CMS-Trigger-Information"
     ],
-    "collision_information": {
-      "energy": "8TeV",
-      "type": "pp"
-    },
     "date_created": [
       "2012"
     ],
@@ -6392,10 +4932,6 @@
     "experiment": "CMS",
     "publisher": "CERN Open Data Portal",
     "recid": "6382",
-    "run_period": [
-      "Run2012B",
-      "Run2012C"
-    ],
     "title": "High-Level Trigger path information HLT_Ele17_CaloIdL_CaloIsoVL (DoubleElectron dataset)",
     "type": {
       "primary": "Supplementaries",
@@ -6416,10 +4952,6 @@
     "collections": [
       "CMS-Trigger-Information"
     ],
-    "collision_information": {
-      "energy": "8TeV",
-      "type": "pp"
-    },
     "date_created": [
       "2012"
     ],
@@ -6427,10 +4959,6 @@
     "experiment": "CMS",
     "publisher": "CERN Open Data Portal",
     "recid": "6383",
-    "run_period": [
-      "Run2012B",
-      "Run2012C"
-    ],
     "title": "High-Level Trigger path information HLT_Ele17_CaloIdT_CaloIsoVL_TrkIdVL_TrkIsoVL (DoubleElectron dataset)",
     "type": {
       "primary": "Supplementaries",
@@ -6451,10 +4979,6 @@
     "collections": [
       "CMS-Trigger-Information"
     ],
-    "collision_information": {
-      "energy": "8TeV",
-      "type": "pp"
-    },
     "date_created": [
       "2012"
     ],
@@ -6462,10 +4986,6 @@
     "experiment": "CMS",
     "publisher": "CERN Open Data Portal",
     "recid": "6384",
-    "run_period": [
-      "Run2012B",
-      "Run2012C"
-    ],
     "title": "High-Level Trigger path information HLT_Ele17_CaloIdT_CaloIsoVL_TrkIdVL_TrkIsoVL_Ele8_CaloIdT_CaloIsoVL_TrkIdVL_TrkIsoVL (DoubleElectron dataset)",
     "type": {
       "primary": "Supplementaries",
@@ -6486,10 +5006,6 @@
     "collections": [
       "CMS-Trigger-Information"
     ],
-    "collision_information": {
-      "energy": "8TeV",
-      "type": "pp"
-    },
     "date_created": [
       "2012"
     ],
@@ -6497,10 +5013,6 @@
     "experiment": "CMS",
     "publisher": "CERN Open Data Portal",
     "recid": "6385",
-    "run_period": [
-      "Run2012B",
-      "Run2012C"
-    ],
     "title": "High-Level Trigger path information HLT_Ele17_CaloIdT_CaloIsoVL_TrkIdVL_TrkIsoVL_Jet30 (DoubleElectron dataset)",
     "type": {
       "primary": "Supplementaries",
@@ -6521,10 +5033,6 @@
     "collections": [
       "CMS-Trigger-Information"
     ],
-    "collision_information": {
-      "energy": "8TeV",
-      "type": "pp"
-    },
     "date_created": [
       "2012"
     ],
@@ -6532,10 +5040,6 @@
     "experiment": "CMS",
     "publisher": "CERN Open Data Portal",
     "recid": "6386",
-    "run_period": [
-      "Run2012B",
-      "Run2012C"
-    ],
     "title": "High-Level Trigger path information HLT_Ele17_CaloIdVT_CaloIsoVT_TrkIdT_TrkIsoVT_Ele8_Mass50 (DoubleElectron dataset)",
     "type": {
       "primary": "Supplementaries",
@@ -6556,10 +5060,6 @@
     "collections": [
       "CMS-Trigger-Information"
     ],
-    "collision_information": {
-      "energy": "8TeV",
-      "type": "pp"
-    },
     "date_created": [
       "2012"
     ],
@@ -6567,10 +5067,6 @@
     "experiment": "CMS",
     "publisher": "CERN Open Data Portal",
     "recid": "6387",
-    "run_period": [
-      "Run2012B",
-      "Run2012C"
-    ],
     "title": "High-Level Trigger path information HLT_Ele20_CaloIdVT_CaloIsoRhoT_TrkIdT_TrkIsoT (TauPlusX dataset)",
     "type": {
       "primary": "Supplementaries",
@@ -6591,10 +5087,6 @@
     "collections": [
       "CMS-Trigger-Information"
     ],
-    "collision_information": {
-      "energy": "8TeV",
-      "type": "pp"
-    },
     "date_created": [
       "2012"
     ],
@@ -6602,10 +5094,6 @@
     "experiment": "CMS",
     "publisher": "CERN Open Data Portal",
     "recid": "6388",
-    "run_period": [
-      "Run2012B",
-      "Run2012C"
-    ],
     "title": "High-Level Trigger path information HLT_Ele20_CaloIdVT_CaloIsoRhoT_TrkIdT_TrkIsoT_LooseIsoPFTau20 (TauPlusX dataset)",
     "type": {
       "primary": "Supplementaries",
@@ -6626,10 +5114,6 @@
     "collections": [
       "CMS-Trigger-Information"
     ],
-    "collision_information": {
-      "energy": "8TeV",
-      "type": "pp"
-    },
     "date_created": [
       "2012"
     ],
@@ -6637,10 +5121,6 @@
     "experiment": "CMS",
     "publisher": "CERN Open Data Portal",
     "recid": "6389",
-    "run_period": [
-      "Run2012B",
-      "Run2012C"
-    ],
     "title": "High-Level Trigger path information HLT_Ele20_CaloIdVT_CaloIsoRhoT_TrkIdT_TrkIsoT_LooseIsoPFTau20L1Jet (TauPlusX dataset)",
     "type": {
       "primary": "Supplementaries",
@@ -6661,10 +5141,6 @@
     "collections": [
       "CMS-Trigger-Information"
     ],
-    "collision_information": {
-      "energy": "8TeV",
-      "type": "pp"
-    },
     "date_created": [
       "2012"
     ],
@@ -6672,10 +5148,6 @@
     "experiment": "CMS",
     "publisher": "CERN Open Data Portal",
     "recid": "6390",
-    "run_period": [
-      "Run2012B",
-      "Run2012C"
-    ],
     "title": "High-Level Trigger path information HLT_Ele20_CaloIdVT_CaloIsoRhoT_TrkIdT_TrkIsoT_LooseIsoPFTau22L1Jet (TauPlusX dataset)",
     "type": {
       "primary": "Supplementaries",
@@ -6696,10 +5168,6 @@
     "collections": [
       "CMS-Trigger-Information"
     ],
-    "collision_information": {
-      "energy": "8TeV",
-      "type": "pp"
-    },
     "date_created": [
       "2012"
     ],
@@ -6707,10 +5175,6 @@
     "experiment": "CMS",
     "publisher": "CERN Open Data Portal",
     "recid": "6391",
-    "run_period": [
-      "Run2012B",
-      "Run2012C"
-    ],
     "title": "High-Level Trigger path information HLT_Ele20_CaloIdVT_CaloIsoVT_TrkIdT_TrkIsoVT_SC4_Mass50 (DoubleElectron dataset)",
     "type": {
       "primary": "Supplementaries",
@@ -6731,10 +5195,6 @@
     "collections": [
       "CMS-Trigger-Information"
     ],
-    "collision_information": {
-      "energy": "8TeV",
-      "type": "pp"
-    },
     "date_created": [
       "2012"
     ],
@@ -6742,10 +5202,6 @@
     "experiment": "CMS",
     "publisher": "CERN Open Data Portal",
     "recid": "6392",
-    "run_period": [
-      "Run2012B",
-      "Run2012C"
-    ],
     "title": "High-Level Trigger path information HLT_Ele20_CaloIdVT_TrkIdT_LooseIsoPFTau20 (TauPlusX dataset)",
     "type": {
       "primary": "Supplementaries",
@@ -6766,10 +5222,6 @@
     "collections": [
       "CMS-Trigger-Information"
     ],
-    "collision_information": {
-      "energy": "8TeV",
-      "type": "pp"
-    },
     "date_created": [
       "2012"
     ],
@@ -6777,10 +5229,6 @@
     "experiment": "CMS",
     "publisher": "CERN Open Data Portal",
     "recid": "6393",
-    "run_period": [
-      "Run2012B",
-      "Run2012C"
-    ],
     "title": "High-Level Trigger path information HLT_Ele22_CaloIdL_CaloIsoVL (SingleElectron dataset)",
     "type": {
       "primary": "Supplementaries",
@@ -6801,10 +5249,6 @@
     "collections": [
       "CMS-Trigger-Information"
     ],
-    "collision_information": {
-      "energy": "8TeV",
-      "type": "pp"
-    },
     "date_created": [
       "2012"
     ],
@@ -6812,10 +5256,6 @@
     "experiment": "CMS",
     "publisher": "CERN Open Data Portal",
     "recid": "6394",
-    "run_period": [
-      "Run2012B",
-      "Run2012C"
-    ],
     "title": "High-Level Trigger path information HLT_Ele22_CaloIdVT_CaloIsoRhoT_TrkIdT_TrkIsoT_LooseIsoPFTau20 (TauPlusX dataset)",
     "type": {
       "primary": "Supplementaries",
@@ -6836,10 +5276,6 @@
     "collections": [
       "CMS-Trigger-Information"
     ],
-    "collision_information": {
-      "energy": "8TeV",
-      "type": "pp"
-    },
     "date_created": [
       "2012"
     ],
@@ -6847,10 +5283,6 @@
     "experiment": "CMS",
     "publisher": "CERN Open Data Portal",
     "recid": "6395",
-    "run_period": [
-      "Run2012B",
-      "Run2012C"
-    ],
     "title": "High-Level Trigger path information HLT_Ele22_eta2p1_WP90NoIso_LooseIsoPFTau20 (TauPlusX dataset)",
     "type": {
       "primary": "Supplementaries",
@@ -6871,10 +5303,6 @@
     "collections": [
       "CMS-Trigger-Information"
     ],
-    "collision_information": {
-      "energy": "8TeV",
-      "type": "pp"
-    },
     "date_created": [
       "2012"
     ],
@@ -6882,10 +5310,6 @@
     "experiment": "CMS",
     "publisher": "CERN Open Data Portal",
     "recid": "6396",
-    "run_period": [
-      "Run2012B",
-      "Run2012C"
-    ],
     "title": "High-Level Trigger path information HLT_Ele22_eta2p1_WP90Rho_LooseIsoPFTau20 (TauPlusX dataset)",
     "type": {
       "primary": "Supplementaries",
@@ -6906,10 +5330,6 @@
     "collections": [
       "CMS-Trigger-Information"
     ],
-    "collision_information": {
-      "energy": "8TeV",
-      "type": "pp"
-    },
     "date_created": [
       "2012"
     ],
@@ -6917,10 +5337,6 @@
     "experiment": "CMS",
     "publisher": "CERN Open Data Portal",
     "recid": "6397",
-    "run_period": [
-      "Run2012B",
-      "Run2012C"
-    ],
     "title": "High-Level Trigger path information HLT_Ele23_CaloIdT_CaloIsoVL_TrkIdVL_TrkIsoVL_HFT30 (DoubleElectron dataset)",
     "type": {
       "primary": "Supplementaries",
@@ -6941,10 +5357,6 @@
     "collections": [
       "CMS-Trigger-Information"
     ],
-    "collision_information": {
-      "energy": "8TeV",
-      "type": "pp"
-    },
     "date_created": [
       "2012"
     ],
@@ -6952,10 +5364,6 @@
     "experiment": "CMS",
     "publisher": "CERN Open Data Portal",
     "recid": "6398",
-    "run_period": [
-      "Run2012B",
-      "Run2012C"
-    ],
     "title": "High-Level Trigger path information HLT_Ele24_WP80_CentralPFJet35_CentralPFJet25 (SingleElectron dataset)",
     "type": {
       "primary": "Supplementaries",
@@ -6976,10 +5384,6 @@
     "collections": [
       "CMS-Trigger-Information"
     ],
-    "collision_information": {
-      "energy": "8TeV",
-      "type": "pp"
-    },
     "date_created": [
       "2012"
     ],
@@ -6987,10 +5391,6 @@
     "experiment": "CMS",
     "publisher": "CERN Open Data Portal",
     "recid": "6399",
-    "run_period": [
-      "Run2012B",
-      "Run2012C"
-    ],
     "title": "High-Level Trigger path information HLT_Ele24_WP80_CentralPFJet35_CentralPFJet25_PFMET20 (SingleElectron dataset)",
     "type": {
       "primary": "Supplementaries",
@@ -7011,10 +5411,6 @@
     "collections": [
       "CMS-Trigger-Information"
     ],
-    "collision_information": {
-      "energy": "8TeV",
-      "type": "pp"
-    },
     "date_created": [
       "2012"
     ],
@@ -7022,10 +5418,6 @@
     "experiment": "CMS",
     "publisher": "CERN Open Data Portal",
     "recid": "6400",
-    "run_period": [
-      "Run2012B",
-      "Run2012C"
-    ],
     "title": "High-Level Trigger path information HLT_Ele24_WP80_PFJet30_PFJet25_Deta3 (SingleElectron dataset)",
     "type": {
       "primary": "Supplementaries",
@@ -7046,10 +5438,6 @@
     "collections": [
       "CMS-Trigger-Information"
     ],
-    "collision_information": {
-      "energy": "8TeV",
-      "type": "pp"
-    },
     "date_created": [
       "2012"
     ],
@@ -7057,10 +5445,6 @@
     "experiment": "CMS",
     "publisher": "CERN Open Data Portal",
     "recid": "6401",
-    "run_period": [
-      "Run2012B",
-      "Run2012C"
-    ],
     "title": "High-Level Trigger path information HLT_Ele24_WP80_PFJet30_PFJet25_Deta3_CentralPFJet30 (SingleElectron dataset)",
     "type": {
       "primary": "Supplementaries",
@@ -7081,10 +5465,6 @@
     "collections": [
       "CMS-Trigger-Information"
     ],
-    "collision_information": {
-      "energy": "8TeV",
-      "type": "pp"
-    },
     "date_created": [
       "2012"
     ],
@@ -7092,10 +5472,6 @@
     "experiment": "CMS",
     "publisher": "CERN Open Data Portal",
     "recid": "6402",
-    "run_period": [
-      "Run2012B",
-      "Run2012C"
-    ],
     "title": "High-Level Trigger path information HLT_Ele25_CaloIdVL_CaloIsoT_TrkIdVL_TrkIsoT_TriCentralPFNoPUJet30 (SingleElectron dataset)",
     "type": {
       "primary": "Supplementaries",
@@ -7116,10 +5492,6 @@
     "collections": [
       "CMS-Trigger-Information"
     ],
-    "collision_information": {
-      "energy": "8TeV",
-      "type": "pp"
-    },
     "date_created": [
       "2012"
     ],
@@ -7127,10 +5499,6 @@
     "experiment": "CMS",
     "publisher": "CERN Open Data Portal",
     "recid": "6403",
-    "run_period": [
-      "Run2012B",
-      "Run2012C"
-    ],
     "title": "High-Level Trigger path information HLT_Ele25_CaloIdVL_CaloIsoT_TrkIdVL_TrkIsoT_TriCentralPFNoPUJet30_30_20 (SingleElectron dataset)",
     "type": {
       "primary": "Supplementaries",
@@ -7151,10 +5519,6 @@
     "collections": [
       "CMS-Trigger-Information"
     ],
-    "collision_information": {
-      "energy": "8TeV",
-      "type": "pp"
-    },
     "date_created": [
       "2012"
     ],
@@ -7162,10 +5526,6 @@
     "experiment": "CMS",
     "publisher": "CERN Open Data Portal",
     "recid": "6404",
-    "run_period": [
-      "Run2012B",
-      "Run2012C"
-    ],
     "title": "High-Level Trigger path information HLT_Ele25_CaloIdVT_CaloIsoT_TrkIdT_TrkIsoT_CentralPFJet30 (ElectronHad dataset)",
     "type": {
       "primary": "Supplementaries",
@@ -7186,10 +5546,6 @@
     "collections": [
       "CMS-Trigger-Information"
     ],
-    "collision_information": {
-      "energy": "8TeV",
-      "type": "pp"
-    },
     "date_created": [
       "2012"
     ],
@@ -7197,10 +5553,6 @@
     "experiment": "CMS",
     "publisher": "CERN Open Data Portal",
     "recid": "6405",
-    "run_period": [
-      "Run2012B",
-      "Run2012C"
-    ],
     "title": "High-Level Trigger path information HLT_Ele25_CaloIdVT_CaloIsoT_TrkIdT_TrkIsoT_CentralPFJet30_BTagIPIter (ElectronHad dataset)",
     "type": {
       "primary": "Supplementaries",
@@ -7221,10 +5573,6 @@
     "collections": [
       "CMS-Trigger-Information"
     ],
-    "collision_information": {
-      "energy": "8TeV",
-      "type": "pp"
-    },
     "date_created": [
       "2012"
     ],
@@ -7232,10 +5580,6 @@
     "experiment": "CMS",
     "publisher": "CERN Open Data Portal",
     "recid": "6406",
-    "run_period": [
-      "Run2012B",
-      "Run2012C"
-    ],
     "title": "High-Level Trigger path information HLT_Ele25_CaloIdVT_CaloIsoT_TrkIdT_TrkIsoT_CentralPFNoPUJet30 (ElectronHad, SingleElectron datasets)",
     "type": {
       "primary": "Supplementaries",
@@ -7256,10 +5600,6 @@
     "collections": [
       "CMS-Trigger-Information"
     ],
-    "collision_information": {
-      "energy": "8TeV",
-      "type": "pp"
-    },
     "date_created": [
       "2012"
     ],
@@ -7267,10 +5607,6 @@
     "experiment": "CMS",
     "publisher": "CERN Open Data Portal",
     "recid": "6407",
-    "run_period": [
-      "Run2012B",
-      "Run2012C"
-    ],
     "title": "High-Level Trigger path information HLT_Ele25_CaloIdVT_CaloIsoT_TrkIdT_TrkIsoT_CentralPFNoPUJet30_BTagIPIter (ElectronHad, SingleElectron datasets)",
     "type": {
       "primary": "Supplementaries",
@@ -7291,10 +5627,6 @@
     "collections": [
       "CMS-Trigger-Information"
     ],
-    "collision_information": {
-      "energy": "8TeV",
-      "type": "pp"
-    },
     "date_created": [
       "2012"
     ],
@@ -7302,10 +5634,6 @@
     "experiment": "CMS",
     "publisher": "CERN Open Data Portal",
     "recid": "6408",
-    "run_period": [
-      "Run2012B",
-      "Run2012C"
-    ],
     "title": "High-Level Trigger path information HLT_Ele25_CaloIdVT_CaloIsoT_TrkIdT_TrkIsoT_DiCentralPFJet30 (ElectronHad dataset)",
     "type": {
       "primary": "Supplementaries",
@@ -7326,10 +5654,6 @@
     "collections": [
       "CMS-Trigger-Information"
     ],
-    "collision_information": {
-      "energy": "8TeV",
-      "type": "pp"
-    },
     "date_created": [
       "2012"
     ],
@@ -7337,10 +5661,6 @@
     "experiment": "CMS",
     "publisher": "CERN Open Data Portal",
     "recid": "6409",
-    "run_period": [
-      "Run2012B",
-      "Run2012C"
-    ],
     "title": "High-Level Trigger path information HLT_Ele25_CaloIdVT_CaloIsoT_TrkIdT_TrkIsoT_DiCentralPFNoPUJet30 (ElectronHad dataset)",
     "type": {
       "primary": "Supplementaries",
@@ -7361,10 +5681,6 @@
     "collections": [
       "CMS-Trigger-Information"
     ],
-    "collision_information": {
-      "energy": "8TeV",
-      "type": "pp"
-    },
     "date_created": [
       "2012"
     ],
@@ -7372,10 +5688,6 @@
     "experiment": "CMS",
     "publisher": "CERN Open Data Portal",
     "recid": "6410",
-    "run_period": [
-      "Run2012B",
-      "Run2012C"
-    ],
     "title": "High-Level Trigger path information HLT_Ele25_CaloIdVT_CaloIsoT_TrkIdT_TrkIsoT_TriCentralPFJet30 (ElectronHad dataset)",
     "type": {
       "primary": "Supplementaries",
@@ -7396,10 +5708,6 @@
     "collections": [
       "CMS-Trigger-Information"
     ],
-    "collision_information": {
-      "energy": "8TeV",
-      "type": "pp"
-    },
     "date_created": [
       "2012"
     ],
@@ -7407,10 +5715,6 @@
     "experiment": "CMS",
     "publisher": "CERN Open Data Portal",
     "recid": "6411",
-    "run_period": [
-      "Run2012B",
-      "Run2012C"
-    ],
     "title": "High-Level Trigger path information HLT_Ele25_CaloIdVT_CaloIsoT_TrkIdT_TrkIsoT_TriCentralPFJet50_40_30 (ElectronHad dataset)",
     "type": {
       "primary": "Supplementaries",
@@ -7431,10 +5735,6 @@
     "collections": [
       "CMS-Trigger-Information"
     ],
-    "collision_information": {
-      "energy": "8TeV",
-      "type": "pp"
-    },
     "date_created": [
       "2012"
     ],
@@ -7442,10 +5742,6 @@
     "experiment": "CMS",
     "publisher": "CERN Open Data Portal",
     "recid": "6412",
-    "run_period": [
-      "Run2012B",
-      "Run2012C"
-    ],
     "title": "High-Level Trigger path information HLT_Ele25_CaloIdVT_CaloIsoT_TrkIdT_TrkIsoT_TriCentralPFNoPUJet30 (ElectronHad dataset)",
     "type": {
       "primary": "Supplementaries",
@@ -7466,10 +5762,6 @@
     "collections": [
       "CMS-Trigger-Information"
     ],
-    "collision_information": {
-      "energy": "8TeV",
-      "type": "pp"
-    },
     "date_created": [
       "2012"
     ],
@@ -7477,10 +5769,6 @@
     "experiment": "CMS",
     "publisher": "CERN Open Data Portal",
     "recid": "6413",
-    "run_period": [
-      "Run2012B",
-      "Run2012C"
-    ],
     "title": "High-Level Trigger path information HLT_Ele25_CaloIdVT_CaloIsoT_TrkIdT_TrkIsoT_TriCentralPFNoPUJet30_30_20 (SingleElectron dataset)",
     "type": {
       "primary": "Supplementaries",
@@ -7501,10 +5789,6 @@
     "collections": [
       "CMS-Trigger-Information"
     ],
-    "collision_information": {
-      "energy": "8TeV",
-      "type": "pp"
-    },
     "date_created": [
       "2012"
     ],
@@ -7512,10 +5796,6 @@
     "experiment": "CMS",
     "publisher": "CERN Open Data Portal",
     "recid": "6414",
-    "run_period": [
-      "Run2012B",
-      "Run2012C"
-    ],
     "title": "High-Level Trigger path information HLT_Ele25_CaloIdVT_CaloIsoT_TrkIdT_TrkIsoT_TriCentralPFNoPUJet50_40_30 (ElectronHad dataset)",
     "type": {
       "primary": "Supplementaries",
@@ -7536,10 +5816,6 @@
     "collections": [
       "CMS-Trigger-Information"
     ],
-    "collision_information": {
-      "energy": "8TeV",
-      "type": "pp"
-    },
     "date_created": [
       "2012"
     ],
@@ -7547,10 +5823,6 @@
     "experiment": "CMS",
     "publisher": "CERN Open Data Portal",
     "recid": "6415",
-    "run_period": [
-      "Run2012B",
-      "Run2012C"
-    ],
     "title": "High-Level Trigger path information HLT_Ele25_CaloIdVT_CaloIsoVL_TrkIdVL_TrkIsoT_DiCentralPFNoPUJet30 (SingleElectron dataset)",
     "type": {
       "primary": "Supplementaries",
@@ -7571,10 +5843,6 @@
     "collections": [
       "CMS-Trigger-Information"
     ],
-    "collision_information": {
-      "energy": "8TeV",
-      "type": "pp"
-    },
     "date_created": [
       "2012"
     ],
@@ -7582,10 +5850,6 @@
     "experiment": "CMS",
     "publisher": "CERN Open Data Portal",
     "recid": "6416",
-    "run_period": [
-      "Run2012B",
-      "Run2012C"
-    ],
     "title": "High-Level Trigger path information HLT_Ele25_CaloIdVT_CaloIsoVL_TrkIdVL_TrkIsoT_TriCentralPFNoPUJet30 (SingleElectron dataset)",
     "type": {
       "primary": "Supplementaries",
@@ -7606,10 +5870,6 @@
     "collections": [
       "CMS-Trigger-Information"
     ],
-    "collision_information": {
-      "energy": "8TeV",
-      "type": "pp"
-    },
     "date_created": [
       "2012"
     ],
@@ -7617,10 +5877,6 @@
     "experiment": "CMS",
     "publisher": "CERN Open Data Portal",
     "recid": "6417",
-    "run_period": [
-      "Run2012B",
-      "Run2012C"
-    ],
     "title": "High-Level Trigger path information HLT_Ele25_CaloIdVT_CaloIsoVL_TrkIdVL_TrkIsoT_TriCentralPFNoPUJet45_35_25 (SingleElectron dataset)",
     "type": {
       "primary": "Supplementaries",
@@ -7641,10 +5897,6 @@
     "collections": [
       "CMS-Trigger-Information"
     ],
-    "collision_information": {
-      "energy": "8TeV",
-      "type": "pp"
-    },
     "date_created": [
       "2012"
     ],
@@ -7652,10 +5904,6 @@
     "experiment": "CMS",
     "publisher": "CERN Open Data Portal",
     "recid": "6418",
-    "run_period": [
-      "Run2012B",
-      "Run2012C"
-    ],
     "title": "High-Level Trigger path information HLT_Ele25_CaloIdVT_CaloIsoVL_TrkIdVL_TrkIsoT_TriCentralPFNoPUJet50_40_30 (SingleElectron dataset)",
     "type": {
       "primary": "Supplementaries",
@@ -7676,10 +5924,6 @@
     "collections": [
       "CMS-Trigger-Information"
     ],
-    "collision_information": {
-      "energy": "8TeV",
-      "type": "pp"
-    },
     "date_created": [
       "2012"
     ],
@@ -7687,10 +5931,6 @@
     "experiment": "CMS",
     "publisher": "CERN Open Data Portal",
     "recid": "6419",
-    "run_period": [
-      "Run2012B",
-      "Run2012C"
-    ],
     "title": "High-Level Trigger path information HLT_Ele25_CaloIdVT_TrkIdT_TriCentralPFJet30 (ElectronHad dataset)",
     "type": {
       "primary": "Supplementaries",
@@ -7711,10 +5951,6 @@
     "collections": [
       "CMS-Trigger-Information"
     ],
-    "collision_information": {
-      "energy": "8TeV",
-      "type": "pp"
-    },
     "date_created": [
       "2012"
     ],
@@ -7722,10 +5958,6 @@
     "experiment": "CMS",
     "publisher": "CERN Open Data Portal",
     "recid": "6420",
-    "run_period": [
-      "Run2012B",
-      "Run2012C"
-    ],
     "title": "High-Level Trigger path information HLT_Ele25_CaloIdVT_TrkIdT_TriCentralPFJet50_40_30 (ElectronHad dataset)",
     "type": {
       "primary": "Supplementaries",
@@ -7746,10 +5978,6 @@
     "collections": [
       "CMS-Trigger-Information"
     ],
-    "collision_information": {
-      "energy": "8TeV",
-      "type": "pp"
-    },
     "date_created": [
       "2012"
     ],
@@ -7757,10 +5985,6 @@
     "experiment": "CMS",
     "publisher": "CERN Open Data Portal",
     "recid": "6421",
-    "run_period": [
-      "Run2012B",
-      "Run2012C"
-    ],
     "title": "High-Level Trigger path information HLT_Ele25_CaloIdVT_TrkIdT_TriCentralPFNoPUJet30 (ElectronHad dataset)",
     "type": {
       "primary": "Supplementaries",
@@ -7781,10 +6005,6 @@
     "collections": [
       "CMS-Trigger-Information"
     ],
-    "collision_information": {
-      "energy": "8TeV",
-      "type": "pp"
-    },
     "date_created": [
       "2012"
     ],
@@ -7792,10 +6012,6 @@
     "experiment": "CMS",
     "publisher": "CERN Open Data Portal",
     "recid": "6422",
-    "run_period": [
-      "Run2012B",
-      "Run2012C"
-    ],
     "title": "High-Level Trigger path information HLT_Ele25_CaloIdVT_TrkIdT_TriCentralPFNoPUJet30_30_20 (SingleElectron dataset)",
     "type": {
       "primary": "Supplementaries",
@@ -7816,10 +6032,6 @@
     "collections": [
       "CMS-Trigger-Information"
     ],
-    "collision_information": {
-      "energy": "8TeV",
-      "type": "pp"
-    },
     "date_created": [
       "2012"
     ],
@@ -7827,10 +6039,6 @@
     "experiment": "CMS",
     "publisher": "CERN Open Data Portal",
     "recid": "6423",
-    "run_period": [
-      "Run2012B",
-      "Run2012C"
-    ],
     "title": "High-Level Trigger path information HLT_Ele25_CaloIdVT_TrkIdT_TriCentralPFNoPUJet50_40_30 (ElectronHad dataset)",
     "type": {
       "primary": "Supplementaries",
@@ -7851,10 +6059,6 @@
     "collections": [
       "CMS-Trigger-Information"
     ],
-    "collision_information": {
-      "energy": "8TeV",
-      "type": "pp"
-    },
     "date_created": [
       "2012"
     ],
@@ -7862,10 +6066,6 @@
     "experiment": "CMS",
     "publisher": "CERN Open Data Portal",
     "recid": "6424",
-    "run_period": [
-      "Run2012B",
-      "Run2012C"
-    ],
     "title": "High-Level Trigger path information HLT_Ele27_CaloIdL_CaloIsoVL_TrkIdVL_TrkIsoVL (SingleElectron dataset)",
     "type": {
       "primary": "Supplementaries",
@@ -7886,10 +6086,6 @@
     "collections": [
       "CMS-Trigger-Information"
     ],
-    "collision_information": {
-      "energy": "8TeV",
-      "type": "pp"
-    },
     "date_created": [
       "2012"
     ],
@@ -7897,10 +6093,6 @@
     "experiment": "CMS",
     "publisher": "CERN Open Data Portal",
     "recid": "6425",
-    "run_period": [
-      "Run2012B",
-      "Run2012C"
-    ],
     "title": "High-Level Trigger path information HLT_Ele27_CaloIdT_CaloIsoVL_TrkIdVL_TrkIsoVL_Ele15_CaloIdT_CaloIsoVL_trackless (DoubleElectron dataset)",
     "type": {
       "primary": "Supplementaries",
@@ -7921,10 +6113,6 @@
     "collections": [
       "CMS-Trigger-Information"
     ],
-    "collision_information": {
-      "energy": "8TeV",
-      "type": "pp"
-    },
     "date_created": [
       "2012"
     ],
@@ -7932,10 +6120,6 @@
     "experiment": "CMS",
     "publisher": "CERN Open Data Portal",
     "recid": "6426",
-    "run_period": [
-      "Run2012B",
-      "Run2012C"
-    ],
     "title": "High-Level Trigger path information HLT_Ele27_CaloIdT_CaloIsoVL_TrkIdVL_TrkIsoVL_HFT15 (DoubleElectron dataset)",
     "type": {
       "primary": "Supplementaries",
@@ -7956,10 +6140,6 @@
     "collections": [
       "CMS-Trigger-Information"
     ],
-    "collision_information": {
-      "energy": "8TeV",
-      "type": "pp"
-    },
     "date_created": [
       "2012"
     ],
@@ -7967,10 +6147,6 @@
     "experiment": "CMS",
     "publisher": "CERN Open Data Portal",
     "recid": "6427",
-    "run_period": [
-      "Run2012B",
-      "Run2012C"
-    ],
     "title": "High-Level Trigger path information HLT_Ele27_WP80 (SingleElectron dataset)",
     "type": {
       "primary": "Supplementaries",
@@ -7991,10 +6167,6 @@
     "collections": [
       "CMS-Trigger-Information"
     ],
-    "collision_information": {
-      "energy": "8TeV",
-      "type": "pp"
-    },
     "date_created": [
       "2012"
     ],
@@ -8002,10 +6174,6 @@
     "experiment": "CMS",
     "publisher": "CERN Open Data Portal",
     "recid": "6428",
-    "run_period": [
-      "Run2012B",
-      "Run2012C"
-    ],
     "title": "High-Level Trigger path information HLT_Ele27_WP80_CentralPFJet30_CentralPFJet25 (ElectronHad dataset)",
     "type": {
       "primary": "Supplementaries",
@@ -8026,10 +6194,6 @@
     "collections": [
       "CMS-Trigger-Information"
     ],
-    "collision_information": {
-      "energy": "8TeV",
-      "type": "pp"
-    },
     "date_created": [
       "2012"
     ],
@@ -8037,10 +6201,6 @@
     "experiment": "CMS",
     "publisher": "CERN Open Data Portal",
     "recid": "6429",
-    "run_period": [
-      "Run2012B",
-      "Run2012C"
-    ],
     "title": "High-Level Trigger path information HLT_Ele27_WP80_CentralPFJet30_CentralPFJet25_PFMET20 (ElectronHad dataset)",
     "type": {
       "primary": "Supplementaries",
@@ -8061,10 +6221,6 @@
     "collections": [
       "CMS-Trigger-Information"
     ],
-    "collision_information": {
-      "energy": "8TeV",
-      "type": "pp"
-    },
     "date_created": [
       "2012"
     ],
@@ -8072,10 +6228,6 @@
     "experiment": "CMS",
     "publisher": "CERN Open Data Portal",
     "recid": "6430",
-    "run_period": [
-      "Run2012B",
-      "Run2012C"
-    ],
     "title": "High-Level Trigger path information HLT_Ele27_WP80_CentralPFJet80 (ElectronHad, SingleElectron datasets)",
     "type": {
       "primary": "Supplementaries",
@@ -8096,10 +6248,6 @@
     "collections": [
       "CMS-Trigger-Information"
     ],
-    "collision_information": {
-      "energy": "8TeV",
-      "type": "pp"
-    },
     "date_created": [
       "2012"
     ],
@@ -8107,10 +6255,6 @@
     "experiment": "CMS",
     "publisher": "CERN Open Data Portal",
     "recid": "6431",
-    "run_period": [
-      "Run2012B",
-      "Run2012C"
-    ],
     "title": "High-Level Trigger path information HLT_Ele27_WP80_PFJet30_PFJet25_Deta3 (ElectronHad dataset)",
     "type": {
       "primary": "Supplementaries",
@@ -8131,10 +6275,6 @@
     "collections": [
       "CMS-Trigger-Information"
     ],
-    "collision_information": {
-      "energy": "8TeV",
-      "type": "pp"
-    },
     "date_created": [
       "2012"
     ],
@@ -8142,10 +6282,6 @@
     "experiment": "CMS",
     "publisher": "CERN Open Data Portal",
     "recid": "6432",
-    "run_period": [
-      "Run2012B",
-      "Run2012C"
-    ],
     "title": "High-Level Trigger path information HLT_Ele27_WP80_PFMET_MT50 (SingleElectron dataset)",
     "type": {
       "primary": "Supplementaries",
@@ -8166,10 +6302,6 @@
     "collections": [
       "CMS-Trigger-Information"
     ],
-    "collision_information": {
-      "energy": "8TeV",
-      "type": "pp"
-    },
     "date_created": [
       "2012"
     ],
@@ -8177,10 +6309,6 @@
     "experiment": "CMS",
     "publisher": "CERN Open Data Portal",
     "recid": "6433",
-    "run_period": [
-      "Run2012B",
-      "Run2012C"
-    ],
     "title": "High-Level Trigger path information HLT_Ele27_WP80_WCandPt80 (ElectronHad, SingleElectron datasets)",
     "type": {
       "primary": "Supplementaries",
@@ -8201,10 +6329,6 @@
     "collections": [
       "CMS-Trigger-Information"
     ],
-    "collision_information": {
-      "energy": "8TeV",
-      "type": "pp"
-    },
     "date_created": [
       "2012"
     ],
@@ -8212,10 +6336,6 @@
     "experiment": "CMS",
     "publisher": "CERN Open Data Portal",
     "recid": "6434",
-    "run_period": [
-      "Run2012B",
-      "Run2012C"
-    ],
     "title": "High-Level Trigger path information HLT_Ele30_CaloIdVT_TrkIdT (SingleElectron dataset)",
     "type": {
       "primary": "Supplementaries",
@@ -8236,10 +6356,6 @@
     "collections": [
       "CMS-Trigger-Information"
     ],
-    "collision_information": {
-      "energy": "8TeV",
-      "type": "pp"
-    },
     "date_created": [
       "2012"
     ],
@@ -8247,10 +6363,6 @@
     "experiment": "CMS",
     "publisher": "CERN Open Data Portal",
     "recid": "6435",
-    "run_period": [
-      "Run2012B",
-      "Run2012C"
-    ],
     "title": "High-Level Trigger path information HLT_Ele30_CaloIdVT_TrkIdT_PFJet100_PFJet25 (ElectronHad dataset)",
     "type": {
       "primary": "Supplementaries",
@@ -8271,10 +6383,6 @@
     "collections": [
       "CMS-Trigger-Information"
     ],
-    "collision_information": {
-      "energy": "8TeV",
-      "type": "pp"
-    },
     "date_created": [
       "2012"
     ],
@@ -8282,10 +6390,6 @@
     "experiment": "CMS",
     "publisher": "CERN Open Data Portal",
     "recid": "6436",
-    "run_period": [
-      "Run2012B",
-      "Run2012C"
-    ],
     "title": "High-Level Trigger path information HLT_Ele30_CaloIdVT_TrkIdT_PFJet150_PFJet25 (ElectronHad dataset)",
     "type": {
       "primary": "Supplementaries",
@@ -8306,10 +6410,6 @@
     "collections": [
       "CMS-Trigger-Information"
     ],
-    "collision_information": {
-      "energy": "8TeV",
-      "type": "pp"
-    },
     "date_created": [
       "2012"
     ],
@@ -8317,10 +6417,6 @@
     "experiment": "CMS",
     "publisher": "CERN Open Data Portal",
     "recid": "6437",
-    "run_period": [
-      "Run2012B",
-      "Run2012C"
-    ],
     "title": "High-Level Trigger path information HLT_Ele30_CaloIdVT_TrkIdT_PFNoPUJet100_PFNoPUJet25 (ElectronHad dataset)",
     "type": {
       "primary": "Supplementaries",
@@ -8341,10 +6437,6 @@
     "collections": [
       "CMS-Trigger-Information"
     ],
-    "collision_information": {
-      "energy": "8TeV",
-      "type": "pp"
-    },
     "date_created": [
       "2012"
     ],
@@ -8352,10 +6444,6 @@
     "experiment": "CMS",
     "publisher": "CERN Open Data Portal",
     "recid": "6438",
-    "run_period": [
-      "Run2012B",
-      "Run2012C"
-    ],
     "title": "High-Level Trigger path information HLT_Ele30_CaloIdVT_TrkIdT_PFNoPUJet150_PFNoPUJet25 (ElectronHad dataset)",
     "type": {
       "primary": "Supplementaries",
@@ -8376,10 +6464,6 @@
     "collections": [
       "CMS-Trigger-Information"
     ],
-    "collision_information": {
-      "energy": "8TeV",
-      "type": "pp"
-    },
     "date_created": [
       "2012"
     ],
@@ -8387,10 +6471,6 @@
     "experiment": "CMS",
     "publisher": "CERN Open Data Portal",
     "recid": "6439",
-    "run_period": [
-      "Run2012B",
-      "Run2012C"
-    ],
     "title": "High-Level Trigger path information HLT_Ele32_CaloIdL_CaloIsoVL_TrkIdVL_TrkIsoVL (SingleElectron dataset)",
     "type": {
       "primary": "Supplementaries",
@@ -8411,10 +6491,6 @@
     "collections": [
       "CMS-Trigger-Information"
     ],
-    "collision_information": {
-      "energy": "8TeV",
-      "type": "pp"
-    },
     "date_created": [
       "2012"
     ],
@@ -8422,10 +6498,6 @@
     "experiment": "CMS",
     "publisher": "CERN Open Data Portal",
     "recid": "6440",
-    "run_period": [
-      "Run2012B",
-      "Run2012C"
-    ],
     "title": "High-Level Trigger path information HLT_Ele32_CaloIdT_CaloIsoT_TrkIdT_TrkIsoT_SC17_Mass50 (DoubleElectron dataset)",
     "type": {
       "primary": "Supplementaries",
@@ -8446,10 +6518,6 @@
     "collections": [
       "CMS-Trigger-Information"
     ],
-    "collision_information": {
-      "energy": "8TeV",
-      "type": "pp"
-    },
     "date_created": [
       "2012"
     ],
@@ -8457,10 +6525,6 @@
     "experiment": "CMS",
     "publisher": "CERN Open Data Portal",
     "recid": "6441",
-    "run_period": [
-      "Run2012B",
-      "Run2012C"
-    ],
     "title": "High-Level Trigger path information HLT_Ele32_WP80_CentralPFJet35_CentralPFJet25 (SingleElectron dataset)",
     "type": {
       "primary": "Supplementaries",
@@ -8481,10 +6545,6 @@
     "collections": [
       "CMS-Trigger-Information"
     ],
-    "collision_information": {
-      "energy": "8TeV",
-      "type": "pp"
-    },
     "date_created": [
       "2012"
     ],
@@ -8492,10 +6552,6 @@
     "experiment": "CMS",
     "publisher": "CERN Open Data Portal",
     "recid": "6442",
-    "run_period": [
-      "Run2012B",
-      "Run2012C"
-    ],
     "title": "High-Level Trigger path information HLT_Ele32_WP80_CentralPFJet35_CentralPFJet25_PFMET20 (SingleElectron dataset)",
     "type": {
       "primary": "Supplementaries",
@@ -8516,10 +6572,6 @@
     "collections": [
       "CMS-Trigger-Information"
     ],
-    "collision_information": {
-      "energy": "8TeV",
-      "type": "pp"
-    },
     "date_created": [
       "2012"
     ],
@@ -8527,10 +6579,6 @@
     "experiment": "CMS",
     "publisher": "CERN Open Data Portal",
     "recid": "6443",
-    "run_period": [
-      "Run2012B",
-      "Run2012C"
-    ],
     "title": "High-Level Trigger path information HLT_Ele32_WP80_PFJet30_PFJet25_Deta3 (SingleElectron dataset)",
     "type": {
       "primary": "Supplementaries",
@@ -8551,10 +6599,6 @@
     "collections": [
       "CMS-Trigger-Information"
     ],
-    "collision_information": {
-      "energy": "8TeV",
-      "type": "pp"
-    },
     "date_created": [
       "2012"
     ],
@@ -8562,10 +6606,6 @@
     "experiment": "CMS",
     "publisher": "CERN Open Data Portal",
     "recid": "6444",
-    "run_period": [
-      "Run2012B",
-      "Run2012C"
-    ],
     "title": "High-Level Trigger path information HLT_Ele32_WP80_PFJet30_PFJet25_Deta3_CentralPFJet30 (SingleElectron dataset)",
     "type": {
       "primary": "Supplementaries",
@@ -8586,10 +6626,6 @@
     "collections": [
       "CMS-Trigger-Information"
     ],
-    "collision_information": {
-      "energy": "8TeV",
-      "type": "pp"
-    },
     "date_created": [
       "2012"
     ],
@@ -8597,10 +6633,6 @@
     "experiment": "CMS",
     "publisher": "CERN Open Data Portal",
     "recid": "6445",
-    "run_period": [
-      "Run2012B",
-      "Run2012C"
-    ],
     "title": "High-Level Trigger path information HLT_Ele5_SC5_Jpsi_Mass2to15 (DoubleElectron dataset)",
     "type": {
       "primary": "Supplementaries",
@@ -8621,10 +6653,6 @@
     "collections": [
       "CMS-Trigger-Information"
     ],
-    "collision_information": {
-      "energy": "8TeV",
-      "type": "pp"
-    },
     "date_created": [
       "2012"
     ],
@@ -8632,10 +6660,6 @@
     "experiment": "CMS",
     "publisher": "CERN Open Data Portal",
     "recid": "6446",
-    "run_period": [
-      "Run2012B",
-      "Run2012C"
-    ],
     "title": "High-Level Trigger path information HLT_Ele65_CaloIdVT_TrkIdT (SingleElectron dataset)",
     "type": {
       "primary": "Supplementaries",
@@ -8656,10 +6680,6 @@
     "collections": [
       "CMS-Trigger-Information"
     ],
-    "collision_information": {
-      "energy": "8TeV",
-      "type": "pp"
-    },
     "date_created": [
       "2012"
     ],
@@ -8667,10 +6687,6 @@
     "experiment": "CMS",
     "publisher": "CERN Open Data Portal",
     "recid": "6447",
-    "run_period": [
-      "Run2012B",
-      "Run2012C"
-    ],
     "title": "High-Level Trigger path information HLT_Ele80_CaloIdVT_GsfTrkIdT (SingleElectron dataset)",
     "type": {
       "primary": "Supplementaries",
@@ -8691,10 +6707,6 @@
     "collections": [
       "CMS-Trigger-Information"
     ],
-    "collision_information": {
-      "energy": "8TeV",
-      "type": "pp"
-    },
     "date_created": [
       "2012"
     ],
@@ -8702,10 +6714,6 @@
     "experiment": "CMS",
     "publisher": "CERN Open Data Portal",
     "recid": "6448",
-    "run_period": [
-      "Run2012B",
-      "Run2012C"
-    ],
     "title": "High-Level Trigger path information HLT_Ele80_CaloIdVT_TrkIdT (SingleElectron dataset)",
     "type": {
       "primary": "Supplementaries",
@@ -8726,10 +6734,6 @@
     "collections": [
       "CMS-Trigger-Information"
     ],
-    "collision_information": {
-      "energy": "8TeV",
-      "type": "pp"
-    },
     "date_created": [
       "2012"
     ],
@@ -8737,10 +6741,6 @@
     "experiment": "CMS",
     "publisher": "CERN Open Data Portal",
     "recid": "6449",
-    "run_period": [
-      "Run2012B",
-      "Run2012C"
-    ],
     "title": "High-Level Trigger path information HLT_Ele8_CaloIdL_CaloIsoVL (DoubleElectron dataset)",
     "type": {
       "primary": "Supplementaries",
@@ -8761,10 +6761,6 @@
     "collections": [
       "CMS-Trigger-Information"
     ],
-    "collision_information": {
-      "energy": "8TeV",
-      "type": "pp"
-    },
     "date_created": [
       "2012"
     ],
@@ -8772,10 +6768,6 @@
     "experiment": "CMS",
     "publisher": "CERN Open Data Portal",
     "recid": "6450",
-    "run_period": [
-      "Run2012B",
-      "Run2012C"
-    ],
     "title": "High-Level Trigger path information HLT_Ele8_CaloIdT_CaloIsoVL_TrkIdVL_TrkIsoVL (DoubleElectron dataset)",
     "type": {
       "primary": "Supplementaries",
@@ -8796,10 +6788,6 @@
     "collections": [
       "CMS-Trigger-Information"
     ],
-    "collision_information": {
-      "energy": "8TeV",
-      "type": "pp"
-    },
     "date_created": [
       "2012"
     ],
@@ -8807,10 +6795,6 @@
     "experiment": "CMS",
     "publisher": "CERN Open Data Portal",
     "recid": "6451",
-    "run_period": [
-      "Run2012B",
-      "Run2012C"
-    ],
     "title": "High-Level Trigger path information HLT_Ele8_CaloIdT_CaloIsoVL_TrkIdVL_TrkIsoVL_Jet30 (DoubleElectron dataset)",
     "type": {
       "primary": "Supplementaries",
@@ -8831,10 +6815,6 @@
     "collections": [
       "CMS-Trigger-Information"
     ],
-    "collision_information": {
-      "energy": "8TeV",
-      "type": "pp"
-    },
     "date_created": [
       "2012"
     ],
@@ -8842,10 +6822,6 @@
     "experiment": "CMS",
     "publisher": "CERN Open Data Portal",
     "recid": "6452",
-    "run_period": [
-      "Run2012B",
-      "Run2012C"
-    ],
     "title": "High-Level Trigger path information HLT_Ele8_CaloIdT_TrkIdT_DiJet30 (ElectronHad dataset)",
     "type": {
       "primary": "Supplementaries",
@@ -8866,10 +6842,6 @@
     "collections": [
       "CMS-Trigger-Information"
     ],
-    "collision_information": {
-      "energy": "8TeV",
-      "type": "pp"
-    },
     "date_created": [
       "2012"
     ],
@@ -8877,10 +6849,6 @@
     "experiment": "CMS",
     "publisher": "CERN Open Data Portal",
     "recid": "6453",
-    "run_period": [
-      "Run2012B",
-      "Run2012C"
-    ],
     "title": "High-Level Trigger path information HLT_Ele8_CaloIdT_TrkIdT_QuadJet30 (ElectronHad dataset)",
     "type": {
       "primary": "Supplementaries",
@@ -8901,10 +6869,6 @@
     "collections": [
       "CMS-Trigger-Information"
     ],
-    "collision_information": {
-      "energy": "8TeV",
-      "type": "pp"
-    },
     "date_created": [
       "2012"
     ],
@@ -8912,10 +6876,6 @@
     "experiment": "CMS",
     "publisher": "CERN Open Data Portal",
     "recid": "6454",
-    "run_period": [
-      "Run2012B",
-      "Run2012C"
-    ],
     "title": "High-Level Trigger path information HLT_Ele8_CaloIdT_TrkIdT_TriJet30 (ElectronHad dataset)",
     "type": {
       "primary": "Supplementaries",
@@ -8936,10 +6896,6 @@
     "collections": [
       "CMS-Trigger-Information"
     ],
-    "collision_information": {
-      "energy": "8TeV",
-      "type": "pp"
-    },
     "date_created": [
       "2012"
     ],
@@ -8947,10 +6903,6 @@
     "experiment": "CMS",
     "publisher": "CERN Open Data Portal",
     "recid": "6455",
-    "run_period": [
-      "Run2012B",
-      "Run2012C"
-    ],
     "title": "High-Level Trigger path information HLT_Ele8_CaloIdT_TrkIdVL (DoubleElectron dataset)",
     "type": {
       "primary": "Supplementaries",
@@ -8971,10 +6923,6 @@
     "collections": [
       "CMS-Trigger-Information"
     ],
-    "collision_information": {
-      "energy": "8TeV",
-      "type": "pp"
-    },
     "date_created": [
       "2012"
     ],
@@ -8982,10 +6930,6 @@
     "experiment": "CMS",
     "publisher": "CERN Open Data Portal",
     "recid": "6456",
-    "run_period": [
-      "Run2012B",
-      "Run2012C"
-    ],
     "title": "High-Level Trigger path information HLT_Ele8_CaloIdT_TrkIdVL_EG7 (DoubleElectron dataset)",
     "type": {
       "primary": "Supplementaries",
@@ -9006,10 +6950,6 @@
     "collections": [
       "CMS-Trigger-Information"
     ],
-    "collision_information": {
-      "energy": "8TeV",
-      "type": "pp"
-    },
     "date_created": [
       "2012"
     ],
@@ -9017,10 +6957,6 @@
     "experiment": "CMS",
     "publisher": "CERN Open Data Portal",
     "recid": "6457",
-    "run_period": [
-      "Run2012B",
-      "Run2012C"
-    ],
     "title": "High-Level Trigger path information HLT_Ele8_CaloIdT_TrkIdVL_Jet30 (DoubleElectron, ElectronHad datasets)",
     "type": {
       "primary": "Supplementaries",
@@ -9041,10 +6977,6 @@
     "collections": [
       "CMS-Trigger-Information"
     ],
-    "collision_information": {
-      "energy": "8TeV",
-      "type": "pp"
-    },
     "date_created": [
       "2012"
     ],
@@ -9052,10 +6984,6 @@
     "experiment": "CMS",
     "publisher": "CERN Open Data Portal",
     "recid": "6458",
-    "run_period": [
-      "Run2012B",
-      "Run2012C"
-    ],
     "title": "High-Level Trigger path information HLT_Ele90_CaloIdVT_GsfTrkIdT (SingleElectron dataset)",
     "type": {
       "primary": "Supplementaries",
@@ -9076,10 +7004,6 @@
     "collections": [
       "CMS-Trigger-Information"
     ],
-    "collision_information": {
-      "energy": "8TeV",
-      "type": "pp"
-    },
     "date_created": [
       "2012"
     ],
@@ -9087,10 +7011,6 @@
     "experiment": "CMS",
     "publisher": "CERN Open Data Portal",
     "recid": "6459",
-    "run_period": [
-      "Run2012B",
-      "Run2012C"
-    ],
     "title": "High-Level Trigger path information HLT_ExclDiJet35_HFAND (MultiJet, MultiJet1Parked datasets)",
     "type": {
       "primary": "Supplementaries",
@@ -9111,10 +7031,6 @@
     "collections": [
       "CMS-Trigger-Information"
     ],
-    "collision_information": {
-      "energy": "8TeV",
-      "type": "pp"
-    },
     "date_created": [
       "2012"
     ],
@@ -9122,10 +7038,6 @@
     "experiment": "CMS",
     "publisher": "CERN Open Data Portal",
     "recid": "6460",
-    "run_period": [
-      "Run2012B",
-      "Run2012C"
-    ],
     "title": "High-Level Trigger path information HLT_ExclDiJet35_HFOR (MultiJet, MultiJet1Parked datasets)",
     "type": {
       "primary": "Supplementaries",
@@ -9146,10 +7058,6 @@
     "collections": [
       "CMS-Trigger-Information"
     ],
-    "collision_information": {
-      "energy": "8TeV",
-      "type": "pp"
-    },
     "date_created": [
       "2012"
     ],
@@ -9157,10 +7065,6 @@
     "experiment": "CMS",
     "publisher": "CERN Open Data Portal",
     "recid": "6461",
-    "run_period": [
-      "Run2012B",
-      "Run2012C"
-    ],
     "title": "High-Level Trigger path information HLT_ExclDiJet80_HFAND (MultiJet, MultiJet1Parked datasets)",
     "type": {
       "primary": "Supplementaries",
@@ -9181,10 +7085,6 @@
     "collections": [
       "CMS-Trigger-Information"
     ],
-    "collision_information": {
-      "energy": "8TeV",
-      "type": "pp"
-    },
     "date_created": [
       "2012"
     ],
@@ -9192,10 +7092,6 @@
     "experiment": "CMS",
     "publisher": "CERN Open Data Portal",
     "recid": "6462",
-    "run_period": [
-      "Run2012B",
-      "Run2012C"
-    ],
     "title": "High-Level Trigger path information HLT_FatDiPFJetMass750_DR1p1_Deta1p5 (HT, JetHT datasets)",
     "type": {
       "primary": "Supplementaries",
@@ -9216,10 +7112,6 @@
     "collections": [
       "CMS-Trigger-Information"
     ],
-    "collision_information": {
-      "energy": "8TeV",
-      "type": "pp"
-    },
     "date_created": [
       "2012"
     ],
@@ -9227,10 +7119,6 @@
     "experiment": "CMS",
     "publisher": "CERN Open Data Portal",
     "recid": "6463",
-    "run_period": [
-      "Run2012B",
-      "Run2012C"
-    ],
     "title": "High-Level Trigger path information HLT_GlobalRunHPDNoise (HcalHPDNoise dataset)",
     "type": {
       "primary": "Supplementaries",
@@ -9251,10 +7139,6 @@
     "collections": [
       "CMS-Trigger-Information"
     ],
-    "collision_information": {
-      "energy": "8TeV",
-      "type": "pp"
-    },
     "date_created": [
       "2012"
     ],
@@ -9262,10 +7146,6 @@
     "experiment": "CMS",
     "publisher": "CERN Open Data Portal",
     "recid": "6464",
-    "run_period": [
-      "Run2012B",
-      "Run2012C"
-    ],
     "title": "High-Level Trigger path information HLT_HT200 (HT, JetHT datasets)",
     "type": {
       "primary": "Supplementaries",
@@ -9286,10 +7166,6 @@
     "collections": [
       "CMS-Trigger-Information"
     ],
-    "collision_information": {
-      "energy": "8TeV",
-      "type": "pp"
-    },
     "date_created": [
       "2012"
     ],
@@ -9297,10 +7173,6 @@
     "experiment": "CMS",
     "publisher": "CERN Open Data Portal",
     "recid": "6465",
-    "run_period": [
-      "Run2012B",
-      "Run2012C"
-    ],
     "title": "High-Level Trigger path information HLT_HT200_AlphaT0p57 (HT, HTMHTParked datasets)",
     "type": {
       "primary": "Supplementaries",
@@ -9321,10 +7193,6 @@
     "collections": [
       "CMS-Trigger-Information"
     ],
-    "collision_information": {
-      "energy": "8TeV",
-      "type": "pp"
-    },
     "date_created": [
       "2012"
     ],
@@ -9332,10 +7200,6 @@
     "experiment": "CMS",
     "publisher": "CERN Open Data Portal",
     "recid": "6466",
-    "run_period": [
-      "Run2012B",
-      "Run2012C"
-    ],
     "title": "High-Level Trigger path information HLT_HT250 (HT, JetHT datasets)",
     "type": {
       "primary": "Supplementaries",
@@ -9356,10 +7220,6 @@
     "collections": [
       "CMS-Trigger-Information"
     ],
-    "collision_information": {
-      "energy": "8TeV",
-      "type": "pp"
-    },
     "date_created": [
       "2012"
     ],
@@ -9367,10 +7227,6 @@
     "experiment": "CMS",
     "publisher": "CERN Open Data Portal",
     "recid": "6467",
-    "run_period": [
-      "Run2012B",
-      "Run2012C"
-    ],
     "title": "High-Level Trigger path information HLT_HT250_AlphaT0p55 (HT, HTMHT, HTMHTParked datasets)",
     "type": {
       "primary": "Supplementaries",
@@ -9391,10 +7247,6 @@
     "collections": [
       "CMS-Trigger-Information"
     ],
-    "collision_information": {
-      "energy": "8TeV",
-      "type": "pp"
-    },
     "date_created": [
       "2012"
     ],
@@ -9402,10 +7254,6 @@
     "experiment": "CMS",
     "publisher": "CERN Open Data Portal",
     "recid": "6468",
-    "run_period": [
-      "Run2012B",
-      "Run2012C"
-    ],
     "title": "High-Level Trigger path information HLT_HT250_AlphaT0p57 (HT, HTMHT, HTMHTParked datasets)",
     "type": {
       "primary": "Supplementaries",
@@ -9426,10 +7274,6 @@
     "collections": [
       "CMS-Trigger-Information"
     ],
-    "collision_information": {
-      "energy": "8TeV",
-      "type": "pp"
-    },
     "date_created": [
       "2012"
     ],
@@ -9437,10 +7281,6 @@
     "experiment": "CMS",
     "publisher": "CERN Open Data Portal",
     "recid": "6469",
-    "run_period": [
-      "Run2012B",
-      "Run2012C"
-    ],
     "title": "High-Level Trigger path information HLT_HT250_DoubleDisplacedPFJet60 (HT dataset)",
     "type": {
       "primary": "Supplementaries",
@@ -9461,10 +7301,6 @@
     "collections": [
       "CMS-Trigger-Information"
     ],
-    "collision_information": {
-      "energy": "8TeV",
-      "type": "pp"
-    },
     "date_created": [
       "2012"
     ],
@@ -9472,10 +7308,6 @@
     "experiment": "CMS",
     "publisher": "CERN Open Data Portal",
     "recid": "6470",
-    "run_period": [
-      "Run2012B",
-      "Run2012C"
-    ],
     "title": "High-Level Trigger path information HLT_HT250_DoubleDisplacedPFJet60_ChgFraction10 (HT dataset)",
     "type": {
       "primary": "Supplementaries",
@@ -9496,10 +7328,6 @@
     "collections": [
       "CMS-Trigger-Information"
     ],
-    "collision_information": {
-      "energy": "8TeV",
-      "type": "pp"
-    },
     "date_created": [
       "2012"
     ],
@@ -9507,10 +7335,6 @@
     "experiment": "CMS",
     "publisher": "CERN Open Data Portal",
     "recid": "6471",
-    "run_period": [
-      "Run2012B",
-      "Run2012C"
-    ],
     "title": "High-Level Trigger path information HLT_HT250_SingleDisplacedPFJet60 (HT dataset)",
     "type": {
       "primary": "Supplementaries",
@@ -9531,10 +7355,6 @@
     "collections": [
       "CMS-Trigger-Information"
     ],
-    "collision_information": {
-      "energy": "8TeV",
-      "type": "pp"
-    },
     "date_created": [
       "2012"
     ],
@@ -9542,10 +7362,6 @@
     "experiment": "CMS",
     "publisher": "CERN Open Data Portal",
     "recid": "6472",
-    "run_period": [
-      "Run2012B",
-      "Run2012C"
-    ],
     "title": "High-Level Trigger path information HLT_HT250_SingleDisplacedPFJet60_ChgFraction10 (HT dataset)",
     "type": {
       "primary": "Supplementaries",
@@ -9566,10 +7382,6 @@
     "collections": [
       "CMS-Trigger-Information"
     ],
-    "collision_information": {
-      "energy": "8TeV",
-      "type": "pp"
-    },
     "date_created": [
       "2012"
     ],
@@ -9577,10 +7389,6 @@
     "experiment": "CMS",
     "publisher": "CERN Open Data Portal",
     "recid": "6473",
-    "run_period": [
-      "Run2012B",
-      "Run2012C"
-    ],
     "title": "High-Level Trigger path information HLT_HT300 (HT, JetHT datasets)",
     "type": {
       "primary": "Supplementaries",
@@ -9601,10 +7409,6 @@
     "collections": [
       "CMS-Trigger-Information"
     ],
-    "collision_information": {
-      "energy": "8TeV",
-      "type": "pp"
-    },
     "date_created": [
       "2012"
     ],
@@ -9612,10 +7416,6 @@
     "experiment": "CMS",
     "publisher": "CERN Open Data Portal",
     "recid": "6474",
-    "run_period": [
-      "Run2012B",
-      "Run2012C"
-    ],
     "title": "High-Level Trigger path information HLT_HT300_AlphaT0p53 (HT, HTMHT, HTMHTParked datasets)",
     "type": {
       "primary": "Supplementaries",
@@ -9636,10 +7436,6 @@
     "collections": [
       "CMS-Trigger-Information"
     ],
-    "collision_information": {
-      "energy": "8TeV",
-      "type": "pp"
-    },
     "date_created": [
       "2012"
     ],
@@ -9647,10 +7443,6 @@
     "experiment": "CMS",
     "publisher": "CERN Open Data Portal",
     "recid": "6475",
-    "run_period": [
-      "Run2012B",
-      "Run2012C"
-    ],
     "title": "High-Level Trigger path information HLT_HT300_AlphaT0p54 (HT, HTMHT, HTMHTParked datasets)",
     "type": {
       "primary": "Supplementaries",
@@ -9671,10 +7463,6 @@
     "collections": [
       "CMS-Trigger-Information"
     ],
-    "collision_information": {
-      "energy": "8TeV",
-      "type": "pp"
-    },
     "date_created": [
       "2012"
     ],
@@ -9682,10 +7470,6 @@
     "experiment": "CMS",
     "publisher": "CERN Open Data Portal",
     "recid": "6476",
-    "run_period": [
-      "Run2012B",
-      "Run2012C"
-    ],
     "title": "High-Level Trigger path information HLT_HT300_DoubleDisplacedPFJet60 (HT, JetHT datasets)",
     "type": {
       "primary": "Supplementaries",
@@ -9706,10 +7490,6 @@
     "collections": [
       "CMS-Trigger-Information"
     ],
-    "collision_information": {
-      "energy": "8TeV",
-      "type": "pp"
-    },
     "date_created": [
       "2012"
     ],
@@ -9717,10 +7497,6 @@
     "experiment": "CMS",
     "publisher": "CERN Open Data Portal",
     "recid": "6477",
-    "run_period": [
-      "Run2012B",
-      "Run2012C"
-    ],
     "title": "High-Level Trigger path information HLT_HT300_DoubleDisplacedPFJet60_ChgFraction10 (HT, JetHT datasets)",
     "type": {
       "primary": "Supplementaries",
@@ -9741,10 +7517,6 @@
     "collections": [
       "CMS-Trigger-Information"
     ],
-    "collision_information": {
-      "energy": "8TeV",
-      "type": "pp"
-    },
     "date_created": [
       "2012"
     ],
@@ -9752,10 +7524,6 @@
     "experiment": "CMS",
     "publisher": "CERN Open Data Portal",
     "recid": "6478",
-    "run_period": [
-      "Run2012B",
-      "Run2012C"
-    ],
     "title": "High-Level Trigger path information HLT_HT300_SingleDisplacedPFJet60 (HT, JetHT datasets)",
     "type": {
       "primary": "Supplementaries",
@@ -9776,10 +7544,6 @@
     "collections": [
       "CMS-Trigger-Information"
     ],
-    "collision_information": {
-      "energy": "8TeV",
-      "type": "pp"
-    },
     "date_created": [
       "2012"
     ],
@@ -9787,10 +7551,6 @@
     "experiment": "CMS",
     "publisher": "CERN Open Data Portal",
     "recid": "6479",
-    "run_period": [
-      "Run2012B",
-      "Run2012C"
-    ],
     "title": "High-Level Trigger path information HLT_HT300_SingleDisplacedPFJet60_ChgFraction10 (HT, JetHT datasets)",
     "type": {
       "primary": "Supplementaries",
@@ -9811,10 +7571,6 @@
     "collections": [
       "CMS-Trigger-Information"
     ],
-    "collision_information": {
-      "energy": "8TeV",
-      "type": "pp"
-    },
     "date_created": [
       "2012"
     ],
@@ -9822,10 +7578,6 @@
     "experiment": "CMS",
     "publisher": "CERN Open Data Portal",
     "recid": "6480",
-    "run_period": [
-      "Run2012B",
-      "Run2012C"
-    ],
     "title": "High-Level Trigger path information HLT_HT350 (HT, JetHT datasets)",
     "type": {
       "primary": "Supplementaries",
@@ -9846,10 +7598,6 @@
     "collections": [
       "CMS-Trigger-Information"
     ],
-    "collision_information": {
-      "energy": "8TeV",
-      "type": "pp"
-    },
     "date_created": [
       "2012"
     ],
@@ -9857,10 +7605,6 @@
     "experiment": "CMS",
     "publisher": "CERN Open Data Portal",
     "recid": "6481",
-    "run_period": [
-      "Run2012B",
-      "Run2012C"
-    ],
     "title": "High-Level Trigger path information HLT_HT350_AlphaT0p52 (HT, HTMHT, HTMHTParked datasets)",
     "type": {
       "primary": "Supplementaries",
@@ -9881,10 +7625,6 @@
     "collections": [
       "CMS-Trigger-Information"
     ],
-    "collision_information": {
-      "energy": "8TeV",
-      "type": "pp"
-    },
     "date_created": [
       "2012"
     ],
@@ -9892,10 +7632,6 @@
     "experiment": "CMS",
     "publisher": "CERN Open Data Portal",
     "recid": "6482",
-    "run_period": [
-      "Run2012B",
-      "Run2012C"
-    ],
     "title": "High-Level Trigger path information HLT_HT350_AlphaT0p53 (HT, HTMHT, HTMHTParked datasets)",
     "type": {
       "primary": "Supplementaries",
@@ -9916,10 +7652,6 @@
     "collections": [
       "CMS-Trigger-Information"
     ],
-    "collision_information": {
-      "energy": "8TeV",
-      "type": "pp"
-    },
     "date_created": [
       "2012"
     ],
@@ -9927,10 +7659,6 @@
     "experiment": "CMS",
     "publisher": "CERN Open Data Portal",
     "recid": "6483",
-    "run_period": [
-      "Run2012B",
-      "Run2012C"
-    ],
     "title": "High-Level Trigger path information HLT_HT400 (HT, JetHT datasets)",
     "type": {
       "primary": "Supplementaries",
@@ -9951,10 +7679,6 @@
     "collections": [
       "CMS-Trigger-Information"
     ],
-    "collision_information": {
-      "energy": "8TeV",
-      "type": "pp"
-    },
     "date_created": [
       "2012"
     ],
@@ -9962,10 +7686,6 @@
     "experiment": "CMS",
     "publisher": "CERN Open Data Portal",
     "recid": "6484",
-    "run_period": [
-      "Run2012B",
-      "Run2012C"
-    ],
     "title": "High-Level Trigger path information HLT_HT400_AlphaT0p51 (HT, HTMHT, HTMHTParked datasets)",
     "type": {
       "primary": "Supplementaries",
@@ -9986,10 +7706,6 @@
     "collections": [
       "CMS-Trigger-Information"
     ],
-    "collision_information": {
-      "energy": "8TeV",
-      "type": "pp"
-    },
     "date_created": [
       "2012"
     ],
@@ -9997,10 +7713,6 @@
     "experiment": "CMS",
     "publisher": "CERN Open Data Portal",
     "recid": "6485",
-    "run_period": [
-      "Run2012B",
-      "Run2012C"
-    ],
     "title": "High-Level Trigger path information HLT_HT400_AlphaT0p52 (HT, HTMHT, HTMHTParked datasets)",
     "type": {
       "primary": "Supplementaries",
@@ -10021,10 +7733,6 @@
     "collections": [
       "CMS-Trigger-Information"
     ],
-    "collision_information": {
-      "energy": "8TeV",
-      "type": "pp"
-    },
     "date_created": [
       "2012"
     ],
@@ -10032,10 +7740,6 @@
     "experiment": "CMS",
     "publisher": "CERN Open Data Portal",
     "recid": "6486",
-    "run_period": [
-      "Run2012B",
-      "Run2012C"
-    ],
     "title": "High-Level Trigger path information HLT_HT450 (HT, JetHT datasets)",
     "type": {
       "primary": "Supplementaries",
@@ -10056,10 +7760,6 @@
     "collections": [
       "CMS-Trigger-Information"
     ],
-    "collision_information": {
-      "energy": "8TeV",
-      "type": "pp"
-    },
     "date_created": [
       "2012"
     ],
@@ -10067,10 +7767,6 @@
     "experiment": "CMS",
     "publisher": "CERN Open Data Portal",
     "recid": "6487",
-    "run_period": [
-      "Run2012B",
-      "Run2012C"
-    ],
     "title": "High-Level Trigger path information HLT_HT450_AlphaT0p51 (HT, HTMHT, HTMHTParked datasets)",
     "type": {
       "primary": "Supplementaries",
@@ -10091,10 +7787,6 @@
     "collections": [
       "CMS-Trigger-Information"
     ],
-    "collision_information": {
-      "energy": "8TeV",
-      "type": "pp"
-    },
     "date_created": [
       "2012"
     ],
@@ -10102,10 +7794,6 @@
     "experiment": "CMS",
     "publisher": "CERN Open Data Portal",
     "recid": "6488",
-    "run_period": [
-      "Run2012B",
-      "Run2012C"
-    ],
     "title": "High-Level Trigger path information HLT_HT500 (HT, JetHT datasets)",
     "type": {
       "primary": "Supplementaries",
@@ -10126,10 +7814,6 @@
     "collections": [
       "CMS-Trigger-Information"
     ],
-    "collision_information": {
-      "energy": "8TeV",
-      "type": "pp"
-    },
     "date_created": [
       "2012"
     ],
@@ -10137,10 +7821,6 @@
     "experiment": "CMS",
     "publisher": "CERN Open Data Portal",
     "recid": "6489",
-    "run_period": [
-      "Run2012B",
-      "Run2012C"
-    ],
     "title": "High-Level Trigger path information HLT_HT550 (HT, JetHT datasets)",
     "type": {
       "primary": "Supplementaries",
@@ -10161,10 +7841,6 @@
     "collections": [
       "CMS-Trigger-Information"
     ],
-    "collision_information": {
-      "energy": "8TeV",
-      "type": "pp"
-    },
     "date_created": [
       "2012"
     ],
@@ -10172,10 +7848,6 @@
     "experiment": "CMS",
     "publisher": "CERN Open Data Portal",
     "recid": "6490",
-    "run_period": [
-      "Run2012B",
-      "Run2012C"
-    ],
     "title": "High-Level Trigger path information HLT_HT650 (HT, JetHT datasets)",
     "type": {
       "primary": "Supplementaries",
@@ -10196,10 +7868,6 @@
     "collections": [
       "CMS-Trigger-Information"
     ],
-    "collision_information": {
-      "energy": "8TeV",
-      "type": "pp"
-    },
     "date_created": [
       "2012"
     ],
@@ -10207,10 +7875,6 @@
     "experiment": "CMS",
     "publisher": "CERN Open Data Portal",
     "recid": "6491",
-    "run_period": [
-      "Run2012B",
-      "Run2012C"
-    ],
     "title": "High-Level Trigger path information HLT_HT650_Track50_dEdx3p6 (ElectronHad, JetHT datasets)",
     "type": {
       "primary": "Supplementaries",
@@ -10231,10 +7895,6 @@
     "collections": [
       "CMS-Trigger-Information"
     ],
-    "collision_information": {
-      "energy": "8TeV",
-      "type": "pp"
-    },
     "date_created": [
       "2012"
     ],
@@ -10242,10 +7902,6 @@
     "experiment": "CMS",
     "publisher": "CERN Open Data Portal",
     "recid": "6492",
-    "run_period": [
-      "Run2012B",
-      "Run2012C"
-    ],
     "title": "High-Level Trigger path information HLT_HT650_Track60_dEdx3p7 (ElectronHad, JetHT datasets)",
     "type": {
       "primary": "Supplementaries",
@@ -10266,10 +7922,6 @@
     "collections": [
       "CMS-Trigger-Information"
     ],
-    "collision_information": {
-      "energy": "8TeV",
-      "type": "pp"
-    },
     "date_created": [
       "2012"
     ],
@@ -10277,10 +7929,6 @@
     "experiment": "CMS",
     "publisher": "CERN Open Data Portal",
     "recid": "6493",
-    "run_period": [
-      "Run2012B",
-      "Run2012C"
-    ],
     "title": "High-Level Trigger path information HLT_HT750 (HT, JetHT datasets)",
     "type": {
       "primary": "Supplementaries",
@@ -10301,10 +7949,6 @@
     "collections": [
       "CMS-Trigger-Information"
     ],
-    "collision_information": {
-      "energy": "8TeV",
-      "type": "pp"
-    },
     "date_created": [
       "2012"
     ],
@@ -10312,10 +7956,6 @@
     "experiment": "CMS",
     "publisher": "CERN Open Data Portal",
     "recid": "6494",
-    "run_period": [
-      "Run2012B",
-      "Run2012C"
-    ],
     "title": "High-Level Trigger path information HLT_HcalCalibration",
     "type": {
       "primary": "Supplementaries",
@@ -10336,10 +7976,6 @@
     "collections": [
       "CMS-Trigger-Information"
     ],
-    "collision_information": {
-      "energy": "8TeV",
-      "type": "pp"
-    },
     "date_created": [
       "2012"
     ],
@@ -10347,10 +7983,6 @@
     "experiment": "CMS",
     "publisher": "CERN Open Data Portal",
     "recid": "6495",
-    "run_period": [
-      "Run2012B",
-      "Run2012C"
-    ],
     "title": "High-Level Trigger path information HLT_HcalNZS (HcalNZS dataset)",
     "type": {
       "primary": "Supplementaries",
@@ -10371,10 +8003,6 @@
     "collections": [
       "CMS-Trigger-Information"
     ],
-    "collision_information": {
-      "energy": "8TeV",
-      "type": "pp"
-    },
     "date_created": [
       "2012"
     ],
@@ -10382,10 +8010,6 @@
     "experiment": "CMS",
     "publisher": "CERN Open Data Portal",
     "recid": "6496",
-    "run_period": [
-      "Run2012B",
-      "Run2012C"
-    ],
     "title": "High-Level Trigger path information HLT_HcalPhiSym (HcalNZS dataset)",
     "type": {
       "primary": "Supplementaries",
@@ -10406,10 +8030,6 @@
     "collections": [
       "CMS-Trigger-Information"
     ],
-    "collision_information": {
-      "energy": "8TeV",
-      "type": "pp"
-    },
     "date_created": [
       "2012"
     ],
@@ -10417,10 +8037,6 @@
     "experiment": "CMS",
     "publisher": "CERN Open Data Portal",
     "recid": "6497",
-    "run_period": [
-      "Run2012B",
-      "Run2012C"
-    ],
     "title": "High-Level Trigger path information HLT_HcalUTCA (HcalNZS dataset)",
     "type": {
       "primary": "Supplementaries",
@@ -10441,10 +8057,6 @@
     "collections": [
       "CMS-Trigger-Information"
     ],
-    "collision_information": {
-      "energy": "8TeV",
-      "type": "pp"
-    },
     "date_created": [
       "2012"
     ],
@@ -10452,10 +8064,6 @@
     "experiment": "CMS",
     "publisher": "CERN Open Data Portal",
     "recid": "6498",
-    "run_period": [
-      "Run2012B",
-      "Run2012C"
-    ],
     "title": "High-Level Trigger path information HLT_IsoMu12_DoubleCentralJet65 (MuHad dataset)",
     "type": {
       "primary": "Supplementaries",
@@ -10476,10 +8084,6 @@
     "collections": [
       "CMS-Trigger-Information"
     ],
-    "collision_information": {
-      "energy": "8TeV",
-      "type": "pp"
-    },
     "date_created": [
       "2012"
     ],
@@ -10487,10 +8091,6 @@
     "experiment": "CMS",
     "publisher": "CERN Open Data Portal",
     "recid": "6499",
-    "run_period": [
-      "Run2012B",
-      "Run2012C"
-    ],
     "title": "High-Level Trigger path information HLT_IsoMu12_RsqMR30_Rsq0p04_MR200 (MuHad dataset)",
     "type": {
       "primary": "Supplementaries",
@@ -10511,10 +8111,6 @@
     "collections": [
       "CMS-Trigger-Information"
     ],
-    "collision_information": {
-      "energy": "8TeV",
-      "type": "pp"
-    },
     "date_created": [
       "2012"
     ],
@@ -10522,10 +8118,6 @@
     "experiment": "CMS",
     "publisher": "CERN Open Data Portal",
     "recid": "6500",
-    "run_period": [
-      "Run2012B",
-      "Run2012C"
-    ],
     "title": "High-Level Trigger path information HLT_IsoMu12_RsqMR40_Rsq0p04_MR200 (MuHad dataset)",
     "type": {
       "primary": "Supplementaries",
@@ -10546,10 +8138,6 @@
     "collections": [
       "CMS-Trigger-Information"
     ],
-    "collision_information": {
-      "energy": "8TeV",
-      "type": "pp"
-    },
     "date_created": [
       "2012"
     ],
@@ -10557,10 +8145,6 @@
     "experiment": "CMS",
     "publisher": "CERN Open Data Portal",
     "recid": "6501",
-    "run_period": [
-      "Run2012B",
-      "Run2012C"
-    ],
     "title": "High-Level Trigger path information HLT_IsoMu15_eta2p1_L1ETM20 (TauPlusX dataset)",
     "type": {
       "primary": "Supplementaries",
@@ -10581,10 +8165,6 @@
     "collections": [
       "CMS-Trigger-Information"
     ],
-    "collision_information": {
-      "energy": "8TeV",
-      "type": "pp"
-    },
     "date_created": [
       "2012"
     ],
@@ -10592,10 +8172,6 @@
     "experiment": "CMS",
     "publisher": "CERN Open Data Portal",
     "recid": "6502",
-    "run_period": [
-      "Run2012B",
-      "Run2012C"
-    ],
     "title": "High-Level Trigger path information HLT_IsoMu15_eta2p1_LooseIsoPFTau35_Trk20_Prong1_L1ETM20 (TauPlusX dataset)",
     "type": {
       "primary": "Supplementaries",
@@ -10616,10 +8192,6 @@
     "collections": [
       "CMS-Trigger-Information"
     ],
-    "collision_information": {
-      "energy": "8TeV",
-      "type": "pp"
-    },
     "date_created": [
       "2012"
     ],
@@ -10627,10 +8199,6 @@
     "experiment": "CMS",
     "publisher": "CERN Open Data Portal",
     "recid": "6503",
-    "run_period": [
-      "Run2012B",
-      "Run2012C"
-    ],
     "title": "High-Level Trigger path information HLT_IsoMu17_eta2p1_CentralPFNoPUJet30 (SingleMu dataset)",
     "type": {
       "primary": "Supplementaries",
@@ -10651,10 +8219,6 @@
     "collections": [
       "CMS-Trigger-Information"
     ],
-    "collision_information": {
-      "energy": "8TeV",
-      "type": "pp"
-    },
     "date_created": [
       "2012"
     ],
@@ -10662,10 +8226,6 @@
     "experiment": "CMS",
     "publisher": "CERN Open Data Portal",
     "recid": "6504",
-    "run_period": [
-      "Run2012B",
-      "Run2012C"
-    ],
     "title": "High-Level Trigger path information HLT_IsoMu17_eta2p1_CentralPFNoPUJet30_BTagIPIter (SingleMu dataset)",
     "type": {
       "primary": "Supplementaries",
@@ -10686,10 +8246,6 @@
     "collections": [
       "CMS-Trigger-Information"
     ],
-    "collision_information": {
-      "energy": "8TeV",
-      "type": "pp"
-    },
     "date_created": [
       "2012"
     ],
@@ -10697,10 +8253,6 @@
     "experiment": "CMS",
     "publisher": "CERN Open Data Portal",
     "recid": "6505",
-    "run_period": [
-      "Run2012B",
-      "Run2012C"
-    ],
     "title": "High-Level Trigger path information HLT_IsoMu17_eta2p1_DiCentralPFJet30_PFHT350_PFMHT40 (MuHad dataset)",
     "type": {
       "primary": "Supplementaries",
@@ -10721,10 +8273,6 @@
     "collections": [
       "CMS-Trigger-Information"
     ],
-    "collision_information": {
-      "energy": "8TeV",
-      "type": "pp"
-    },
     "date_created": [
       "2012"
     ],
@@ -10732,10 +8280,6 @@
     "experiment": "CMS",
     "publisher": "CERN Open Data Portal",
     "recid": "6506",
-    "run_period": [
-      "Run2012B",
-      "Run2012C"
-    ],
     "title": "High-Level Trigger path information HLT_IsoMu17_eta2p1_DiCentralPFNoPUJet30 (SingleMu dataset)",
     "type": {
       "primary": "Supplementaries",
@@ -10756,10 +8300,6 @@
     "collections": [
       "CMS-Trigger-Information"
     ],
-    "collision_information": {
-      "energy": "8TeV",
-      "type": "pp"
-    },
     "date_created": [
       "2012"
     ],
@@ -10767,10 +8307,6 @@
     "experiment": "CMS",
     "publisher": "CERN Open Data Portal",
     "recid": "6507",
-    "run_period": [
-      "Run2012B",
-      "Run2012C"
-    ],
     "title": "High-Level Trigger path information HLT_IsoMu17_eta2p1_DiCentralPFNoPUJet30_PFNoPUHT350_PFMHT40 (MuHad dataset)",
     "type": {
       "primary": "Supplementaries",
@@ -10791,10 +8327,6 @@
     "collections": [
       "CMS-Trigger-Information"
     ],
-    "collision_information": {
-      "energy": "8TeV",
-      "type": "pp"
-    },
     "date_created": [
       "2012"
     ],
@@ -10802,10 +8334,6 @@
     "experiment": "CMS",
     "publisher": "CERN Open Data Portal",
     "recid": "6508",
-    "run_period": [
-      "Run2012B",
-      "Run2012C"
-    ],
     "title": "High-Level Trigger path information HLT_IsoMu17_eta2p1_LooseIsoPFTau20 (TauPlusX dataset)",
     "type": {
       "primary": "Supplementaries",
@@ -10826,10 +8354,6 @@
     "collections": [
       "CMS-Trigger-Information"
     ],
-    "collision_information": {
-      "energy": "8TeV",
-      "type": "pp"
-    },
     "date_created": [
       "2012"
     ],
@@ -10837,10 +8361,6 @@
     "experiment": "CMS",
     "publisher": "CERN Open Data Portal",
     "recid": "6509",
-    "run_period": [
-      "Run2012B",
-      "Run2012C"
-    ],
     "title": "High-Level Trigger path information HLT_IsoMu17_eta2p1_TriCentralPFJet30 (MuHad dataset)",
     "type": {
       "primary": "Supplementaries",
@@ -10861,10 +8381,6 @@
     "collections": [
       "CMS-Trigger-Information"
     ],
-    "collision_information": {
-      "energy": "8TeV",
-      "type": "pp"
-    },
     "date_created": [
       "2012"
     ],
@@ -10872,10 +8388,6 @@
     "experiment": "CMS",
     "publisher": "CERN Open Data Portal",
     "recid": "6510",
-    "run_period": [
-      "Run2012B",
-      "Run2012C"
-    ],
     "title": "High-Level Trigger path information HLT_IsoMu17_eta2p1_TriCentralPFNoPUJet30 (SingleMu dataset)",
     "type": {
       "primary": "Supplementaries",
@@ -10896,10 +8408,6 @@
     "collections": [
       "CMS-Trigger-Information"
     ],
-    "collision_information": {
-      "energy": "8TeV",
-      "type": "pp"
-    },
     "date_created": [
       "2012"
     ],
@@ -10907,10 +8415,6 @@
     "experiment": "CMS",
     "publisher": "CERN Open Data Portal",
     "recid": "6511",
-    "run_period": [
-      "Run2012B",
-      "Run2012C"
-    ],
     "title": "High-Level Trigger path information HLT_IsoMu17_eta2p1_TriCentralPFNoPUJet30_30_20 (SingleMu dataset)",
     "type": {
       "primary": "Supplementaries",
@@ -10931,10 +8435,6 @@
     "collections": [
       "CMS-Trigger-Information"
     ],
-    "collision_information": {
-      "energy": "8TeV",
-      "type": "pp"
-    },
     "date_created": [
       "2012"
     ],
@@ -10942,10 +8442,6 @@
     "experiment": "CMS",
     "publisher": "CERN Open Data Portal",
     "recid": "6512",
-    "run_period": [
-      "Run2012B",
-      "Run2012C"
-    ],
     "title": "High-Level Trigger path information HLT_IsoMu17_eta2p1_TriCentralPFNoPUJet45_35_25 (SingleMu dataset)",
     "type": {
       "primary": "Supplementaries",
@@ -10966,10 +8462,6 @@
     "collections": [
       "CMS-Trigger-Information"
     ],
-    "collision_information": {
-      "energy": "8TeV",
-      "type": "pp"
-    },
     "date_created": [
       "2012"
     ],
@@ -10977,10 +8469,6 @@
     "experiment": "CMS",
     "publisher": "CERN Open Data Portal",
     "recid": "6513",
-    "run_period": [
-      "Run2012B",
-      "Run2012C"
-    ],
     "title": "High-Level Trigger path information HLT_IsoMu17_eta2p1_TriCentralPFNoPUJet50_40_30 (SingleMu dataset)",
     "type": {
       "primary": "Supplementaries",
@@ -11001,10 +8489,6 @@
     "collections": [
       "CMS-Trigger-Information"
     ],
-    "collision_information": {
-      "energy": "8TeV",
-      "type": "pp"
-    },
     "date_created": [
       "2012"
     ],
@@ -11012,10 +8496,6 @@
     "experiment": "CMS",
     "publisher": "CERN Open Data Portal",
     "recid": "6514",
-    "run_period": [
-      "Run2012B",
-      "Run2012C"
-    ],
     "title": "High-Level Trigger path information HLT_IsoMu18_CentralPFJet30_CentralPFJet25 (SingleMu dataset)",
     "type": {
       "primary": "Supplementaries",
@@ -11036,10 +8516,6 @@
     "collections": [
       "CMS-Trigger-Information"
     ],
-    "collision_information": {
-      "energy": "8TeV",
-      "type": "pp"
-    },
     "date_created": [
       "2012"
     ],
@@ -11047,10 +8523,6 @@
     "experiment": "CMS",
     "publisher": "CERN Open Data Portal",
     "recid": "6515",
-    "run_period": [
-      "Run2012B",
-      "Run2012C"
-    ],
     "title": "High-Level Trigger path information HLT_IsoMu18_CentralPFJet30_CentralPFJet25_PFMET20 (SingleMu dataset)",
     "type": {
       "primary": "Supplementaries",
@@ -11071,10 +8543,6 @@
     "collections": [
       "CMS-Trigger-Information"
     ],
-    "collision_information": {
-      "energy": "8TeV",
-      "type": "pp"
-    },
     "date_created": [
       "2012"
     ],
@@ -11082,10 +8550,6 @@
     "experiment": "CMS",
     "publisher": "CERN Open Data Portal",
     "recid": "6516",
-    "run_period": [
-      "Run2012B",
-      "Run2012C"
-    ],
     "title": "High-Level Trigger path information HLT_IsoMu18_PFJet30_PFJet25_Deta3 (SingleMu dataset)",
     "type": {
       "primary": "Supplementaries",
@@ -11106,10 +8570,6 @@
     "collections": [
       "CMS-Trigger-Information"
     ],
-    "collision_information": {
-      "energy": "8TeV",
-      "type": "pp"
-    },
     "date_created": [
       "2012"
     ],
@@ -11117,10 +8577,6 @@
     "experiment": "CMS",
     "publisher": "CERN Open Data Portal",
     "recid": "6517",
-    "run_period": [
-      "Run2012B",
-      "Run2012C"
-    ],
     "title": "High-Level Trigger path information HLT_IsoMu18_PFJet30_PFJet25_Deta3_CentralPFJet25 (SingleMu dataset)",
     "type": {
       "primary": "Supplementaries",
@@ -11141,10 +8597,6 @@
     "collections": [
       "CMS-Trigger-Information"
     ],
-    "collision_information": {
-      "energy": "8TeV",
-      "type": "pp"
-    },
     "date_created": [
       "2012"
     ],
@@ -11152,10 +8604,6 @@
     "experiment": "CMS",
     "publisher": "CERN Open Data Portal",
     "recid": "6518",
-    "run_period": [
-      "Run2012B",
-      "Run2012C"
-    ],
     "title": "High-Level Trigger path information HLT_IsoMu18_eta2p1_LooseIsoPFTau20 (TauPlusX dataset)",
     "type": {
       "primary": "Supplementaries",
@@ -11176,10 +8624,6 @@
     "collections": [
       "CMS-Trigger-Information"
     ],
-    "collision_information": {
-      "energy": "8TeV",
-      "type": "pp"
-    },
     "date_created": [
       "2012"
     ],
@@ -11187,10 +8631,6 @@
     "experiment": "CMS",
     "publisher": "CERN Open Data Portal",
     "recid": "6519",
-    "run_period": [
-      "Run2012B",
-      "Run2012C"
-    ],
     "title": "High-Level Trigger path information HLT_IsoMu18_eta2p1_MediumIsoPFTau25_Trk1_eta2p1 (TauPlusX dataset)",
     "type": {
       "primary": "Supplementaries",
@@ -11211,10 +8651,6 @@
     "collections": [
       "CMS-Trigger-Information"
     ],
-    "collision_information": {
-      "energy": "8TeV",
-      "type": "pp"
-    },
     "date_created": [
       "2012"
     ],
@@ -11222,10 +8658,6 @@
     "experiment": "CMS",
     "publisher": "CERN Open Data Portal",
     "recid": "6520",
-    "run_period": [
-      "Run2012B",
-      "Run2012C"
-    ],
     "title": "High-Level Trigger path information HLT_IsoMu18_eta2p1_MediumIsoPFTau25_Trk1_eta2p1_Reg (TauPlusX dataset)",
     "type": {
       "primary": "Supplementaries",
@@ -11246,10 +8678,6 @@
     "collections": [
       "CMS-Trigger-Information"
     ],
-    "collision_information": {
-      "energy": "8TeV",
-      "type": "pp"
-    },
     "date_created": [
       "2012"
     ],
@@ -11257,10 +8685,6 @@
     "experiment": "CMS",
     "publisher": "CERN Open Data Portal",
     "recid": "6521",
-    "run_period": [
-      "Run2012B",
-      "Run2012C"
-    ],
     "title": "High-Level Trigger path information HLT_IsoMu18_eta2p1_MediumIsoPFTau25_Trk5_eta2p1 (TauPlusX dataset)",
     "type": {
       "primary": "Supplementaries",
@@ -11281,10 +8705,6 @@
     "collections": [
       "CMS-Trigger-Information"
     ],
-    "collision_information": {
-      "energy": "8TeV",
-      "type": "pp"
-    },
     "date_created": [
       "2012"
     ],
@@ -11292,10 +8712,6 @@
     "experiment": "CMS",
     "publisher": "CERN Open Data Portal",
     "recid": "6522",
-    "run_period": [
-      "Run2012B",
-      "Run2012C"
-    ],
     "title": "High-Level Trigger path information HLT_IsoMu20_WCandPt80 (SingleMu dataset)",
     "type": {
       "primary": "Supplementaries",
@@ -11316,10 +8732,6 @@
     "collections": [
       "CMS-Trigger-Information"
     ],
-    "collision_information": {
-      "energy": "8TeV",
-      "type": "pp"
-    },
     "date_created": [
       "2012"
     ],
@@ -11327,10 +8739,6 @@
     "experiment": "CMS",
     "publisher": "CERN Open Data Portal",
     "recid": "6523",
-    "run_period": [
-      "Run2012B",
-      "Run2012C"
-    ],
     "title": "High-Level Trigger path information HLT_IsoMu20_eta2p1 (SingleMu dataset)",
     "type": {
       "primary": "Supplementaries",
@@ -11351,10 +8759,6 @@
     "collections": [
       "CMS-Trigger-Information"
     ],
-    "collision_information": {
-      "energy": "8TeV",
-      "type": "pp"
-    },
     "date_created": [
       "2012"
     ],
@@ -11362,10 +8766,6 @@
     "experiment": "CMS",
     "publisher": "CERN Open Data Portal",
     "recid": "6524",
-    "run_period": [
-      "Run2012B",
-      "Run2012C"
-    ],
     "title": "High-Level Trigger path information HLT_IsoMu20_eta2p1_CentralPFJet30 (MuHad dataset)",
     "type": {
       "primary": "Supplementaries",
@@ -11386,10 +8786,6 @@
     "collections": [
       "CMS-Trigger-Information"
     ],
-    "collision_information": {
-      "energy": "8TeV",
-      "type": "pp"
-    },
     "date_created": [
       "2012"
     ],
@@ -11397,10 +8793,6 @@
     "experiment": "CMS",
     "publisher": "CERN Open Data Portal",
     "recid": "6525",
-    "run_period": [
-      "Run2012B",
-      "Run2012C"
-    ],
     "title": "High-Level Trigger path information HLT_IsoMu20_eta2p1_CentralPFJet30_BTagIPIter (MuHad dataset)",
     "type": {
       "primary": "Supplementaries",
@@ -11421,10 +8813,6 @@
     "collections": [
       "CMS-Trigger-Information"
     ],
-    "collision_information": {
-      "energy": "8TeV",
-      "type": "pp"
-    },
     "date_created": [
       "2012"
     ],
@@ -11432,10 +8820,6 @@
     "experiment": "CMS",
     "publisher": "CERN Open Data Portal",
     "recid": "6526",
-    "run_period": [
-      "Run2012B",
-      "Run2012C"
-    ],
     "title": "High-Level Trigger path information HLT_IsoMu20_eta2p1_CentralPFJet80 (MuHad, SingleMu datasets)",
     "type": {
       "primary": "Supplementaries",
@@ -11456,10 +8840,6 @@
     "collections": [
       "CMS-Trigger-Information"
     ],
-    "collision_information": {
-      "energy": "8TeV",
-      "type": "pp"
-    },
     "date_created": [
       "2012"
     ],
@@ -11467,10 +8847,6 @@
     "experiment": "CMS",
     "publisher": "CERN Open Data Portal",
     "recid": "6527",
-    "run_period": [
-      "Run2012B",
-      "Run2012C"
-    ],
     "title": "High-Level Trigger path information HLT_IsoMu20_eta2p1_CentralPFNoPUJet30 (MuHad dataset)",
     "type": {
       "primary": "Supplementaries",
@@ -11491,10 +8867,6 @@
     "collections": [
       "CMS-Trigger-Information"
     ],
-    "collision_information": {
-      "energy": "8TeV",
-      "type": "pp"
-    },
     "date_created": [
       "2012"
     ],
@@ -11502,10 +8874,6 @@
     "experiment": "CMS",
     "publisher": "CERN Open Data Portal",
     "recid": "6528",
-    "run_period": [
-      "Run2012B",
-      "Run2012C"
-    ],
     "title": "High-Level Trigger path information HLT_IsoMu20_eta2p1_CentralPFNoPUJet30_BTagIPIter (MuHad dataset)",
     "type": {
       "primary": "Supplementaries",
@@ -11526,10 +8894,6 @@
     "collections": [
       "CMS-Trigger-Information"
     ],
-    "collision_information": {
-      "energy": "8TeV",
-      "type": "pp"
-    },
     "date_created": [
       "2012"
     ],
@@ -11537,10 +8901,6 @@
     "experiment": "CMS",
     "publisher": "CERN Open Data Portal",
     "recid": "6529",
-    "run_period": [
-      "Run2012B",
-      "Run2012C"
-    ],
     "title": "High-Level Trigger path information HLT_IsoMu20_eta2p1_DiCentralPFJet30 (MuHad dataset)",
     "type": {
       "primary": "Supplementaries",
@@ -11561,10 +8921,6 @@
     "collections": [
       "CMS-Trigger-Information"
     ],
-    "collision_information": {
-      "energy": "8TeV",
-      "type": "pp"
-    },
     "date_created": [
       "2012"
     ],
@@ -11572,10 +8928,6 @@
     "experiment": "CMS",
     "publisher": "CERN Open Data Portal",
     "recid": "6530",
-    "run_period": [
-      "Run2012B",
-      "Run2012C"
-    ],
     "title": "High-Level Trigger path information HLT_IsoMu20_eta2p1_DiCentralPFNoPUJet30 (MuHad dataset)",
     "type": {
       "primary": "Supplementaries",
@@ -11596,10 +8948,6 @@
     "collections": [
       "CMS-Trigger-Information"
     ],
-    "collision_information": {
-      "energy": "8TeV",
-      "type": "pp"
-    },
     "date_created": [
       "2012"
     ],
@@ -11607,10 +8955,6 @@
     "experiment": "CMS",
     "publisher": "CERN Open Data Portal",
     "recid": "6531",
-    "run_period": [
-      "Run2012B",
-      "Run2012C"
-    ],
     "title": "High-Level Trigger path information HLT_IsoMu20_eta2p1_LooseIsoPFTau20 (TauPlusX dataset)",
     "type": {
       "primary": "Supplementaries",
@@ -11631,10 +8975,6 @@
     "collections": [
       "CMS-Trigger-Information"
     ],
-    "collision_information": {
-      "energy": "8TeV",
-      "type": "pp"
-    },
     "date_created": [
       "2012"
     ],
@@ -11642,10 +8982,6 @@
     "experiment": "CMS",
     "publisher": "CERN Open Data Portal",
     "recid": "6532",
-    "run_period": [
-      "Run2012B",
-      "Run2012C"
-    ],
     "title": "High-Level Trigger path information HLT_IsoMu20_eta2p1_TriCentralPFJet30 (MuHad dataset)",
     "type": {
       "primary": "Supplementaries",
@@ -11666,10 +9002,6 @@
     "collections": [
       "CMS-Trigger-Information"
     ],
-    "collision_information": {
-      "energy": "8TeV",
-      "type": "pp"
-    },
     "date_created": [
       "2012"
     ],
@@ -11677,10 +9009,6 @@
     "experiment": "CMS",
     "publisher": "CERN Open Data Portal",
     "recid": "6533",
-    "run_period": [
-      "Run2012B",
-      "Run2012C"
-    ],
     "title": "High-Level Trigger path information HLT_IsoMu20_eta2p1_TriCentralPFJet50_40_30 (MuHad dataset)",
     "type": {
       "primary": "Supplementaries",
@@ -11701,10 +9029,6 @@
     "collections": [
       "CMS-Trigger-Information"
     ],
-    "collision_information": {
-      "energy": "8TeV",
-      "type": "pp"
-    },
     "date_created": [
       "2012"
     ],
@@ -11712,10 +9036,6 @@
     "experiment": "CMS",
     "publisher": "CERN Open Data Portal",
     "recid": "6534",
-    "run_period": [
-      "Run2012B",
-      "Run2012C"
-    ],
     "title": "High-Level Trigger path information HLT_IsoMu20_eta2p1_TriCentralPFNoPUJet30 (MuHad dataset)",
     "type": {
       "primary": "Supplementaries",
@@ -11736,10 +9056,6 @@
     "collections": [
       "CMS-Trigger-Information"
     ],
-    "collision_information": {
-      "energy": "8TeV",
-      "type": "pp"
-    },
     "date_created": [
       "2012"
     ],
@@ -11747,10 +9063,6 @@
     "experiment": "CMS",
     "publisher": "CERN Open Data Portal",
     "recid": "6535",
-    "run_period": [
-      "Run2012B",
-      "Run2012C"
-    ],
     "title": "High-Level Trigger path information HLT_IsoMu20_eta2p1_TriCentralPFNoPUJet50_40_30 (MuHad dataset)",
     "type": {
       "primary": "Supplementaries",
@@ -11771,10 +9083,6 @@
     "collections": [
       "CMS-Trigger-Information"
     ],
-    "collision_information": {
-      "energy": "8TeV",
-      "type": "pp"
-    },
     "date_created": [
       "2012"
     ],
@@ -11782,10 +9090,6 @@
     "experiment": "CMS",
     "publisher": "CERN Open Data Portal",
     "recid": "6536",
-    "run_period": [
-      "Run2012B",
-      "Run2012C"
-    ],
     "title": "High-Level Trigger path information HLT_IsoMu20_eta2p1_WCandPt80 (MuHad, SingleMu datasets)",
     "type": {
       "primary": "Supplementaries",
@@ -11806,10 +9110,6 @@
     "collections": [
       "CMS-Trigger-Information"
     ],
-    "collision_information": {
-      "energy": "8TeV",
-      "type": "pp"
-    },
     "date_created": [
       "2012"
     ],
@@ -11817,10 +9117,6 @@
     "experiment": "CMS",
     "publisher": "CERN Open Data Portal",
     "recid": "6537",
-    "run_period": [
-      "Run2012B",
-      "Run2012C"
-    ],
     "title": "High-Level Trigger path information HLT_IsoMu24 (SingleMu dataset)",
     "type": {
       "primary": "Supplementaries",
@@ -11841,10 +9137,6 @@
     "collections": [
       "CMS-Trigger-Information"
     ],
-    "collision_information": {
-      "energy": "8TeV",
-      "type": "pp"
-    },
     "date_created": [
       "2012"
     ],
@@ -11852,10 +9144,6 @@
     "experiment": "CMS",
     "publisher": "CERN Open Data Portal",
     "recid": "6538",
-    "run_period": [
-      "Run2012B",
-      "Run2012C"
-    ],
     "title": "High-Level Trigger path information HLT_IsoMu24_CentralPFJet30_CentralPFJet25 (SingleMu dataset)",
     "type": {
       "primary": "Supplementaries",
@@ -11876,10 +9164,6 @@
     "collections": [
       "CMS-Trigger-Information"
     ],
-    "collision_information": {
-      "energy": "8TeV",
-      "type": "pp"
-    },
     "date_created": [
       "2012"
     ],
@@ -11887,10 +9171,6 @@
     "experiment": "CMS",
     "publisher": "CERN Open Data Portal",
     "recid": "6539",
-    "run_period": [
-      "Run2012B",
-      "Run2012C"
-    ],
     "title": "High-Level Trigger path information HLT_IsoMu24_CentralPFJet30_CentralPFJet25_PFMET20 (SingleMu dataset)",
     "type": {
       "primary": "Supplementaries",
@@ -11911,10 +9191,6 @@
     "collections": [
       "CMS-Trigger-Information"
     ],
-    "collision_information": {
-      "energy": "8TeV",
-      "type": "pp"
-    },
     "date_created": [
       "2012"
     ],
@@ -11922,10 +9198,6 @@
     "experiment": "CMS",
     "publisher": "CERN Open Data Portal",
     "recid": "6540",
-    "run_period": [
-      "Run2012B",
-      "Run2012C"
-    ],
     "title": "High-Level Trigger path information HLT_IsoMu24_PFJet30_PFJet25_Deta3_CentralPFJet25 (SingleMu dataset)",
     "type": {
       "primary": "Supplementaries",
@@ -11946,10 +9218,6 @@
     "collections": [
       "CMS-Trigger-Information"
     ],
-    "collision_information": {
-      "energy": "8TeV",
-      "type": "pp"
-    },
     "date_created": [
       "2012"
     ],
@@ -11957,10 +9225,6 @@
     "experiment": "CMS",
     "publisher": "CERN Open Data Portal",
     "recid": "6541",
-    "run_period": [
-      "Run2012B",
-      "Run2012C"
-    ],
     "title": "High-Level Trigger path information HLT_IsoMu24_eta2p1 (SingleMu dataset)",
     "type": {
       "primary": "Supplementaries",
@@ -11981,10 +9245,6 @@
     "collections": [
       "CMS-Trigger-Information"
     ],
-    "collision_information": {
-      "energy": "8TeV",
-      "type": "pp"
-    },
     "date_created": [
       "2012"
     ],
@@ -11992,10 +9252,6 @@
     "experiment": "CMS",
     "publisher": "CERN Open Data Portal",
     "recid": "6542",
-    "run_period": [
-      "Run2012B",
-      "Run2012C"
-    ],
     "title": "High-Level Trigger path information HLT_IsoMu24_eta2p1_CentralPFJet30_CentralPFJet25 (MuHad dataset)",
     "type": {
       "primary": "Supplementaries",
@@ -12016,10 +9272,6 @@
     "collections": [
       "CMS-Trigger-Information"
     ],
-    "collision_information": {
-      "energy": "8TeV",
-      "type": "pp"
-    },
     "date_created": [
       "2012"
     ],
@@ -12027,10 +9279,6 @@
     "experiment": "CMS",
     "publisher": "CERN Open Data Portal",
     "recid": "6543",
-    "run_period": [
-      "Run2012B",
-      "Run2012C"
-    ],
     "title": "High-Level Trigger path information HLT_IsoMu24_eta2p1_CentralPFJet30_CentralPFJet25_PFMET20 (MuHad dataset)",
     "type": {
       "primary": "Supplementaries",
@@ -12051,10 +9299,6 @@
     "collections": [
       "CMS-Trigger-Information"
     ],
-    "collision_information": {
-      "energy": "8TeV",
-      "type": "pp"
-    },
     "date_created": [
       "2012"
     ],
@@ -12062,10 +9306,6 @@
     "experiment": "CMS",
     "publisher": "CERN Open Data Portal",
     "recid": "6544",
-    "run_period": [
-      "Run2012B",
-      "Run2012C"
-    ],
     "title": "High-Level Trigger path information HLT_IsoMu24_eta2p1_PFJet30_PFJet25_Deta3 (MuHad dataset)",
     "type": {
       "primary": "Supplementaries",
@@ -12086,10 +9326,6 @@
     "collections": [
       "CMS-Trigger-Information"
     ],
-    "collision_information": {
-      "energy": "8TeV",
-      "type": "pp"
-    },
     "date_created": [
       "2012"
     ],
@@ -12097,10 +9333,6 @@
     "experiment": "CMS",
     "publisher": "CERN Open Data Portal",
     "recid": "6545",
-    "run_period": [
-      "Run2012B",
-      "Run2012C"
-    ],
     "title": "High-Level Trigger path information HLT_IsoMu30 (SingleMu dataset)",
     "type": {
       "primary": "Supplementaries",
@@ -12121,10 +9353,6 @@
     "collections": [
       "CMS-Trigger-Information"
     ],
-    "collision_information": {
-      "energy": "8TeV",
-      "type": "pp"
-    },
     "date_created": [
       "2012"
     ],
@@ -12132,10 +9360,6 @@
     "experiment": "CMS",
     "publisher": "CERN Open Data Portal",
     "recid": "6546",
-    "run_period": [
-      "Run2012B",
-      "Run2012C"
-    ],
     "title": "High-Level Trigger path information HLT_IsoMu30_eta2p1 (SingleMu dataset)",
     "type": {
       "primary": "Supplementaries",
@@ -12156,10 +9380,6 @@
     "collections": [
       "CMS-Trigger-Information"
     ],
-    "collision_information": {
-      "energy": "8TeV",
-      "type": "pp"
-    },
     "date_created": [
       "2012"
     ],
@@ -12167,10 +9387,6 @@
     "experiment": "CMS",
     "publisher": "CERN Open Data Portal",
     "recid": "6547",
-    "run_period": [
-      "Run2012B",
-      "Run2012C"
-    ],
     "title": "High-Level Trigger path information HLT_IsoMu34_eta2p1 (SingleMu dataset)",
     "type": {
       "primary": "Supplementaries",
@@ -12191,10 +9407,6 @@
     "collections": [
       "CMS-Trigger-Information"
     ],
-    "collision_information": {
-      "energy": "8TeV",
-      "type": "pp"
-    },
     "date_created": [
       "2012"
     ],
@@ -12202,10 +9414,6 @@
     "experiment": "CMS",
     "publisher": "CERN Open Data Portal",
     "recid": "6548",
-    "run_period": [
-      "Run2012B",
-      "Run2012C"
-    ],
     "title": "High-Level Trigger path information HLT_IsoMu40_eta2p1 (SingleMu dataset)",
     "type": {
       "primary": "Supplementaries",
@@ -12226,10 +9434,6 @@
     "collections": [
       "CMS-Trigger-Information"
     ],
-    "collision_information": {
-      "energy": "8TeV",
-      "type": "pp"
-    },
     "date_created": [
       "2012"
     ],
@@ -12237,10 +9441,6 @@
     "experiment": "CMS",
     "publisher": "CERN Open Data Portal",
     "recid": "6549",
-    "run_period": [
-      "Run2012B",
-      "Run2012C"
-    ],
     "title": "High-Level Trigger path information HLT_IsoMu8_eta2p1_LooseIsoPFTau20 (TauPlusX dataset)",
     "type": {
       "primary": "Supplementaries",
@@ -12261,10 +9461,6 @@
     "collections": [
       "CMS-Trigger-Information"
     ],
-    "collision_information": {
-      "energy": "8TeV",
-      "type": "pp"
-    },
     "date_created": [
       "2012"
     ],
@@ -12272,10 +9468,6 @@
     "experiment": "CMS",
     "publisher": "CERN Open Data Portal",
     "recid": "6550",
-    "run_period": [
-      "Run2012B",
-      "Run2012C"
-    ],
     "title": "High-Level Trigger path information HLT_IsoMu8_eta2p1_LooseIsoPFTau20_L1ETM26 (TauPlusX dataset)",
     "type": {
       "primary": "Supplementaries",
@@ -12296,10 +9488,6 @@
     "collections": [
       "CMS-Trigger-Information"
     ],
-    "collision_information": {
-      "energy": "8TeV",
-      "type": "pp"
-    },
     "date_created": [
       "2012"
     ],
@@ -12307,10 +9495,6 @@
     "experiment": "CMS",
     "publisher": "CERN Open Data Portal",
     "recid": "6551",
-    "run_period": [
-      "Run2012B",
-      "Run2012C"
-    ],
     "title": "High-Level Trigger path information HLT_IsoTrackHB (Commissioning dataset)",
     "type": {
       "primary": "Supplementaries",
@@ -12331,10 +9515,6 @@
     "collections": [
       "CMS-Trigger-Information"
     ],
-    "collision_information": {
-      "energy": "8TeV",
-      "type": "pp"
-    },
     "date_created": [
       "2012"
     ],
@@ -12342,10 +9522,6 @@
     "experiment": "CMS",
     "publisher": "CERN Open Data Portal",
     "recid": "6552",
-    "run_period": [
-      "Run2012B",
-      "Run2012C"
-    ],
     "title": "High-Level Trigger path information HLT_IsoTrackHE (Commissioning dataset)",
     "type": {
       "primary": "Supplementaries",
@@ -12366,10 +9542,6 @@
     "collections": [
       "CMS-Trigger-Information"
     ],
-    "collision_information": {
-      "energy": "8TeV",
-      "type": "pp"
-    },
     "date_created": [
       "2012"
     ],
@@ -12377,10 +9549,6 @@
     "experiment": "CMS",
     "publisher": "CERN Open Data Portal",
     "recid": "6553",
-    "run_period": [
-      "Run2012B",
-      "Run2012C"
-    ],
     "title": "High-Level Trigger path information HLT_Jet160Eta2p4_Jet120Eta2p4_DiBTagIP3DFastPVLoose (BJetPlusX, MultiJet datasets)",
     "type": {
       "primary": "Supplementaries",
@@ -12401,10 +9569,6 @@
     "collections": [
       "CMS-Trigger-Information"
     ],
-    "collision_information": {
-      "energy": "8TeV",
-      "type": "pp"
-    },
     "date_created": [
       "2012"
     ],
@@ -12412,10 +9576,6 @@
     "experiment": "CMS",
     "publisher": "CERN Open Data Portal",
     "recid": "6554",
-    "run_period": [
-      "Run2012B",
-      "Run2012C"
-    ],
     "title": "High-Level Trigger path information HLT_Jet160Eta2p4_Jet120Eta2p4_DiBTagIP3DLoose (MultiJet dataset)",
     "type": {
       "primary": "Supplementaries",
@@ -12436,10 +9596,6 @@
     "collections": [
       "CMS-Trigger-Information"
     ],
-    "collision_information": {
-      "energy": "8TeV",
-      "type": "pp"
-    },
     "date_created": [
       "2012"
     ],
@@ -12447,10 +9603,6 @@
     "experiment": "CMS",
     "publisher": "CERN Open Data Portal",
     "recid": "6555",
-    "run_period": [
-      "Run2012B",
-      "Run2012C"
-    ],
     "title": "High-Level Trigger path information HLT_Jet20_NoL1FastJet (Jet dataset)",
     "type": {
       "primary": "Supplementaries",
@@ -12471,10 +9623,6 @@
     "collections": [
       "CMS-Trigger-Information"
     ],
-    "collision_information": {
-      "energy": "8TeV",
-      "type": "pp"
-    },
     "date_created": [
       "2012"
     ],
@@ -12482,10 +9630,6 @@
     "experiment": "CMS",
     "publisher": "CERN Open Data Portal",
     "recid": "6556",
-    "run_period": [
-      "Run2012B",
-      "Run2012C"
-    ],
     "title": "High-Level Trigger path information HLT_Jet370_NoJetID (Jet, JetHT datasets)",
     "type": {
       "primary": "Supplementaries",
@@ -12506,10 +9650,6 @@
     "collections": [
       "CMS-Trigger-Information"
     ],
-    "collision_information": {
-      "energy": "8TeV",
-      "type": "pp"
-    },
     "date_created": [
       "2012"
     ],
@@ -12517,10 +9657,6 @@
     "experiment": "CMS",
     "publisher": "CERN Open Data Portal",
     "recid": "6557",
-    "run_period": [
-      "Run2012B",
-      "Run2012C"
-    ],
     "title": "High-Level Trigger path information HLT_Jet50_NoL1FastJet (Jet dataset)",
     "type": {
       "primary": "Supplementaries",
@@ -12541,10 +9677,6 @@
     "collections": [
       "CMS-Trigger-Information"
     ],
-    "collision_information": {
-      "energy": "8TeV",
-      "type": "pp"
-    },
     "date_created": [
       "2012"
     ],
@@ -12552,10 +9684,6 @@
     "experiment": "CMS",
     "publisher": "CERN Open Data Portal",
     "recid": "6558",
-    "run_period": [
-      "Run2012B",
-      "Run2012C"
-    ],
     "title": "High-Level Trigger path information HLT_Jet60Eta1p7_Jet53Eta1p7_DiBTagIP3D (MultiJet dataset)",
     "type": {
       "primary": "Supplementaries",
@@ -12576,10 +9704,6 @@
     "collections": [
       "CMS-Trigger-Information"
     ],
-    "collision_information": {
-      "energy": "8TeV",
-      "type": "pp"
-    },
     "date_created": [
       "2012"
     ],
@@ -12587,10 +9711,6 @@
     "experiment": "CMS",
     "publisher": "CERN Open Data Portal",
     "recid": "6559",
-    "run_period": [
-      "Run2012B",
-      "Run2012C"
-    ],
     "title": "High-Level Trigger path information HLT_Jet60Eta1p7_Jet53Eta1p7_DiBTagIP3DFastPV (BJetPlusX, MultiJet datasets)",
     "type": {
       "primary": "Supplementaries",
@@ -12611,10 +9731,6 @@
     "collections": [
       "CMS-Trigger-Information"
     ],
-    "collision_information": {
-      "energy": "8TeV",
-      "type": "pp"
-    },
     "date_created": [
       "2012"
     ],
@@ -12622,10 +9738,6 @@
     "experiment": "CMS",
     "publisher": "CERN Open Data Portal",
     "recid": "6560",
-    "run_period": [
-      "Run2012B",
-      "Run2012C"
-    ],
     "title": "High-Level Trigger path information HLT_Jet80Eta1p7_Jet70Eta1p7_DiBTagIP3D (MultiJet dataset)",
     "type": {
       "primary": "Supplementaries",
@@ -12646,10 +9758,6 @@
     "collections": [
       "CMS-Trigger-Information"
     ],
-    "collision_information": {
-      "energy": "8TeV",
-      "type": "pp"
-    },
     "date_created": [
       "2012"
     ],
@@ -12657,10 +9765,6 @@
     "experiment": "CMS",
     "publisher": "CERN Open Data Portal",
     "recid": "6561",
-    "run_period": [
-      "Run2012B",
-      "Run2012C"
-    ],
     "title": "High-Level Trigger path information HLT_Jet80Eta1p7_Jet70Eta1p7_DiBTagIP3DFastPV (BJetPlusX, MultiJet datasets)",
     "type": {
       "primary": "Supplementaries",
@@ -12681,10 +9785,6 @@
     "collections": [
       "CMS-Trigger-Information"
     ],
-    "collision_information": {
-      "energy": "8TeV",
-      "type": "pp"
-    },
     "date_created": [
       "2012"
     ],
@@ -12692,10 +9792,6 @@
     "experiment": "CMS",
     "publisher": "CERN Open Data Portal",
     "recid": "6562",
-    "run_period": [
-      "Run2012B",
-      "Run2012C"
-    ],
     "title": "High-Level Trigger path information HLT_JetE30_NoBPTX (MinimumBias, NoBPTX datasets)",
     "type": {
       "primary": "Supplementaries",
@@ -12716,10 +9812,6 @@
     "collections": [
       "CMS-Trigger-Information"
     ],
-    "collision_information": {
-      "energy": "8TeV",
-      "type": "pp"
-    },
     "date_created": [
       "2012"
     ],
@@ -12727,10 +9819,6 @@
     "experiment": "CMS",
     "publisher": "CERN Open Data Portal",
     "recid": "6563",
-    "run_period": [
-      "Run2012B",
-      "Run2012C"
-    ],
     "title": "High-Level Trigger path information HLT_JetE30_NoBPTX3BX (NoBPTX dataset)",
     "type": {
       "primary": "Supplementaries",
@@ -12751,10 +9839,6 @@
     "collections": [
       "CMS-Trigger-Information"
     ],
-    "collision_information": {
-      "energy": "8TeV",
-      "type": "pp"
-    },
     "date_created": [
       "2012"
     ],
@@ -12762,10 +9846,6 @@
     "experiment": "CMS",
     "publisher": "CERN Open Data Portal",
     "recid": "6564",
-    "run_period": [
-      "Run2012B",
-      "Run2012C"
-    ],
     "title": "High-Level Trigger path information HLT_JetE30_NoBPTX3BX_NoHalo (MinimumBias, NoBPTX datasets)",
     "type": {
       "primary": "Supplementaries",
@@ -12786,10 +9866,6 @@
     "collections": [
       "CMS-Trigger-Information"
     ],
-    "collision_information": {
-      "energy": "8TeV",
-      "type": "pp"
-    },
     "date_created": [
       "2012"
     ],
@@ -12797,10 +9873,6 @@
     "experiment": "CMS",
     "publisher": "CERN Open Data Portal",
     "recid": "6565",
-    "run_period": [
-      "Run2012B",
-      "Run2012C"
-    ],
     "title": "High-Level Trigger path information HLT_JetE50_NoBPTX3BX (NoBPTX dataset)",
     "type": {
       "primary": "Supplementaries",
@@ -12821,10 +9893,6 @@
     "collections": [
       "CMS-Trigger-Information"
     ],
-    "collision_information": {
-      "energy": "8TeV",
-      "type": "pp"
-    },
     "date_created": [
       "2012"
     ],
@@ -12832,10 +9900,6 @@
     "experiment": "CMS",
     "publisher": "CERN Open Data Portal",
     "recid": "6566",
-    "run_period": [
-      "Run2012B",
-      "Run2012C"
-    ],
     "title": "High-Level Trigger path information HLT_JetE50_NoBPTX3BX_NoHalo (MinimumBias, NoBPTX datasets)",
     "type": {
       "primary": "Supplementaries",
@@ -12856,10 +9920,6 @@
     "collections": [
       "CMS-Trigger-Information"
     ],
-    "collision_information": {
-      "energy": "8TeV",
-      "type": "pp"
-    },
     "date_created": [
       "2012"
     ],
@@ -12867,10 +9927,6 @@
     "experiment": "CMS",
     "publisher": "CERN Open Data Portal",
     "recid": "6567",
-    "run_period": [
-      "Run2012B",
-      "Run2012C"
-    ],
     "title": "High-Level Trigger path information HLT_JetE70_NoBPTX3BX (NoBPTX dataset)",
     "type": {
       "primary": "Supplementaries",
@@ -12891,10 +9947,6 @@
     "collections": [
       "CMS-Trigger-Information"
     ],
-    "collision_information": {
-      "energy": "8TeV",
-      "type": "pp"
-    },
     "date_created": [
       "2012"
     ],
@@ -12902,10 +9954,6 @@
     "experiment": "CMS",
     "publisher": "CERN Open Data Portal",
     "recid": "6568",
-    "run_period": [
-      "Run2012B",
-      "Run2012C"
-    ],
     "title": "High-Level Trigger path information HLT_JetE70_NoBPTX3BX_NoHalo (MinimumBias, NoBPTX datasets)",
     "type": {
       "primary": "Supplementaries",
@@ -12926,10 +9974,6 @@
     "collections": [
       "CMS-Trigger-Information"
     ],
-    "collision_information": {
-      "energy": "8TeV",
-      "type": "pp"
-    },
     "date_created": [
       "2012"
     ],
@@ -12937,10 +9981,6 @@
     "experiment": "CMS",
     "publisher": "CERN Open Data Portal",
     "recid": "6569",
-    "run_period": [
-      "Run2012B",
-      "Run2012C"
-    ],
     "title": "High-Level Trigger path information HLT_L1DoubleEG3_FwdVeto (SinglePhoton dataset)",
     "type": {
       "primary": "Supplementaries",
@@ -12961,10 +10001,6 @@
     "collections": [
       "CMS-Trigger-Information"
     ],
-    "collision_information": {
-      "energy": "8TeV",
-      "type": "pp"
-    },
     "date_created": [
       "2012"
     ],
@@ -12972,10 +10008,6 @@
     "experiment": "CMS",
     "publisher": "CERN Open Data Portal",
     "recid": "6570",
-    "run_period": [
-      "Run2012B",
-      "Run2012C"
-    ],
     "title": "High-Level Trigger path information HLT_L1DoubleJet20_RomanPotsOR (LP_Jets1 dataset)",
     "type": {
       "primary": "Supplementaries",
@@ -12996,10 +10028,6 @@
     "collections": [
       "CMS-Trigger-Information"
     ],
-    "collision_information": {
-      "energy": "8TeV",
-      "type": "pp"
-    },
     "date_created": [
       "2012"
     ],
@@ -13007,10 +10035,6 @@
     "experiment": "CMS",
     "publisher": "CERN Open Data Portal",
     "recid": "6571",
-    "run_period": [
-      "Run2012B",
-      "Run2012C"
-    ],
     "title": "High-Level Trigger path information HLT_L1DoubleJet20part1 (LP_Jets1 dataset)",
     "type": {
       "primary": "Supplementaries",
@@ -13031,10 +10055,6 @@
     "collections": [
       "CMS-Trigger-Information"
     ],
-    "collision_information": {
-      "energy": "8TeV",
-      "type": "pp"
-    },
     "date_created": [
       "2012"
     ],
@@ -13042,10 +10062,6 @@
     "experiment": "CMS",
     "publisher": "CERN Open Data Portal",
     "recid": "6572",
-    "run_period": [
-      "Run2012B",
-      "Run2012C"
-    ],
     "title": "High-Level Trigger path information HLT_L1DoubleJet20part2 (LP_Jets2 dataset)",
     "type": {
       "primary": "Supplementaries",
@@ -13066,10 +10082,6 @@
     "collections": [
       "CMS-Trigger-Information"
     ],
-    "collision_information": {
-      "energy": "8TeV",
-      "type": "pp"
-    },
     "date_created": [
       "2012"
     ],
@@ -13077,10 +10089,6 @@
     "experiment": "CMS",
     "publisher": "CERN Open Data Portal",
     "recid": "6573",
-    "run_period": [
-      "Run2012B",
-      "Run2012C"
-    ],
     "title": "High-Level Trigger path information HLT_L1DoubleJet24 (LP_Jets1 dataset)",
     "type": {
       "primary": "Supplementaries",
@@ -13101,10 +10109,6 @@
     "collections": [
       "CMS-Trigger-Information"
     ],
-    "collision_information": {
-      "energy": "8TeV",
-      "type": "pp"
-    },
     "date_created": [
       "2012"
     ],
@@ -13112,10 +10116,6 @@
     "experiment": "CMS",
     "publisher": "CERN Open Data Portal",
     "recid": "6574",
-    "run_period": [
-      "Run2012B",
-      "Run2012C"
-    ],
     "title": "High-Level Trigger path information HLT_L1DoubleJet36Central (BJetPlusX, MultiJet datasets)",
     "type": {
       "primary": "Supplementaries",
@@ -13136,10 +10136,6 @@
     "collections": [
       "CMS-Trigger-Information"
     ],
-    "collision_information": {
-      "energy": "8TeV",
-      "type": "pp"
-    },
     "date_created": [
       "2012"
     ],
@@ -13147,10 +10143,6 @@
     "experiment": "CMS",
     "publisher": "CERN Open Data Portal",
     "recid": "6575",
-    "run_period": [
-      "Run2012B",
-      "Run2012C"
-    ],
     "title": "High-Level Trigger path information HLT_L1DoubleMu0 (LP_ExclEGMU dataset)",
     "type": {
       "primary": "Supplementaries",
@@ -13171,10 +10163,6 @@
     "collections": [
       "CMS-Trigger-Information"
     ],
-    "collision_information": {
-      "energy": "8TeV",
-      "type": "pp"
-    },
     "date_created": [
       "2012"
     ],
@@ -13182,10 +10170,6 @@
     "experiment": "CMS",
     "publisher": "CERN Open Data Portal",
     "recid": "6576",
-    "run_period": [
-      "Run2012B",
-      "Run2012C"
-    ],
     "title": "High-Level Trigger path information HLT_L1ETM100 (Commissioning, MET datasets)",
     "type": {
       "primary": "Supplementaries",
@@ -13206,10 +10190,6 @@
     "collections": [
       "CMS-Trigger-Information"
     ],
-    "collision_information": {
-      "energy": "8TeV",
-      "type": "pp"
-    },
     "date_created": [
       "2012"
     ],
@@ -13217,10 +10197,6 @@
     "experiment": "CMS",
     "publisher": "CERN Open Data Portal",
     "recid": "6577",
-    "run_period": [
-      "Run2012B",
-      "Run2012C"
-    ],
     "title": "High-Level Trigger path information HLT_L1ETM30 (Commissioning, MET datasets)",
     "type": {
       "primary": "Supplementaries",
@@ -13241,10 +10217,6 @@
     "collections": [
       "CMS-Trigger-Information"
     ],
-    "collision_information": {
-      "energy": "8TeV",
-      "type": "pp"
-    },
     "date_created": [
       "2012"
     ],
@@ -13252,10 +10224,6 @@
     "experiment": "CMS",
     "publisher": "CERN Open Data Portal",
     "recid": "6578",
-    "run_period": [
-      "Run2012B",
-      "Run2012C"
-    ],
     "title": "High-Level Trigger path information HLT_L1ETM40 (Commissioning, MET datasets)",
     "type": {
       "primary": "Supplementaries",
@@ -13276,10 +10244,6 @@
     "collections": [
       "CMS-Trigger-Information"
     ],
-    "collision_information": {
-      "energy": "8TeV",
-      "type": "pp"
-    },
     "date_created": [
       "2012"
     ],
@@ -13287,10 +10251,6 @@
     "experiment": "CMS",
     "publisher": "CERN Open Data Portal",
     "recid": "6579",
-    "run_period": [
-      "Run2012B",
-      "Run2012C"
-    ],
     "title": "High-Level Trigger path information HLT_L1ETM70 (Commissioning, MET datasets)",
     "type": {
       "primary": "Supplementaries",
@@ -13311,10 +10271,6 @@
     "collections": [
       "CMS-Trigger-Information"
     ],
-    "collision_information": {
-      "energy": "8TeV",
-      "type": "pp"
-    },
     "date_created": [
       "2012"
     ],
@@ -13322,10 +10278,6 @@
     "experiment": "CMS",
     "publisher": "CERN Open Data Portal",
     "recid": "6580",
-    "run_period": [
-      "Run2012B",
-      "Run2012C"
-    ],
     "title": "High-Level Trigger path information HLT_L1RomanPots_OR (LP_Forward dataset)",
     "type": {
       "primary": "Supplementaries",
@@ -13346,10 +10298,6 @@
     "collections": [
       "CMS-Trigger-Information"
     ],
-    "collision_information": {
-      "energy": "8TeV",
-      "type": "pp"
-    },
     "date_created": [
       "2012"
     ],
@@ -13357,10 +10305,6 @@
     "experiment": "CMS",
     "publisher": "CERN Open Data Portal",
     "recid": "6581",
-    "run_period": [
-      "Run2012B",
-      "Run2012C"
-    ],
     "title": "High-Level Trigger path information HLT_L1SingleEG12 (Commissioning dataset)",
     "type": {
       "primary": "Supplementaries",
@@ -13381,10 +10325,6 @@
     "collections": [
       "CMS-Trigger-Information"
     ],
-    "collision_information": {
-      "energy": "8TeV",
-      "type": "pp"
-    },
     "date_created": [
       "2012"
     ],
@@ -13392,10 +10332,6 @@
     "experiment": "CMS",
     "publisher": "CERN Open Data Portal",
     "recid": "6582",
-    "run_period": [
-      "Run2012B",
-      "Run2012C"
-    ],
     "title": "High-Level Trigger path information HLT_L1SingleEG20 (Commissioning dataset)",
     "type": {
       "primary": "Supplementaries",
@@ -13416,10 +10352,6 @@
     "collections": [
       "CMS-Trigger-Information"
     ],
-    "collision_information": {
-      "energy": "8TeV",
-      "type": "pp"
-    },
     "date_created": [
       "2012"
     ],
@@ -13427,10 +10359,6 @@
     "experiment": "CMS",
     "publisher": "CERN Open Data Portal",
     "recid": "6583",
-    "run_period": [
-      "Run2012B",
-      "Run2012C"
-    ],
     "title": "High-Level Trigger path information HLT_L1SingleEG5 (Commissioning dataset)",
     "type": {
       "primary": "Supplementaries",
@@ -13451,10 +10379,6 @@
     "collections": [
       "CMS-Trigger-Information"
     ],
-    "collision_information": {
-      "energy": "8TeV",
-      "type": "pp"
-    },
     "date_created": [
       "2012"
     ],
@@ -13462,10 +10386,6 @@
     "experiment": "CMS",
     "publisher": "CERN Open Data Portal",
     "recid": "6584",
-    "run_period": [
-      "Run2012B",
-      "Run2012C"
-    ],
     "title": "High-Level Trigger path information HLT_L1SingleJet16 (Commissioning dataset)",
     "type": {
       "primary": "Supplementaries",
@@ -13486,10 +10406,6 @@
     "collections": [
       "CMS-Trigger-Information"
     ],
-    "collision_information": {
-      "energy": "8TeV",
-      "type": "pp"
-    },
     "date_created": [
       "2012"
     ],
@@ -13497,10 +10413,6 @@
     "experiment": "CMS",
     "publisher": "CERN Open Data Portal",
     "recid": "6585",
-    "run_period": [
-      "Run2012B",
-      "Run2012C"
-    ],
     "title": "High-Level Trigger path information HLT_L1SingleJet36 (Commissioning dataset)",
     "type": {
       "primary": "Supplementaries",
@@ -13521,10 +10433,6 @@
     "collections": [
       "CMS-Trigger-Information"
     ],
-    "collision_information": {
-      "energy": "8TeV",
-      "type": "pp"
-    },
     "date_created": [
       "2012"
     ],
@@ -13532,10 +10440,6 @@
     "experiment": "CMS",
     "publisher": "CERN Open Data Portal",
     "recid": "6586",
-    "run_period": [
-      "Run2012B",
-      "Run2012C"
-    ],
     "title": "High-Level Trigger path information HLT_L1SingleMu12 (Commissioning, SingleMu datasets)",
     "type": {
       "primary": "Supplementaries",
@@ -13556,10 +10460,6 @@
     "collections": [
       "CMS-Trigger-Information"
     ],
-    "collision_information": {
-      "energy": "8TeV",
-      "type": "pp"
-    },
     "date_created": [
       "2012"
     ],
@@ -13567,10 +10467,6 @@
     "experiment": "CMS",
     "publisher": "CERN Open Data Portal",
     "recid": "6587",
-    "run_period": [
-      "Run2012B",
-      "Run2012C"
-    ],
     "title": "High-Level Trigger path information HLT_L1SingleMu20 (Commissioning dataset)",
     "type": {
       "primary": "Supplementaries",
@@ -13591,10 +10487,6 @@
     "collections": [
       "CMS-Trigger-Information"
     ],
-    "collision_information": {
-      "energy": "8TeV",
-      "type": "pp"
-    },
     "date_created": [
       "2012"
     ],
@@ -13602,10 +10494,6 @@
     "experiment": "CMS",
     "publisher": "CERN Open Data Portal",
     "recid": "6588",
-    "run_period": [
-      "Run2012B",
-      "Run2012C"
-    ],
     "title": "High-Level Trigger path information HLT_L1SingleMu3 (Commissioning dataset)",
     "type": {
       "primary": "Supplementaries",
@@ -13626,10 +10514,6 @@
     "collections": [
       "CMS-Trigger-Information"
     ],
-    "collision_information": {
-      "energy": "8TeV",
-      "type": "pp"
-    },
     "date_created": [
       "2012"
     ],
@@ -13637,10 +10521,6 @@
     "experiment": "CMS",
     "publisher": "CERN Open Data Portal",
     "recid": "6589",
-    "run_period": [
-      "Run2012B",
-      "Run2012C"
-    ],
     "title": "High-Level Trigger path information HLT_L1SingleMuOpen (Commissioning dataset)",
     "type": {
       "primary": "Supplementaries",
@@ -13661,10 +10541,6 @@
     "collections": [
       "CMS-Trigger-Information"
     ],
-    "collision_information": {
-      "energy": "8TeV",
-      "type": "pp"
-    },
     "date_created": [
       "2012"
     ],
@@ -13672,10 +10548,6 @@
     "experiment": "CMS",
     "publisher": "CERN Open Data Portal",
     "recid": "6590",
-    "run_period": [
-      "Run2012B",
-      "Run2012C"
-    ],
     "title": "High-Level Trigger path information HLT_L1SingleMuOpen_AntiBPTX (Cosmics dataset)",
     "type": {
       "primary": "Supplementaries",
@@ -13696,10 +10568,6 @@
     "collections": [
       "CMS-Trigger-Information"
     ],
-    "collision_information": {
-      "energy": "8TeV",
-      "type": "pp"
-    },
     "date_created": [
       "2012"
     ],
@@ -13707,10 +10575,6 @@
     "experiment": "CMS",
     "publisher": "CERN Open Data Portal",
     "recid": "6591",
-    "run_period": [
-      "Run2012B",
-      "Run2012C"
-    ],
     "title": "High-Level Trigger path information HLT_L1Tech40_BPTXAND (LP_MinBias1 dataset)",
     "type": {
       "primary": "Supplementaries",
@@ -13731,10 +10595,6 @@
     "collections": [
       "CMS-Trigger-Information"
     ],
-    "collision_information": {
-      "energy": "8TeV",
-      "type": "pp"
-    },
     "date_created": [
       "2012"
     ],
@@ -13742,10 +10602,6 @@
     "experiment": "CMS",
     "publisher": "CERN Open Data Portal",
     "recid": "6592",
-    "run_period": [
-      "Run2012B",
-      "Run2012C"
-    ],
     "title": "High-Level Trigger path information HLT_L1Tech40_BPTXAND_1 (LP_MinBias1 dataset)",
     "type": {
       "primary": "Supplementaries",
@@ -13766,10 +10622,6 @@
     "collections": [
       "CMS-Trigger-Information"
     ],
-    "collision_information": {
-      "energy": "8TeV",
-      "type": "pp"
-    },
     "date_created": [
       "2012"
     ],
@@ -13777,10 +10629,6 @@
     "experiment": "CMS",
     "publisher": "CERN Open Data Portal",
     "recid": "6593",
-    "run_period": [
-      "Run2012B",
-      "Run2012C"
-    ],
     "title": "High-Level Trigger path information HLT_L1Tech40_BPTXAND_2 (LP_MinBias2 dataset)",
     "type": {
       "primary": "Supplementaries",
@@ -13801,10 +10649,6 @@
     "collections": [
       "CMS-Trigger-Information"
     ],
-    "collision_information": {
-      "energy": "8TeV",
-      "type": "pp"
-    },
     "date_created": [
       "2012"
     ],
@@ -13812,10 +10656,6 @@
     "experiment": "CMS",
     "publisher": "CERN Open Data Portal",
     "recid": "6594",
-    "run_period": [
-      "Run2012B",
-      "Run2012C"
-    ],
     "title": "High-Level Trigger path information HLT_L1Tech53_MB_1 (LP_MinBias1 dataset)",
     "type": {
       "primary": "Supplementaries",
@@ -13836,10 +10676,6 @@
     "collections": [
       "CMS-Trigger-Information"
     ],
-    "collision_information": {
-      "energy": "8TeV",
-      "type": "pp"
-    },
     "date_created": [
       "2012"
     ],
@@ -13847,10 +10683,6 @@
     "experiment": "CMS",
     "publisher": "CERN Open Data Portal",
     "recid": "6595",
-    "run_period": [
-      "Run2012B",
-      "Run2012C"
-    ],
     "title": "High-Level Trigger path information HLT_L1Tech53_MB_2 (LP_MinBias2 dataset)",
     "type": {
       "primary": "Supplementaries",
@@ -13871,10 +10703,6 @@
     "collections": [
       "CMS-Trigger-Information"
     ],
-    "collision_information": {
-      "energy": "8TeV",
-      "type": "pp"
-    },
     "date_created": [
       "2012"
     ],
@@ -13882,10 +10710,6 @@
     "experiment": "CMS",
     "publisher": "CERN Open Data Portal",
     "recid": "6596",
-    "run_period": [
-      "Run2012B",
-      "Run2012C"
-    ],
     "title": "High-Level Trigger path information HLT_L1Tech53_MB_3 (LP_MinBias3 dataset)",
     "type": {
       "primary": "Supplementaries",
@@ -13906,10 +10730,6 @@
     "collections": [
       "CMS-Trigger-Information"
     ],
-    "collision_information": {
-      "energy": "8TeV",
-      "type": "pp"
-    },
     "date_created": [
       "2012"
     ],
@@ -13917,10 +10737,6 @@
     "experiment": "CMS",
     "publisher": "CERN Open Data Portal",
     "recid": "6597",
-    "run_period": [
-      "Run2012B",
-      "Run2012C"
-    ],
     "title": "High-Level Trigger path information HLT_L1Tech54_ZeroBias (LP_ZeroBias dataset)",
     "type": {
       "primary": "Supplementaries",
@@ -13941,10 +10757,6 @@
     "collections": [
       "CMS-Trigger-Information"
     ],
-    "collision_information": {
-      "energy": "8TeV",
-      "type": "pp"
-    },
     "date_created": [
       "2012"
     ],
@@ -13952,10 +10764,6 @@
     "experiment": "CMS",
     "publisher": "CERN Open Data Portal",
     "recid": "6598",
-    "run_period": [
-      "Run2012B",
-      "Run2012C"
-    ],
     "title": "High-Level Trigger path information HLT_L1Tech_HBHEHO_totalOR (HcalHPDNoise dataset)",
     "type": {
       "primary": "Supplementaries",
@@ -13976,10 +10784,6 @@
     "collections": [
       "CMS-Trigger-Information"
     ],
-    "collision_information": {
-      "energy": "8TeV",
-      "type": "pp"
-    },
     "date_created": [
       "2012"
     ],
@@ -13987,10 +10791,6 @@
     "experiment": "CMS",
     "publisher": "CERN Open Data Portal",
     "recid": "6599",
-    "run_period": [
-      "Run2012B",
-      "Run2012C"
-    ],
     "title": "High-Level Trigger path information HLT_L1Tech_HCAL_HF_single_channel (HcalHPDNoise dataset)",
     "type": {
       "primary": "Supplementaries",
@@ -14011,10 +10811,6 @@
     "collections": [
       "CMS-Trigger-Information"
     ],
-    "collision_information": {
-      "energy": "8TeV",
-      "type": "pp"
-    },
     "date_created": [
       "2012"
     ],
@@ -14022,10 +10818,6 @@
     "experiment": "CMS",
     "publisher": "CERN Open Data Portal",
     "recid": "6600",
-    "run_period": [
-      "Run2012B",
-      "Run2012C"
-    ],
     "title": "High-Level Trigger path information HLT_L1Tech_HF9OR10 (LP_MinBias1 dataset)",
     "type": {
       "primary": "Supplementaries",
@@ -14046,10 +10838,6 @@
     "collections": [
       "CMS-Trigger-Information"
     ],
-    "collision_information": {
-      "energy": "8TeV",
-      "type": "pp"
-    },
     "date_created": [
       "2012"
     ],
@@ -14057,10 +10845,6 @@
     "experiment": "CMS",
     "publisher": "CERN Open Data Portal",
     "recid": "6601",
-    "run_period": [
-      "Run2012B",
-      "Run2012C"
-    ],
     "title": "High-Level Trigger path information HLT_L1TrackerCosmics (Cosmics dataset)",
     "type": {
       "primary": "Supplementaries",
@@ -14081,10 +10865,6 @@
     "collections": [
       "CMS-Trigger-Information"
     ],
-    "collision_information": {
-      "energy": "8TeV",
-      "type": "pp"
-    },
     "date_created": [
       "2012"
     ],
@@ -14092,10 +10872,6 @@
     "experiment": "CMS",
     "publisher": "CERN Open Data Portal",
     "recid": "6602",
-    "run_period": [
-      "Run2012B",
-      "Run2012C"
-    ],
     "title": "High-Level Trigger path information HLT_L2DoubleMu23_NoVertex (DoubleMu, DoubleMuParked datasets)",
     "type": {
       "primary": "Supplementaries",
@@ -14116,10 +10892,6 @@
     "collections": [
       "CMS-Trigger-Information"
     ],
-    "collision_information": {
-      "energy": "8TeV",
-      "type": "pp"
-    },
     "date_created": [
       "2012"
     ],
@@ -14127,10 +10899,6 @@
     "experiment": "CMS",
     "publisher": "CERN Open Data Portal",
     "recid": "6603",
-    "run_period": [
-      "Run2012B",
-      "Run2012C"
-    ],
     "title": "High-Level Trigger path information HLT_L2DoubleMu23_NoVertex_2Cha_Angle2p5 (DoubleMu, DoubleMuParked datasets)",
     "type": {
       "primary": "Supplementaries",
@@ -14151,10 +10919,6 @@
     "collections": [
       "CMS-Trigger-Information"
     ],
-    "collision_information": {
-      "energy": "8TeV",
-      "type": "pp"
-    },
     "date_created": [
       "2012"
     ],
@@ -14162,10 +10926,6 @@
     "experiment": "CMS",
     "publisher": "CERN Open Data Portal",
     "recid": "6604",
-    "run_period": [
-      "Run2012B",
-      "Run2012C"
-    ],
     "title": "High-Level Trigger path information HLT_L2DoubleMu38_NoVertex_2Cha_Angle2p5 (DoubleMu, DoubleMuParked datasets)",
     "type": {
       "primary": "Supplementaries",
@@ -14186,10 +10946,6 @@
     "collections": [
       "CMS-Trigger-Information"
     ],
-    "collision_information": {
-      "energy": "8TeV",
-      "type": "pp"
-    },
     "date_created": [
       "2012"
     ],
@@ -14197,10 +10953,6 @@
     "experiment": "CMS",
     "publisher": "CERN Open Data Portal",
     "recid": "6605",
-    "run_period": [
-      "Run2012B",
-      "Run2012C"
-    ],
     "title": "High-Level Trigger path information HLT_L2Mu10_NoVertex_NoBPTX3BX (NoBPTX dataset)",
     "type": {
       "primary": "Supplementaries",
@@ -14221,10 +10973,6 @@
     "collections": [
       "CMS-Trigger-Information"
     ],
-    "collision_information": {
-      "energy": "8TeV",
-      "type": "pp"
-    },
     "date_created": [
       "2012"
     ],
@@ -14232,10 +10980,6 @@
     "experiment": "CMS",
     "publisher": "CERN Open Data Portal",
     "recid": "6606",
-    "run_period": [
-      "Run2012B",
-      "Run2012C"
-    ],
     "title": "High-Level Trigger path information HLT_L2Mu10_NoVertex_NoBPTX3BX_NoHalo (NoBPTX, SingleMu datasets)",
     "type": {
       "primary": "Supplementaries",
@@ -14256,10 +11000,6 @@
     "collections": [
       "CMS-Trigger-Information"
     ],
-    "collision_information": {
-      "energy": "8TeV",
-      "type": "pp"
-    },
     "date_created": [
       "2012"
     ],
@@ -14267,10 +11007,6 @@
     "experiment": "CMS",
     "publisher": "CERN Open Data Portal",
     "recid": "6607",
-    "run_period": [
-      "Run2012B",
-      "Run2012C"
-    ],
     "title": "High-Level Trigger path information HLT_L2Mu20_NoVertex_2Cha_NoBPTX3BX_NoHalo (NoBPTX dataset)",
     "type": {
       "primary": "Supplementaries",
@@ -14291,10 +11027,6 @@
     "collections": [
       "CMS-Trigger-Information"
     ],
-    "collision_information": {
-      "energy": "8TeV",
-      "type": "pp"
-    },
     "date_created": [
       "2012"
     ],
@@ -14302,10 +11034,6 @@
     "experiment": "CMS",
     "publisher": "CERN Open Data Portal",
     "recid": "6608",
-    "run_period": [
-      "Run2012B",
-      "Run2012C"
-    ],
     "title": "High-Level Trigger path information HLT_L2Mu20_NoVertex_NoBPTX3BX (NoBPTX dataset)",
     "type": {
       "primary": "Supplementaries",
@@ -14326,10 +11054,6 @@
     "collections": [
       "CMS-Trigger-Information"
     ],
-    "collision_information": {
-      "energy": "8TeV",
-      "type": "pp"
-    },
     "date_created": [
       "2012"
     ],
@@ -14337,10 +11061,6 @@
     "experiment": "CMS",
     "publisher": "CERN Open Data Portal",
     "recid": "6609",
-    "run_period": [
-      "Run2012B",
-      "Run2012C"
-    ],
     "title": "High-Level Trigger path information HLT_L2Mu20_NoVertex_NoBPTX3BX_NoHalo (NoBPTX, SingleMu datasets)",
     "type": {
       "primary": "Supplementaries",
@@ -14361,10 +11081,6 @@
     "collections": [
       "CMS-Trigger-Information"
     ],
-    "collision_information": {
-      "energy": "8TeV",
-      "type": "pp"
-    },
     "date_created": [
       "2012"
     ],
@@ -14372,10 +11088,6 @@
     "experiment": "CMS",
     "publisher": "CERN Open Data Portal",
     "recid": "6610",
-    "run_period": [
-      "Run2012B",
-      "Run2012C"
-    ],
     "title": "High-Level Trigger path information HLT_L2Mu20_eta2p1_NoVertex (NoBPTX, SingleMu datasets)",
     "type": {
       "primary": "Supplementaries",
@@ -14396,10 +11108,6 @@
     "collections": [
       "CMS-Trigger-Information"
     ],
-    "collision_information": {
-      "energy": "8TeV",
-      "type": "pp"
-    },
     "date_created": [
       "2012"
     ],
@@ -14407,10 +11115,6 @@
     "experiment": "CMS",
     "publisher": "CERN Open Data Portal",
     "recid": "6611",
-    "run_period": [
-      "Run2012B",
-      "Run2012C"
-    ],
     "title": "High-Level Trigger path information HLT_L2Mu30_NoVertex_2Cha_NoBPTX3BX_NoHalo (NoBPTX dataset)",
     "type": {
       "primary": "Supplementaries",
@@ -14431,10 +11135,6 @@
     "collections": [
       "CMS-Trigger-Information"
     ],
-    "collision_information": {
-      "energy": "8TeV",
-      "type": "pp"
-    },
     "date_created": [
       "2012"
     ],
@@ -14442,10 +11142,6 @@
     "experiment": "CMS",
     "publisher": "CERN Open Data Portal",
     "recid": "6612",
-    "run_period": [
-      "Run2012B",
-      "Run2012C"
-    ],
     "title": "High-Level Trigger path information HLT_L2Mu30_NoVertex_NoBPTX3BX (NoBPTX dataset)",
     "type": {
       "primary": "Supplementaries",
@@ -14466,10 +11162,6 @@
     "collections": [
       "CMS-Trigger-Information"
     ],
-    "collision_information": {
-      "energy": "8TeV",
-      "type": "pp"
-    },
     "date_created": [
       "2012"
     ],
@@ -14477,10 +11169,6 @@
     "experiment": "CMS",
     "publisher": "CERN Open Data Portal",
     "recid": "6613",
-    "run_period": [
-      "Run2012B",
-      "Run2012C"
-    ],
     "title": "High-Level Trigger path information HLT_L2Mu30_NoVertex_NoBPTX3BX_NoHalo (NoBPTX, SingleMu datasets)",
     "type": {
       "primary": "Supplementaries",
@@ -14501,10 +11189,6 @@
     "collections": [
       "CMS-Trigger-Information"
     ],
-    "collision_information": {
-      "energy": "8TeV",
-      "type": "pp"
-    },
     "date_created": [
       "2012"
     ],
@@ -14512,10 +11196,6 @@
     "experiment": "CMS",
     "publisher": "CERN Open Data Portal",
     "recid": "6614",
-    "run_period": [
-      "Run2012B",
-      "Run2012C"
-    ],
     "title": "High-Level Trigger path information HLT_L2Mu70_2Cha_eta2p1_PFMET55 (SingleMu dataset)",
     "type": {
       "primary": "Supplementaries",
@@ -14536,10 +11216,6 @@
     "collections": [
       "CMS-Trigger-Information"
     ],
-    "collision_information": {
-      "energy": "8TeV",
-      "type": "pp"
-    },
     "date_created": [
       "2012"
     ],
@@ -14547,10 +11223,6 @@
     "experiment": "CMS",
     "publisher": "CERN Open Data Portal",
     "recid": "6615",
-    "run_period": [
-      "Run2012B",
-      "Run2012C"
-    ],
     "title": "High-Level Trigger path information HLT_L2Mu70_2Cha_eta2p1_PFMET60 (SingleMu dataset)",
     "type": {
       "primary": "Supplementaries",
@@ -14571,10 +11243,6 @@
     "collections": [
       "CMS-Trigger-Information"
     ],
-    "collision_information": {
-      "energy": "8TeV",
-      "type": "pp"
-    },
     "date_created": [
       "2012"
     ],
@@ -14582,10 +11250,6 @@
     "experiment": "CMS",
     "publisher": "CERN Open Data Portal",
     "recid": "6616",
-    "run_period": [
-      "Run2012B",
-      "Run2012C"
-    ],
     "title": "High-Level Trigger path information HLT_L2Mu70_eta2p1_PFMET55 (SingleMu dataset)",
     "type": {
       "primary": "Supplementaries",
@@ -14606,10 +11270,6 @@
     "collections": [
       "CMS-Trigger-Information"
     ],
-    "collision_information": {
-      "energy": "8TeV",
-      "type": "pp"
-    },
     "date_created": [
       "2012"
     ],
@@ -14617,10 +11277,6 @@
     "experiment": "CMS",
     "publisher": "CERN Open Data Portal",
     "recid": "6617",
-    "run_period": [
-      "Run2012B",
-      "Run2012C"
-    ],
     "title": "High-Level Trigger path information HLT_L2Mu70_eta2p1_PFMET60 (SingleMu dataset)",
     "type": {
       "primary": "Supplementaries",
@@ -14641,10 +11297,6 @@
     "collections": [
       "CMS-Trigger-Information"
     ],
-    "collision_information": {
-      "energy": "8TeV",
-      "type": "pp"
-    },
     "date_created": [
       "2012"
     ],
@@ -14652,10 +11304,6 @@
     "experiment": "CMS",
     "publisher": "CERN Open Data Portal",
     "recid": "6618",
-    "run_period": [
-      "Run2012B",
-      "Run2012C"
-    ],
     "title": "High-Level Trigger path information HLT_L2Mu70_eta2p1_PFMET65 (SingleMu dataset)",
     "type": {
       "primary": "Supplementaries",
@@ -14676,10 +11324,6 @@
     "collections": [
       "CMS-Trigger-Information"
     ],
-    "collision_information": {
-      "energy": "8TeV",
-      "type": "pp"
-    },
     "date_created": [
       "2012"
     ],
@@ -14687,10 +11331,6 @@
     "experiment": "CMS",
     "publisher": "CERN Open Data Portal",
     "recid": "6619",
-    "run_period": [
-      "Run2012B",
-      "Run2012C"
-    ],
     "title": "High-Level Trigger path information HLT_L2Mu80_eta2p1_PFMET70 (SingleMu dataset)",
     "type": {
       "primary": "Supplementaries",
@@ -14711,10 +11351,6 @@
     "collections": [
       "CMS-Trigger-Information"
     ],
-    "collision_information": {
-      "energy": "8TeV",
-      "type": "pp"
-    },
     "date_created": [
       "2012"
     ],
@@ -14722,10 +11358,6 @@
     "experiment": "CMS",
     "publisher": "CERN Open Data Portal",
     "recid": "6620",
-    "run_period": [
-      "Run2012B",
-      "Run2012C"
-    ],
     "title": "High-Level Trigger path information HLT_L2TripleMu10_0_0_NoVertex_PFJet40Neutral (MuHad dataset)",
     "type": {
       "primary": "Supplementaries",
@@ -14746,10 +11378,6 @@
     "collections": [
       "CMS-Trigger-Information"
     ],
-    "collision_information": {
-      "energy": "8TeV",
-      "type": "pp"
-    },
     "date_created": [
       "2012"
     ],
@@ -14757,10 +11385,6 @@
     "experiment": "CMS",
     "publisher": "CERN Open Data Portal",
     "recid": "6621",
-    "run_period": [
-      "Run2012B",
-      "Run2012C"
-    ],
     "title": "High-Level Trigger path information HLT_LogMonitor (LogMonitor dataset)",
     "type": {
       "primary": "Supplementaries",
@@ -14781,10 +11405,6 @@
     "collections": [
       "CMS-Trigger-Information"
     ],
-    "collision_information": {
-      "energy": "8TeV",
-      "type": "pp"
-    },
     "date_created": [
       "2012"
     ],
@@ -14792,10 +11412,6 @@
     "experiment": "CMS",
     "publisher": "CERN Open Data Portal",
     "recid": "6622",
-    "run_period": [
-      "Run2012B",
-      "Run2012C"
-    ],
     "title": "High-Level Trigger path information HLT_LooseIsoPFTau35_Trk20_Prong1 (Tau, TauParked datasets)",
     "type": {
       "primary": "Supplementaries",
@@ -14816,10 +11432,6 @@
     "collections": [
       "CMS-Trigger-Information"
     ],
-    "collision_information": {
-      "energy": "8TeV",
-      "type": "pp"
-    },
     "date_created": [
       "2012"
     ],
@@ -14827,10 +11439,6 @@
     "experiment": "CMS",
     "publisher": "CERN Open Data Portal",
     "recid": "6623",
-    "run_period": [
-      "Run2012B",
-      "Run2012C"
-    ],
     "title": "High-Level Trigger path information HLT_LooseIsoPFTau35_Trk20_Prong1_MET70 (Tau, TauParked datasets)",
     "type": {
       "primary": "Supplementaries",
@@ -14851,10 +11459,6 @@
     "collections": [
       "CMS-Trigger-Information"
     ],
-    "collision_information": {
-      "energy": "8TeV",
-      "type": "pp"
-    },
     "date_created": [
       "2012"
     ],
@@ -14862,10 +11466,6 @@
     "experiment": "CMS",
     "publisher": "CERN Open Data Portal",
     "recid": "6624",
-    "run_period": [
-      "Run2012B",
-      "Run2012C"
-    ],
     "title": "High-Level Trigger path information HLT_LooseIsoPFTau35_Trk20_Prong1_MET75 (Tau, TauParked datasets)",
     "type": {
       "primary": "Supplementaries",
@@ -14886,10 +11486,6 @@
     "collections": [
       "CMS-Trigger-Information"
     ],
-    "collision_information": {
-      "energy": "8TeV",
-      "type": "pp"
-    },
     "date_created": [
       "2012"
     ],
@@ -14897,10 +11493,6 @@
     "experiment": "CMS",
     "publisher": "CERN Open Data Portal",
     "recid": "6625",
-    "run_period": [
-      "Run2012B",
-      "Run2012C"
-    ],
     "title": "High-Level Trigger path information HLT_MET100_HBHENoiseCleaned (METParked dataset)",
     "type": {
       "primary": "Supplementaries",
@@ -14921,10 +11513,6 @@
     "collections": [
       "CMS-Trigger-Information"
     ],
-    "collision_information": {
-      "energy": "8TeV",
-      "type": "pp"
-    },
     "date_created": [
       "2012"
     ],
@@ -14932,10 +11520,6 @@
     "experiment": "CMS",
     "publisher": "CERN Open Data Portal",
     "recid": "6626",
-    "run_period": [
-      "Run2012B",
-      "Run2012C"
-    ],
     "title": "High-Level Trigger path information HLT_MET120 (MET, METParked datasets)",
     "type": {
       "primary": "Supplementaries",
@@ -14956,10 +11540,6 @@
     "collections": [
       "CMS-Trigger-Information"
     ],
-    "collision_information": {
-      "energy": "8TeV",
-      "type": "pp"
-    },
     "date_created": [
       "2012"
     ],
@@ -14967,10 +11547,6 @@
     "experiment": "CMS",
     "publisher": "CERN Open Data Portal",
     "recid": "6627",
-    "run_period": [
-      "Run2012B",
-      "Run2012C"
-    ],
     "title": "High-Level Trigger path information HLT_MET120_HBHENoiseCleaned (MET, METParked datasets)",
     "type": {
       "primary": "Supplementaries",
@@ -14991,10 +11567,6 @@
     "collections": [
       "CMS-Trigger-Information"
     ],
-    "collision_information": {
-      "energy": "8TeV",
-      "type": "pp"
-    },
     "date_created": [
       "2012"
     ],
@@ -15002,10 +11574,6 @@
     "experiment": "CMS",
     "publisher": "CERN Open Data Portal",
     "recid": "6628",
-    "run_period": [
-      "Run2012B",
-      "Run2012C"
-    ],
     "title": "High-Level Trigger path information HLT_MET200 (MET dataset)",
     "type": {
       "primary": "Supplementaries",
@@ -15026,10 +11594,6 @@
     "collections": [
       "CMS-Trigger-Information"
     ],
-    "collision_information": {
-      "energy": "8TeV",
-      "type": "pp"
-    },
     "date_created": [
       "2012"
     ],
@@ -15037,10 +11601,6 @@
     "experiment": "CMS",
     "publisher": "CERN Open Data Portal",
     "recid": "6629",
-    "run_period": [
-      "Run2012B",
-      "Run2012C"
-    ],
     "title": "High-Level Trigger path information HLT_MET200_HBHENoiseCleaned (MET dataset)",
     "type": {
       "primary": "Supplementaries",
@@ -15061,10 +11621,6 @@
     "collections": [
       "CMS-Trigger-Information"
     ],
-    "collision_information": {
-      "energy": "8TeV",
-      "type": "pp"
-    },
     "date_created": [
       "2012"
     ],
@@ -15072,10 +11628,6 @@
     "experiment": "CMS",
     "publisher": "CERN Open Data Portal",
     "recid": "6630",
-    "run_period": [
-      "Run2012B",
-      "Run2012C"
-    ],
     "title": "High-Level Trigger path information HLT_MET300 (MET dataset)",
     "type": {
       "primary": "Supplementaries",
@@ -15096,10 +11648,6 @@
     "collections": [
       "CMS-Trigger-Information"
     ],
-    "collision_information": {
-      "energy": "8TeV",
-      "type": "pp"
-    },
     "date_created": [
       "2012"
     ],
@@ -15107,10 +11655,6 @@
     "experiment": "CMS",
     "publisher": "CERN Open Data Portal",
     "recid": "6631",
-    "run_period": [
-      "Run2012B",
-      "Run2012C"
-    ],
     "title": "High-Level Trigger path information HLT_MET300_HBHENoiseCleaned (MET dataset)",
     "type": {
       "primary": "Supplementaries",
@@ -15131,10 +11675,6 @@
     "collections": [
       "CMS-Trigger-Information"
     ],
-    "collision_information": {
-      "energy": "8TeV",
-      "type": "pp"
-    },
     "date_created": [
       "2012"
     ],
@@ -15142,10 +11682,6 @@
     "experiment": "CMS",
     "publisher": "CERN Open Data Portal",
     "recid": "6632",
-    "run_period": [
-      "Run2012B",
-      "Run2012C"
-    ],
     "title": "High-Level Trigger path information HLT_MET400 (MET dataset)",
     "type": {
       "primary": "Supplementaries",
@@ -15166,10 +11702,6 @@
     "collections": [
       "CMS-Trigger-Information"
     ],
-    "collision_information": {
-      "energy": "8TeV",
-      "type": "pp"
-    },
     "date_created": [
       "2012"
     ],
@@ -15177,10 +11709,6 @@
     "experiment": "CMS",
     "publisher": "CERN Open Data Portal",
     "recid": "6633",
-    "run_period": [
-      "Run2012B",
-      "Run2012C"
-    ],
     "title": "High-Level Trigger path information HLT_MET400_HBHENoiseCleaned (MET dataset)",
     "type": {
       "primary": "Supplementaries",
@@ -15201,10 +11729,6 @@
     "collections": [
       "CMS-Trigger-Information"
     ],
-    "collision_information": {
-      "energy": "8TeV",
-      "type": "pp"
-    },
     "date_created": [
       "2012"
     ],
@@ -15212,10 +11736,6 @@
     "experiment": "CMS",
     "publisher": "CERN Open Data Portal",
     "recid": "6634",
-    "run_period": [
-      "Run2012B",
-      "Run2012C"
-    ],
     "title": "High-Level Trigger path information HLT_MET80 (ElectronHad, JetHT datasets)",
     "type": {
       "primary": "Supplementaries",
@@ -15236,10 +11756,6 @@
     "collections": [
       "CMS-Trigger-Information"
     ],
-    "collision_information": {
-      "energy": "8TeV",
-      "type": "pp"
-    },
     "date_created": [
       "2012"
     ],
@@ -15247,10 +11763,6 @@
     "experiment": "CMS",
     "publisher": "CERN Open Data Portal",
     "recid": "6635",
-    "run_period": [
-      "Run2012B",
-      "Run2012C"
-    ],
     "title": "High-Level Trigger path information HLT_MET80_HBHENoiseCleaned",
     "type": {
       "primary": "Supplementaries",
@@ -15271,10 +11783,6 @@
     "collections": [
       "CMS-Trigger-Information"
     ],
-    "collision_information": {
-      "energy": "8TeV",
-      "type": "pp"
-    },
     "date_created": [
       "2012"
     ],
@@ -15282,10 +11790,6 @@
     "experiment": "CMS",
     "publisher": "CERN Open Data Portal",
     "recid": "6636",
-    "run_period": [
-      "Run2012B",
-      "Run2012C"
-    ],
     "title": "High-Level Trigger path information HLT_MET80_Parked (METParked dataset)",
     "type": {
       "primary": "Supplementaries",
@@ -15306,10 +11810,6 @@
     "collections": [
       "CMS-Trigger-Information"
     ],
-    "collision_information": {
-      "energy": "8TeV",
-      "type": "pp"
-    },
     "date_created": [
       "2012"
     ],
@@ -15317,10 +11817,6 @@
     "experiment": "CMS",
     "publisher": "CERN Open Data Portal",
     "recid": "6637",
-    "run_period": [
-      "Run2012B",
-      "Run2012C"
-    ],
     "title": "High-Level Trigger path information HLT_MET80_Track50_dEdx3p6 (ElectronHad, JetHT datasets)",
     "type": {
       "primary": "Supplementaries",
@@ -15341,10 +11837,6 @@
     "collections": [
       "CMS-Trigger-Information"
     ],
-    "collision_information": {
-      "energy": "8TeV",
-      "type": "pp"
-    },
     "date_created": [
       "2012"
     ],
@@ -15352,10 +11844,6 @@
     "experiment": "CMS",
     "publisher": "CERN Open Data Portal",
     "recid": "6638",
-    "run_period": [
-      "Run2012B",
-      "Run2012C"
-    ],
     "title": "High-Level Trigger path information HLT_MET80_Track60_dEdx3p7 (ElectronHad, JetHT datasets)",
     "type": {
       "primary": "Supplementaries",
@@ -15376,10 +11864,6 @@
     "collections": [
       "CMS-Trigger-Information"
     ],
-    "collision_information": {
-      "energy": "8TeV",
-      "type": "pp"
-    },
     "date_created": [
       "2012"
     ],
@@ -15387,10 +11871,6 @@
     "experiment": "CMS",
     "publisher": "CERN Open Data Portal",
     "recid": "6639",
-    "run_period": [
-      "Run2012B",
-      "Run2012C"
-    ],
     "title": "High-Level Trigger path information HLT_MonoCentralPFJet80_PFMETnoMu105_NHEF0p95 (MET dataset)",
     "type": {
       "primary": "Supplementaries",
@@ -15411,10 +11891,6 @@
     "collections": [
       "CMS-Trigger-Information"
     ],
-    "collision_information": {
-      "energy": "8TeV",
-      "type": "pp"
-    },
     "date_created": [
       "2012"
     ],
@@ -15422,10 +11898,6 @@
     "experiment": "CMS",
     "publisher": "CERN Open Data Portal",
     "recid": "6640",
-    "run_period": [
-      "Run2012B",
-      "Run2012C"
-    ],
     "title": "High-Level Trigger path information HLT_MonoCentralPFJet80_PFMETnoMu95_NHEF0p95 (MET dataset)",
     "type": {
       "primary": "Supplementaries",
@@ -15446,10 +11918,6 @@
     "collections": [
       "CMS-Trigger-Information"
     ],
-    "collision_information": {
-      "energy": "8TeV",
-      "type": "pp"
-    },
     "date_created": [
       "2012"
     ],
@@ -15457,10 +11925,6 @@
     "experiment": "CMS",
     "publisher": "CERN Open Data Portal",
     "recid": "6641",
-    "run_period": [
-      "Run2012B",
-      "Run2012C"
-    ],
     "title": "High-Level Trigger path information HLT_Mu12 (SingleMu dataset)",
     "type": {
       "primary": "Supplementaries",
@@ -15481,10 +11945,6 @@
     "collections": [
       "CMS-Trigger-Information"
     ],
-    "collision_information": {
-      "energy": "8TeV",
-      "type": "pp"
-    },
     "date_created": [
       "2012"
     ],
@@ -15492,10 +11952,6 @@
     "experiment": "CMS",
     "publisher": "CERN Open Data Portal",
     "recid": "6642",
-    "run_period": [
-      "Run2012B",
-      "Run2012C"
-    ],
     "title": "High-Level Trigger path information HLT_Mu12_DoubleCentralJet65 (MuHad dataset)",
     "type": {
       "primary": "Supplementaries",
@@ -15516,10 +11972,6 @@
     "collections": [
       "CMS-Trigger-Information"
     ],
-    "collision_information": {
-      "energy": "8TeV",
-      "type": "pp"
-    },
     "date_created": [
       "2012"
     ],
@@ -15527,10 +11979,6 @@
     "experiment": "CMS",
     "publisher": "CERN Open Data Portal",
     "recid": "6643",
-    "run_period": [
-      "Run2012B",
-      "Run2012C"
-    ],
     "title": "High-Level Trigger path information HLT_Mu12_RsqMR30_Rsq0p04_MR200 (MuHad dataset)",
     "type": {
       "primary": "Supplementaries",
@@ -15551,10 +11999,6 @@
     "collections": [
       "CMS-Trigger-Information"
     ],
-    "collision_information": {
-      "energy": "8TeV",
-      "type": "pp"
-    },
     "date_created": [
       "2012"
     ],
@@ -15562,10 +12006,6 @@
     "experiment": "CMS",
     "publisher": "CERN Open Data Portal",
     "recid": "6644",
-    "run_period": [
-      "Run2012B",
-      "Run2012C"
-    ],
     "title": "High-Level Trigger path information HLT_Mu12_RsqMR40_Rsq0p04_MR200 (MuHad dataset)",
     "type": {
       "primary": "Supplementaries",
@@ -15586,10 +12026,6 @@
     "collections": [
       "CMS-Trigger-Information"
     ],
-    "collision_information": {
-      "energy": "8TeV",
-      "type": "pp"
-    },
     "date_created": [
       "2012"
     ],
@@ -15597,10 +12033,6 @@
     "experiment": "CMS",
     "publisher": "CERN Open Data Portal",
     "recid": "6645",
-    "run_period": [
-      "Run2012B",
-      "Run2012C"
-    ],
     "title": "High-Level Trigger path information HLT_Mu12_RsqMR45_Rsq0p04_MR200 (MuHad dataset)",
     "type": {
       "primary": "Supplementaries",
@@ -15621,10 +12053,6 @@
     "collections": [
       "CMS-Trigger-Information"
     ],
-    "collision_information": {
-      "energy": "8TeV",
-      "type": "pp"
-    },
     "date_created": [
       "2012"
     ],
@@ -15632,10 +12060,6 @@
     "experiment": "CMS",
     "publisher": "CERN Open Data Portal",
     "recid": "6646",
-    "run_period": [
-      "Run2012B",
-      "Run2012C"
-    ],
     "title": "High-Level Trigger path information HLT_Mu12_eta2p1_DiCentral_20 (MuHad, SingleMu datasets)",
     "type": {
       "primary": "Supplementaries",
@@ -15656,10 +12080,6 @@
     "collections": [
       "CMS-Trigger-Information"
     ],
-    "collision_information": {
-      "energy": "8TeV",
-      "type": "pp"
-    },
     "date_created": [
       "2012"
     ],
@@ -15667,10 +12087,6 @@
     "experiment": "CMS",
     "publisher": "CERN Open Data Portal",
     "recid": "6647",
-    "run_period": [
-      "Run2012B",
-      "Run2012C"
-    ],
     "title": "High-Level Trigger path information HLT_Mu12_eta2p1_DiCentral_40_20 (MuHad, SingleMu datasets)",
     "type": {
       "primary": "Supplementaries",
@@ -15691,10 +12107,6 @@
     "collections": [
       "CMS-Trigger-Information"
     ],
-    "collision_information": {
-      "energy": "8TeV",
-      "type": "pp"
-    },
     "date_created": [
       "2012"
     ],
@@ -15702,10 +12114,6 @@
     "experiment": "CMS",
     "publisher": "CERN Open Data Portal",
     "recid": "6648",
-    "run_period": [
-      "Run2012B",
-      "Run2012C"
-    ],
     "title": "High-Level Trigger path information HLT_Mu12_eta2p1_DiCentral_40_20_BTagIP3D1stTrack (MuHad, SingleMu datasets)",
     "type": {
       "primary": "Supplementaries",
@@ -15726,10 +12134,6 @@
     "collections": [
       "CMS-Trigger-Information"
     ],
-    "collision_information": {
-      "energy": "8TeV",
-      "type": "pp"
-    },
     "date_created": [
       "2012"
     ],
@@ -15737,10 +12141,6 @@
     "experiment": "CMS",
     "publisher": "CERN Open Data Portal",
     "recid": "6649",
-    "run_period": [
-      "Run2012B",
-      "Run2012C"
-    ],
     "title": "High-Level Trigger path information HLT_Mu12_eta2p1_DiCentral_40_20_DiBTagIP3D1stTrack (MuHad, SingleMu datasets)",
     "type": {
       "primary": "Supplementaries",
@@ -15761,10 +12161,6 @@
     "collections": [
       "CMS-Trigger-Information"
     ],
-    "collision_information": {
-      "energy": "8TeV",
-      "type": "pp"
-    },
     "date_created": [
       "2012"
     ],
@@ -15772,10 +12168,6 @@
     "experiment": "CMS",
     "publisher": "CERN Open Data Portal",
     "recid": "6650",
-    "run_period": [
-      "Run2012B",
-      "Run2012C"
-    ],
     "title": "High-Level Trigger path information HLT_Mu12_eta2p1_L1Mu10erJetC12WdEtaPhi1DiJetsC (MuHad, SingleMu datasets)",
     "type": {
       "primary": "Supplementaries",
@@ -15796,10 +12188,6 @@
     "collections": [
       "CMS-Trigger-Information"
     ],
-    "collision_information": {
-      "energy": "8TeV",
-      "type": "pp"
-    },
     "date_created": [
       "2012"
     ],
@@ -15807,10 +12195,6 @@
     "experiment": "CMS",
     "publisher": "CERN Open Data Portal",
     "recid": "6651",
-    "run_period": [
-      "Run2012B",
-      "Run2012C"
-    ],
     "title": "High-Level Trigger path information HLT_Mu13_Mu8 (DoubleMuParked dataset)",
     "type": {
       "primary": "Supplementaries",
@@ -15831,10 +12215,6 @@
     "collections": [
       "CMS-Trigger-Information"
     ],
-    "collision_information": {
-      "energy": "8TeV",
-      "type": "pp"
-    },
     "date_created": [
       "2012"
     ],
@@ -15842,10 +12222,6 @@
     "experiment": "CMS",
     "publisher": "CERN Open Data Portal",
     "recid": "6652",
-    "run_period": [
-      "Run2012B",
-      "Run2012C"
-    ],
     "title": "High-Level Trigger path information HLT_Mu13_Mu8_NoDZ (DoubleMu, DoubleMuParked datasets)",
     "type": {
       "primary": "Supplementaries",
@@ -15866,10 +12242,6 @@
     "collections": [
       "CMS-Trigger-Information"
     ],
-    "collision_information": {
-      "energy": "8TeV",
-      "type": "pp"
-    },
     "date_created": [
       "2012"
     ],
@@ -15877,10 +12249,6 @@
     "experiment": "CMS",
     "publisher": "CERN Open Data Portal",
     "recid": "6653",
-    "run_period": [
-      "Run2012B",
-      "Run2012C"
-    ],
     "title": "High-Level Trigger path information HLT_Mu14_Ele14_CaloIdT_TrkIdVL_Mass8_PFMET40 (MuHad dataset)",
     "type": {
       "primary": "Supplementaries",
@@ -15901,10 +12269,6 @@
     "collections": [
       "CMS-Trigger-Information"
     ],
-    "collision_information": {
-      "energy": "8TeV",
-      "type": "pp"
-    },
     "date_created": [
       "2012"
     ],
@@ -15912,10 +12276,6 @@
     "experiment": "CMS",
     "publisher": "CERN Open Data Portal",
     "recid": "6654",
-    "run_period": [
-      "Run2012B",
-      "Run2012C"
-    ],
     "title": "High-Level Trigger path information HLT_Mu14_Ele14_CaloIdT_TrkIdVL_Mass8_PFMET50 (MuHad dataset)",
     "type": {
       "primary": "Supplementaries",
@@ -15936,10 +12296,6 @@
     "collections": [
       "CMS-Trigger-Information"
     ],
-    "collision_information": {
-      "energy": "8TeV",
-      "type": "pp"
-    },
     "date_created": [
       "2012"
     ],
@@ -15947,10 +12303,6 @@
     "experiment": "CMS",
     "publisher": "CERN Open Data Portal",
     "recid": "6655",
-    "run_period": [
-      "Run2012B",
-      "Run2012C"
-    ],
     "title": "High-Level Trigger path information HLT_Mu15_TkMu5_Onia (MuOniaParked dataset)",
     "type": {
       "primary": "Supplementaries",
@@ -15971,10 +12323,6 @@
     "collections": [
       "CMS-Trigger-Information"
     ],
-    "collision_information": {
-      "energy": "8TeV",
-      "type": "pp"
-    },
     "date_created": [
       "2012"
     ],
@@ -15982,10 +12330,6 @@
     "experiment": "CMS",
     "publisher": "CERN Open Data Portal",
     "recid": "6656",
-    "run_period": [
-      "Run2012B",
-      "Run2012C"
-    ],
     "title": "High-Level Trigger path information HLT_Mu15_eta2p1 (SingleMu dataset)",
     "type": {
       "primary": "Supplementaries",
@@ -16006,10 +12350,6 @@
     "collections": [
       "CMS-Trigger-Information"
     ],
-    "collision_information": {
-      "energy": "8TeV",
-      "type": "pp"
-    },
     "date_created": [
       "2012"
     ],
@@ -16017,10 +12357,6 @@
     "experiment": "CMS",
     "publisher": "CERN Open Data Portal",
     "recid": "6657",
-    "run_period": [
-      "Run2012B",
-      "Run2012C"
-    ],
     "title": "High-Level Trigger path information HLT_Mu15_eta2p1_DiCentral_20 (SingleMu dataset)",
     "type": {
       "primary": "Supplementaries",
@@ -16041,10 +12377,6 @@
     "collections": [
       "CMS-Trigger-Information"
     ],
-    "collision_information": {
-      "energy": "8TeV",
-      "type": "pp"
-    },
     "date_created": [
       "2012"
     ],
@@ -16052,10 +12384,6 @@
     "experiment": "CMS",
     "publisher": "CERN Open Data Portal",
     "recid": "6658",
-    "run_period": [
-      "Run2012B",
-      "Run2012C"
-    ],
     "title": "High-Level Trigger path information HLT_Mu15_eta2p1_DiCentral_40_20 (SingleMu dataset)",
     "type": {
       "primary": "Supplementaries",
@@ -16076,10 +12404,6 @@
     "collections": [
       "CMS-Trigger-Information"
     ],
-    "collision_information": {
-      "energy": "8TeV",
-      "type": "pp"
-    },
     "date_created": [
       "2012"
     ],
@@ -16087,10 +12411,6 @@
     "experiment": "CMS",
     "publisher": "CERN Open Data Portal",
     "recid": "6659",
-    "run_period": [
-      "Run2012B",
-      "Run2012C"
-    ],
     "title": "High-Level Trigger path information HLT_Mu15_eta2p1_L1ETM20 (TauPlusX dataset)",
     "type": {
       "primary": "Supplementaries",
@@ -16111,10 +12431,6 @@
     "collections": [
       "CMS-Trigger-Information"
     ],
-    "collision_information": {
-      "energy": "8TeV",
-      "type": "pp"
-    },
     "date_created": [
       "2012"
     ],
@@ -16122,10 +12438,6 @@
     "experiment": "CMS",
     "publisher": "CERN Open Data Portal",
     "recid": "6660",
-    "run_period": [
-      "Run2012B",
-      "Run2012C"
-    ],
     "title": "High-Level Trigger path information HLT_Mu15_eta2p1_L1Mu10erJetC12WdEtaPhi1DiJetsC (SingleMu dataset)",
     "type": {
       "primary": "Supplementaries",
@@ -16146,10 +12458,6 @@
     "collections": [
       "CMS-Trigger-Information"
     ],
-    "collision_information": {
-      "energy": "8TeV",
-      "type": "pp"
-    },
     "date_created": [
       "2012"
     ],
@@ -16157,10 +12465,6 @@
     "experiment": "CMS",
     "publisher": "CERN Open Data Portal",
     "recid": "6661",
-    "run_period": [
-      "Run2012B",
-      "Run2012C"
-    ],
     "title": "High-Level Trigger path information HLT_Mu15_eta2p1_TriCentral_40_20_20 (MuHad, SingleMu datasets)",
     "type": {
       "primary": "Supplementaries",
@@ -16181,10 +12485,6 @@
     "collections": [
       "CMS-Trigger-Information"
     ],
-    "collision_information": {
-      "energy": "8TeV",
-      "type": "pp"
-    },
     "date_created": [
       "2012"
     ],
@@ -16192,10 +12492,6 @@
     "experiment": "CMS",
     "publisher": "CERN Open Data Portal",
     "recid": "6662",
-    "run_period": [
-      "Run2012B",
-      "Run2012C"
-    ],
     "title": "High-Level Trigger path information HLT_Mu15_eta2p1_TriCentral_40_20_20_BTagIP3D1stTrack (MuHad, SingleMu datasets)",
     "type": {
       "primary": "Supplementaries",
@@ -16216,10 +12512,6 @@
     "collections": [
       "CMS-Trigger-Information"
     ],
-    "collision_information": {
-      "energy": "8TeV",
-      "type": "pp"
-    },
     "date_created": [
       "2012"
     ],
@@ -16227,10 +12519,6 @@
     "experiment": "CMS",
     "publisher": "CERN Open Data Portal",
     "recid": "6663",
-    "run_period": [
-      "Run2012B",
-      "Run2012C"
-    ],
     "title": "High-Level Trigger path information HLT_Mu15_eta2p1_TriCentral_40_20_20_DiBTagIP3D1stTrack (MuHad, SingleMu datasets)",
     "type": {
       "primary": "Supplementaries",
@@ -16251,10 +12539,6 @@
     "collections": [
       "CMS-Trigger-Information"
     ],
-    "collision_information": {
-      "energy": "8TeV",
-      "type": "pp"
-    },
     "date_created": [
       "2012"
     ],
@@ -16262,10 +12546,6 @@
     "experiment": "CMS",
     "publisher": "CERN Open Data Portal",
     "recid": "6664",
-    "run_period": [
-      "Run2012B",
-      "Run2012C"
-    ],
     "title": "High-Level Trigger path information HLT_Mu17 (DoubleMu, DoubleMuParked datasets)",
     "type": {
       "primary": "Supplementaries",
@@ -16286,10 +12566,6 @@
     "collections": [
       "CMS-Trigger-Information"
     ],
-    "collision_information": {
-      "energy": "8TeV",
-      "type": "pp"
-    },
     "date_created": [
       "2012"
     ],
@@ -16297,10 +12573,6 @@
     "experiment": "CMS",
     "publisher": "CERN Open Data Portal",
     "recid": "6665",
-    "run_period": [
-      "Run2012B",
-      "Run2012C"
-    ],
     "title": "High-Level Trigger path information HLT_Mu17_Ele8_CaloIdT_CaloIsoVL_TrkIdVL_TrkIsoVL (MuEG dataset)",
     "type": {
       "primary": "Supplementaries",
@@ -16321,10 +12593,6 @@
     "collections": [
       "CMS-Trigger-Information"
     ],
-    "collision_information": {
-      "energy": "8TeV",
-      "type": "pp"
-    },
     "date_created": [
       "2012"
     ],
@@ -16332,10 +12600,6 @@
     "experiment": "CMS",
     "publisher": "CERN Open Data Portal",
     "recid": "6666",
-    "run_period": [
-      "Run2012B",
-      "Run2012C"
-    ],
     "title": "High-Level Trigger path information HLT_Mu17_Mu8 (DoubleMu, DoubleMuParked datasets)",
     "type": {
       "primary": "Supplementaries",
@@ -16356,10 +12620,6 @@
     "collections": [
       "CMS-Trigger-Information"
     ],
-    "collision_information": {
-      "energy": "8TeV",
-      "type": "pp"
-    },
     "date_created": [
       "2012"
     ],
@@ -16367,10 +12627,6 @@
     "experiment": "CMS",
     "publisher": "CERN Open Data Portal",
     "recid": "6667",
-    "run_period": [
-      "Run2012B",
-      "Run2012C"
-    ],
     "title": "High-Level Trigger path information HLT_Mu17_TkMu8 (DoubleMu, DoubleMuParked datasets)",
     "type": {
       "primary": "Supplementaries",
@@ -16391,10 +12647,6 @@
     "collections": [
       "CMS-Trigger-Information"
     ],
-    "collision_information": {
-      "energy": "8TeV",
-      "type": "pp"
-    },
     "date_created": [
       "2012"
     ],
@@ -16402,10 +12654,6 @@
     "experiment": "CMS",
     "publisher": "CERN Open Data Portal",
     "recid": "6668",
-    "run_period": [
-      "Run2012B",
-      "Run2012C"
-    ],
     "title": "High-Level Trigger path information HLT_Mu17_TkMu8_NoDZ (DoubleMu, DoubleMuParked datasets)",
     "type": {
       "primary": "Supplementaries",
@@ -16426,10 +12674,6 @@
     "collections": [
       "CMS-Trigger-Information"
     ],
-    "collision_information": {
-      "energy": "8TeV",
-      "type": "pp"
-    },
     "date_created": [
       "2012"
     ],
@@ -16437,10 +12681,6 @@
     "experiment": "CMS",
     "publisher": "CERN Open Data Portal",
     "recid": "6669",
-    "run_period": [
-      "Run2012B",
-      "Run2012C"
-    ],
     "title": "High-Level Trigger path information HLT_Mu17_eta2p1_CentralPFNoPUJet30_BTagIPIter (SingleMu dataset)",
     "type": {
       "primary": "Supplementaries",
@@ -16461,10 +12701,6 @@
     "collections": [
       "CMS-Trigger-Information"
     ],
-    "collision_information": {
-      "energy": "8TeV",
-      "type": "pp"
-    },
     "date_created": [
       "2012"
     ],
@@ -16472,10 +12708,6 @@
     "experiment": "CMS",
     "publisher": "CERN Open Data Portal",
     "recid": "6670",
-    "run_period": [
-      "Run2012B",
-      "Run2012C"
-    ],
     "title": "High-Level Trigger path information HLT_Mu17_eta2p1_LooseIsoPFTau20 (TauPlusX dataset)",
     "type": {
       "primary": "Supplementaries",
@@ -16496,10 +12728,6 @@
     "collections": [
       "CMS-Trigger-Information"
     ],
-    "collision_information": {
-      "energy": "8TeV",
-      "type": "pp"
-    },
     "date_created": [
       "2012"
     ],
@@ -16507,10 +12735,6 @@
     "experiment": "CMS",
     "publisher": "CERN Open Data Portal",
     "recid": "6671",
-    "run_period": [
-      "Run2012B",
-      "Run2012C"
-    ],
     "title": "High-Level Trigger path information HLT_Mu17_eta2p1_TriCentralPFNoPUJet30 (SingleMu dataset)",
     "type": {
       "primary": "Supplementaries",
@@ -16531,10 +12755,6 @@
     "collections": [
       "CMS-Trigger-Information"
     ],
-    "collision_information": {
-      "energy": "8TeV",
-      "type": "pp"
-    },
     "date_created": [
       "2012"
     ],
@@ -16542,10 +12762,6 @@
     "experiment": "CMS",
     "publisher": "CERN Open Data Portal",
     "recid": "6672",
-    "run_period": [
-      "Run2012B",
-      "Run2012C"
-    ],
     "title": "High-Level Trigger path information HLT_Mu17_eta2p1_TriCentralPFNoPUJet30_30_20 (SingleMu dataset)",
     "type": {
       "primary": "Supplementaries",
@@ -16566,10 +12782,6 @@
     "collections": [
       "CMS-Trigger-Information"
     ],
-    "collision_information": {
-      "energy": "8TeV",
-      "type": "pp"
-    },
     "date_created": [
       "2012"
     ],
@@ -16577,10 +12789,6 @@
     "experiment": "CMS",
     "publisher": "CERN Open Data Portal",
     "recid": "6673",
-    "run_period": [
-      "Run2012B",
-      "Run2012C"
-    ],
     "title": "High-Level Trigger path information HLT_Mu17_eta2p1_TriCentralPFNoPUJet45_35_25 (SingleMu dataset)",
     "type": {
       "primary": "Supplementaries",
@@ -16601,10 +12809,6 @@
     "collections": [
       "CMS-Trigger-Information"
     ],
-    "collision_information": {
-      "energy": "8TeV",
-      "type": "pp"
-    },
     "date_created": [
       "2012"
     ],
@@ -16612,10 +12816,6 @@
     "experiment": "CMS",
     "publisher": "CERN Open Data Portal",
     "recid": "6674",
-    "run_period": [
-      "Run2012B",
-      "Run2012C"
-    ],
     "title": "High-Level Trigger path information HLT_Mu17_eta2p1_TriCentralPFNoPUJet50_40_30 (SingleMu dataset)",
     "type": {
       "primary": "Supplementaries",
@@ -16636,10 +12836,6 @@
     "collections": [
       "CMS-Trigger-Information"
     ],
-    "collision_information": {
-      "energy": "8TeV",
-      "type": "pp"
-    },
     "date_created": [
       "2012"
     ],
@@ -16647,10 +12843,6 @@
     "experiment": "CMS",
     "publisher": "CERN Open Data Portal",
     "recid": "6675",
-    "run_period": [
-      "Run2012B",
-      "Run2012C"
-    ],
     "title": "High-Level Trigger path information HLT_Mu18_CentralPFJet30_CentralPFJet25 (SingleMu dataset)",
     "type": {
       "primary": "Supplementaries",
@@ -16671,10 +12863,6 @@
     "collections": [
       "CMS-Trigger-Information"
     ],
-    "collision_information": {
-      "energy": "8TeV",
-      "type": "pp"
-    },
     "date_created": [
       "2012"
     ],
@@ -16682,10 +12870,6 @@
     "experiment": "CMS",
     "publisher": "CERN Open Data Portal",
     "recid": "6676",
-    "run_period": [
-      "Run2012B",
-      "Run2012C"
-    ],
     "title": "High-Level Trigger path information HLT_Mu18_PFJet30_PFJet25_Deta3_CentralPFJet25 (SingleMu dataset)",
     "type": {
       "primary": "Supplementaries",
@@ -16706,10 +12890,6 @@
     "collections": [
       "CMS-Trigger-Information"
     ],
-    "collision_information": {
-      "energy": "8TeV",
-      "type": "pp"
-    },
     "date_created": [
       "2012"
     ],
@@ -16717,10 +12897,6 @@
     "experiment": "CMS",
     "publisher": "CERN Open Data Portal",
     "recid": "6677",
-    "run_period": [
-      "Run2012B",
-      "Run2012C"
-    ],
     "title": "High-Level Trigger path information HLT_Mu18_eta2p1_LooseIsoPFTau20 (TauPlusX dataset)",
     "type": {
       "primary": "Supplementaries",
@@ -16741,10 +12917,6 @@
     "collections": [
       "CMS-Trigger-Information"
     ],
-    "collision_information": {
-      "energy": "8TeV",
-      "type": "pp"
-    },
     "date_created": [
       "2012"
     ],
@@ -16752,10 +12924,6 @@
     "experiment": "CMS",
     "publisher": "CERN Open Data Portal",
     "recid": "6678",
-    "run_period": [
-      "Run2012B",
-      "Run2012C"
-    ],
     "title": "High-Level Trigger path information HLT_Mu20_eta2p1_CentralPFJet30_BTagIPIter (MuHad dataset)",
     "type": {
       "primary": "Supplementaries",
@@ -16776,10 +12944,6 @@
     "collections": [
       "CMS-Trigger-Information"
     ],
-    "collision_information": {
-      "energy": "8TeV",
-      "type": "pp"
-    },
     "date_created": [
       "2012"
     ],
@@ -16787,10 +12951,6 @@
     "experiment": "CMS",
     "publisher": "CERN Open Data Portal",
     "recid": "6679",
-    "run_period": [
-      "Run2012B",
-      "Run2012C"
-    ],
     "title": "High-Level Trigger path information HLT_Mu20_eta2p1_CentralPFNoPUJet30_BTagIPIter (MuHad dataset)",
     "type": {
       "primary": "Supplementaries",
@@ -16811,10 +12971,6 @@
     "collections": [
       "CMS-Trigger-Information"
     ],
-    "collision_information": {
-      "energy": "8TeV",
-      "type": "pp"
-    },
     "date_created": [
       "2012"
     ],
@@ -16822,10 +12978,6 @@
     "experiment": "CMS",
     "publisher": "CERN Open Data Portal",
     "recid": "6680",
-    "run_period": [
-      "Run2012B",
-      "Run2012C"
-    ],
     "title": "High-Level Trigger path information HLT_Mu20_eta2p1_TriCentralPFJet30 (MuHad dataset)",
     "type": {
       "primary": "Supplementaries",
@@ -16846,10 +12998,6 @@
     "collections": [
       "CMS-Trigger-Information"
     ],
-    "collision_information": {
-      "energy": "8TeV",
-      "type": "pp"
-    },
     "date_created": [
       "2012"
     ],
@@ -16857,10 +13005,6 @@
     "experiment": "CMS",
     "publisher": "CERN Open Data Portal",
     "recid": "6681",
-    "run_period": [
-      "Run2012B",
-      "Run2012C"
-    ],
     "title": "High-Level Trigger path information HLT_Mu20_eta2p1_TriCentralPFJet50_40_30 (MuHad dataset)",
     "type": {
       "primary": "Supplementaries",
@@ -16881,10 +13025,6 @@
     "collections": [
       "CMS-Trigger-Information"
     ],
-    "collision_information": {
-      "energy": "8TeV",
-      "type": "pp"
-    },
     "date_created": [
       "2012"
     ],
@@ -16892,10 +13032,6 @@
     "experiment": "CMS",
     "publisher": "CERN Open Data Portal",
     "recid": "6682",
-    "run_period": [
-      "Run2012B",
-      "Run2012C"
-    ],
     "title": "High-Level Trigger path information HLT_Mu20_eta2p1_TriCentralPFNoPUJet30 (MuHad dataset)",
     "type": {
       "primary": "Supplementaries",
@@ -16916,10 +13052,6 @@
     "collections": [
       "CMS-Trigger-Information"
     ],
-    "collision_information": {
-      "energy": "8TeV",
-      "type": "pp"
-    },
     "date_created": [
       "2012"
     ],
@@ -16927,10 +13059,6 @@
     "experiment": "CMS",
     "publisher": "CERN Open Data Portal",
     "recid": "6683",
-    "run_period": [
-      "Run2012B",
-      "Run2012C"
-    ],
     "title": "High-Level Trigger path information HLT_Mu20_eta2p1_TriCentralPFNoPUJet50_40_30 (MuHad dataset)",
     "type": {
       "primary": "Supplementaries",
@@ -16951,10 +13079,6 @@
     "collections": [
       "CMS-Trigger-Information"
     ],
-    "collision_information": {
-      "energy": "8TeV",
-      "type": "pp"
-    },
     "date_created": [
       "2012"
     ],
@@ -16962,10 +13086,6 @@
     "experiment": "CMS",
     "publisher": "CERN Open Data Portal",
     "recid": "6684",
-    "run_period": [
-      "Run2012B",
-      "Run2012C"
-    ],
     "title": "High-Level Trigger path information HLT_Mu22_Photon22_CaloIdL (MuEG dataset)",
     "type": {
       "primary": "Supplementaries",
@@ -16986,10 +13106,6 @@
     "collections": [
       "CMS-Trigger-Information"
     ],
-    "collision_information": {
-      "energy": "8TeV",
-      "type": "pp"
-    },
     "date_created": [
       "2012"
     ],
@@ -16997,10 +13113,6 @@
     "experiment": "CMS",
     "publisher": "CERN Open Data Portal",
     "recid": "6685",
-    "run_period": [
-      "Run2012B",
-      "Run2012C"
-    ],
     "title": "High-Level Trigger path information HLT_Mu22_TkMu22 (DoubleMu, DoubleMuParked datasets)",
     "type": {
       "primary": "Supplementaries",
@@ -17021,10 +13133,6 @@
     "collections": [
       "CMS-Trigger-Information"
     ],
-    "collision_information": {
-      "energy": "8TeV",
-      "type": "pp"
-    },
     "date_created": [
       "2012"
     ],
@@ -17032,10 +13140,6 @@
     "experiment": "CMS",
     "publisher": "CERN Open Data Portal",
     "recid": "6686",
-    "run_period": [
-      "Run2012B",
-      "Run2012C"
-    ],
     "title": "High-Level Trigger path information HLT_Mu22_TkMu8 (DoubleMu, DoubleMuParked datasets)",
     "type": {
       "primary": "Supplementaries",
@@ -17056,10 +13160,6 @@
     "collections": [
       "CMS-Trigger-Information"
     ],
-    "collision_information": {
-      "energy": "8TeV",
-      "type": "pp"
-    },
     "date_created": [
       "2012"
     ],
@@ -17067,10 +13167,6 @@
     "experiment": "CMS",
     "publisher": "CERN Open Data Portal",
     "recid": "6687",
-    "run_period": [
-      "Run2012B",
-      "Run2012C"
-    ],
     "title": "High-Level Trigger path information HLT_Mu24 (SingleMu dataset)",
     "type": {
       "primary": "Supplementaries",
@@ -17091,10 +13187,6 @@
     "collections": [
       "CMS-Trigger-Information"
     ],
-    "collision_information": {
-      "energy": "8TeV",
-      "type": "pp"
-    },
     "date_created": [
       "2012"
     ],
@@ -17102,10 +13194,6 @@
     "experiment": "CMS",
     "publisher": "CERN Open Data Portal",
     "recid": "6688",
-    "run_period": [
-      "Run2012B",
-      "Run2012C"
-    ],
     "title": "High-Level Trigger path information HLT_Mu24_CentralPFJet30_CentralPFJet25 (SingleMu dataset)",
     "type": {
       "primary": "Supplementaries",
@@ -17126,10 +13214,6 @@
     "collections": [
       "CMS-Trigger-Information"
     ],
-    "collision_information": {
-      "energy": "8TeV",
-      "type": "pp"
-    },
     "date_created": [
       "2012"
     ],
@@ -17137,10 +13221,6 @@
     "experiment": "CMS",
     "publisher": "CERN Open Data Portal",
     "recid": "6689",
-    "run_period": [
-      "Run2012B",
-      "Run2012C"
-    ],
     "title": "High-Level Trigger path information HLT_Mu24_PFJet30_PFJet25_Deta3_CentralPFJet25 (SingleMu dataset)",
     "type": {
       "primary": "Supplementaries",
@@ -17161,10 +13241,6 @@
     "collections": [
       "CMS-Trigger-Information"
     ],
-    "collision_information": {
-      "energy": "8TeV",
-      "type": "pp"
-    },
     "date_created": [
       "2012"
     ],
@@ -17172,10 +13248,6 @@
     "experiment": "CMS",
     "publisher": "CERN Open Data Portal",
     "recid": "6690",
-    "run_period": [
-      "Run2012B",
-      "Run2012C"
-    ],
     "title": "High-Level Trigger path information HLT_Mu24_eta2p1 (SingleMu dataset)",
     "type": {
       "primary": "Supplementaries",
@@ -17196,10 +13268,6 @@
     "collections": [
       "CMS-Trigger-Information"
     ],
-    "collision_information": {
-      "energy": "8TeV",
-      "type": "pp"
-    },
     "date_created": [
       "2012"
     ],
@@ -17207,10 +13275,6 @@
     "experiment": "CMS",
     "publisher": "CERN Open Data Portal",
     "recid": "6691",
-    "run_period": [
-      "Run2012B",
-      "Run2012C"
-    ],
     "title": "High-Level Trigger path information HLT_Mu24_eta2p1_CentralPFJet30_CentralPFJet25 (MuHad dataset)",
     "type": {
       "primary": "Supplementaries",
@@ -17231,10 +13295,6 @@
     "collections": [
       "CMS-Trigger-Information"
     ],
-    "collision_information": {
-      "energy": "8TeV",
-      "type": "pp"
-    },
     "date_created": [
       "2012"
     ],
@@ -17242,10 +13302,6 @@
     "experiment": "CMS",
     "publisher": "CERN Open Data Portal",
     "recid": "6692",
-    "run_period": [
-      "Run2012B",
-      "Run2012C"
-    ],
     "title": "High-Level Trigger path information HLT_Mu24_eta2p1_PFJet30_PFJet25_Deta3 (MuHad dataset)",
     "type": {
       "primary": "Supplementaries",
@@ -17266,10 +13322,6 @@
     "collections": [
       "CMS-Trigger-Information"
     ],
-    "collision_information": {
-      "energy": "8TeV",
-      "type": "pp"
-    },
     "date_created": [
       "2012"
     ],
@@ -17277,10 +13329,6 @@
     "experiment": "CMS",
     "publisher": "CERN Open Data Portal",
     "recid": "6693",
-    "run_period": [
-      "Run2012B",
-      "Run2012C"
-    ],
     "title": "High-Level Trigger path information HLT_Mu30 (SingleMu dataset)",
     "type": {
       "primary": "Supplementaries",
@@ -17301,10 +13349,6 @@
     "collections": [
       "CMS-Trigger-Information"
     ],
-    "collision_information": {
-      "energy": "8TeV",
-      "type": "pp"
-    },
     "date_created": [
       "2012"
     ],
@@ -17312,10 +13356,6 @@
     "experiment": "CMS",
     "publisher": "CERN Open Data Portal",
     "recid": "6694",
-    "run_period": [
-      "Run2012B",
-      "Run2012C"
-    ],
     "title": "High-Level Trigger path information HLT_Mu30_Ele30_CaloIdL (MuEG dataset)",
     "type": {
       "primary": "Supplementaries",
@@ -17336,10 +13376,6 @@
     "collections": [
       "CMS-Trigger-Information"
     ],
-    "collision_information": {
-      "energy": "8TeV",
-      "type": "pp"
-    },
     "date_created": [
       "2012"
     ],
@@ -17347,10 +13383,6 @@
     "experiment": "CMS",
     "publisher": "CERN Open Data Portal",
     "recid": "6695",
-    "run_period": [
-      "Run2012B",
-      "Run2012C"
-    ],
     "title": "High-Level Trigger path information HLT_Mu30_eta2p1 (SingleMu dataset)",
     "type": {
       "primary": "Supplementaries",
@@ -17371,10 +13403,6 @@
     "collections": [
       "CMS-Trigger-Information"
     ],
-    "collision_information": {
-      "energy": "8TeV",
-      "type": "pp"
-    },
     "date_created": [
       "2012"
     ],
@@ -17382,10 +13410,6 @@
     "experiment": "CMS",
     "publisher": "CERN Open Data Portal",
     "recid": "6696",
-    "run_period": [
-      "Run2012B",
-      "Run2012C"
-    ],
     "title": "High-Level Trigger path information HLT_Mu40 (SingleMu dataset)",
     "type": {
       "primary": "Supplementaries",
@@ -17406,10 +13430,6 @@
     "collections": [
       "CMS-Trigger-Information"
     ],
-    "collision_information": {
-      "energy": "8TeV",
-      "type": "pp"
-    },
     "date_created": [
       "2012"
     ],
@@ -17417,10 +13437,6 @@
     "experiment": "CMS",
     "publisher": "CERN Open Data Portal",
     "recid": "6697",
-    "run_period": [
-      "Run2012B",
-      "Run2012C"
-    ],
     "title": "High-Level Trigger path information HLT_Mu40_FJHT200 (MuHad dataset)",
     "type": {
       "primary": "Supplementaries",
@@ -17441,10 +13457,6 @@
     "collections": [
       "CMS-Trigger-Information"
     ],
-    "collision_information": {
-      "energy": "8TeV",
-      "type": "pp"
-    },
     "date_created": [
       "2012"
     ],
@@ -17452,10 +13464,6 @@
     "experiment": "CMS",
     "publisher": "CERN Open Data Portal",
     "recid": "6698",
-    "run_period": [
-      "Run2012B",
-      "Run2012C"
-    ],
     "title": "High-Level Trigger path information HLT_Mu40_HT200 (MuHad dataset)",
     "type": {
       "primary": "Supplementaries",
@@ -17476,10 +13484,6 @@
     "collections": [
       "CMS-Trigger-Information"
     ],
-    "collision_information": {
-      "energy": "8TeV",
-      "type": "pp"
-    },
     "date_created": [
       "2012"
     ],
@@ -17487,10 +13491,6 @@
     "experiment": "CMS",
     "publisher": "CERN Open Data Portal",
     "recid": "6699",
-    "run_period": [
-      "Run2012B",
-      "Run2012C"
-    ],
     "title": "High-Level Trigger path information HLT_Mu40_PFHT350 (MuHad dataset)",
     "type": {
       "primary": "Supplementaries",
@@ -17511,10 +13511,6 @@
     "collections": [
       "CMS-Trigger-Information"
     ],
-    "collision_information": {
-      "energy": "8TeV",
-      "type": "pp"
-    },
     "date_created": [
       "2012"
     ],
@@ -17522,10 +13518,6 @@
     "experiment": "CMS",
     "publisher": "CERN Open Data Portal",
     "recid": "6700",
-    "run_period": [
-      "Run2012B",
-      "Run2012C"
-    ],
     "title": "High-Level Trigger path information HLT_Mu40_PFNoPUHT350 (MuHad dataset)",
     "type": {
       "primary": "Supplementaries",
@@ -17546,10 +13538,6 @@
     "collections": [
       "CMS-Trigger-Information"
     ],
-    "collision_information": {
-      "energy": "8TeV",
-      "type": "pp"
-    },
     "date_created": [
       "2012"
     ],
@@ -17557,10 +13545,6 @@
     "experiment": "CMS",
     "publisher": "CERN Open Data Portal",
     "recid": "6701",
-    "run_period": [
-      "Run2012B",
-      "Run2012C"
-    ],
     "title": "High-Level Trigger path information HLT_Mu40_eta2p1 (SingleMu dataset)",
     "type": {
       "primary": "Supplementaries",
@@ -17581,10 +13565,6 @@
     "collections": [
       "CMS-Trigger-Information"
     ],
-    "collision_information": {
-      "energy": "8TeV",
-      "type": "pp"
-    },
     "date_created": [
       "2012"
     ],
@@ -17592,10 +13572,6 @@
     "experiment": "CMS",
     "publisher": "CERN Open Data Portal",
     "recid": "6702",
-    "run_period": [
-      "Run2012B",
-      "Run2012C"
-    ],
     "title": "High-Level Trigger path information HLT_Mu40_eta2p1_Track50_dEdx3p6 (SingleMu dataset)",
     "type": {
       "primary": "Supplementaries",
@@ -17616,10 +13592,6 @@
     "collections": [
       "CMS-Trigger-Information"
     ],
-    "collision_information": {
-      "energy": "8TeV",
-      "type": "pp"
-    },
     "date_created": [
       "2012"
     ],
@@ -17627,10 +13599,6 @@
     "experiment": "CMS",
     "publisher": "CERN Open Data Portal",
     "recid": "6703",
-    "run_period": [
-      "Run2012B",
-      "Run2012C"
-    ],
     "title": "High-Level Trigger path information HLT_Mu40_eta2p1_Track60_dEdx3p7 (SingleMu dataset)",
     "type": {
       "primary": "Supplementaries",
@@ -17651,10 +13619,6 @@
     "collections": [
       "CMS-Trigger-Information"
     ],
-    "collision_information": {
-      "energy": "8TeV",
-      "type": "pp"
-    },
     "date_created": [
       "2012"
     ],
@@ -17662,10 +13626,6 @@
     "experiment": "CMS",
     "publisher": "CERN Open Data Portal",
     "recid": "6704",
-    "run_period": [
-      "Run2012B",
-      "Run2012C"
-    ],
     "title": "High-Level Trigger path information HLT_Mu5 (SingleMu dataset)",
     "type": {
       "primary": "Supplementaries",
@@ -17686,10 +13646,6 @@
     "collections": [
       "CMS-Trigger-Information"
     ],
-    "collision_information": {
-      "energy": "8TeV",
-      "type": "pp"
-    },
     "date_created": [
       "2012"
     ],
@@ -17697,10 +13653,6 @@
     "experiment": "CMS",
     "publisher": "CERN Open Data Portal",
     "recid": "6705",
-    "run_period": [
-      "Run2012B",
-      "Run2012C"
-    ],
     "title": "High-Level Trigger path information HLT_Mu50_eta2p1 (SingleMu dataset)",
     "type": {
       "primary": "Supplementaries",
@@ -17721,10 +13673,6 @@
     "collections": [
       "CMS-Trigger-Information"
     ],
-    "collision_information": {
-      "energy": "8TeV",
-      "type": "pp"
-    },
     "date_created": [
       "2012"
     ],
@@ -17732,10 +13680,6 @@
     "experiment": "CMS",
     "publisher": "CERN Open Data Portal",
     "recid": "6706",
-    "run_period": [
-      "Run2012B",
-      "Run2012C"
-    ],
     "title": "High-Level Trigger path information HLT_Mu5_L2Mu3_Jpsi (MuOnia dataset)",
     "type": {
       "primary": "Supplementaries",
@@ -17756,10 +13700,6 @@
     "collections": [
       "CMS-Trigger-Information"
     ],
-    "collision_information": {
-      "energy": "8TeV",
-      "type": "pp"
-    },
     "date_created": [
       "2012"
     ],
@@ -17767,10 +13707,6 @@
     "experiment": "CMS",
     "publisher": "CERN Open Data Portal",
     "recid": "6707",
-    "run_period": [
-      "Run2012B",
-      "Run2012C"
-    ],
     "title": "High-Level Trigger path information HLT_Mu5_Track2_Jpsi (MuOnia dataset)",
     "type": {
       "primary": "Supplementaries",
@@ -17791,10 +13727,6 @@
     "collections": [
       "CMS-Trigger-Information"
     ],
-    "collision_information": {
-      "energy": "8TeV",
-      "type": "pp"
-    },
     "date_created": [
       "2012"
     ],
@@ -17802,10 +13734,6 @@
     "experiment": "CMS",
     "publisher": "CERN Open Data Portal",
     "recid": "6708",
-    "run_period": [
-      "Run2012B",
-      "Run2012C"
-    ],
     "title": "High-Level Trigger path information HLT_Mu5_Track3p5_Jpsi (MuOnia dataset)",
     "type": {
       "primary": "Supplementaries",
@@ -17826,10 +13754,6 @@
     "collections": [
       "CMS-Trigger-Information"
     ],
-    "collision_information": {
-      "energy": "8TeV",
-      "type": "pp"
-    },
     "date_created": [
       "2012"
     ],
@@ -17837,10 +13761,6 @@
     "experiment": "CMS",
     "publisher": "CERN Open Data Portal",
     "recid": "6709",
-    "run_period": [
-      "Run2012B",
-      "Run2012C"
-    ],
     "title": "High-Level Trigger path information HLT_Mu60_PFHT350 (MuHad dataset)",
     "type": {
       "primary": "Supplementaries",
@@ -17861,10 +13781,6 @@
     "collections": [
       "CMS-Trigger-Information"
     ],
-    "collision_information": {
-      "energy": "8TeV",
-      "type": "pp"
-    },
     "date_created": [
       "2012"
     ],
@@ -17872,10 +13788,6 @@
     "experiment": "CMS",
     "publisher": "CERN Open Data Portal",
     "recid": "6710",
-    "run_period": [
-      "Run2012B",
-      "Run2012C"
-    ],
     "title": "High-Level Trigger path information HLT_Mu60_PFNoPUHT350 (MuHad dataset)",
     "type": {
       "primary": "Supplementaries",
@@ -17896,10 +13808,6 @@
     "collections": [
       "CMS-Trigger-Information"
     ],
-    "collision_information": {
-      "energy": "8TeV",
-      "type": "pp"
-    },
     "date_created": [
       "2012"
     ],
@@ -17907,10 +13815,6 @@
     "experiment": "CMS",
     "publisher": "CERN Open Data Portal",
     "recid": "6711",
-    "run_period": [
-      "Run2012B",
-      "Run2012C"
-    ],
     "title": "High-Level Trigger path information HLT_Mu7_Ele7_CaloIdT_CaloIsoVL (MuEG dataset)",
     "type": {
       "primary": "Supplementaries",
@@ -17931,10 +13835,6 @@
     "collections": [
       "CMS-Trigger-Information"
     ],
-    "collision_information": {
-      "energy": "8TeV",
-      "type": "pp"
-    },
     "date_created": [
       "2012"
     ],
@@ -17942,10 +13842,6 @@
     "experiment": "CMS",
     "publisher": "CERN Open Data Portal",
     "recid": "6712",
-    "run_period": [
-      "Run2012B",
-      "Run2012C"
-    ],
     "title": "High-Level Trigger path information HLT_Mu7_Track7_Jpsi (MuOnia dataset)",
     "type": {
       "primary": "Supplementaries",
@@ -17966,10 +13862,6 @@
     "collections": [
       "CMS-Trigger-Information"
     ],
-    "collision_information": {
-      "energy": "8TeV",
-      "type": "pp"
-    },
     "date_created": [
       "2012"
     ],
@@ -17977,10 +13869,6 @@
     "experiment": "CMS",
     "publisher": "CERN Open Data Portal",
     "recid": "6713",
-    "run_period": [
-      "Run2012B",
-      "Run2012C"
-    ],
     "title": "High-Level Trigger path information HLT_Mu8 (DoubleMu, DoubleMuParked datasets)",
     "type": {
       "primary": "Supplementaries",
@@ -18001,10 +13889,6 @@
     "collections": [
       "CMS-Trigger-Information"
     ],
-    "collision_information": {
-      "energy": "8TeV",
-      "type": "pp"
-    },
     "date_created": [
       "2012"
     ],
@@ -18012,10 +13896,6 @@
     "experiment": "CMS",
     "publisher": "CERN Open Data Portal",
     "recid": "6714",
-    "run_period": [
-      "Run2012B",
-      "Run2012C"
-    ],
     "title": "High-Level Trigger path information HLT_Mu8_DiJet30 (MuHad dataset)",
     "type": {
       "primary": "Supplementaries",
@@ -18036,10 +13916,6 @@
     "collections": [
       "CMS-Trigger-Information"
     ],
-    "collision_information": {
-      "energy": "8TeV",
-      "type": "pp"
-    },
     "date_created": [
       "2012"
     ],
@@ -18047,10 +13923,6 @@
     "experiment": "CMS",
     "publisher": "CERN Open Data Portal",
     "recid": "6715",
-    "run_period": [
-      "Run2012B",
-      "Run2012C"
-    ],
     "title": "High-Level Trigger path information HLT_Mu8_DoubleEle8_CaloIdT_TrkIdVL (MuEG dataset)",
     "type": {
       "primary": "Supplementaries",
@@ -18071,10 +13943,6 @@
     "collections": [
       "CMS-Trigger-Information"
     ],
-    "collision_information": {
-      "energy": "8TeV",
-      "type": "pp"
-    },
     "date_created": [
       "2012"
     ],
@@ -18082,10 +13950,6 @@
     "experiment": "CMS",
     "publisher": "CERN Open Data Portal",
     "recid": "6716",
-    "run_period": [
-      "Run2012B",
-      "Run2012C"
-    ],
     "title": "High-Level Trigger path information HLT_Mu8_Ele17_CaloIdT_CaloIsoVL_TrkIdVL_TrkIsoVL (MuEG dataset)",
     "type": {
       "primary": "Supplementaries",
@@ -18106,10 +13970,6 @@
     "collections": [
       "CMS-Trigger-Information"
     ],
-    "collision_information": {
-      "energy": "8TeV",
-      "type": "pp"
-    },
     "date_created": [
       "2012"
     ],
@@ -18117,10 +13977,6 @@
     "experiment": "CMS",
     "publisher": "CERN Open Data Portal",
     "recid": "6717",
-    "run_period": [
-      "Run2012B",
-      "Run2012C"
-    ],
     "title": "High-Level Trigger path information HLT_Mu8_Ele8_CaloIdT_TrkIdVL_Ele8_CaloIdL_TrkIdVL (MuEG dataset)",
     "type": {
       "primary": "Supplementaries",
@@ -18141,10 +13997,6 @@
     "collections": [
       "CMS-Trigger-Information"
     ],
-    "collision_information": {
-      "energy": "8TeV",
-      "type": "pp"
-    },
     "date_created": [
       "2012"
     ],
@@ -18152,10 +14004,6 @@
     "experiment": "CMS",
     "publisher": "CERN Open Data Portal",
     "recid": "6718",
-    "run_period": [
-      "Run2012B",
-      "Run2012C"
-    ],
     "title": "High-Level Trigger path information HLT_Mu8_Ele8_CaloIdT_TrkIdVL_Mass8_PFHT175 (MuHad dataset)",
     "type": {
       "primary": "Supplementaries",
@@ -18176,10 +14024,6 @@
     "collections": [
       "CMS-Trigger-Information"
     ],
-    "collision_information": {
-      "energy": "8TeV",
-      "type": "pp"
-    },
     "date_created": [
       "2012"
     ],
@@ -18187,10 +14031,6 @@
     "experiment": "CMS",
     "publisher": "CERN Open Data Portal",
     "recid": "6719",
-    "run_period": [
-      "Run2012B",
-      "Run2012C"
-    ],
     "title": "High-Level Trigger path information HLT_Mu8_Ele8_CaloIdT_TrkIdVL_Mass8_PFHT225 (MuHad dataset)",
     "type": {
       "primary": "Supplementaries",
@@ -18211,10 +14051,6 @@
     "collections": [
       "CMS-Trigger-Information"
     ],
-    "collision_information": {
-      "energy": "8TeV",
-      "type": "pp"
-    },
     "date_created": [
       "2012"
     ],
@@ -18222,10 +14058,6 @@
     "experiment": "CMS",
     "publisher": "CERN Open Data Portal",
     "recid": "6720",
-    "run_period": [
-      "Run2012B",
-      "Run2012C"
-    ],
     "title": "High-Level Trigger path information HLT_Mu8_Ele8_CaloIdT_TrkIdVL_Mass8_PFNoPUHT175 (MuHad dataset)",
     "type": {
       "primary": "Supplementaries",
@@ -18246,10 +14078,6 @@
     "collections": [
       "CMS-Trigger-Information"
     ],
-    "collision_information": {
-      "energy": "8TeV",
-      "type": "pp"
-    },
     "date_created": [
       "2012"
     ],
@@ -18257,10 +14085,6 @@
     "experiment": "CMS",
     "publisher": "CERN Open Data Portal",
     "recid": "6721",
-    "run_period": [
-      "Run2012B",
-      "Run2012C"
-    ],
     "title": "High-Level Trigger path information HLT_Mu8_Ele8_CaloIdT_TrkIdVL_Mass8_PFNoPUHT225 (MuHad dataset)",
     "type": {
       "primary": "Supplementaries",
@@ -18281,10 +14105,6 @@
     "collections": [
       "CMS-Trigger-Information"
     ],
-    "collision_information": {
-      "energy": "8TeV",
-      "type": "pp"
-    },
     "date_created": [
       "2012"
     ],
@@ -18292,10 +14112,6 @@
     "experiment": "CMS",
     "publisher": "CERN Open Data Portal",
     "recid": "6722",
-    "run_period": [
-      "Run2012B",
-      "Run2012C"
-    ],
     "title": "High-Level Trigger path information HLT_Mu8_QuadJet30 (MuHad dataset)",
     "type": {
       "primary": "Supplementaries",
@@ -18316,10 +14132,6 @@
     "collections": [
       "CMS-Trigger-Information"
     ],
-    "collision_information": {
-      "energy": "8TeV",
-      "type": "pp"
-    },
     "date_created": [
       "2012"
     ],
@@ -18327,10 +14139,6 @@
     "experiment": "CMS",
     "publisher": "CERN Open Data Portal",
     "recid": "6723",
-    "run_period": [
-      "Run2012B",
-      "Run2012C"
-    ],
     "title": "High-Level Trigger path information HLT_Mu8_TriJet30 (MuHad dataset)",
     "type": {
       "primary": "Supplementaries",
@@ -18351,10 +14159,6 @@
     "collections": [
       "CMS-Trigger-Information"
     ],
-    "collision_information": {
-      "energy": "8TeV",
-      "type": "pp"
-    },
     "date_created": [
       "2012"
     ],
@@ -18362,10 +14166,6 @@
     "experiment": "CMS",
     "publisher": "CERN Open Data Portal",
     "recid": "6724",
-    "run_period": [
-      "Run2012B",
-      "Run2012C"
-    ],
     "title": "High-Level Trigger path information HLT_Mu8_eta2p1_LooseIsoPFTau20_L1ETM26 (TauPlusX dataset)",
     "type": {
       "primary": "Supplementaries",
@@ -18386,10 +14186,6 @@
     "collections": [
       "CMS-Trigger-Information"
     ],
-    "collision_information": {
-      "energy": "8TeV",
-      "type": "pp"
-    },
     "date_created": [
       "2012"
     ],
@@ -18397,10 +14193,6 @@
     "experiment": "CMS",
     "publisher": "CERN Open Data Portal",
     "recid": "6725",
-    "run_period": [
-      "Run2012B",
-      "Run2012C"
-    ],
     "title": "High-Level Trigger path information HLT_PADimuon0_NoVertexing (PAPhysics dataset)",
     "type": {
       "primary": "Supplementaries",
@@ -18421,10 +14213,6 @@
     "collections": [
       "CMS-Trigger-Information"
     ],
-    "collision_information": {
-      "energy": "8TeV",
-      "type": "pp"
-    },
     "date_created": [
       "2012"
     ],
@@ -18432,10 +14220,6 @@
     "experiment": "CMS",
     "publisher": "CERN Open Data Portal",
     "recid": "6726",
-    "run_period": [
-      "Run2012B",
-      "Run2012C"
-    ],
     "title": "High-Level Trigger path information HLT_PADoubleJet20_ForwardBackward (PAPhysics dataset)",
     "type": {
       "primary": "Supplementaries",
@@ -18456,10 +14240,6 @@
     "collections": [
       "CMS-Trigger-Information"
     ],
-    "collision_information": {
-      "energy": "8TeV",
-      "type": "pp"
-    },
     "date_created": [
       "2012"
     ],
@@ -18467,10 +14247,6 @@
     "experiment": "CMS",
     "publisher": "CERN Open Data Portal",
     "recid": "6727",
-    "run_period": [
-      "Run2012B",
-      "Run2012C"
-    ],
     "title": "High-Level Trigger path information HLT_PADoubleMu4_Acoplanarity03 (PAPhysics dataset)",
     "type": {
       "primary": "Supplementaries",
@@ -18491,10 +14267,6 @@
     "collections": [
       "CMS-Trigger-Information"
     ],
-    "collision_information": {
-      "energy": "8TeV",
-      "type": "pp"
-    },
     "date_created": [
       "2012"
     ],
@@ -18502,10 +14274,6 @@
     "experiment": "CMS",
     "publisher": "CERN Open Data Portal",
     "recid": "6728",
-    "run_period": [
-      "Run2012B",
-      "Run2012C"
-    ],
     "title": "High-Level Trigger path information HLT_PAExclDijet35_HFAND (PAPhysics dataset)",
     "type": {
       "primary": "Supplementaries",
@@ -18526,10 +14294,6 @@
     "collections": [
       "CMS-Trigger-Information"
     ],
-    "collision_information": {
-      "energy": "8TeV",
-      "type": "pp"
-    },
     "date_created": [
       "2012"
     ],
@@ -18537,10 +14301,6 @@
     "experiment": "CMS",
     "publisher": "CERN Open Data Portal",
     "recid": "6729",
-    "run_period": [
-      "Run2012B",
-      "Run2012C"
-    ],
     "title": "High-Level Trigger path information HLT_PAHFOR_SingleTrack (PAPhysics dataset)",
     "type": {
       "primary": "Supplementaries",
@@ -18561,10 +14321,6 @@
     "collections": [
       "CMS-Trigger-Information"
     ],
-    "collision_information": {
-      "energy": "8TeV",
-      "type": "pp"
-    },
     "date_created": [
       "2012"
     ],
@@ -18572,10 +14328,6 @@
     "experiment": "CMS",
     "publisher": "CERN Open Data Portal",
     "recid": "6730",
-    "run_period": [
-      "Run2012B",
-      "Run2012C"
-    ],
     "title": "High-Level Trigger path information HLT_PAL1DoubleEG3_FwdVeto (PAPhysics dataset)",
     "type": {
       "primary": "Supplementaries",
@@ -18596,10 +14348,6 @@
     "collections": [
       "CMS-Trigger-Information"
     ],
-    "collision_information": {
-      "energy": "8TeV",
-      "type": "pp"
-    },
     "date_created": [
       "2012"
     ],
@@ -18607,10 +14355,6 @@
     "experiment": "CMS",
     "publisher": "CERN Open Data Portal",
     "recid": "6731",
-    "run_period": [
-      "Run2012B",
-      "Run2012C"
-    ],
     "title": "High-Level Trigger path information HLT_PAL1DoubleJet20_RomanPotsOR (PAPhysics dataset)",
     "type": {
       "primary": "Supplementaries",
@@ -18631,10 +14375,6 @@
     "collections": [
       "CMS-Trigger-Information"
     ],
-    "collision_information": {
-      "energy": "8TeV",
-      "type": "pp"
-    },
     "date_created": [
       "2012"
     ],
@@ -18642,10 +14382,6 @@
     "experiment": "CMS",
     "publisher": "CERN Open Data Portal",
     "recid": "6732",
-    "run_period": [
-      "Run2012B",
-      "Run2012C"
-    ],
     "title": "High-Level Trigger path information HLT_PAL1DoubleMu0 (PAPhysics dataset)",
     "type": {
       "primary": "Supplementaries",
@@ -18666,10 +14402,6 @@
     "collections": [
       "CMS-Trigger-Information"
     ],
-    "collision_information": {
-      "energy": "8TeV",
-      "type": "pp"
-    },
     "date_created": [
       "2012"
     ],
@@ -18677,10 +14409,6 @@
     "experiment": "CMS",
     "publisher": "CERN Open Data Portal",
     "recid": "6733",
-    "run_period": [
-      "Run2012B",
-      "Run2012C"
-    ],
     "title": "High-Level Trigger path information HLT_PAL1ETM30 (PAPhysics dataset)",
     "type": {
       "primary": "Supplementaries",
@@ -18701,10 +14429,6 @@
     "collections": [
       "CMS-Trigger-Information"
     ],
-    "collision_information": {
-      "energy": "8TeV",
-      "type": "pp"
-    },
     "date_created": [
       "2012"
     ],
@@ -18712,10 +14436,6 @@
     "experiment": "CMS",
     "publisher": "CERN Open Data Portal",
     "recid": "6734",
-    "run_period": [
-      "Run2012B",
-      "Run2012C"
-    ],
     "title": "High-Level Trigger path information HLT_PAL1ETM70 (PAPhysics dataset)",
     "type": {
       "primary": "Supplementaries",
@@ -18736,10 +14456,6 @@
     "collections": [
       "CMS-Trigger-Information"
     ],
-    "collision_information": {
-      "energy": "8TeV",
-      "type": "pp"
-    },
     "date_created": [
       "2012"
     ],
@@ -18747,10 +14463,6 @@
     "experiment": "CMS",
     "publisher": "CERN Open Data Portal",
     "recid": "6735",
-    "run_period": [
-      "Run2012B",
-      "Run2012C"
-    ],
     "title": "High-Level Trigger path information HLT_PAL1SingleEG12 (PAPhysics dataset)",
     "type": {
       "primary": "Supplementaries",
@@ -18771,10 +14483,6 @@
     "collections": [
       "CMS-Trigger-Information"
     ],
-    "collision_information": {
-      "energy": "8TeV",
-      "type": "pp"
-    },
     "date_created": [
       "2012"
     ],
@@ -18782,10 +14490,6 @@
     "experiment": "CMS",
     "publisher": "CERN Open Data Portal",
     "recid": "6736",
-    "run_period": [
-      "Run2012B",
-      "Run2012C"
-    ],
     "title": "High-Level Trigger path information HLT_PAL1SingleEG5 (PAPhysics dataset)",
     "type": {
       "primary": "Supplementaries",
@@ -18806,10 +14510,6 @@
     "collections": [
       "CMS-Trigger-Information"
     ],
-    "collision_information": {
-      "energy": "8TeV",
-      "type": "pp"
-    },
     "date_created": [
       "2012"
     ],
@@ -18817,10 +14517,6 @@
     "experiment": "CMS",
     "publisher": "CERN Open Data Portal",
     "recid": "6737",
-    "run_period": [
-      "Run2012B",
-      "Run2012C"
-    ],
     "title": "High-Level Trigger path information HLT_PAL1SingleEG7 (PAPhysics dataset)",
     "type": {
       "primary": "Supplementaries",
@@ -18841,10 +14537,6 @@
     "collections": [
       "CMS-Trigger-Information"
     ],
-    "collision_information": {
-      "energy": "8TeV",
-      "type": "pp"
-    },
     "date_created": [
       "2012"
     ],
@@ -18852,10 +14544,6 @@
     "experiment": "CMS",
     "publisher": "CERN Open Data Portal",
     "recid": "6738",
-    "run_period": [
-      "Run2012B",
-      "Run2012C"
-    ],
     "title": "High-Level Trigger path information HLT_PAL1SingleJet16 (PAPhysics dataset)",
     "type": {
       "primary": "Supplementaries",
@@ -18876,10 +14564,6 @@
     "collections": [
       "CMS-Trigger-Information"
     ],
-    "collision_information": {
-      "energy": "8TeV",
-      "type": "pp"
-    },
     "date_created": [
       "2012"
     ],
@@ -18887,10 +14571,6 @@
     "experiment": "CMS",
     "publisher": "CERN Open Data Portal",
     "recid": "6739",
-    "run_period": [
-      "Run2012B",
-      "Run2012C"
-    ],
     "title": "High-Level Trigger path information HLT_PAL1SingleJet36 (PAPhysics dataset)",
     "type": {
       "primary": "Supplementaries",
@@ -18911,10 +14591,6 @@
     "collections": [
       "CMS-Trigger-Information"
     ],
-    "collision_information": {
-      "energy": "8TeV",
-      "type": "pp"
-    },
     "date_created": [
       "2012"
     ],
@@ -18922,10 +14598,6 @@
     "experiment": "CMS",
     "publisher": "CERN Open Data Portal",
     "recid": "6740",
-    "run_period": [
-      "Run2012B",
-      "Run2012C"
-    ],
     "title": "High-Level Trigger path information HLT_PAL1SingleMu12 (PAPhysics dataset)",
     "type": {
       "primary": "Supplementaries",
@@ -18946,10 +14618,6 @@
     "collections": [
       "CMS-Trigger-Information"
     ],
-    "collision_information": {
-      "energy": "8TeV",
-      "type": "pp"
-    },
     "date_created": [
       "2012"
     ],
@@ -18957,10 +14625,6 @@
     "experiment": "CMS",
     "publisher": "CERN Open Data Portal",
     "recid": "6741",
-    "run_period": [
-      "Run2012B",
-      "Run2012C"
-    ],
     "title": "High-Level Trigger path information HLT_PAL1SingleMu3 (PAPhysics dataset)",
     "type": {
       "primary": "Supplementaries",
@@ -18981,10 +14645,6 @@
     "collections": [
       "CMS-Trigger-Information"
     ],
-    "collision_information": {
-      "energy": "8TeV",
-      "type": "pp"
-    },
     "date_created": [
       "2012"
     ],
@@ -18992,10 +14652,6 @@
     "experiment": "CMS",
     "publisher": "CERN Open Data Portal",
     "recid": "6742",
-    "run_period": [
-      "Run2012B",
-      "Run2012C"
-    ],
     "title": "High-Level Trigger path information HLT_PAL1SingleMu7 (PAPhysics dataset)",
     "type": {
       "primary": "Supplementaries",
@@ -19016,10 +14672,6 @@
     "collections": [
       "CMS-Trigger-Information"
     ],
-    "collision_information": {
-      "energy": "8TeV",
-      "type": "pp"
-    },
     "date_created": [
       "2012"
     ],
@@ -19027,10 +14679,6 @@
     "experiment": "CMS",
     "publisher": "CERN Open Data Portal",
     "recid": "6743",
-    "run_period": [
-      "Run2012B",
-      "Run2012C"
-    ],
     "title": "High-Level Trigger path information HLT_PAL1SingleMuOpen (PAPhysics dataset)",
     "type": {
       "primary": "Supplementaries",
@@ -19051,10 +14699,6 @@
     "collections": [
       "CMS-Trigger-Information"
     ],
-    "collision_information": {
-      "energy": "8TeV",
-      "type": "pp"
-    },
     "date_created": [
       "2012"
     ],
@@ -19062,10 +14706,6 @@
     "experiment": "CMS",
     "publisher": "CERN Open Data Portal",
     "recid": "6744",
-    "run_period": [
-      "Run2012B",
-      "Run2012C"
-    ],
     "title": "High-Level Trigger path information HLT_PAL1Tech53_MB (PAPhysics dataset)",
     "type": {
       "primary": "Supplementaries",
@@ -19086,10 +14726,6 @@
     "collections": [
       "CMS-Trigger-Information"
     ],
-    "collision_information": {
-      "energy": "8TeV",
-      "type": "pp"
-    },
     "date_created": [
       "2012"
     ],
@@ -19097,10 +14733,6 @@
     "experiment": "CMS",
     "publisher": "CERN Open Data Portal",
     "recid": "6745",
-    "run_period": [
-      "Run2012B",
-      "Run2012C"
-    ],
     "title": "High-Level Trigger path information HLT_PAL1Tech53_MB_SingleTrack (PAPhysics dataset)",
     "type": {
       "primary": "Supplementaries",
@@ -19121,10 +14753,6 @@
     "collections": [
       "CMS-Trigger-Information"
     ],
-    "collision_information": {
-      "energy": "8TeV",
-      "type": "pp"
-    },
     "date_created": [
       "2012"
     ],
@@ -19132,10 +14760,6 @@
     "experiment": "CMS",
     "publisher": "CERN Open Data Portal",
     "recid": "6746",
-    "run_period": [
-      "Run2012B",
-      "Run2012C"
-    ],
     "title": "High-Level Trigger path information HLT_PAL1Tech54_ZeroBias (PAZeroBias2 dataset)",
     "type": {
       "primary": "Supplementaries",
@@ -19156,10 +14780,6 @@
     "collections": [
       "CMS-Trigger-Information"
     ],
-    "collision_information": {
-      "energy": "8TeV",
-      "type": "pp"
-    },
     "date_created": [
       "2012"
     ],
@@ -19167,10 +14787,6 @@
     "experiment": "CMS",
     "publisher": "CERN Open Data Portal",
     "recid": "6747",
-    "run_period": [
-      "Run2012B",
-      "Run2012C"
-    ],
     "title": "High-Level Trigger path information HLT_PAL1Tech_HBHEHO_totalOR (PAPhysics dataset)",
     "type": {
       "primary": "Supplementaries",
@@ -19191,10 +14807,6 @@
     "collections": [
       "CMS-Trigger-Information"
     ],
-    "collision_information": {
-      "energy": "8TeV",
-      "type": "pp"
-    },
     "date_created": [
       "2012"
     ],
@@ -19202,10 +14814,6 @@
     "experiment": "CMS",
     "publisher": "CERN Open Data Portal",
     "recid": "6748",
-    "run_period": [
-      "Run2012B",
-      "Run2012C"
-    ],
     "title": "High-Level Trigger path information HLT_PAMinBiasBSC (PAPhysics dataset)",
     "type": {
       "primary": "Supplementaries",
@@ -19226,10 +14834,6 @@
     "collections": [
       "CMS-Trigger-Information"
     ],
-    "collision_information": {
-      "energy": "8TeV",
-      "type": "pp"
-    },
     "date_created": [
       "2012"
     ],
@@ -19237,10 +14841,6 @@
     "experiment": "CMS",
     "publisher": "CERN Open Data Portal",
     "recid": "6749",
-    "run_period": [
-      "Run2012B",
-      "Run2012C"
-    ],
     "title": "High-Level Trigger path information HLT_PAMinBiasBSC_OR (PAPhysics dataset)",
     "type": {
       "primary": "Supplementaries",
@@ -19261,10 +14861,6 @@
     "collections": [
       "CMS-Trigger-Information"
     ],
-    "collision_information": {
-      "energy": "8TeV",
-      "type": "pp"
-    },
     "date_created": [
       "2012"
     ],
@@ -19272,10 +14868,6 @@
     "experiment": "CMS",
     "publisher": "CERN Open Data Portal",
     "recid": "6750",
-    "run_period": [
-      "Run2012B",
-      "Run2012C"
-    ],
     "title": "High-Level Trigger path information HLT_PAMinBiasHF (PAPhysics dataset)",
     "type": {
       "primary": "Supplementaries",
@@ -19296,10 +14888,6 @@
     "collections": [
       "CMS-Trigger-Information"
     ],
-    "collision_information": {
-      "energy": "8TeV",
-      "type": "pp"
-    },
     "date_created": [
       "2012"
     ],
@@ -19307,10 +14895,6 @@
     "experiment": "CMS",
     "publisher": "CERN Open Data Portal",
     "recid": "6751",
-    "run_period": [
-      "Run2012B",
-      "Run2012C"
-    ],
     "title": "High-Level Trigger path information HLT_PAMinBiasHF_OR (PAPhysics dataset)",
     "type": {
       "primary": "Supplementaries",
@@ -19331,10 +14915,6 @@
     "collections": [
       "CMS-Trigger-Information"
     ],
-    "collision_information": {
-      "energy": "8TeV",
-      "type": "pp"
-    },
     "date_created": [
       "2012"
     ],
@@ -19342,10 +14922,6 @@
     "experiment": "CMS",
     "publisher": "CERN Open Data Portal",
     "recid": "6752",
-    "run_period": [
-      "Run2012B",
-      "Run2012C"
-    ],
     "title": "High-Level Trigger path information HLT_PAMinBiasHfOrBSC (PAPhysics dataset)",
     "type": {
       "primary": "Supplementaries",
@@ -19366,10 +14942,6 @@
     "collections": [
       "CMS-Trigger-Information"
     ],
-    "collision_information": {
-      "energy": "8TeV",
-      "type": "pp"
-    },
     "date_created": [
       "2012"
     ],
@@ -19377,10 +14949,6 @@
     "experiment": "CMS",
     "publisher": "CERN Open Data Portal",
     "recid": "6753",
-    "run_period": [
-      "Run2012B",
-      "Run2012C"
-    ],
     "title": "High-Level Trigger path information HLT_PAMu5 (PAPhysics dataset)",
     "type": {
       "primary": "Supplementaries",
@@ -19401,10 +14969,6 @@
     "collections": [
       "CMS-Trigger-Information"
     ],
-    "collision_information": {
-      "energy": "8TeV",
-      "type": "pp"
-    },
     "date_created": [
       "2012"
     ],
@@ -19412,10 +14976,6 @@
     "experiment": "CMS",
     "publisher": "CERN Open Data Portal",
     "recid": "6754",
-    "run_period": [
-      "Run2012B",
-      "Run2012C"
-    ],
     "title": "High-Level Trigger path information HLT_PAMu8 (PAPhysics dataset)",
     "type": {
       "primary": "Supplementaries",
@@ -19436,10 +14996,6 @@
     "collections": [
       "CMS-Trigger-Information"
     ],
-    "collision_information": {
-      "energy": "8TeV",
-      "type": "pp"
-    },
     "date_created": [
       "2012"
     ],
@@ -19447,10 +15003,6 @@
     "experiment": "CMS",
     "publisher": "CERN Open Data Portal",
     "recid": "6755",
-    "run_period": [
-      "Run2012B",
-      "Run2012C"
-    ],
     "title": "High-Level Trigger path information HLT_PAPhoton10_CaloIdVL (PAPhysics dataset)",
     "type": {
       "primary": "Supplementaries",
@@ -19471,10 +15023,6 @@
     "collections": [
       "CMS-Trigger-Information"
     ],
-    "collision_information": {
-      "energy": "8TeV",
-      "type": "pp"
-    },
     "date_created": [
       "2012"
     ],
@@ -19482,10 +15030,6 @@
     "experiment": "CMS",
     "publisher": "CERN Open Data Portal",
     "recid": "6756",
-    "run_period": [
-      "Run2012B",
-      "Run2012C"
-    ],
     "title": "High-Level Trigger path information HLT_PAPhoton15_CaloIdVL (PAPhysics dataset)",
     "type": {
       "primary": "Supplementaries",
@@ -19506,10 +15050,6 @@
     "collections": [
       "CMS-Trigger-Information"
     ],
-    "collision_information": {
-      "energy": "8TeV",
-      "type": "pp"
-    },
     "date_created": [
       "2012"
     ],
@@ -19517,10 +15057,6 @@
     "experiment": "CMS",
     "publisher": "CERN Open Data Portal",
     "recid": "6757",
-    "run_period": [
-      "Run2012B",
-      "Run2012C"
-    ],
     "title": "High-Level Trigger path information HLT_PAPhoton20_CaloIdVL (PAPhysics dataset)",
     "type": {
       "primary": "Supplementaries",
@@ -19541,10 +15077,6 @@
     "collections": [
       "CMS-Trigger-Information"
     ],
-    "collision_information": {
-      "energy": "8TeV",
-      "type": "pp"
-    },
     "date_created": [
       "2012"
     ],
@@ -19552,10 +15084,6 @@
     "experiment": "CMS",
     "publisher": "CERN Open Data Portal",
     "recid": "6758",
-    "run_period": [
-      "Run2012B",
-      "Run2012C"
-    ],
     "title": "High-Level Trigger path information HLT_PAPhoton30_CaloIdVL (PAPhysics dataset)",
     "type": {
       "primary": "Supplementaries",
@@ -19576,10 +15104,6 @@
     "collections": [
       "CMS-Trigger-Information"
     ],
-    "collision_information": {
-      "energy": "8TeV",
-      "type": "pp"
-    },
     "date_created": [
       "2012"
     ],
@@ -19587,10 +15111,6 @@
     "experiment": "CMS",
     "publisher": "CERN Open Data Portal",
     "recid": "6759",
-    "run_period": [
-      "Run2012B",
-      "Run2012C"
-    ],
     "title": "High-Level Trigger path information HLT_PAPixelTracks_Multiplicity70 (PAPhysics dataset)",
     "type": {
       "primary": "Supplementaries",
@@ -19611,10 +15131,6 @@
     "collections": [
       "CMS-Trigger-Information"
     ],
-    "collision_information": {
-      "energy": "8TeV",
-      "type": "pp"
-    },
     "date_created": [
       "2012"
     ],
@@ -19622,10 +15138,6 @@
     "experiment": "CMS",
     "publisher": "CERN Open Data Portal",
     "recid": "6760",
-    "run_period": [
-      "Run2012B",
-      "Run2012C"
-    ],
     "title": "High-Level Trigger path information HLT_PAPixelTracks_Multiplicity90 (PAPhysics dataset)",
     "type": {
       "primary": "Supplementaries",
@@ -19646,10 +15158,6 @@
     "collections": [
       "CMS-Trigger-Information"
     ],
-    "collision_information": {
-      "energy": "8TeV",
-      "type": "pp"
-    },
     "date_created": [
       "2012"
     ],
@@ -19657,10 +15165,6 @@
     "experiment": "CMS",
     "publisher": "CERN Open Data Portal",
     "recid": "6761",
-    "run_period": [
-      "Run2012B",
-      "Run2012C"
-    ],
     "title": "High-Level Trigger path information HLT_PARandom (PAPhysics, PAZeroBias1, PAZeroBias2 datasets)",
     "type": {
       "primary": "Supplementaries",
@@ -19681,10 +15185,6 @@
     "collections": [
       "CMS-Trigger-Information"
     ],
-    "collision_information": {
-      "energy": "8TeV",
-      "type": "pp"
-    },
     "date_created": [
       "2012"
     ],
@@ -19692,10 +15192,6 @@
     "experiment": "CMS",
     "publisher": "CERN Open Data Portal",
     "recid": "6762",
-    "run_period": [
-      "Run2012B",
-      "Run2012C"
-    ],
     "title": "High-Level Trigger path information HLT_PARomanPots_Tech52 (PAPhysics dataset)",
     "type": {
       "primary": "Supplementaries",
@@ -19716,10 +15212,6 @@
     "collections": [
       "CMS-Trigger-Information"
     ],
-    "collision_information": {
-      "energy": "8TeV",
-      "type": "pp"
-    },
     "date_created": [
       "2012"
     ],
@@ -19727,10 +15219,6 @@
     "experiment": "CMS",
     "publisher": "CERN Open Data Portal",
     "recid": "6763",
-    "run_period": [
-      "Run2012B",
-      "Run2012C"
-    ],
     "title": "High-Level Trigger path information HLT_PASingleForJet15 (JetMon, PAPhysics datasets)",
     "type": {
       "primary": "Supplementaries",
@@ -19751,10 +15239,6 @@
     "collections": [
       "CMS-Trigger-Information"
     ],
-    "collision_information": {
-      "energy": "8TeV",
-      "type": "pp"
-    },
     "date_created": [
       "2012"
     ],
@@ -19762,10 +15246,6 @@
     "experiment": "CMS",
     "publisher": "CERN Open Data Portal",
     "recid": "6764",
-    "run_period": [
-      "Run2012B",
-      "Run2012C"
-    ],
     "title": "High-Level Trigger path information HLT_PASingleForJet25 (JetMon, PAPhysics datasets)",
     "type": {
       "primary": "Supplementaries",
@@ -19786,10 +15266,6 @@
     "collections": [
       "CMS-Trigger-Information"
     ],
-    "collision_information": {
-      "energy": "8TeV",
-      "type": "pp"
-    },
     "date_created": [
       "2012"
     ],
@@ -19797,10 +15273,6 @@
     "experiment": "CMS",
     "publisher": "CERN Open Data Portal",
     "recid": "6765",
-    "run_period": [
-      "Run2012B",
-      "Run2012C"
-    ],
     "title": "High-Level Trigger path information HLT_PAT1minbias_Tech55 (PAPhysics dataset)",
     "type": {
       "primary": "Supplementaries",
@@ -19821,10 +15293,6 @@
     "collections": [
       "CMS-Trigger-Information"
     ],
-    "collision_information": {
-      "energy": "8TeV",
-      "type": "pp"
-    },
     "date_created": [
       "2012"
     ],
@@ -19832,10 +15300,6 @@
     "experiment": "CMS",
     "publisher": "CERN Open Data Portal",
     "recid": "6766",
-    "run_period": [
-      "Run2012B",
-      "Run2012C"
-    ],
     "title": "High-Level Trigger path information HLT_PAZeroBias (PAZeroBias1 dataset)",
     "type": {
       "primary": "Supplementaries",
@@ -19856,10 +15320,6 @@
     "collections": [
       "CMS-Trigger-Information"
     ],
-    "collision_information": {
-      "energy": "8TeV",
-      "type": "pp"
-    },
     "date_created": [
       "2012"
     ],
@@ -19867,10 +15327,6 @@
     "experiment": "CMS",
     "publisher": "CERN Open Data Portal",
     "recid": "6767",
-    "run_period": [
-      "Run2012B",
-      "Run2012C"
-    ],
     "title": "High-Level Trigger path information HLT_PAZeroBiasPixel_DoubleTrack (PAPhysics dataset)",
     "type": {
       "primary": "Supplementaries",
@@ -19891,10 +15347,6 @@
     "collections": [
       "CMS-Trigger-Information"
     ],
-    "collision_information": {
-      "energy": "8TeV",
-      "type": "pp"
-    },
     "date_created": [
       "2012"
     ],
@@ -19902,10 +15354,6 @@
     "experiment": "CMS",
     "publisher": "CERN Open Data Portal",
     "recid": "6768",
-    "run_period": [
-      "Run2012B",
-      "Run2012C"
-    ],
     "title": "High-Level Trigger path information HLT_PAZeroBiasPixel_SingleTrack (PAPhysics dataset)",
     "type": {
       "primary": "Supplementaries",
@@ -19926,10 +15374,6 @@
     "collections": [
       "CMS-Trigger-Information"
     ],
-    "collision_information": {
-      "energy": "8TeV",
-      "type": "pp"
-    },
     "date_created": [
       "2012"
     ],
@@ -19937,10 +15381,6 @@
     "experiment": "CMS",
     "publisher": "CERN Open Data Portal",
     "recid": "6769",
-    "run_period": [
-      "Run2012B",
-      "Run2012C"
-    ],
     "title": "High-Level Trigger path information HLT_PAak5CaloJet20_NoJetID (PAPhysics dataset)",
     "type": {
       "primary": "Supplementaries",
@@ -19961,10 +15401,6 @@
     "collections": [
       "CMS-Trigger-Information"
     ],
-    "collision_information": {
-      "energy": "8TeV",
-      "type": "pp"
-    },
     "date_created": [
       "2012"
     ],
@@ -19972,10 +15408,6 @@
     "experiment": "CMS",
     "publisher": "CERN Open Data Portal",
     "recid": "6770",
-    "run_period": [
-      "Run2012B",
-      "Run2012C"
-    ],
     "title": "High-Level Trigger path information HLT_PAak5CaloJet40_NoJetID (PAPhysics dataset)",
     "type": {
       "primary": "Supplementaries",
@@ -19996,10 +15428,6 @@
     "collections": [
       "CMS-Trigger-Information"
     ],
-    "collision_information": {
-      "energy": "8TeV",
-      "type": "pp"
-    },
     "date_created": [
       "2012"
     ],
@@ -20007,10 +15435,6 @@
     "experiment": "CMS",
     "publisher": "CERN Open Data Portal",
     "recid": "6771",
-    "run_period": [
-      "Run2012B",
-      "Run2012C"
-    ],
     "title": "High-Level Trigger path information HLT_PAak5CaloJet60_NoJetID (PAPhysics dataset)",
     "type": {
       "primary": "Supplementaries",
@@ -20031,10 +15455,6 @@
     "collections": [
       "CMS-Trigger-Information"
     ],
-    "collision_information": {
-      "energy": "8TeV",
-      "type": "pp"
-    },
     "date_created": [
       "2012"
     ],
@@ -20042,10 +15462,6 @@
     "experiment": "CMS",
     "publisher": "CERN Open Data Portal",
     "recid": "6772",
-    "run_period": [
-      "Run2012B",
-      "Run2012C"
-    ],
     "title": "High-Level Trigger path information HLT_PFHT350 (HT, JetHT datasets)",
     "type": {
       "primary": "Supplementaries",
@@ -20066,10 +15482,6 @@
     "collections": [
       "CMS-Trigger-Information"
     ],
-    "collision_information": {
-      "energy": "8TeV",
-      "type": "pp"
-    },
     "date_created": [
       "2012"
     ],
@@ -20077,10 +15489,6 @@
     "experiment": "CMS",
     "publisher": "CERN Open Data Portal",
     "recid": "6773",
-    "run_period": [
-      "Run2012B",
-      "Run2012C"
-    ],
     "title": "High-Level Trigger path information HLT_PFHT350_Mu15_PFMET45 (MuHad dataset)",
     "type": {
       "primary": "Supplementaries",
@@ -20101,10 +15509,6 @@
     "collections": [
       "CMS-Trigger-Information"
     ],
-    "collision_information": {
-      "energy": "8TeV",
-      "type": "pp"
-    },
     "date_created": [
       "2012"
     ],
@@ -20112,10 +15516,6 @@
     "experiment": "CMS",
     "publisher": "CERN Open Data Portal",
     "recid": "6774",
-    "run_period": [
-      "Run2012B",
-      "Run2012C"
-    ],
     "title": "High-Level Trigger path information HLT_PFHT350_Mu15_PFMET50 (MuHad dataset)",
     "type": {
       "primary": "Supplementaries",
@@ -20136,10 +15536,6 @@
     "collections": [
       "CMS-Trigger-Information"
     ],
-    "collision_information": {
-      "energy": "8TeV",
-      "type": "pp"
-    },
     "date_created": [
       "2012"
     ],
@@ -20147,10 +15543,6 @@
     "experiment": "CMS",
     "publisher": "CERN Open Data Portal",
     "recid": "6775",
-    "run_period": [
-      "Run2012B",
-      "Run2012C"
-    ],
     "title": "High-Level Trigger path information HLT_PFHT350_PFMET100 (HT, HTMHT, HTMHTParked datasets)",
     "type": {
       "primary": "Supplementaries",
@@ -20171,10 +15563,6 @@
     "collections": [
       "CMS-Trigger-Information"
     ],
-    "collision_information": {
-      "energy": "8TeV",
-      "type": "pp"
-    },
     "date_created": [
       "2012"
     ],
@@ -20182,10 +15570,6 @@
     "experiment": "CMS",
     "publisher": "CERN Open Data Portal",
     "recid": "6776",
-    "run_period": [
-      "Run2012B",
-      "Run2012C"
-    ],
     "title": "High-Level Trigger path information HLT_PFHT400_Mu5_PFMET45 (MuHad dataset)",
     "type": {
       "primary": "Supplementaries",
@@ -20206,10 +15590,6 @@
     "collections": [
       "CMS-Trigger-Information"
     ],
-    "collision_information": {
-      "energy": "8TeV",
-      "type": "pp"
-    },
     "date_created": [
       "2012"
     ],
@@ -20217,10 +15597,6 @@
     "experiment": "CMS",
     "publisher": "CERN Open Data Portal",
     "recid": "6777",
-    "run_period": [
-      "Run2012B",
-      "Run2012C"
-    ],
     "title": "High-Level Trigger path information HLT_PFHT400_Mu5_PFMET50 (MuHad dataset)",
     "type": {
       "primary": "Supplementaries",
@@ -20241,10 +15617,6 @@
     "collections": [
       "CMS-Trigger-Information"
     ],
-    "collision_information": {
-      "energy": "8TeV",
-      "type": "pp"
-    },
     "date_created": [
       "2012"
     ],
@@ -20252,10 +15624,6 @@
     "experiment": "CMS",
     "publisher": "CERN Open Data Portal",
     "recid": "6778",
-    "run_period": [
-      "Run2012B",
-      "Run2012C"
-    ],
     "title": "High-Level Trigger path information HLT_PFHT400_PFMET100 (HT, HTMHT, HTMHTParked datasets)",
     "type": {
       "primary": "Supplementaries",
@@ -20276,10 +15644,6 @@
     "collections": [
       "CMS-Trigger-Information"
     ],
-    "collision_information": {
-      "energy": "8TeV",
-      "type": "pp"
-    },
     "date_created": [
       "2012"
     ],
@@ -20287,10 +15651,6 @@
     "experiment": "CMS",
     "publisher": "CERN Open Data Portal",
     "recid": "6779",
-    "run_period": [
-      "Run2012B",
-      "Run2012C"
-    ],
     "title": "High-Level Trigger path information HLT_PFHT650 (HT, JetHT datasets)",
     "type": {
       "primary": "Supplementaries",
@@ -20311,10 +15671,6 @@
     "collections": [
       "CMS-Trigger-Information"
     ],
-    "collision_information": {
-      "energy": "8TeV",
-      "type": "pp"
-    },
     "date_created": [
       "2012"
     ],
@@ -20322,10 +15678,6 @@
     "experiment": "CMS",
     "publisher": "CERN Open Data Portal",
     "recid": "6780",
-    "run_period": [
-      "Run2012B",
-      "Run2012C"
-    ],
     "title": "High-Level Trigger path information HLT_PFHT650_DiCentralPFJet80_CenPFJet40 (HT, JetHT datasets)",
     "type": {
       "primary": "Supplementaries",
@@ -20346,10 +15698,6 @@
     "collections": [
       "CMS-Trigger-Information"
     ],
-    "collision_information": {
-      "energy": "8TeV",
-      "type": "pp"
-    },
     "date_created": [
       "2012"
     ],
@@ -20357,10 +15705,6 @@
     "experiment": "CMS",
     "publisher": "CERN Open Data Portal",
     "recid": "6781",
-    "run_period": [
-      "Run2012B",
-      "Run2012C"
-    ],
     "title": "High-Level Trigger path information HLT_PFHT700 (HT, JetHT datasets)",
     "type": {
       "primary": "Supplementaries",
@@ -20381,10 +15725,6 @@
     "collections": [
       "CMS-Trigger-Information"
     ],
-    "collision_information": {
-      "energy": "8TeV",
-      "type": "pp"
-    },
     "date_created": [
       "2012"
     ],
@@ -20392,10 +15732,6 @@
     "experiment": "CMS",
     "publisher": "CERN Open Data Portal",
     "recid": "6782",
-    "run_period": [
-      "Run2012B",
-      "Run2012C"
-    ],
     "title": "High-Level Trigger path information HLT_PFHT750 (HT, JetHT datasets)",
     "type": {
       "primary": "Supplementaries",
@@ -20416,10 +15752,6 @@
     "collections": [
       "CMS-Trigger-Information"
     ],
-    "collision_information": {
-      "energy": "8TeV",
-      "type": "pp"
-    },
     "date_created": [
       "2012"
     ],
@@ -20427,10 +15759,6 @@
     "experiment": "CMS",
     "publisher": "CERN Open Data Portal",
     "recid": "6783",
-    "run_period": [
-      "Run2012B",
-      "Run2012C"
-    ],
     "title": "High-Level Trigger path information HLT_PFJet140 (Jet, JetMon datasets)",
     "type": {
       "primary": "Supplementaries",
@@ -20451,10 +15779,6 @@
     "collections": [
       "CMS-Trigger-Information"
     ],
-    "collision_information": {
-      "energy": "8TeV",
-      "type": "pp"
-    },
     "date_created": [
       "2012"
     ],
@@ -20462,10 +15786,6 @@
     "experiment": "CMS",
     "publisher": "CERN Open Data Portal",
     "recid": "6784",
-    "run_period": [
-      "Run2012B",
-      "Run2012C"
-    ],
     "title": "High-Level Trigger path information HLT_PFJet200 (Jet, JetMon datasets)",
     "type": {
       "primary": "Supplementaries",
@@ -20486,10 +15806,6 @@
     "collections": [
       "CMS-Trigger-Information"
     ],
-    "collision_information": {
-      "energy": "8TeV",
-      "type": "pp"
-    },
     "date_created": [
       "2012"
     ],
@@ -20497,10 +15813,6 @@
     "experiment": "CMS",
     "publisher": "CERN Open Data Portal",
     "recid": "6785",
-    "run_period": [
-      "Run2012B",
-      "Run2012C"
-    ],
     "title": "High-Level Trigger path information HLT_PFJet260 (Jet, JetMon datasets)",
     "type": {
       "primary": "Supplementaries",
@@ -20521,10 +15833,6 @@
     "collections": [
       "CMS-Trigger-Information"
     ],
-    "collision_information": {
-      "energy": "8TeV",
-      "type": "pp"
-    },
     "date_created": [
       "2012"
     ],
@@ -20532,10 +15840,6 @@
     "experiment": "CMS",
     "publisher": "CERN Open Data Portal",
     "recid": "6786",
-    "run_period": [
-      "Run2012B",
-      "Run2012C"
-    ],
     "title": "High-Level Trigger path information HLT_PFJet320 (Jet, JetHT datasets)",
     "type": {
       "primary": "Supplementaries",
@@ -20556,10 +15860,6 @@
     "collections": [
       "CMS-Trigger-Information"
     ],
-    "collision_information": {
-      "energy": "8TeV",
-      "type": "pp"
-    },
     "date_created": [
       "2012"
     ],
@@ -20567,10 +15867,6 @@
     "experiment": "CMS",
     "publisher": "CERN Open Data Portal",
     "recid": "6787",
-    "run_period": [
-      "Run2012B",
-      "Run2012C"
-    ],
     "title": "High-Level Trigger path information HLT_PFJet40 (Jet, JetMon datasets)",
     "type": {
       "primary": "Supplementaries",
@@ -20591,10 +15887,6 @@
     "collections": [
       "CMS-Trigger-Information"
     ],
-    "collision_information": {
-      "energy": "8TeV",
-      "type": "pp"
-    },
     "date_created": [
       "2012"
     ],
@@ -20602,10 +15894,6 @@
     "experiment": "CMS",
     "publisher": "CERN Open Data Portal",
     "recid": "6788",
-    "run_period": [
-      "Run2012B",
-      "Run2012C"
-    ],
     "title": "High-Level Trigger path information HLT_PFJet400 (Jet, JetHT datasets)",
     "type": {
       "primary": "Supplementaries",
@@ -20626,10 +15914,6 @@
     "collections": [
       "CMS-Trigger-Information"
     ],
-    "collision_information": {
-      "energy": "8TeV",
-      "type": "pp"
-    },
     "date_created": [
       "2012"
     ],
@@ -20637,10 +15921,6 @@
     "experiment": "CMS",
     "publisher": "CERN Open Data Portal",
     "recid": "6789",
-    "run_period": [
-      "Run2012B",
-      "Run2012C"
-    ],
     "title": "High-Level Trigger path information HLT_PFJet80 (Jet, JetMon datasets)",
     "type": {
       "primary": "Supplementaries",
@@ -20661,10 +15941,6 @@
     "collections": [
       "CMS-Trigger-Information"
     ],
-    "collision_information": {
-      "energy": "8TeV",
-      "type": "pp"
-    },
     "date_created": [
       "2012"
     ],
@@ -20672,10 +15948,6 @@
     "experiment": "CMS",
     "publisher": "CERN Open Data Portal",
     "recid": "6790",
-    "run_period": [
-      "Run2012B",
-      "Run2012C"
-    ],
     "title": "High-Level Trigger path information HLT_PFMET150 (MET dataset)",
     "type": {
       "primary": "Supplementaries",
@@ -20696,10 +15968,6 @@
     "collections": [
       "CMS-Trigger-Information"
     ],
-    "collision_information": {
-      "energy": "8TeV",
-      "type": "pp"
-    },
     "date_created": [
       "2012"
     ],
@@ -20707,10 +15975,6 @@
     "experiment": "CMS",
     "publisher": "CERN Open Data Portal",
     "recid": "6791",
-    "run_period": [
-      "Run2012B",
-      "Run2012C"
-    ],
     "title": "High-Level Trigger path information HLT_PFMET180 (MET dataset)",
     "type": {
       "primary": "Supplementaries",
@@ -20731,10 +15995,6 @@
     "collections": [
       "CMS-Trigger-Information"
     ],
-    "collision_information": {
-      "energy": "8TeV",
-      "type": "pp"
-    },
     "date_created": [
       "2012"
     ],
@@ -20742,10 +16002,6 @@
     "experiment": "CMS",
     "publisher": "CERN Open Data Portal",
     "recid": "6792",
-    "run_period": [
-      "Run2012B",
-      "Run2012C"
-    ],
     "title": "High-Level Trigger path information HLT_PFNoPUHT350 (JetHT dataset)",
     "type": {
       "primary": "Supplementaries",
@@ -20766,10 +16022,6 @@
     "collections": [
       "CMS-Trigger-Information"
     ],
-    "collision_information": {
-      "energy": "8TeV",
-      "type": "pp"
-    },
     "date_created": [
       "2012"
     ],
@@ -20777,10 +16029,6 @@
     "experiment": "CMS",
     "publisher": "CERN Open Data Portal",
     "recid": "6793",
-    "run_period": [
-      "Run2012B",
-      "Run2012C"
-    ],
     "title": "High-Level Trigger path information HLT_PFNoPUHT350_Mu15_PFMET45 (MuHad dataset)",
     "type": {
       "primary": "Supplementaries",
@@ -20801,10 +16049,6 @@
     "collections": [
       "CMS-Trigger-Information"
     ],
-    "collision_information": {
-      "energy": "8TeV",
-      "type": "pp"
-    },
     "date_created": [
       "2012"
     ],
@@ -20812,10 +16056,6 @@
     "experiment": "CMS",
     "publisher": "CERN Open Data Portal",
     "recid": "6794",
-    "run_period": [
-      "Run2012B",
-      "Run2012C"
-    ],
     "title": "High-Level Trigger path information HLT_PFNoPUHT350_Mu15_PFMET50 (MuHad dataset)",
     "type": {
       "primary": "Supplementaries",
@@ -20836,10 +16076,6 @@
     "collections": [
       "CMS-Trigger-Information"
     ],
-    "collision_information": {
-      "energy": "8TeV",
-      "type": "pp"
-    },
     "date_created": [
       "2012"
     ],
@@ -20847,10 +16083,6 @@
     "experiment": "CMS",
     "publisher": "CERN Open Data Portal",
     "recid": "6795",
-    "run_period": [
-      "Run2012B",
-      "Run2012C"
-    ],
     "title": "High-Level Trigger path information HLT_PFNoPUHT350_PFMET100 (HTMHT, HTMHTParked datasets)",
     "type": {
       "primary": "Supplementaries",
@@ -20871,10 +16103,6 @@
     "collections": [
       "CMS-Trigger-Information"
     ],
-    "collision_information": {
-      "energy": "8TeV",
-      "type": "pp"
-    },
     "date_created": [
       "2012"
     ],
@@ -20882,10 +16110,6 @@
     "experiment": "CMS",
     "publisher": "CERN Open Data Portal",
     "recid": "6796",
-    "run_period": [
-      "Run2012B",
-      "Run2012C"
-    ],
     "title": "High-Level Trigger path information HLT_PFNoPUHT400_Mu5_PFMET45 (MuHad dataset)",
     "type": {
       "primary": "Supplementaries",
@@ -20906,10 +16130,6 @@
     "collections": [
       "CMS-Trigger-Information"
     ],
-    "collision_information": {
-      "energy": "8TeV",
-      "type": "pp"
-    },
     "date_created": [
       "2012"
     ],
@@ -20917,10 +16137,6 @@
     "experiment": "CMS",
     "publisher": "CERN Open Data Portal",
     "recid": "6797",
-    "run_period": [
-      "Run2012B",
-      "Run2012C"
-    ],
     "title": "High-Level Trigger path information HLT_PFNoPUHT400_Mu5_PFMET50 (MuHad dataset)",
     "type": {
       "primary": "Supplementaries",
@@ -20941,10 +16157,6 @@
     "collections": [
       "CMS-Trigger-Information"
     ],
-    "collision_information": {
-      "energy": "8TeV",
-      "type": "pp"
-    },
     "date_created": [
       "2012"
     ],
@@ -20952,10 +16164,6 @@
     "experiment": "CMS",
     "publisher": "CERN Open Data Portal",
     "recid": "6798",
-    "run_period": [
-      "Run2012B",
-      "Run2012C"
-    ],
     "title": "High-Level Trigger path information HLT_PFNoPUHT400_PFMET100 (HTMHT, HTMHTParked datasets)",
     "type": {
       "primary": "Supplementaries",
@@ -20976,10 +16184,6 @@
     "collections": [
       "CMS-Trigger-Information"
     ],
-    "collision_information": {
-      "energy": "8TeV",
-      "type": "pp"
-    },
     "date_created": [
       "2012"
     ],
@@ -20987,10 +16191,6 @@
     "experiment": "CMS",
     "publisher": "CERN Open Data Portal",
     "recid": "6799",
-    "run_period": [
-      "Run2012B",
-      "Run2012C"
-    ],
     "title": "High-Level Trigger path information HLT_PFNoPUHT650 (JetHT dataset)",
     "type": {
       "primary": "Supplementaries",
@@ -21011,10 +16211,6 @@
     "collections": [
       "CMS-Trigger-Information"
     ],
-    "collision_information": {
-      "energy": "8TeV",
-      "type": "pp"
-    },
     "date_created": [
       "2012"
     ],
@@ -21022,10 +16218,6 @@
     "experiment": "CMS",
     "publisher": "CERN Open Data Portal",
     "recid": "6800",
-    "run_period": [
-      "Run2012B",
-      "Run2012C"
-    ],
     "title": "High-Level Trigger path information HLT_PFNoPUHT650_DiCentralPFNoPUJet80_CenPFNoPUJet40 (JetHT dataset)",
     "type": {
       "primary": "Supplementaries",
@@ -21046,10 +16238,6 @@
     "collections": [
       "CMS-Trigger-Information"
     ],
-    "collision_information": {
-      "energy": "8TeV",
-      "type": "pp"
-    },
     "date_created": [
       "2012"
     ],
@@ -21057,10 +16245,6 @@
     "experiment": "CMS",
     "publisher": "CERN Open Data Portal",
     "recid": "6801",
-    "run_period": [
-      "Run2012B",
-      "Run2012C"
-    ],
     "title": "High-Level Trigger path information HLT_PFNoPUHT700 (JetHT dataset)",
     "type": {
       "primary": "Supplementaries",
@@ -21081,10 +16265,6 @@
     "collections": [
       "CMS-Trigger-Information"
     ],
-    "collision_information": {
-      "energy": "8TeV",
-      "type": "pp"
-    },
     "date_created": [
       "2012"
     ],
@@ -21092,10 +16272,6 @@
     "experiment": "CMS",
     "publisher": "CERN Open Data Portal",
     "recid": "6802",
-    "run_period": [
-      "Run2012B",
-      "Run2012C"
-    ],
     "title": "High-Level Trigger path information HLT_PFNoPUHT750 (JetHT dataset)",
     "type": {
       "primary": "Supplementaries",
@@ -21116,10 +16292,6 @@
     "collections": [
       "CMS-Trigger-Information"
     ],
-    "collision_information": {
-      "energy": "8TeV",
-      "type": "pp"
-    },
     "date_created": [
       "2012"
     ],
@@ -21127,10 +16299,6 @@
     "experiment": "CMS",
     "publisher": "CERN Open Data Portal",
     "recid": "6803",
-    "run_period": [
-      "Run2012B",
-      "Run2012C"
-    ],
     "title": "High-Level Trigger path information HLT_Photon135 (Photon, SinglePhoton datasets)",
     "type": {
       "primary": "Supplementaries",
@@ -21151,10 +16319,6 @@
     "collections": [
       "CMS-Trigger-Information"
     ],
-    "collision_information": {
-      "energy": "8TeV",
-      "type": "pp"
-    },
     "date_created": [
       "2012"
     ],
@@ -21162,10 +16326,6 @@
     "experiment": "CMS",
     "publisher": "CERN Open Data Portal",
     "recid": "6804",
-    "run_period": [
-      "Run2012B",
-      "Run2012C"
-    ],
     "title": "High-Level Trigger path information HLT_Photon150 (Photon, SinglePhoton datasets)",
     "type": {
       "primary": "Supplementaries",
@@ -21186,10 +16346,6 @@
     "collections": [
       "CMS-Trigger-Information"
     ],
-    "collision_information": {
-      "energy": "8TeV",
-      "type": "pp"
-    },
     "date_created": [
       "2012"
     ],
@@ -21197,10 +16353,6 @@
     "experiment": "CMS",
     "publisher": "CERN Open Data Portal",
     "recid": "6805",
-    "run_period": [
-      "Run2012B",
-      "Run2012C"
-    ],
     "title": "High-Level Trigger path information HLT_Photon160 (Photon, SinglePhoton datasets)",
     "type": {
       "primary": "Supplementaries",
@@ -21221,10 +16373,6 @@
     "collections": [
       "CMS-Trigger-Information"
     ],
-    "collision_information": {
-      "energy": "8TeV",
-      "type": "pp"
-    },
     "date_created": [
       "2012"
     ],
@@ -21232,10 +16380,6 @@
     "experiment": "CMS",
     "publisher": "CERN Open Data Portal",
     "recid": "6806",
-    "run_period": [
-      "Run2012B",
-      "Run2012C"
-    ],
     "title": "High-Level Trigger path information HLT_Photon20_CaloIdVL (Photon, SinglePhoton datasets)",
     "type": {
       "primary": "Supplementaries",
@@ -21256,10 +16400,6 @@
     "collections": [
       "CMS-Trigger-Information"
     ],
-    "collision_information": {
-      "energy": "8TeV",
-      "type": "pp"
-    },
     "date_created": [
       "2012"
     ],
@@ -21267,10 +16407,6 @@
     "experiment": "CMS",
     "publisher": "CERN Open Data Portal",
     "recid": "6807",
-    "run_period": [
-      "Run2012B",
-      "Run2012C"
-    ],
     "title": "High-Level Trigger path information HLT_Photon20_CaloIdVL_IsoL (Photon, SinglePhoton datasets)",
     "type": {
       "primary": "Supplementaries",
@@ -21291,10 +16427,6 @@
     "collections": [
       "CMS-Trigger-Information"
     ],
-    "collision_information": {
-      "energy": "8TeV",
-      "type": "pp"
-    },
     "date_created": [
       "2012"
     ],
@@ -21302,10 +16434,6 @@
     "experiment": "CMS",
     "publisher": "CERN Open Data Portal",
     "recid": "6808",
-    "run_period": [
-      "Run2012B",
-      "Run2012C"
-    ],
     "title": "High-Level Trigger path information HLT_Photon22_R9Id90_HE10_Iso40_EBOnly (DoubleElectron dataset)",
     "type": {
       "primary": "Supplementaries",
@@ -21326,10 +16454,6 @@
     "collections": [
       "CMS-Trigger-Information"
     ],
-    "collision_information": {
-      "energy": "8TeV",
-      "type": "pp"
-    },
     "date_created": [
       "2012"
     ],
@@ -21337,10 +16461,6 @@
     "experiment": "CMS",
     "publisher": "CERN Open Data Portal",
     "recid": "6809",
-    "run_period": [
-      "Run2012B",
-      "Run2012C"
-    ],
     "title": "High-Level Trigger path information HLT_Photon250_NoHE (Photon dataset)",
     "type": {
       "primary": "Supplementaries",
@@ -21361,10 +16481,6 @@
     "collections": [
       "CMS-Trigger-Information"
     ],
-    "collision_information": {
-      "energy": "8TeV",
-      "type": "pp"
-    },
     "date_created": [
       "2012"
     ],
@@ -21372,10 +16488,6 @@
     "experiment": "CMS",
     "publisher": "CERN Open Data Portal",
     "recid": "6810",
-    "run_period": [
-      "Run2012B",
-      "Run2012C"
-    ],
     "title": "High-Level Trigger path information HLT_Photon26_CaloId10_Iso50_Photon18_CaloId10_Iso50_Mass60 (DoublePhoton, Photon datasets)",
     "type": {
       "primary": "Supplementaries",
@@ -21396,10 +16508,6 @@
     "collections": [
       "CMS-Trigger-Information"
     ],
-    "collision_information": {
-      "energy": "8TeV",
-      "type": "pp"
-    },
     "date_created": [
       "2012"
     ],
@@ -21407,10 +16515,6 @@
     "experiment": "CMS",
     "publisher": "CERN Open Data Portal",
     "recid": "6811",
-    "run_period": [
-      "Run2012B",
-      "Run2012C"
-    ],
     "title": "High-Level Trigger path information HLT_Photon26_CaloId10_Iso50_Photon18_R9Id85_Mass60 (DoublePhoton, Photon datasets)",
     "type": {
       "primary": "Supplementaries",
@@ -21431,10 +16535,6 @@
     "collections": [
       "CMS-Trigger-Information"
     ],
-    "collision_information": {
-      "energy": "8TeV",
-      "type": "pp"
-    },
     "date_created": [
       "2012"
     ],
@@ -21442,10 +16542,6 @@
     "experiment": "CMS",
     "publisher": "CERN Open Data Portal",
     "recid": "6812",
-    "run_period": [
-      "Run2012B",
-      "Run2012C"
-    ],
     "title": "High-Level Trigger path information HLT_Photon26_Photon18 (DoublePhoton, Photon datasets)",
     "type": {
       "primary": "Supplementaries",
@@ -21466,10 +16562,6 @@
     "collections": [
       "CMS-Trigger-Information"
     ],
-    "collision_information": {
-      "energy": "8TeV",
-      "type": "pp"
-    },
     "date_created": [
       "2012"
     ],
@@ -21477,10 +16569,6 @@
     "experiment": "CMS",
     "publisher": "CERN Open Data Portal",
     "recid": "6813",
-    "run_period": [
-      "Run2012B",
-      "Run2012C"
-    ],
     "title": "High-Level Trigger path information HLT_Photon26_R9Id85_OR_CaloId10_Iso50_Photon18 (DoublePhoton, Photon datasets)",
     "type": {
       "primary": "Supplementaries",
@@ -21501,10 +16589,6 @@
     "collections": [
       "CMS-Trigger-Information"
     ],
-    "collision_information": {
-      "energy": "8TeV",
-      "type": "pp"
-    },
     "date_created": [
       "2012"
     ],
@@ -21512,10 +16596,6 @@
     "experiment": "CMS",
     "publisher": "CERN Open Data Portal",
     "recid": "6814",
-    "run_period": [
-      "Run2012B",
-      "Run2012C"
-    ],
     "title": "High-Level Trigger path information HLT_Photon26_R9Id85_OR_CaloId10_Iso50_Photon18_R9Id85_OR_CaloId10_Iso50_Mass60 (DoublePhoton, Photon datasets)",
     "type": {
       "primary": "Supplementaries",
@@ -21536,10 +16616,6 @@
     "collections": [
       "CMS-Trigger-Information"
     ],
-    "collision_information": {
-      "energy": "8TeV",
-      "type": "pp"
-    },
     "date_created": [
       "2012"
     ],
@@ -21547,10 +16623,6 @@
     "experiment": "CMS",
     "publisher": "CERN Open Data Portal",
     "recid": "6815",
-    "run_period": [
-      "Run2012B",
-      "Run2012C"
-    ],
     "title": "High-Level Trigger path information HLT_Photon26_R9Id85_OR_CaloId10_Iso50_Photon18_R9Id85_OR_CaloId10_Iso50_Mass70 (DoublePhoton dataset)",
     "type": {
       "primary": "Supplementaries",
@@ -21571,10 +16643,6 @@
     "collections": [
       "CMS-Trigger-Information"
     ],
-    "collision_information": {
-      "energy": "8TeV",
-      "type": "pp"
-    },
     "date_created": [
       "2012"
     ],
@@ -21582,10 +16650,6 @@
     "experiment": "CMS",
     "publisher": "CERN Open Data Portal",
     "recid": "6816",
-    "run_period": [
-      "Run2012B",
-      "Run2012C"
-    ],
     "title": "High-Level Trigger path information HLT_Photon26_R9Id85_Photon18_CaloId10_Iso50_Mass60 (DoublePhoton, Photon datasets)",
     "type": {
       "primary": "Supplementaries",
@@ -21606,10 +16670,6 @@
     "collections": [
       "CMS-Trigger-Information"
     ],
-    "collision_information": {
-      "energy": "8TeV",
-      "type": "pp"
-    },
     "date_created": [
       "2012"
     ],
@@ -21617,10 +16677,6 @@
     "experiment": "CMS",
     "publisher": "CERN Open Data Portal",
     "recid": "6817",
-    "run_period": [
-      "Run2012B",
-      "Run2012C"
-    ],
     "title": "High-Level Trigger path information HLT_Photon26_R9Id85_Photon18_R9Id85_Mass60 (DoublePhoton, Photon datasets)",
     "type": {
       "primary": "Supplementaries",
@@ -21641,10 +16697,6 @@
     "collections": [
       "CMS-Trigger-Information"
     ],
-    "collision_information": {
-      "energy": "8TeV",
-      "type": "pp"
-    },
     "date_created": [
       "2012"
     ],
@@ -21652,10 +16704,6 @@
     "experiment": "CMS",
     "publisher": "CERN Open Data Portal",
     "recid": "6818",
-    "run_period": [
-      "Run2012B",
-      "Run2012C"
-    ],
     "title": "High-Level Trigger path information HLT_Photon30 (SinglePhotonParked dataset)",
     "type": {
       "primary": "Supplementaries",
@@ -21676,10 +16724,6 @@
     "collections": [
       "CMS-Trigger-Information"
     ],
-    "collision_information": {
-      "energy": "8TeV",
-      "type": "pp"
-    },
     "date_created": [
       "2012"
     ],
@@ -21687,10 +16731,6 @@
     "experiment": "CMS",
     "publisher": "CERN Open Data Portal",
     "recid": "6819",
-    "run_period": [
-      "Run2012B",
-      "Run2012C"
-    ],
     "title": "High-Level Trigger path information HLT_Photon300_NoHE (Photon, SinglePhoton datasets)",
     "type": {
       "primary": "Supplementaries",
@@ -21711,10 +16751,6 @@
     "collections": [
       "CMS-Trigger-Information"
     ],
-    "collision_information": {
-      "energy": "8TeV",
-      "type": "pp"
-    },
     "date_created": [
       "2012"
     ],
@@ -21722,10 +16758,6 @@
     "experiment": "CMS",
     "publisher": "CERN Open Data Portal",
     "recid": "6820",
-    "run_period": [
-      "Run2012B",
-      "Run2012C"
-    ],
     "title": "High-Level Trigger path information HLT_Photon30_CaloIdVL (Photon, SinglePhoton datasets)",
     "type": {
       "primary": "Supplementaries",
@@ -21746,10 +16778,6 @@
     "collections": [
       "CMS-Trigger-Information"
     ],
-    "collision_information": {
-      "energy": "8TeV",
-      "type": "pp"
-    },
     "date_created": [
       "2012"
     ],
@@ -21757,10 +16785,6 @@
     "experiment": "CMS",
     "publisher": "CERN Open Data Portal",
     "recid": "6821",
-    "run_period": [
-      "Run2012B",
-      "Run2012C"
-    ],
     "title": "High-Level Trigger path information HLT_Photon30_CaloIdVL_IsoL (Photon, SinglePhoton datasets)",
     "type": {
       "primary": "Supplementaries",
@@ -21781,10 +16805,6 @@
     "collections": [
       "CMS-Trigger-Information"
     ],
-    "collision_information": {
-      "energy": "8TeV",
-      "type": "pp"
-    },
     "date_created": [
       "2012"
     ],
@@ -21792,10 +16812,6 @@
     "experiment": "CMS",
     "publisher": "CERN Open Data Portal",
     "recid": "6822",
-    "run_period": [
-      "Run2012B",
-      "Run2012C"
-    ],
     "title": "High-Level Trigger path information HLT_Photon30_R9Id90_CaloId_HE10_Iso40_EBOnly (SinglePhotonParked dataset)",
     "type": {
       "primary": "Supplementaries",
@@ -21816,10 +16832,6 @@
     "collections": [
       "CMS-Trigger-Information"
     ],
-    "collision_information": {
-      "energy": "8TeV",
-      "type": "pp"
-    },
     "date_created": [
       "2012"
     ],
@@ -21827,10 +16839,6 @@
     "experiment": "CMS",
     "publisher": "CERN Open Data Portal",
     "recid": "6823",
-    "run_period": [
-      "Run2012B",
-      "Run2012C"
-    ],
     "title": "High-Level Trigger path information HLT_Photon30_R9Id90_CaloId_HE10_Iso40_EBOnly_Met25_HBHENoiseCleaned (SinglePhotonParked dataset)",
     "type": {
       "primary": "Supplementaries",
@@ -21851,10 +16859,6 @@
     "collections": [
       "CMS-Trigger-Information"
     ],
-    "collision_information": {
-      "energy": "8TeV",
-      "type": "pp"
-    },
     "date_created": [
       "2012"
     ],
@@ -21862,10 +16866,6 @@
     "experiment": "CMS",
     "publisher": "CERN Open Data Portal",
     "recid": "6824",
-    "run_period": [
-      "Run2012B",
-      "Run2012C"
-    ],
     "title": "High-Level Trigger path information HLT_Photon36_CaloId10_Iso50_Photon22_CaloId10_Iso50 (DoublePhoton, Photon datasets)",
     "type": {
       "primary": "Supplementaries",
@@ -21886,10 +16886,6 @@
     "collections": [
       "CMS-Trigger-Information"
     ],
-    "collision_information": {
-      "energy": "8TeV",
-      "type": "pp"
-    },
     "date_created": [
       "2012"
     ],
@@ -21897,10 +16893,6 @@
     "experiment": "CMS",
     "publisher": "CERN Open Data Portal",
     "recid": "6825",
-    "run_period": [
-      "Run2012B",
-      "Run2012C"
-    ],
     "title": "High-Level Trigger path information HLT_Photon36_CaloId10_Iso50_Photon22_R9Id85 (DoublePhoton, Photon datasets)",
     "type": {
       "primary": "Supplementaries",
@@ -21921,10 +16913,6 @@
     "collections": [
       "CMS-Trigger-Information"
     ],
-    "collision_information": {
-      "energy": "8TeV",
-      "type": "pp"
-    },
     "date_created": [
       "2012"
     ],
@@ -21932,10 +16920,6 @@
     "experiment": "CMS",
     "publisher": "CERN Open Data Portal",
     "recid": "6826",
-    "run_period": [
-      "Run2012B",
-      "Run2012C"
-    ],
     "title": "High-Level Trigger path information HLT_Photon36_Photon22 (DoublePhoton, Photon datasets)",
     "type": {
       "primary": "Supplementaries",
@@ -21956,10 +16940,6 @@
     "collections": [
       "CMS-Trigger-Information"
     ],
-    "collision_information": {
-      "energy": "8TeV",
-      "type": "pp"
-    },
     "date_created": [
       "2012"
     ],
@@ -21967,10 +16947,6 @@
     "experiment": "CMS",
     "publisher": "CERN Open Data Portal",
     "recid": "6827",
-    "run_period": [
-      "Run2012B",
-      "Run2012C"
-    ],
     "title": "High-Level Trigger path information HLT_Photon36_R9Id85_OR_CaloId10_Iso50_Photon10_R9Id85_OR_CaloId10_Iso50_Mass80 (DoublePhoton dataset)",
     "type": {
       "primary": "Supplementaries",
@@ -21991,10 +16967,6 @@
     "collections": [
       "CMS-Trigger-Information"
     ],
-    "collision_information": {
-      "energy": "8TeV",
-      "type": "pp"
-    },
     "date_created": [
       "2012"
     ],
@@ -22002,10 +16974,6 @@
     "experiment": "CMS",
     "publisher": "CERN Open Data Portal",
     "recid": "6828",
-    "run_period": [
-      "Run2012B",
-      "Run2012C"
-    ],
     "title": "High-Level Trigger path information HLT_Photon36_R9Id85_OR_CaloId10_Iso50_Photon22 (DoublePhoton, Photon datasets)",
     "type": {
       "primary": "Supplementaries",
@@ -22026,10 +16994,6 @@
     "collections": [
       "CMS-Trigger-Information"
     ],
-    "collision_information": {
-      "energy": "8TeV",
-      "type": "pp"
-    },
     "date_created": [
       "2012"
     ],
@@ -22037,10 +17001,6 @@
     "experiment": "CMS",
     "publisher": "CERN Open Data Portal",
     "recid": "6829",
-    "run_period": [
-      "Run2012B",
-      "Run2012C"
-    ],
     "title": "High-Level Trigger path information HLT_Photon36_R9Id85_OR_CaloId10_Iso50_Photon22_R9Id85_OR_CaloId10_Iso50 (DoublePhoton, Photon datasets)",
     "type": {
       "primary": "Supplementaries",
@@ -22061,10 +17021,6 @@
     "collections": [
       "CMS-Trigger-Information"
     ],
-    "collision_information": {
-      "energy": "8TeV",
-      "type": "pp"
-    },
     "date_created": [
       "2012"
     ],
@@ -22072,10 +17028,6 @@
     "experiment": "CMS",
     "publisher": "CERN Open Data Portal",
     "recid": "6830",
-    "run_period": [
-      "Run2012B",
-      "Run2012C"
-    ],
     "title": "High-Level Trigger path information HLT_Photon36_R9Id85_Photon22_CaloId10_Iso50 (DoublePhoton, Photon datasets)",
     "type": {
       "primary": "Supplementaries",
@@ -22096,10 +17048,6 @@
     "collections": [
       "CMS-Trigger-Information"
     ],
-    "collision_information": {
-      "energy": "8TeV",
-      "type": "pp"
-    },
     "date_created": [
       "2012"
     ],
@@ -22107,10 +17055,6 @@
     "experiment": "CMS",
     "publisher": "CERN Open Data Portal",
     "recid": "6831",
-    "run_period": [
-      "Run2012B",
-      "Run2012C"
-    ],
     "title": "High-Level Trigger path information HLT_Photon36_R9Id85_Photon22_R9Id85 (DoublePhoton, Photon datasets)",
     "type": {
       "primary": "Supplementaries",
@@ -22131,10 +17075,6 @@
     "collections": [
       "CMS-Trigger-Information"
     ],
-    "collision_information": {
-      "energy": "8TeV",
-      "type": "pp"
-    },
     "date_created": [
       "2012"
     ],
@@ -22142,10 +17082,6 @@
     "experiment": "CMS",
     "publisher": "CERN Open Data Portal",
     "recid": "6832",
-    "run_period": [
-      "Run2012B",
-      "Run2012C"
-    ],
     "title": "High-Level Trigger path information HLT_Photon36_R9Id90_HE10_Iso40_EBOnly (DoubleElectron dataset)",
     "type": {
       "primary": "Supplementaries",
@@ -22166,10 +17102,6 @@
     "collections": [
       "CMS-Trigger-Information"
     ],
-    "collision_information": {
-      "energy": "8TeV",
-      "type": "pp"
-    },
     "date_created": [
       "2012"
     ],
@@ -22177,10 +17109,6 @@
     "experiment": "CMS",
     "publisher": "CERN Open Data Portal",
     "recid": "6833",
-    "run_period": [
-      "Run2012B",
-      "Run2012C"
-    ],
     "title": "High-Level Trigger path information HLT_Photon40_CaloIdL_RsqMR35_Rsq0p09_MR150 (PhotonHad dataset)",
     "type": {
       "primary": "Supplementaries",
@@ -22201,10 +17129,6 @@
     "collections": [
       "CMS-Trigger-Information"
     ],
-    "collision_information": {
-      "energy": "8TeV",
-      "type": "pp"
-    },
     "date_created": [
       "2012"
     ],
@@ -22212,10 +17136,6 @@
     "experiment": "CMS",
     "publisher": "CERN Open Data Portal",
     "recid": "6834",
-    "run_period": [
-      "Run2012B",
-      "Run2012C"
-    ],
     "title": "High-Level Trigger path information HLT_Photon40_CaloIdL_RsqMR40_Rsq0p09_MR150 (PhotonHad dataset)",
     "type": {
       "primary": "Supplementaries",
@@ -22236,10 +17156,6 @@
     "collections": [
       "CMS-Trigger-Information"
     ],
-    "collision_information": {
-      "energy": "8TeV",
-      "type": "pp"
-    },
     "date_created": [
       "2012"
     ],
@@ -22247,10 +17163,6 @@
     "experiment": "CMS",
     "publisher": "CERN Open Data Portal",
     "recid": "6835",
-    "run_period": [
-      "Run2012B",
-      "Run2012C"
-    ],
     "title": "High-Level Trigger path information HLT_Photon40_CaloIdL_RsqMR45_Rsq0p09_MR150 (PhotonHad dataset)",
     "type": {
       "primary": "Supplementaries",
@@ -22271,10 +17183,6 @@
     "collections": [
       "CMS-Trigger-Information"
     ],
-    "collision_information": {
-      "energy": "8TeV",
-      "type": "pp"
-    },
     "date_created": [
       "2012"
     ],
@@ -22282,10 +17190,6 @@
     "experiment": "CMS",
     "publisher": "CERN Open Data Portal",
     "recid": "6836",
-    "run_period": [
-      "Run2012B",
-      "Run2012C"
-    ],
     "title": "High-Level Trigger path information HLT_Photon40_CaloIdL_RsqMR50_Rsq0p09_MR150 (PhotonHad dataset)",
     "type": {
       "primary": "Supplementaries",
@@ -22306,10 +17210,6 @@
     "collections": [
       "CMS-Trigger-Information"
     ],
-    "collision_information": {
-      "energy": "8TeV",
-      "type": "pp"
-    },
     "date_created": [
       "2012"
     ],
@@ -22317,10 +17217,6 @@
     "experiment": "CMS",
     "publisher": "CERN Open Data Portal",
     "recid": "6837",
-    "run_period": [
-      "Run2012B",
-      "Run2012C"
-    ],
     "title": "High-Level Trigger path information HLT_Photon50_CaloIdVL (Photon, SinglePhoton datasets)",
     "type": {
       "primary": "Supplementaries",
@@ -22341,10 +17237,6 @@
     "collections": [
       "CMS-Trigger-Information"
     ],
-    "collision_information": {
-      "energy": "8TeV",
-      "type": "pp"
-    },
     "date_created": [
       "2012"
     ],
@@ -22352,10 +17244,6 @@
     "experiment": "CMS",
     "publisher": "CERN Open Data Portal",
     "recid": "6838",
-    "run_period": [
-      "Run2012B",
-      "Run2012C"
-    ],
     "title": "High-Level Trigger path information HLT_Photon50_CaloIdVL_IsoL (Photon, SinglePhoton datasets)",
     "type": {
       "primary": "Supplementaries",
@@ -22376,10 +17264,6 @@
     "collections": [
       "CMS-Trigger-Information"
     ],
-    "collision_information": {
-      "energy": "8TeV",
-      "type": "pp"
-    },
     "date_created": [
       "2012"
     ],
@@ -22387,10 +17271,6 @@
     "experiment": "CMS",
     "publisher": "CERN Open Data Portal",
     "recid": "6839",
-    "run_period": [
-      "Run2012B",
-      "Run2012C"
-    ],
     "title": "High-Level Trigger path information HLT_Photon50_R9Id90_HE10_Iso40_EBOnly (DoubleElectron dataset)",
     "type": {
       "primary": "Supplementaries",
@@ -22411,10 +17291,6 @@
     "collections": [
       "CMS-Trigger-Information"
     ],
-    "collision_information": {
-      "energy": "8TeV",
-      "type": "pp"
-    },
     "date_created": [
       "2012"
     ],
@@ -22422,10 +17298,6 @@
     "experiment": "CMS",
     "publisher": "CERN Open Data Portal",
     "recid": "6840",
-    "run_period": [
-      "Run2012B",
-      "Run2012C"
-    ],
     "title": "High-Level Trigger path information HLT_Photon60_CaloIdL_FJHT300 (PhotonHad dataset)",
     "type": {
       "primary": "Supplementaries",
@@ -22446,10 +17318,6 @@
     "collections": [
       "CMS-Trigger-Information"
     ],
-    "collision_information": {
-      "energy": "8TeV",
-      "type": "pp"
-    },
     "date_created": [
       "2012"
     ],
@@ -22457,10 +17325,6 @@
     "experiment": "CMS",
     "publisher": "CERN Open Data Portal",
     "recid": "6841",
-    "run_period": [
-      "Run2012B",
-      "Run2012C"
-    ],
     "title": "High-Level Trigger path information HLT_Photon60_CaloIdL_HT300 (PhotonHad dataset)",
     "type": {
       "primary": "Supplementaries",
@@ -22481,10 +17345,6 @@
     "collections": [
       "CMS-Trigger-Information"
     ],
-    "collision_information": {
-      "energy": "8TeV",
-      "type": "pp"
-    },
     "date_created": [
       "2012"
     ],
@@ -22492,10 +17352,6 @@
     "experiment": "CMS",
     "publisher": "CERN Open Data Portal",
     "recid": "6842",
-    "run_period": [
-      "Run2012B",
-      "Run2012C"
-    ],
     "title": "High-Level Trigger path information HLT_Photon60_CaloIdL_MHT70 (PhotonHad dataset)",
     "type": {
       "primary": "Supplementaries",
@@ -22516,10 +17372,6 @@
     "collections": [
       "CMS-Trigger-Information"
     ],
-    "collision_information": {
-      "energy": "8TeV",
-      "type": "pp"
-    },
     "date_created": [
       "2012"
     ],
@@ -22527,10 +17379,6 @@
     "experiment": "CMS",
     "publisher": "CERN Open Data Portal",
     "recid": "6843",
-    "run_period": [
-      "Run2012B",
-      "Run2012C"
-    ],
     "title": "High-Level Trigger path information HLT_Photon70_CaloIdXL_PFHT400 (PhotonHad dataset)",
     "type": {
       "primary": "Supplementaries",
@@ -22551,10 +17399,6 @@
     "collections": [
       "CMS-Trigger-Information"
     ],
-    "collision_information": {
-      "energy": "8TeV",
-      "type": "pp"
-    },
     "date_created": [
       "2012"
     ],
@@ -22562,10 +17406,6 @@
     "experiment": "CMS",
     "publisher": "CERN Open Data Portal",
     "recid": "6844",
-    "run_period": [
-      "Run2012B",
-      "Run2012C"
-    ],
     "title": "High-Level Trigger path information HLT_Photon70_CaloIdXL_PFHT500 (PhotonHad dataset)",
     "type": {
       "primary": "Supplementaries",
@@ -22586,10 +17426,6 @@
     "collections": [
       "CMS-Trigger-Information"
     ],
-    "collision_information": {
-      "energy": "8TeV",
-      "type": "pp"
-    },
     "date_created": [
       "2012"
     ],
@@ -22597,10 +17433,6 @@
     "experiment": "CMS",
     "publisher": "CERN Open Data Portal",
     "recid": "6845",
-    "run_period": [
-      "Run2012B",
-      "Run2012C"
-    ],
     "title": "High-Level Trigger path information HLT_Photon70_CaloIdXL_PFMET100 (PhotonHad dataset)",
     "type": {
       "primary": "Supplementaries",
@@ -22621,10 +17453,6 @@
     "collections": [
       "CMS-Trigger-Information"
     ],
-    "collision_information": {
-      "energy": "8TeV",
-      "type": "pp"
-    },
     "date_created": [
       "2012"
     ],
@@ -22632,10 +17460,6 @@
     "experiment": "CMS",
     "publisher": "CERN Open Data Portal",
     "recid": "6846",
-    "run_period": [
-      "Run2012B",
-      "Run2012C"
-    ],
     "title": "High-Level Trigger path information HLT_Photon70_CaloIdXL_PFNoPUHT400 (PhotonHad dataset)",
     "type": {
       "primary": "Supplementaries",
@@ -22656,10 +17480,6 @@
     "collections": [
       "CMS-Trigger-Information"
     ],
-    "collision_information": {
-      "energy": "8TeV",
-      "type": "pp"
-    },
     "date_created": [
       "2012"
     ],
@@ -22667,10 +17487,6 @@
     "experiment": "CMS",
     "publisher": "CERN Open Data Portal",
     "recid": "6847",
-    "run_period": [
-      "Run2012B",
-      "Run2012C"
-    ],
     "title": "High-Level Trigger path information HLT_Photon70_CaloIdXL_PFNoPUHT500 (PhotonHad dataset)",
     "type": {
       "primary": "Supplementaries",
@@ -22691,10 +17507,6 @@
     "collections": [
       "CMS-Trigger-Information"
     ],
-    "collision_information": {
-      "energy": "8TeV",
-      "type": "pp"
-    },
     "date_created": [
       "2012"
     ],
@@ -22702,10 +17514,6 @@
     "experiment": "CMS",
     "publisher": "CERN Open Data Portal",
     "recid": "6848",
-    "run_period": [
-      "Run2012B",
-      "Run2012C"
-    ],
     "title": "High-Level Trigger path information HLT_Photon75_CaloIdVL (Photon, SinglePhoton datasets)",
     "type": {
       "primary": "Supplementaries",
@@ -22726,10 +17534,6 @@
     "collections": [
       "CMS-Trigger-Information"
     ],
-    "collision_information": {
-      "energy": "8TeV",
-      "type": "pp"
-    },
     "date_created": [
       "2012"
     ],
@@ -22737,10 +17541,6 @@
     "experiment": "CMS",
     "publisher": "CERN Open Data Portal",
     "recid": "6849",
-    "run_period": [
-      "Run2012B",
-      "Run2012C"
-    ],
     "title": "High-Level Trigger path information HLT_Photon75_CaloIdVL_IsoL (Photon, SinglePhoton datasets)",
     "type": {
       "primary": "Supplementaries",
@@ -22761,10 +17561,6 @@
     "collections": [
       "CMS-Trigger-Information"
     ],
-    "collision_information": {
-      "energy": "8TeV",
-      "type": "pp"
-    },
     "date_created": [
       "2012"
     ],
@@ -22772,10 +17568,6 @@
     "experiment": "CMS",
     "publisher": "CERN Open Data Portal",
     "recid": "6850",
-    "run_period": [
-      "Run2012B",
-      "Run2012C"
-    ],
     "title": "High-Level Trigger path information HLT_Photon75_R9Id90_HE10_Iso40_EBOnly (DoubleElectron dataset)",
     "type": {
       "primary": "Supplementaries",
@@ -22796,10 +17588,6 @@
     "collections": [
       "CMS-Trigger-Information"
     ],
-    "collision_information": {
-      "energy": "8TeV",
-      "type": "pp"
-    },
     "date_created": [
       "2012"
     ],
@@ -22807,10 +17595,6 @@
     "experiment": "CMS",
     "publisher": "CERN Open Data Portal",
     "recid": "6851",
-    "run_period": [
-      "Run2012B",
-      "Run2012C"
-    ],
     "title": "High-Level Trigger path information HLT_Photon90EBOnly_CaloIdVL_IsoL_TriPFJet25 (PhotonHad dataset)",
     "type": {
       "primary": "Supplementaries",
@@ -22831,10 +17615,6 @@
     "collections": [
       "CMS-Trigger-Information"
     ],
-    "collision_information": {
-      "energy": "8TeV",
-      "type": "pp"
-    },
     "date_created": [
       "2012"
     ],
@@ -22842,10 +17622,6 @@
     "experiment": "CMS",
     "publisher": "CERN Open Data Portal",
     "recid": "6852",
-    "run_period": [
-      "Run2012B",
-      "Run2012C"
-    ],
     "title": "High-Level Trigger path information HLT_Photon90EBOnly_CaloIdVL_IsoL_TriPFJet30 (PhotonHad dataset)",
     "type": {
       "primary": "Supplementaries",
@@ -22866,10 +17642,6 @@
     "collections": [
       "CMS-Trigger-Information"
     ],
-    "collision_information": {
-      "energy": "8TeV",
-      "type": "pp"
-    },
     "date_created": [
       "2012"
     ],
@@ -22877,10 +17649,6 @@
     "experiment": "CMS",
     "publisher": "CERN Open Data Portal",
     "recid": "6853",
-    "run_period": [
-      "Run2012B",
-      "Run2012C"
-    ],
     "title": "High-Level Trigger path information HLT_Photon90_CaloIdVL (Photon, SinglePhoton datasets)",
     "type": {
       "primary": "Supplementaries",
@@ -22901,10 +17669,6 @@
     "collections": [
       "CMS-Trigger-Information"
     ],
-    "collision_information": {
-      "energy": "8TeV",
-      "type": "pp"
-    },
     "date_created": [
       "2012"
     ],
@@ -22912,10 +17676,6 @@
     "experiment": "CMS",
     "publisher": "CERN Open Data Portal",
     "recid": "6854",
-    "run_period": [
-      "Run2012B",
-      "Run2012C"
-    ],
     "title": "High-Level Trigger path information HLT_Photon90_CaloIdVL_IsoL (Photon, SinglePhoton datasets)",
     "type": {
       "primary": "Supplementaries",
@@ -22936,10 +17696,6 @@
     "collections": [
       "CMS-Trigger-Information"
     ],
-    "collision_information": {
-      "energy": "8TeV",
-      "type": "pp"
-    },
     "date_created": [
       "2012"
     ],
@@ -22947,10 +17703,6 @@
     "experiment": "CMS",
     "publisher": "CERN Open Data Portal",
     "recid": "6855",
-    "run_period": [
-      "Run2012B",
-      "Run2012C"
-    ],
     "title": "High-Level Trigger path information HLT_Photon90_R9Id90_HE10_Iso40_EBOnly (DoubleElectron dataset)",
     "type": {
       "primary": "Supplementaries",
@@ -22971,10 +17723,6 @@
     "collections": [
       "CMS-Trigger-Information"
     ],
-    "collision_information": {
-      "energy": "8TeV",
-      "type": "pp"
-    },
     "date_created": [
       "2012"
     ],
@@ -22982,10 +17730,6 @@
     "experiment": "CMS",
     "publisher": "CERN Open Data Portal",
     "recid": "6856",
-    "run_period": [
-      "Run2012B",
-      "Run2012C"
-    ],
     "title": "High-Level Trigger path information HLT_Physics (MinimumBias dataset)",
     "type": {
       "primary": "Supplementaries",
@@ -23006,10 +17750,6 @@
     "collections": [
       "CMS-Trigger-Information"
     ],
-    "collision_information": {
-      "energy": "8TeV",
-      "type": "pp"
-    },
     "date_created": [
       "2012"
     ],
@@ -23017,10 +17757,6 @@
     "experiment": "CMS",
     "publisher": "CERN Open Data Portal",
     "recid": "6857",
-    "run_period": [
-      "Run2012B",
-      "Run2012C"
-    ],
     "title": "High-Level Trigger path information HLT_Physics5E33_2b (MinimumBias dataset)",
     "type": {
       "primary": "Supplementaries",
@@ -23041,10 +17777,6 @@
     "collections": [
       "CMS-Trigger-Information"
     ],
-    "collision_information": {
-      "energy": "8TeV",
-      "type": "pp"
-    },
     "date_created": [
       "2012"
     ],
@@ -23052,10 +17784,6 @@
     "experiment": "CMS",
     "publisher": "CERN Open Data Portal",
     "recid": "6858",
-    "run_period": [
-      "Run2012B",
-      "Run2012C"
-    ],
     "title": "High-Level Trigger path information HLT_Physics5E33_48b (MinimumBias dataset)",
     "type": {
       "primary": "Supplementaries",
@@ -23076,10 +17804,6 @@
     "collections": [
       "CMS-Trigger-Information"
     ],
-    "collision_information": {
-      "energy": "8TeV",
-      "type": "pp"
-    },
     "date_created": [
       "2012"
     ],
@@ -23087,10 +17811,6 @@
     "experiment": "CMS",
     "publisher": "CERN Open Data Portal",
     "recid": "6859",
-    "run_period": [
-      "Run2012B",
-      "Run2012C"
-    ],
     "title": "High-Level Trigger path information HLT_Physics5E33_84b (MinimumBias dataset)",
     "type": {
       "primary": "Supplementaries",
@@ -23111,10 +17831,6 @@
     "collections": [
       "CMS-Trigger-Information"
     ],
-    "collision_information": {
-      "energy": "8TeV",
-      "type": "pp"
-    },
     "date_created": [
       "2012"
     ],
@@ -23122,10 +17838,6 @@
     "experiment": "CMS",
     "publisher": "CERN Open Data Portal",
     "recid": "6860",
-    "run_period": [
-      "Run2012B",
-      "Run2012C"
-    ],
     "title": "High-Level Trigger path information HLT_PhysicsPart1 (HLTPhysics25ns1 dataset)",
     "type": {
       "primary": "Supplementaries",
@@ -23146,10 +17858,6 @@
     "collections": [
       "CMS-Trigger-Information"
     ],
-    "collision_information": {
-      "energy": "8TeV",
-      "type": "pp"
-    },
     "date_created": [
       "2012"
     ],
@@ -23157,10 +17865,6 @@
     "experiment": "CMS",
     "publisher": "CERN Open Data Portal",
     "recid": "6861",
-    "run_period": [
-      "Run2012B",
-      "Run2012C"
-    ],
     "title": "High-Level Trigger path information HLT_PhysicsPart2 (HLTPhysics25ns2 dataset)",
     "type": {
       "primary": "Supplementaries",
@@ -23181,10 +17885,6 @@
     "collections": [
       "CMS-Trigger-Information"
     ],
-    "collision_information": {
-      "energy": "8TeV",
-      "type": "pp"
-    },
     "date_created": [
       "2012"
     ],
@@ -23192,10 +17892,6 @@
     "experiment": "CMS",
     "publisher": "CERN Open Data Portal",
     "recid": "6862",
-    "run_period": [
-      "Run2012B",
-      "Run2012C"
-    ],
     "title": "High-Level Trigger path information HLT_PhysicsPart3 (HLTPhysics25ns3 dataset)",
     "type": {
       "primary": "Supplementaries",
@@ -23216,10 +17912,6 @@
     "collections": [
       "CMS-Trigger-Information"
     ],
-    "collision_information": {
-      "energy": "8TeV",
-      "type": "pp"
-    },
     "date_created": [
       "2012"
     ],
@@ -23227,10 +17919,6 @@
     "experiment": "CMS",
     "publisher": "CERN Open Data Portal",
     "recid": "6863",
-    "run_period": [
-      "Run2012B",
-      "Run2012C"
-    ],
     "title": "High-Level Trigger path information HLT_PhysicsPart4 (HLTPhysics25ns4 dataset)",
     "type": {
       "primary": "Supplementaries",
@@ -23251,10 +17939,6 @@
     "collections": [
       "CMS-Trigger-Information"
     ],
-    "collision_information": {
-      "energy": "8TeV",
-      "type": "pp"
-    },
     "date_created": [
       "2012"
     ],
@@ -23262,10 +17946,6 @@
     "experiment": "CMS",
     "publisher": "CERN Open Data Portal",
     "recid": "6864",
-    "run_period": [
-      "Run2012B",
-      "Run2012C"
-    ],
     "title": "High-Level Trigger path information HLT_Physics_Parked (HLTPhysicsParked dataset)",
     "type": {
       "primary": "Supplementaries",
@@ -23286,10 +17966,6 @@
     "collections": [
       "CMS-Trigger-Information"
     ],
-    "collision_information": {
-      "energy": "8TeV",
-      "type": "pp"
-    },
     "date_created": [
       "2012"
     ],
@@ -23297,10 +17973,6 @@
     "experiment": "CMS",
     "publisher": "CERN Open Data Portal",
     "recid": "6865",
-    "run_period": [
-      "Run2012B",
-      "Run2012C"
-    ],
     "title": "High-Level Trigger path information HLT_Physics_Part1 (MinimumBias1 dataset)",
     "type": {
       "primary": "Supplementaries",
@@ -23321,10 +17993,6 @@
     "collections": [
       "CMS-Trigger-Information"
     ],
-    "collision_information": {
-      "energy": "8TeV",
-      "type": "pp"
-    },
     "date_created": [
       "2012"
     ],
@@ -23332,10 +18000,6 @@
     "experiment": "CMS",
     "publisher": "CERN Open Data Portal",
     "recid": "6866",
-    "run_period": [
-      "Run2012B",
-      "Run2012C"
-    ],
     "title": "High-Level Trigger path information HLT_Physics_Part2 (MinimumBias2 dataset)",
     "type": {
       "primary": "Supplementaries",
@@ -23356,10 +18020,6 @@
     "collections": [
       "CMS-Trigger-Information"
     ],
-    "collision_information": {
-      "energy": "8TeV",
-      "type": "pp"
-    },
     "date_created": [
       "2012"
     ],
@@ -23367,10 +18027,6 @@
     "experiment": "CMS",
     "publisher": "CERN Open Data Portal",
     "recid": "6867",
-    "run_period": [
-      "Run2012B",
-      "Run2012C"
-    ],
     "title": "High-Level Trigger path information HLT_Physics_part1 (ZeroBias1 dataset)",
     "type": {
       "primary": "Supplementaries",
@@ -23391,10 +18047,6 @@
     "collections": [
       "CMS-Trigger-Information"
     ],
-    "collision_information": {
-      "energy": "8TeV",
-      "type": "pp"
-    },
     "date_created": [
       "2012"
     ],
@@ -23402,10 +18054,6 @@
     "experiment": "CMS",
     "publisher": "CERN Open Data Portal",
     "recid": "6868",
-    "run_period": [
-      "Run2012B",
-      "Run2012C"
-    ],
     "title": "High-Level Trigger path information HLT_PixelTracks_Multiplicity70 (MinimumBias dataset)",
     "type": {
       "primary": "Supplementaries",
@@ -23426,10 +18074,6 @@
     "collections": [
       "CMS-Trigger-Information"
     ],
-    "collision_information": {
-      "energy": "8TeV",
-      "type": "pp"
-    },
     "date_created": [
       "2012"
     ],
@@ -23437,10 +18081,6 @@
     "experiment": "CMS",
     "publisher": "CERN Open Data Portal",
     "recid": "6869",
-    "run_period": [
-      "Run2012B",
-      "Run2012C"
-    ],
     "title": "High-Level Trigger path information HLT_PixelTracks_Multiplicity80 (MinimumBias dataset)",
     "type": {
       "primary": "Supplementaries",
@@ -23461,10 +18101,6 @@
     "collections": [
       "CMS-Trigger-Information"
     ],
-    "collision_information": {
-      "energy": "8TeV",
-      "type": "pp"
-    },
     "date_created": [
       "2012"
     ],
@@ -23472,10 +18108,6 @@
     "experiment": "CMS",
     "publisher": "CERN Open Data Portal",
     "recid": "6870",
-    "run_period": [
-      "Run2012B",
-      "Run2012C"
-    ],
     "title": "High-Level Trigger path information HLT_PixelTracks_Multiplicity90 (MinimumBias dataset)",
     "type": {
       "primary": "Supplementaries",
@@ -23496,10 +18128,6 @@
     "collections": [
       "CMS-Trigger-Information"
     ],
-    "collision_information": {
-      "energy": "8TeV",
-      "type": "pp"
-    },
     "date_created": [
       "2012"
     ],
@@ -23507,10 +18135,6 @@
     "experiment": "CMS",
     "publisher": "CERN Open Data Portal",
     "recid": "6871",
-    "run_period": [
-      "Run2012B",
-      "Run2012C"
-    ],
     "title": "High-Level Trigger path information HLT_QuadJet45 (MultiJet1Parked dataset)",
     "type": {
       "primary": "Supplementaries",
@@ -23531,10 +18155,6 @@
     "collections": [
       "CMS-Trigger-Information"
     ],
-    "collision_information": {
-      "energy": "8TeV",
-      "type": "pp"
-    },
     "date_created": [
       "2012"
     ],
@@ -23542,10 +18162,6 @@
     "experiment": "CMS",
     "publisher": "CERN Open Data Portal",
     "recid": "6872",
-    "run_period": [
-      "Run2012B",
-      "Run2012C"
-    ],
     "title": "High-Level Trigger path information HLT_QuadJet50 (MultiJet, MultiJet1Parked datasets)",
     "type": {
       "primary": "Supplementaries",
@@ -23566,10 +18182,6 @@
     "collections": [
       "CMS-Trigger-Information"
     ],
-    "collision_information": {
-      "energy": "8TeV",
-      "type": "pp"
-    },
     "date_created": [
       "2012"
     ],
@@ -23577,10 +18189,6 @@
     "experiment": "CMS",
     "publisher": "CERN Open Data Portal",
     "recid": "6873",
-    "run_period": [
-      "Run2012B",
-      "Run2012C"
-    ],
     "title": "High-Level Trigger path information HLT_QuadJet50_Jet20 (MultiJet1Parked dataset)",
     "type": {
       "primary": "Supplementaries",
@@ -23601,10 +18209,6 @@
     "collections": [
       "CMS-Trigger-Information"
     ],
-    "collision_information": {
-      "energy": "8TeV",
-      "type": "pp"
-    },
     "date_created": [
       "2012"
     ],
@@ -23612,10 +18216,6 @@
     "experiment": "CMS",
     "publisher": "CERN Open Data Portal",
     "recid": "6874",
-    "run_period": [
-      "Run2012B",
-      "Run2012C"
-    ],
     "title": "High-Level Trigger path information HLT_QuadJet60_DiJet20 (MultiJet, MultiJet1Parked datasets)",
     "type": {
       "primary": "Supplementaries",
@@ -23636,10 +18236,6 @@
     "collections": [
       "CMS-Trigger-Information"
     ],
-    "collision_information": {
-      "energy": "8TeV",
-      "type": "pp"
-    },
     "date_created": [
       "2012"
     ],
@@ -23647,10 +18243,6 @@
     "experiment": "CMS",
     "publisher": "CERN Open Data Portal",
     "recid": "6875",
-    "run_period": [
-      "Run2012B",
-      "Run2012C"
-    ],
     "title": "High-Level Trigger path information HLT_QuadJet70 (MultiJet, MultiJet1Parked datasets)",
     "type": {
       "primary": "Supplementaries",
@@ -23671,10 +18263,6 @@
     "collections": [
       "CMS-Trigger-Information"
     ],
-    "collision_information": {
-      "energy": "8TeV",
-      "type": "pp"
-    },
     "date_created": [
       "2012"
     ],
@@ -23682,10 +18270,6 @@
     "experiment": "CMS",
     "publisher": "CERN Open Data Portal",
     "recid": "6876",
-    "run_period": [
-      "Run2012B",
-      "Run2012C"
-    ],
     "title": "High-Level Trigger path information HLT_QuadJet75_55_35_20_BTagIP_VBF (BJetPlusX, MultiJet datasets)",
     "type": {
       "primary": "Supplementaries",
@@ -23706,10 +18290,6 @@
     "collections": [
       "CMS-Trigger-Information"
     ],
-    "collision_information": {
-      "energy": "8TeV",
-      "type": "pp"
-    },
     "date_created": [
       "2012"
     ],
@@ -23717,10 +18297,6 @@
     "experiment": "CMS",
     "publisher": "CERN Open Data Portal",
     "recid": "6877",
-    "run_period": [
-      "Run2012B",
-      "Run2012C"
-    ],
     "title": "High-Level Trigger path information HLT_QuadJet75_55_35_20_VBF (BJetPlusX dataset)",
     "type": {
       "primary": "Supplementaries",
@@ -23741,10 +18317,6 @@
     "collections": [
       "CMS-Trigger-Information"
     ],
-    "collision_information": {
-      "energy": "8TeV",
-      "type": "pp"
-    },
     "date_created": [
       "2012"
     ],
@@ -23752,10 +18324,6 @@
     "experiment": "CMS",
     "publisher": "CERN Open Data Portal",
     "recid": "6878",
-    "run_period": [
-      "Run2012B",
-      "Run2012C"
-    ],
     "title": "High-Level Trigger path information HLT_QuadJet75_55_38_20_BTagIP_VBF (BJetPlusX, MultiJet datasets)",
     "type": {
       "primary": "Supplementaries",
@@ -23776,10 +18344,6 @@
     "collections": [
       "CMS-Trigger-Information"
     ],
-    "collision_information": {
-      "energy": "8TeV",
-      "type": "pp"
-    },
     "date_created": [
       "2012"
     ],
@@ -23787,10 +18351,6 @@
     "experiment": "CMS",
     "publisher": "CERN Open Data Portal",
     "recid": "6879",
-    "run_period": [
-      "Run2012B",
-      "Run2012C"
-    ],
     "title": "High-Level Trigger path information HLT_QuadJet80 (MultiJet, MultiJet1Parked datasets)",
     "type": {
       "primary": "Supplementaries",
@@ -23811,10 +18371,6 @@
     "collections": [
       "CMS-Trigger-Information"
     ],
-    "collision_information": {
-      "energy": "8TeV",
-      "type": "pp"
-    },
     "date_created": [
       "2012"
     ],
@@ -23822,10 +18378,6 @@
     "experiment": "CMS",
     "publisher": "CERN Open Data Portal",
     "recid": "6880",
-    "run_period": [
-      "Run2012B",
-      "Run2012C"
-    ],
     "title": "High-Level Trigger path information HLT_QuadJet90 (MultiJet, MultiJet1Parked datasets)",
     "type": {
       "primary": "Supplementaries",
@@ -23846,10 +18398,6 @@
     "collections": [
       "CMS-Trigger-Information"
     ],
-    "collision_information": {
-      "energy": "8TeV",
-      "type": "pp"
-    },
     "date_created": [
       "2012"
     ],
@@ -23857,10 +18405,6 @@
     "experiment": "CMS",
     "publisher": "CERN Open Data Portal",
     "recid": "6881",
-    "run_period": [
-      "Run2012B",
-      "Run2012C"
-    ],
     "title": "High-Level Trigger path information HLT_QuadPFJet75_55_35_20_BTagCSV_VBF (MultiJet dataset)",
     "type": {
       "primary": "Supplementaries",
@@ -23881,10 +18425,6 @@
     "collections": [
       "CMS-Trigger-Information"
     ],
-    "collision_information": {
-      "energy": "8TeV",
-      "type": "pp"
-    },
     "date_created": [
       "2012"
     ],
@@ -23892,10 +18432,6 @@
     "experiment": "CMS",
     "publisher": "CERN Open Data Portal",
     "recid": "6882",
-    "run_period": [
-      "Run2012B",
-      "Run2012C"
-    ],
     "title": "High-Level Trigger path information HLT_QuadPFJet75_55_38_20_BTagCSV_VBF (MultiJet dataset)",
     "type": {
       "primary": "Supplementaries",
@@ -23916,10 +18452,6 @@
     "collections": [
       "CMS-Trigger-Information"
     ],
-    "collision_information": {
-      "energy": "8TeV",
-      "type": "pp"
-    },
     "date_created": [
       "2012"
     ],
@@ -23927,10 +18459,6 @@
     "experiment": "CMS",
     "publisher": "CERN Open Data Portal",
     "recid": "6883",
-    "run_period": [
-      "Run2012B",
-      "Run2012C"
-    ],
     "title": "High-Level Trigger path information HLT_QuadPFJet78_61_44_31_BTagCSV_VBF (BJetPlusX dataset)",
     "type": {
       "primary": "Supplementaries",
@@ -23951,10 +18479,6 @@
     "collections": [
       "CMS-Trigger-Information"
     ],
-    "collision_information": {
-      "energy": "8TeV",
-      "type": "pp"
-    },
     "date_created": [
       "2012"
     ],
@@ -23962,10 +18486,6 @@
     "experiment": "CMS",
     "publisher": "CERN Open Data Portal",
     "recid": "6884",
-    "run_period": [
-      "Run2012B",
-      "Run2012C"
-    ],
     "title": "High-Level Trigger path information HLT_QuadPFJet78_61_44_31_VBF (BJetPlusX dataset)",
     "type": {
       "primary": "Supplementaries",
@@ -23986,10 +18506,6 @@
     "collections": [
       "CMS-Trigger-Information"
     ],
-    "collision_information": {
-      "energy": "8TeV",
-      "type": "pp"
-    },
     "date_created": [
       "2012"
     ],
@@ -23997,10 +18513,6 @@
     "experiment": "CMS",
     "publisher": "CERN Open Data Portal",
     "recid": "6885",
-    "run_period": [
-      "Run2012B",
-      "Run2012C"
-    ],
     "title": "High-Level Trigger path information HLT_QuadPFJet82_65_48_35_BTagCSV_VBF (BJetPlusX dataset)",
     "type": {
       "primary": "Supplementaries",
@@ -24021,10 +18533,6 @@
     "collections": [
       "CMS-Trigger-Information"
     ],
-    "collision_information": {
-      "energy": "8TeV",
-      "type": "pp"
-    },
     "date_created": [
       "2012"
     ],
@@ -24032,10 +18540,6 @@
     "experiment": "CMS",
     "publisher": "CERN Open Data Portal",
     "recid": "6886",
-    "run_period": [
-      "Run2012B",
-      "Run2012C"
-    ],
     "title": "High-Level Trigger path information HLT_Random (MinimumBias dataset)",
     "type": {
       "primary": "Supplementaries",
@@ -24056,10 +18560,6 @@
     "collections": [
       "CMS-Trigger-Information"
     ],
-    "collision_information": {
-      "energy": "8TeV",
-      "type": "pp"
-    },
     "date_created": [
       "2012"
     ],
@@ -24067,10 +18567,6 @@
     "experiment": "CMS",
     "publisher": "CERN Open Data Portal",
     "recid": "6887",
-    "run_period": [
-      "Run2012B",
-      "Run2012C"
-    ],
     "title": "High-Level Trigger path information HLT_RelIso1p0Mu17 (SingleMu dataset)",
     "type": {
       "primary": "Supplementaries",
@@ -24091,10 +18587,6 @@
     "collections": [
       "CMS-Trigger-Information"
     ],
-    "collision_information": {
-      "energy": "8TeV",
-      "type": "pp"
-    },
     "date_created": [
       "2012"
     ],
@@ -24102,10 +18594,6 @@
     "experiment": "CMS",
     "publisher": "CERN Open Data Portal",
     "recid": "6888",
-    "run_period": [
-      "Run2012B",
-      "Run2012C"
-    ],
     "title": "High-Level Trigger path information HLT_RelIso1p0Mu20 (SingleMu dataset)",
     "type": {
       "primary": "Supplementaries",
@@ -24126,10 +18614,6 @@
     "collections": [
       "CMS-Trigger-Information"
     ],
-    "collision_information": {
-      "energy": "8TeV",
-      "type": "pp"
-    },
     "date_created": [
       "2012"
     ],
@@ -24137,10 +18621,6 @@
     "experiment": "CMS",
     "publisher": "CERN Open Data Portal",
     "recid": "6889",
-    "run_period": [
-      "Run2012B",
-      "Run2012C"
-    ],
     "title": "High-Level Trigger path information HLT_RelIso1p0Mu5 (SingleMu dataset)",
     "type": {
       "primary": "Supplementaries",
@@ -24161,10 +18641,6 @@
     "collections": [
       "CMS-Trigger-Information"
     ],
-    "collision_information": {
-      "energy": "8TeV",
-      "type": "pp"
-    },
     "date_created": [
       "2012"
     ],
@@ -24172,10 +18648,6 @@
     "experiment": "CMS",
     "publisher": "CERN Open Data Portal",
     "recid": "6890",
-    "run_period": [
-      "Run2012B",
-      "Run2012C"
-    ],
     "title": "High-Level Trigger path information HLT_RelIso1p0Mu5_Ele8_CaloIdT_TrkIdVL_Mass8_PFHT175 (MuHad dataset)",
     "type": {
       "primary": "Supplementaries",
@@ -24196,10 +18668,6 @@
     "collections": [
       "CMS-Trigger-Information"
     ],
-    "collision_information": {
-      "energy": "8TeV",
-      "type": "pp"
-    },
     "date_created": [
       "2012"
     ],
@@ -24207,10 +18675,6 @@
     "experiment": "CMS",
     "publisher": "CERN Open Data Portal",
     "recid": "6891",
-    "run_period": [
-      "Run2012B",
-      "Run2012C"
-    ],
     "title": "High-Level Trigger path information HLT_RelIso1p0Mu5_Ele8_CaloIdT_TrkIdVL_Mass8_PFHT225 (MuHad dataset)",
     "type": {
       "primary": "Supplementaries",
@@ -24231,10 +18695,6 @@
     "collections": [
       "CMS-Trigger-Information"
     ],
-    "collision_information": {
-      "energy": "8TeV",
-      "type": "pp"
-    },
     "date_created": [
       "2012"
     ],
@@ -24242,10 +18702,6 @@
     "experiment": "CMS",
     "publisher": "CERN Open Data Portal",
     "recid": "6892",
-    "run_period": [
-      "Run2012B",
-      "Run2012C"
-    ],
     "title": "High-Level Trigger path information HLT_RelIso1p0Mu5_Ele8_CaloIdT_TrkIdVL_Mass8_PFNoPUHT175 (MuHad dataset)",
     "type": {
       "primary": "Supplementaries",
@@ -24266,10 +18722,6 @@
     "collections": [
       "CMS-Trigger-Information"
     ],
-    "collision_information": {
-      "energy": "8TeV",
-      "type": "pp"
-    },
     "date_created": [
       "2012"
     ],
@@ -24277,10 +18729,6 @@
     "experiment": "CMS",
     "publisher": "CERN Open Data Portal",
     "recid": "6893",
-    "run_period": [
-      "Run2012B",
-      "Run2012C"
-    ],
     "title": "High-Level Trigger path information HLT_RelIso1p0Mu5_Ele8_CaloIdT_TrkIdVL_Mass8_PFNoPUHT225 (MuHad dataset)",
     "type": {
       "primary": "Supplementaries",
@@ -24301,10 +18749,6 @@
     "collections": [
       "CMS-Trigger-Information"
     ],
-    "collision_information": {
-      "energy": "8TeV",
-      "type": "pp"
-    },
     "date_created": [
       "2012"
     ],
@@ -24312,10 +18756,6 @@
     "experiment": "CMS",
     "publisher": "CERN Open Data Portal",
     "recid": "6894",
-    "run_period": [
-      "Run2012B",
-      "Run2012C"
-    ],
     "title": "High-Level Trigger path information HLT_RomanPots_Tech52 (LP_RomanPots dataset)",
     "type": {
       "primary": "Supplementaries",
@@ -24336,10 +18776,6 @@
     "collections": [
       "CMS-Trigger-Information"
     ],
-    "collision_information": {
-      "energy": "8TeV",
-      "type": "pp"
-    },
     "date_created": [
       "2012"
     ],
@@ -24347,10 +18783,6 @@
     "experiment": "CMS",
     "publisher": "CERN Open Data Portal",
     "recid": "6895",
-    "run_period": [
-      "Run2012B",
-      "Run2012C"
-    ],
     "title": "High-Level Trigger path information HLT_RsqMR40_Rsq0p04 (HT, HTMHT, HTMHTParked datasets)",
     "type": {
       "primary": "Supplementaries",
@@ -24371,10 +18803,6 @@
     "collections": [
       "CMS-Trigger-Information"
     ],
-    "collision_information": {
-      "energy": "8TeV",
-      "type": "pp"
-    },
     "date_created": [
       "2012"
     ],
@@ -24382,10 +18810,6 @@
     "experiment": "CMS",
     "publisher": "CERN Open Data Portal",
     "recid": "6896",
-    "run_period": [
-      "Run2012B",
-      "Run2012C"
-    ],
     "title": "High-Level Trigger path information HLT_RsqMR45_Rsq0p09 (HT, HTMHTParked datasets)",
     "type": {
       "primary": "Supplementaries",
@@ -24406,10 +18830,6 @@
     "collections": [
       "CMS-Trigger-Information"
     ],
-    "collision_information": {
-      "energy": "8TeV",
-      "type": "pp"
-    },
     "date_created": [
       "2012"
     ],
@@ -24417,10 +18837,6 @@
     "experiment": "CMS",
     "publisher": "CERN Open Data Portal",
     "recid": "6897",
-    "run_period": [
-      "Run2012B",
-      "Run2012C"
-    ],
     "title": "High-Level Trigger path information HLT_RsqMR55_Rsq0p09_MR150 (HT, HTMHT, HTMHTParked datasets)",
     "type": {
       "primary": "Supplementaries",
@@ -24441,10 +18857,6 @@
     "collections": [
       "CMS-Trigger-Information"
     ],
-    "collision_information": {
-      "energy": "8TeV",
-      "type": "pp"
-    },
     "date_created": [
       "2012"
     ],
@@ -24452,10 +18864,6 @@
     "experiment": "CMS",
     "publisher": "CERN Open Data Portal",
     "recid": "6898",
-    "run_period": [
-      "Run2012B",
-      "Run2012C"
-    ],
     "title": "High-Level Trigger path information HLT_RsqMR60_Rsq0p09_MR150 (HT, HTMHT, HTMHTParked datasets)",
     "type": {
       "primary": "Supplementaries",
@@ -24476,10 +18884,6 @@
     "collections": [
       "CMS-Trigger-Information"
     ],
-    "collision_information": {
-      "energy": "8TeV",
-      "type": "pp"
-    },
     "date_created": [
       "2012"
     ],
@@ -24487,10 +18891,6 @@
     "experiment": "CMS",
     "publisher": "CERN Open Data Portal",
     "recid": "6899",
-    "run_period": [
-      "Run2012B",
-      "Run2012C"
-    ],
     "title": "High-Level Trigger path information HLT_RsqMR65_Rsq0p09_MR150 (HT, HTMHT, HTMHTParked datasets)",
     "type": {
       "primary": "Supplementaries",
@@ -24511,10 +18911,6 @@
     "collections": [
       "CMS-Trigger-Information"
     ],
-    "collision_information": {
-      "energy": "8TeV",
-      "type": "pp"
-    },
     "date_created": [
       "2012"
     ],
@@ -24522,10 +18918,6 @@
     "experiment": "CMS",
     "publisher": "CERN Open Data Portal",
     "recid": "6900",
-    "run_period": [
-      "Run2012B",
-      "Run2012C"
-    ],
     "title": "High-Level Trigger path information HLT_SingleForJet15 (Jet, JetMon datasets)",
     "type": {
       "primary": "Supplementaries",
@@ -24546,10 +18938,6 @@
     "collections": [
       "CMS-Trigger-Information"
     ],
-    "collision_information": {
-      "energy": "8TeV",
-      "type": "pp"
-    },
     "date_created": [
       "2012"
     ],
@@ -24557,10 +18945,6 @@
     "experiment": "CMS",
     "publisher": "CERN Open Data Portal",
     "recid": "6901",
-    "run_period": [
-      "Run2012B",
-      "Run2012C"
-    ],
     "title": "High-Level Trigger path information HLT_SingleForJet15_BHC (LP_Forward dataset)",
     "type": {
       "primary": "Supplementaries",
@@ -24581,10 +18965,6 @@
     "collections": [
       "CMS-Trigger-Information"
     ],
-    "collision_information": {
-      "energy": "8TeV",
-      "type": "pp"
-    },
     "date_created": [
       "2012"
     ],
@@ -24592,10 +18972,6 @@
     "experiment": "CMS",
     "publisher": "CERN Open Data Portal",
     "recid": "6902",
-    "run_period": [
-      "Run2012B",
-      "Run2012C"
-    ],
     "title": "High-Level Trigger path information HLT_SingleForJet15_HF (LP_Forward dataset)",
     "type": {
       "primary": "Supplementaries",
@@ -24616,10 +18992,6 @@
     "collections": [
       "CMS-Trigger-Information"
     ],
-    "collision_information": {
-      "energy": "8TeV",
-      "type": "pp"
-    },
     "date_created": [
       "2012"
     ],
@@ -24627,10 +18999,6 @@
     "experiment": "CMS",
     "publisher": "CERN Open Data Portal",
     "recid": "6903",
-    "run_period": [
-      "Run2012B",
-      "Run2012C"
-    ],
     "title": "High-Level Trigger path information HLT_SingleForJet25 (Jet, JetMon datasets)",
     "type": {
       "primary": "Supplementaries",
@@ -24651,10 +19019,6 @@
     "collections": [
       "CMS-Trigger-Information"
     ],
-    "collision_information": {
-      "energy": "8TeV",
-      "type": "pp"
-    },
     "date_created": [
       "2012"
     ],
@@ -24662,10 +19026,6 @@
     "experiment": "CMS",
     "publisher": "CERN Open Data Portal",
     "recid": "6904",
-    "run_period": [
-      "Run2012B",
-      "Run2012C"
-    ],
     "title": "High-Level Trigger path information HLT_SingleJetC5 (Jet dataset)",
     "type": {
       "primary": "Supplementaries",
@@ -24686,10 +19046,6 @@
     "collections": [
       "CMS-Trigger-Information"
     ],
-    "collision_information": {
-      "energy": "8TeV",
-      "type": "pp"
-    },
     "date_created": [
       "2012"
     ],
@@ -24697,10 +19053,6 @@
     "experiment": "CMS",
     "publisher": "CERN Open Data Portal",
     "recid": "6905",
-    "run_period": [
-      "Run2012B",
-      "Run2012C"
-    ],
     "title": "High-Level Trigger path information HLT_SingleJetC5_BHC (LP_Central dataset)",
     "type": {
       "primary": "Supplementaries",
@@ -24721,10 +19073,6 @@
     "collections": [
       "CMS-Trigger-Information"
     ],
-    "collision_information": {
-      "energy": "8TeV",
-      "type": "pp"
-    },
     "date_created": [
       "2012"
     ],
@@ -24732,10 +19080,6 @@
     "experiment": "CMS",
     "publisher": "CERN Open Data Portal",
     "recid": "6906",
-    "run_period": [
-      "Run2012B",
-      "Run2012C"
-    ],
     "title": "High-Level Trigger path information HLT_SingleJetC5_HF (LP_Central dataset)",
     "type": {
       "primary": "Supplementaries",
@@ -24756,10 +19100,6 @@
     "collections": [
       "CMS-Trigger-Information"
     ],
-    "collision_information": {
-      "energy": "8TeV",
-      "type": "pp"
-    },
     "date_created": [
       "2012"
     ],
@@ -24767,10 +19107,6 @@
     "experiment": "CMS",
     "publisher": "CERN Open Data Portal",
     "recid": "6907",
-    "run_period": [
-      "Run2012B",
-      "Run2012C"
-    ],
     "title": "High-Level Trigger path information HLT_SixJet35 (MultiJet, MultiJet1Parked datasets)",
     "type": {
       "primary": "Supplementaries",
@@ -24791,10 +19127,6 @@
     "collections": [
       "CMS-Trigger-Information"
     ],
-    "collision_information": {
-      "energy": "8TeV",
-      "type": "pp"
-    },
     "date_created": [
       "2012"
     ],
@@ -24802,10 +19134,6 @@
     "experiment": "CMS",
     "publisher": "CERN Open Data Portal",
     "recid": "6908",
-    "run_period": [
-      "Run2012B",
-      "Run2012C"
-    ],
     "title": "High-Level Trigger path information HLT_SixJet45 (MultiJet, MultiJet1Parked datasets)",
     "type": {
       "primary": "Supplementaries",
@@ -24826,10 +19154,6 @@
     "collections": [
       "CMS-Trigger-Information"
     ],
-    "collision_information": {
-      "energy": "8TeV",
-      "type": "pp"
-    },
     "date_created": [
       "2012"
     ],
@@ -24837,10 +19161,6 @@
     "experiment": "CMS",
     "publisher": "CERN Open Data Portal",
     "recid": "6909",
-    "run_period": [
-      "Run2012B",
-      "Run2012C"
-    ],
     "title": "High-Level Trigger path information HLT_SixJet50 (MultiJet, MultiJet1Parked datasets)",
     "type": {
       "primary": "Supplementaries",
@@ -24861,10 +19181,6 @@
     "collections": [
       "CMS-Trigger-Information"
     ],
-    "collision_information": {
-      "energy": "8TeV",
-      "type": "pp"
-    },
     "date_created": [
       "2012"
     ],
@@ -24872,10 +19188,6 @@
     "experiment": "CMS",
     "publisher": "CERN Open Data Portal",
     "recid": "6910",
-    "run_period": [
-      "Run2012B",
-      "Run2012C"
-    ],
     "title": "High-Level Trigger path information HLT_T1minbias_Tech55 (LP_MinBias1 dataset)",
     "type": {
       "primary": "Supplementaries",
@@ -24896,10 +19208,6 @@
     "collections": [
       "CMS-Trigger-Information"
     ],
-    "collision_information": {
-      "energy": "8TeV",
-      "type": "pp"
-    },
     "date_created": [
       "2012"
     ],
@@ -24907,10 +19215,6 @@
     "experiment": "CMS",
     "publisher": "CERN Open Data Portal",
     "recid": "6911",
-    "run_period": [
-      "Run2012B",
-      "Run2012C"
-    ],
     "title": "High-Level Trigger path information HLT_Tau2Mu_ItTrack (MuOnia dataset)",
     "type": {
       "primary": "Supplementaries",
@@ -24931,10 +19235,6 @@
     "collections": [
       "CMS-Trigger-Information"
     ],
-    "collision_information": {
-      "energy": "8TeV",
-      "type": "pp"
-    },
     "date_created": [
       "2012"
     ],
@@ -24942,10 +19242,6 @@
     "experiment": "CMS",
     "publisher": "CERN Open Data Portal",
     "recid": "6912",
-    "run_period": [
-      "Run2012B",
-      "Run2012C"
-    ],
     "title": "High-Level Trigger path information HLT_TrackerCalibration",
     "type": {
       "primary": "Supplementaries",
@@ -24966,10 +19262,6 @@
     "collections": [
       "CMS-Trigger-Information"
     ],
-    "collision_information": {
-      "energy": "8TeV",
-      "type": "pp"
-    },
     "date_created": [
       "2012"
     ],
@@ -24977,10 +19269,6 @@
     "experiment": "CMS",
     "publisher": "CERN Open Data Portal",
     "recid": "6913",
-    "run_period": [
-      "Run2012B",
-      "Run2012C"
-    ],
     "title": "High-Level Trigger path information HLT_TripleEle10_CaloIdL_TrkIdVL (DoubleElectron dataset)",
     "type": {
       "primary": "Supplementaries",
@@ -25001,10 +19289,6 @@
     "collections": [
       "CMS-Trigger-Information"
     ],
-    "collision_information": {
-      "energy": "8TeV",
-      "type": "pp"
-    },
     "date_created": [
       "2012"
     ],
@@ -25012,10 +19296,6 @@
     "experiment": "CMS",
     "publisher": "CERN Open Data Portal",
     "recid": "6914",
-    "run_period": [
-      "Run2012B",
-      "Run2012C"
-    ],
     "title": "High-Level Trigger path information HLT_TripleMu5 (DoubleMu, DoubleMuParked datasets)",
     "type": {
       "primary": "Supplementaries",
@@ -25036,10 +19316,6 @@
     "collections": [
       "CMS-Trigger-Information"
     ],
-    "collision_information": {
-      "energy": "8TeV",
-      "type": "pp"
-    },
     "date_created": [
       "2012"
     ],
@@ -25047,10 +19323,6 @@
     "experiment": "CMS",
     "publisher": "CERN Open Data Portal",
     "recid": "6915",
-    "run_period": [
-      "Run2012B",
-      "Run2012C"
-    ],
     "title": "High-Level Trigger path information HLT_TripleTrack02_BHC (LP_Central dataset)",
     "type": {
       "primary": "Supplementaries",
@@ -25071,10 +19343,6 @@
     "collections": [
       "CMS-Trigger-Information"
     ],
-    "collision_information": {
-      "energy": "8TeV",
-      "type": "pp"
-    },
     "date_created": [
       "2012"
     ],
@@ -25082,10 +19350,6 @@
     "experiment": "CMS",
     "publisher": "CERN Open Data Portal",
     "recid": "6916",
-    "run_period": [
-      "Run2012B",
-      "Run2012C"
-    ],
     "title": "High-Level Trigger path information HLT_TripleTrack02_HF (LP_Central dataset)",
     "type": {
       "primary": "Supplementaries",
@@ -25106,10 +19370,6 @@
     "collections": [
       "CMS-Trigger-Information"
     ],
-    "collision_information": {
-      "energy": "8TeV",
-      "type": "pp"
-    },
     "date_created": [
       "2012"
     ],
@@ -25117,10 +19377,6 @@
     "experiment": "CMS",
     "publisher": "CERN Open Data Portal",
     "recid": "6917",
-    "run_period": [
-      "Run2012B",
-      "Run2012C"
-    ],
     "title": "High-Level Trigger path information HLT_ZeroBias (MinimumBias dataset)",
     "type": {
       "primary": "Supplementaries",
@@ -25141,10 +19397,6 @@
     "collections": [
       "CMS-Trigger-Information"
     ],
-    "collision_information": {
-      "energy": "8TeV",
-      "type": "pp"
-    },
     "date_created": [
       "2012"
     ],
@@ -25152,10 +19404,6 @@
     "experiment": "CMS",
     "publisher": "CERN Open Data Portal",
     "recid": "6918",
-    "run_period": [
-      "Run2012B",
-      "Run2012C"
-    ],
     "title": "High-Level Trigger path information HLT_ZeroBiasPart1 (ZeroBias1 dataset)",
     "type": {
       "primary": "Supplementaries",
@@ -25176,10 +19424,6 @@
     "collections": [
       "CMS-Trigger-Information"
     ],
-    "collision_information": {
-      "energy": "8TeV",
-      "type": "pp"
-    },
     "date_created": [
       "2012"
     ],
@@ -25187,10 +19431,6 @@
     "experiment": "CMS",
     "publisher": "CERN Open Data Portal",
     "recid": "6919",
-    "run_period": [
-      "Run2012B",
-      "Run2012C"
-    ],
     "title": "High-Level Trigger path information HLT_ZeroBiasPart2 (ZeroBias2 dataset)",
     "type": {
       "primary": "Supplementaries",
@@ -25211,10 +19451,6 @@
     "collections": [
       "CMS-Trigger-Information"
     ],
-    "collision_information": {
-      "energy": "8TeV",
-      "type": "pp"
-    },
     "date_created": [
       "2012"
     ],
@@ -25222,10 +19458,6 @@
     "experiment": "CMS",
     "publisher": "CERN Open Data Portal",
     "recid": "6920",
-    "run_period": [
-      "Run2012B",
-      "Run2012C"
-    ],
     "title": "High-Level Trigger path information HLT_ZeroBiasPart3 (ZeroBias3 dataset)",
     "type": {
       "primary": "Supplementaries",
@@ -25246,10 +19478,6 @@
     "collections": [
       "CMS-Trigger-Information"
     ],
-    "collision_information": {
-      "energy": "8TeV",
-      "type": "pp"
-    },
     "date_created": [
       "2012"
     ],
@@ -25257,10 +19485,6 @@
     "experiment": "CMS",
     "publisher": "CERN Open Data Portal",
     "recid": "6921",
-    "run_period": [
-      "Run2012B",
-      "Run2012C"
-    ],
     "title": "High-Level Trigger path information HLT_ZeroBiasPart4 (ZeroBias4 dataset)",
     "type": {
       "primary": "Supplementaries",
@@ -25281,10 +19505,6 @@
     "collections": [
       "CMS-Trigger-Information"
     ],
-    "collision_information": {
-      "energy": "8TeV",
-      "type": "pp"
-    },
     "date_created": [
       "2012"
     ],
@@ -25292,10 +19512,6 @@
     "experiment": "CMS",
     "publisher": "CERN Open Data Portal",
     "recid": "6922",
-    "run_period": [
-      "Run2012B",
-      "Run2012C"
-    ],
     "title": "High-Level Trigger path information HLT_ZeroBiasPart5 (ZeroBias25ns5 dataset)",
     "type": {
       "primary": "Supplementaries",
@@ -25316,10 +19532,6 @@
     "collections": [
       "CMS-Trigger-Information"
     ],
-    "collision_information": {
-      "energy": "8TeV",
-      "type": "pp"
-    },
     "date_created": [
       "2012"
     ],
@@ -25327,10 +19539,6 @@
     "experiment": "CMS",
     "publisher": "CERN Open Data Portal",
     "recid": "6923",
-    "run_period": [
-      "Run2012B",
-      "Run2012C"
-    ],
     "title": "High-Level Trigger path information HLT_ZeroBiasPart6 (ZeroBias25ns6 dataset)",
     "type": {
       "primary": "Supplementaries",
@@ -25351,10 +19559,6 @@
     "collections": [
       "CMS-Trigger-Information"
     ],
-    "collision_information": {
-      "energy": "8TeV",
-      "type": "pp"
-    },
     "date_created": [
       "2012"
     ],
@@ -25362,10 +19566,6 @@
     "experiment": "CMS",
     "publisher": "CERN Open Data Portal",
     "recid": "6924",
-    "run_period": [
-      "Run2012B",
-      "Run2012C"
-    ],
     "title": "High-Level Trigger path information HLT_ZeroBiasPart7 (ZeroBias25ns7 dataset)",
     "type": {
       "primary": "Supplementaries",
@@ -25386,10 +19586,6 @@
     "collections": [
       "CMS-Trigger-Information"
     ],
-    "collision_information": {
-      "energy": "8TeV",
-      "type": "pp"
-    },
     "date_created": [
       "2012"
     ],
@@ -25397,10 +19593,6 @@
     "experiment": "CMS",
     "publisher": "CERN Open Data Portal",
     "recid": "6925",
-    "run_period": [
-      "Run2012B",
-      "Run2012C"
-    ],
     "title": "High-Level Trigger path information HLT_ZeroBiasPart8 (ZeroBias25ns8 dataset)",
     "type": {
       "primary": "Supplementaries",
@@ -25421,10 +19613,6 @@
     "collections": [
       "CMS-Trigger-Information"
     ],
-    "collision_information": {
-      "energy": "8TeV",
-      "type": "pp"
-    },
     "date_created": [
       "2012"
     ],
@@ -25432,10 +19620,6 @@
     "experiment": "CMS",
     "publisher": "CERN Open Data Portal",
     "recid": "6926",
-    "run_period": [
-      "Run2012B",
-      "Run2012C"
-    ],
     "title": "High-Level Trigger path information HLT_ZeroBiasPixel_DoubleTrack (MinimumBias dataset)",
     "type": {
       "primary": "Supplementaries",
@@ -25456,10 +19640,6 @@
     "collections": [
       "CMS-Trigger-Information"
     ],
-    "collision_information": {
-      "energy": "8TeV",
-      "type": "pp"
-    },
     "date_created": [
       "2012"
     ],
@@ -25467,10 +19647,6 @@
     "experiment": "CMS",
     "publisher": "CERN Open Data Portal",
     "recid": "6927",
-    "run_period": [
-      "Run2012B",
-      "Run2012C"
-    ],
     "title": "High-Level Trigger path information HLT_ZeroBias_Parked (ZeroBiasParked dataset)",
     "type": {
       "primary": "Supplementaries",
@@ -25491,10 +19667,6 @@
     "collections": [
       "CMS-Trigger-Information"
     ],
-    "collision_information": {
-      "energy": "8TeV",
-      "type": "pp"
-    },
     "date_created": [
       "2012"
     ],
@@ -25502,10 +19674,6 @@
     "experiment": "CMS",
     "publisher": "CERN Open Data Portal",
     "recid": "6928",
-    "run_period": [
-      "Run2012B",
-      "Run2012C"
-    ],
     "title": "High-Level Trigger path information HLT_ZeroBias_Part1 (ZeroBias1 dataset)",
     "type": {
       "primary": "Supplementaries",
@@ -25526,10 +19694,6 @@
     "collections": [
       "CMS-Trigger-Information"
     ],
-    "collision_information": {
-      "energy": "8TeV",
-      "type": "pp"
-    },
     "date_created": [
       "2012"
     ],
@@ -25537,10 +19701,6 @@
     "experiment": "CMS",
     "publisher": "CERN Open Data Portal",
     "recid": "6929",
-    "run_period": [
-      "Run2012B",
-      "Run2012C"
-    ],
     "title": "High-Level Trigger path information HLT_ZeroBias_Part2 (ZeroBias2 dataset)",
     "type": {
       "primary": "Supplementaries",
@@ -25561,10 +19721,6 @@
     "collections": [
       "CMS-Trigger-Information"
     ],
-    "collision_information": {
-      "energy": "8TeV",
-      "type": "pp"
-    },
     "date_created": [
       "2012"
     ],
@@ -25572,10 +19728,6 @@
     "experiment": "CMS",
     "publisher": "CERN Open Data Portal",
     "recid": "6930",
-    "run_period": [
-      "Run2012B",
-      "Run2012C"
-    ],
     "title": "High-Level Trigger path information HLT_ZeroBias_Part3 (ZeroBias3 dataset)",
     "type": {
       "primary": "Supplementaries",
@@ -25596,10 +19748,6 @@
     "collections": [
       "CMS-Trigger-Information"
     ],
-    "collision_information": {
-      "energy": "8TeV",
-      "type": "pp"
-    },
     "date_created": [
       "2012"
     ],
@@ -25607,10 +19755,6 @@
     "experiment": "CMS",
     "publisher": "CERN Open Data Portal",
     "recid": "6931",
-    "run_period": [
-      "Run2012B",
-      "Run2012C"
-    ],
     "title": "High-Level Trigger path information HLT_ZeroBias_Part4 (ZeroBias4 dataset)",
     "type": {
       "primary": "Supplementaries",
@@ -25631,10 +19775,6 @@
     "collections": [
       "CMS-Trigger-Information"
     ],
-    "collision_information": {
-      "energy": "8TeV",
-      "type": "pp"
-    },
     "date_created": [
       "2012"
     ],
@@ -25642,10 +19782,6 @@
     "experiment": "CMS",
     "publisher": "CERN Open Data Portal",
     "recid": "6932",
-    "run_period": [
-      "Run2012B",
-      "Run2012C"
-    ],
     "title": "High-Level Trigger path information HLT_ZeroBias_part0 (ZeroBias1 dataset)",
     "type": {
       "primary": "Supplementaries",
@@ -25666,10 +19802,6 @@
     "collections": [
       "CMS-Trigger-Information"
     ],
-    "collision_information": {
-      "energy": "8TeV",
-      "type": "pp"
-    },
     "date_created": [
       "2012"
     ],
@@ -25677,10 +19809,6 @@
     "experiment": "CMS",
     "publisher": "CERN Open Data Portal",
     "recid": "6933",
-    "run_period": [
-      "Run2012B",
-      "Run2012C"
-    ],
     "title": "High-Level Trigger path information HLT_ZeroBias_part1 (ZeroBias1 dataset)",
     "type": {
       "primary": "Supplementaries",
@@ -25701,10 +19829,6 @@
     "collections": [
       "CMS-Trigger-Information"
     ],
-    "collision_information": {
-      "energy": "8TeV",
-      "type": "pp"
-    },
     "date_created": [
       "2012"
     ],
@@ -25712,10 +19836,6 @@
     "experiment": "CMS",
     "publisher": "CERN Open Data Portal",
     "recid": "6934",
-    "run_period": [
-      "Run2012B",
-      "Run2012C"
-    ],
     "title": "High-Level Trigger path information HLT_ZeroBias_part2 (ZeroBias3 dataset)",
     "type": {
       "primary": "Supplementaries",
@@ -25736,10 +19856,6 @@
     "collections": [
       "CMS-Trigger-Information"
     ],
-    "collision_information": {
-      "energy": "8TeV",
-      "type": "pp"
-    },
     "date_created": [
       "2012"
     ],
@@ -25747,10 +19863,6 @@
     "experiment": "CMS",
     "publisher": "CERN Open Data Portal",
     "recid": "6935",
-    "run_period": [
-      "Run2012B",
-      "Run2012C"
-    ],
     "title": "High-Level Trigger path information HLT_ZeroBias_part3 (ZeroBias4 dataset)",
     "type": {
       "primary": "Supplementaries",
@@ -25771,10 +19883,6 @@
     "collections": [
       "CMS-Trigger-Information"
     ],
-    "collision_information": {
-      "energy": "8TeV",
-      "type": "pp"
-    },
     "date_created": [
       "2012"
     ],
@@ -25782,10 +19890,6 @@
     "experiment": "CMS",
     "publisher": "CERN Open Data Portal",
     "recid": "6936",
-    "run_period": [
-      "Run2012B",
-      "Run2012C"
-    ],
     "title": "High-Level Trigger path information HLT_ZeroBias_part4 (ZeroBias5 dataset)",
     "type": {
       "primary": "Supplementaries",
@@ -25806,10 +19910,6 @@
     "collections": [
       "CMS-Trigger-Information"
     ],
-    "collision_information": {
-      "energy": "8TeV",
-      "type": "pp"
-    },
     "date_created": [
       "2012"
     ],
@@ -25817,10 +19917,6 @@
     "experiment": "CMS",
     "publisher": "CERN Open Data Portal",
     "recid": "6937",
-    "run_period": [
-      "Run2012B",
-      "Run2012C"
-    ],
     "title": "High-Level Trigger path information HLT_ZeroBias_part5 (ZeroBias6 dataset)",
     "type": {
       "primary": "Supplementaries",
@@ -25841,10 +19937,6 @@
     "collections": [
       "CMS-Trigger-Information"
     ],
-    "collision_information": {
-      "energy": "8TeV",
-      "type": "pp"
-    },
     "date_created": [
       "2012"
     ],
@@ -25852,10 +19944,6 @@
     "experiment": "CMS",
     "publisher": "CERN Open Data Portal",
     "recid": "6938",
-    "run_period": [
-      "Run2012B",
-      "Run2012C"
-    ],
     "title": "High-Level Trigger path information HLT_ZeroBias_part6 (ZeroBias7 dataset)",
     "type": {
       "primary": "Supplementaries",
@@ -25876,10 +19964,6 @@
     "collections": [
       "CMS-Trigger-Information"
     ],
-    "collision_information": {
-      "energy": "8TeV",
-      "type": "pp"
-    },
     "date_created": [
       "2012"
     ],
@@ -25887,10 +19971,6 @@
     "experiment": "CMS",
     "publisher": "CERN Open Data Portal",
     "recid": "6939",
-    "run_period": [
-      "Run2012B",
-      "Run2012C"
-    ],
     "title": "High-Level Trigger path information HLT_ZeroBias_part7 (ZeroBias8 dataset)",
     "type": {
       "primary": "Supplementaries",
@@ -25911,10 +19991,6 @@
     "collections": [
       "CMS-Trigger-Information"
     ],
-    "collision_information": {
-      "energy": "8TeV",
-      "type": "pp"
-    },
     "date_created": [
       "2012"
     ],
@@ -25922,10 +19998,6 @@
     "experiment": "CMS",
     "publisher": "CERN Open Data Portal",
     "recid": "6940",
-    "run_period": [
-      "Run2012B",
-      "Run2012C"
-    ],
     "title": "High-Level Trigger path information HLTriggerFinalPath",
     "type": {
       "primary": "Supplementaries",
@@ -25946,10 +20018,6 @@
     "collections": [
       "CMS-Trigger-Information"
     ],
-    "collision_information": {
-      "energy": "8TeV",
-      "type": "pp"
-    },
     "date_created": [
       "2012"
     ],
@@ -25957,10 +20025,6 @@
     "experiment": "CMS",
     "publisher": "CERN Open Data Portal",
     "recid": "6941",
-    "run_period": [
-      "Run2012B",
-      "Run2012C"
-    ],
     "title": "High-Level Trigger path information HLTriggerFirstPath",
     "type": {
       "primary": "Supplementaries",
@@ -25981,10 +20045,6 @@
     "collections": [
       "CMS-Trigger-Information"
     ],
-    "collision_information": {
-      "energy": "8TeV",
-      "type": "pp"
-    },
     "date_created": [
       "2012"
     ],
@@ -25992,10 +20052,6 @@
     "experiment": "CMS",
     "publisher": "CERN Open Data Portal",
     "recid": "6942",
-    "run_period": [
-      "Run2012B",
-      "Run2012C"
-    ],
     "title": "High-Level Trigger path information NanoDSTOutput",
     "type": {
       "primary": "Supplementaries",
@@ -26016,10 +20072,6 @@
     "collections": [
       "CMS-Trigger-Information"
     ],
-    "collision_information": {
-      "energy": "8TeV",
-      "type": "pp"
-    },
     "date_created": [
       "2012"
     ],
@@ -26027,10 +20079,6 @@
     "experiment": "CMS",
     "publisher": "CERN Open Data Portal",
     "recid": "6943",
-    "run_period": [
-      "Run2012B",
-      "Run2012C"
-    ],
     "title": "High-Level Trigger path information PhysicsDSTOutput",
     "type": {
       "primary": "Supplementaries",
@@ -26051,10 +20099,6 @@
     "collections": [
       "CMS-Trigger-Information"
     ],
-    "collision_information": {
-      "energy": "8TeV",
-      "type": "pp"
-    },
     "date_created": [
       "2012"
     ],
@@ -26062,10 +20106,6 @@
     "experiment": "CMS",
     "publisher": "CERN Open Data Portal",
     "recid": "6944",
-    "run_period": [
-      "Run2012B",
-      "Run2012C"
-    ],
     "title": "High-Level Trigger path information RPCMONOutput",
     "type": {
       "primary": "Supplementaries",

--- a/cernopendata/modules/fixtures/data/records/cms-trigger-path-Run2011A.json
+++ b/cernopendata/modules/fixtures/data/records/cms-trigger-path-Run2011A.json
@@ -11,9 +11,6 @@
     "collections": [
       "CMS-Trigger-Information"
     ],
-    "collision_information": {
-      "energy": "7TeV"
-    },
     "date_created": [
       "2011"
     ],
@@ -21,9 +18,6 @@
     "experiment": "CMS",
     "publisher": "CERN Open Data Portal",
     "recid": "2000",
-    "run_period": [
-      "Run2011A"
-    ],
     "title": "High-Level Trigger path information AForHIOutput",
     "type": {
       "primary": "Supplementaries",
@@ -44,9 +38,6 @@
     "collections": [
       "CMS-Trigger-Information"
     ],
-    "collision_information": {
-      "energy": "7TeV"
-    },
     "date_created": [
       "2011"
     ],
@@ -54,9 +45,6 @@
     "experiment": "CMS",
     "publisher": "CERN Open Data Portal",
     "recid": "2001",
-    "run_period": [
-      "Run2011A"
-    ],
     "title": "High-Level Trigger path information ALCALUMIPIXELSOutput",
     "type": {
       "primary": "Supplementaries",
@@ -77,9 +65,6 @@
     "collections": [
       "CMS-Trigger-Information"
     ],
-    "collision_information": {
-      "energy": "7TeV"
-    },
     "date_created": [
       "2011"
     ],
@@ -87,9 +72,6 @@
     "experiment": "CMS",
     "publisher": "CERN Open Data Portal",
     "recid": "2002",
-    "run_period": [
-      "Run2011A"
-    ],
     "title": "High-Level Trigger path information ALCAP0Output",
     "type": {
       "primary": "Supplementaries",
@@ -110,9 +92,6 @@
     "collections": [
       "CMS-Trigger-Information"
     ],
-    "collision_information": {
-      "energy": "7TeV"
-    },
     "date_created": [
       "2011"
     ],
@@ -120,9 +99,6 @@
     "experiment": "CMS",
     "publisher": "CERN Open Data Portal",
     "recid": "2003",
-    "run_period": [
-      "Run2011A"
-    ],
     "title": "High-Level Trigger path information ALCAPHISYMOutput",
     "type": {
       "primary": "Supplementaries",
@@ -143,9 +119,6 @@
     "collections": [
       "CMS-Trigger-Information"
     ],
-    "collision_information": {
-      "energy": "7TeV"
-    },
     "date_created": [
       "2011"
     ],
@@ -153,9 +126,6 @@
     "experiment": "CMS",
     "publisher": "CERN Open Data Portal",
     "recid": "2004",
-    "run_period": [
-      "Run2011A"
-    ],
     "title": "High-Level Trigger path information AOutput",
     "type": {
       "primary": "Supplementaries",
@@ -176,9 +146,6 @@
     "collections": [
       "CMS-Trigger-Information"
     ],
-    "collision_information": {
-      "energy": "7TeV"
-    },
     "date_created": [
       "2011"
     ],
@@ -186,9 +153,6 @@
     "experiment": "CMS",
     "publisher": "CERN Open Data Portal",
     "recid": "2005",
-    "run_period": [
-      "Run2011A"
-    ],
     "title": "High-Level Trigger path information AlCa_EcalEta",
     "type": {
       "primary": "Supplementaries",
@@ -209,9 +173,6 @@
     "collections": [
       "CMS-Trigger-Information"
     ],
-    "collision_information": {
-      "energy": "7TeV"
-    },
     "date_created": [
       "2011"
     ],
@@ -219,9 +180,6 @@
     "experiment": "CMS",
     "publisher": "CERN Open Data Portal",
     "recid": "2006",
-    "run_period": [
-      "Run2011A"
-    ],
     "title": "High-Level Trigger path information AlCa_EcalPhiSym",
     "type": {
       "primary": "Supplementaries",
@@ -242,9 +200,6 @@
     "collections": [
       "CMS-Trigger-Information"
     ],
-    "collision_information": {
-      "energy": "7TeV"
-    },
     "date_created": [
       "2011"
     ],
@@ -252,9 +207,6 @@
     "experiment": "CMS",
     "publisher": "CERN Open Data Portal",
     "recid": "2007",
-    "run_period": [
-      "Run2011A"
-    ],
     "title": "High-Level Trigger path information AlCa_EcalPi0",
     "type": {
       "primary": "Supplementaries",
@@ -275,9 +227,6 @@
     "collections": [
       "CMS-Trigger-Information"
     ],
-    "collision_information": {
-      "energy": "7TeV"
-    },
     "date_created": [
       "2011"
     ],
@@ -285,9 +234,6 @@
     "experiment": "CMS",
     "publisher": "CERN Open Data Portal",
     "recid": "2008",
-    "run_period": [
-      "Run2011A"
-    ],
     "title": "High-Level Trigger path information AlCa_LumiPixels",
     "type": {
       "primary": "Supplementaries",
@@ -308,9 +254,6 @@
     "collections": [
       "CMS-Trigger-Information"
     ],
-    "collision_information": {
-      "energy": "7TeV"
-    },
     "date_created": [
       "2011"
     ],
@@ -318,9 +261,6 @@
     "experiment": "CMS",
     "publisher": "CERN Open Data Portal",
     "recid": "2009",
-    "run_period": [
-      "Run2011A"
-    ],
     "title": "High-Level Trigger path information AlCa_RPCMuonNoHits",
     "type": {
       "primary": "Supplementaries",
@@ -341,9 +281,6 @@
     "collections": [
       "CMS-Trigger-Information"
     ],
-    "collision_information": {
-      "energy": "7TeV"
-    },
     "date_created": [
       "2011"
     ],
@@ -351,9 +288,6 @@
     "experiment": "CMS",
     "publisher": "CERN Open Data Portal",
     "recid": "2010",
-    "run_period": [
-      "Run2011A"
-    ],
     "title": "High-Level Trigger path information AlCa_RPCMuonNoTriggers",
     "type": {
       "primary": "Supplementaries",
@@ -374,9 +308,6 @@
     "collections": [
       "CMS-Trigger-Information"
     ],
-    "collision_information": {
-      "energy": "7TeV"
-    },
     "date_created": [
       "2011"
     ],
@@ -384,9 +315,6 @@
     "experiment": "CMS",
     "publisher": "CERN Open Data Portal",
     "recid": "2011",
-    "run_period": [
-      "Run2011A"
-    ],
     "title": "High-Level Trigger path information AlCa_RPCMuonNormalisation",
     "type": {
       "primary": "Supplementaries",
@@ -407,9 +335,6 @@
     "collections": [
       "CMS-Trigger-Information"
     ],
-    "collision_information": {
-      "energy": "7TeV"
-    },
     "date_created": [
       "2011"
     ],
@@ -417,9 +342,6 @@
     "experiment": "CMS",
     "publisher": "CERN Open Data Portal",
     "recid": "2012",
-    "run_period": [
-      "Run2011A"
-    ],
     "title": "High-Level Trigger path information CalibrationOutput",
     "type": {
       "primary": "Supplementaries",
@@ -440,9 +362,6 @@
     "collections": [
       "CMS-Trigger-Information"
     ],
-    "collision_information": {
-      "energy": "7TeV"
-    },
     "date_created": [
       "2011"
     ],
@@ -450,9 +369,6 @@
     "experiment": "CMS",
     "publisher": "CERN Open Data Portal",
     "recid": "2013",
-    "run_period": [
-      "Run2011A"
-    ],
     "title": "High-Level Trigger path information DQMForHIOutput",
     "type": {
       "primary": "Supplementaries",
@@ -473,9 +389,6 @@
     "collections": [
       "CMS-Trigger-Information"
     ],
-    "collision_information": {
-      "energy": "7TeV"
-    },
     "date_created": [
       "2011"
     ],
@@ -483,9 +396,6 @@
     "experiment": "CMS",
     "publisher": "CERN Open Data Portal",
     "recid": "2014",
-    "run_period": [
-      "Run2011A"
-    ],
     "title": "High-Level Trigger path information DQMOutput",
     "type": {
       "primary": "Supplementaries",
@@ -506,9 +416,6 @@
     "collections": [
       "CMS-Trigger-Information"
     ],
-    "collision_information": {
-      "energy": "7TeV"
-    },
     "date_created": [
       "2011"
     ],
@@ -516,9 +423,6 @@
     "experiment": "CMS",
     "publisher": "CERN Open Data Portal",
     "recid": "2015",
-    "run_period": [
-      "Run2011A"
-    ],
     "title": "High-Level Trigger path information DQM_FEDIntegrity",
     "type": {
       "primary": "Supplementaries",
@@ -539,9 +443,6 @@
     "collections": [
       "CMS-Trigger-Information"
     ],
-    "collision_information": {
-      "energy": "7TeV"
-    },
     "date_created": [
       "2011"
     ],
@@ -549,9 +450,6 @@
     "experiment": "CMS",
     "publisher": "CERN Open Data Portal",
     "recid": "2016",
-    "run_period": [
-      "Run2011A"
-    ],
     "title": "High-Level Trigger path information DST_FatJetMass300_DR1p1_Deta2p0 (PhysicsDST dataset)",
     "type": {
       "primary": "Supplementaries",
@@ -572,9 +470,6 @@
     "collections": [
       "CMS-Trigger-Information"
     ],
-    "collision_information": {
-      "energy": "7TeV"
-    },
     "date_created": [
       "2011"
     ],
@@ -582,9 +477,6 @@
     "experiment": "CMS",
     "publisher": "CERN Open Data Portal",
     "recid": "2017",
-    "run_period": [
-      "Run2011A"
-    ],
     "title": "High-Level Trigger path information DST_FatJetMass400_DR1p1_Deta2p0_RunPF (PhysicsDST dataset)",
     "type": {
       "primary": "Supplementaries",
@@ -605,9 +497,6 @@
     "collections": [
       "CMS-Trigger-Information"
     ],
-    "collision_information": {
-      "energy": "7TeV"
-    },
     "date_created": [
       "2011"
     ],
@@ -615,9 +504,6 @@
     "experiment": "CMS",
     "publisher": "CERN Open Data Portal",
     "recid": "2018",
-    "run_period": [
-      "Run2011A"
-    ],
     "title": "High-Level Trigger path information DST_HT350_RunPF (PhysicsDST dataset)",
     "type": {
       "primary": "Supplementaries",
@@ -638,9 +524,6 @@
     "collections": [
       "CMS-Trigger-Information"
     ],
-    "collision_information": {
-      "energy": "7TeV"
-    },
     "date_created": [
       "2011"
     ],
@@ -648,9 +531,6 @@
     "experiment": "CMS",
     "publisher": "CERN Open Data Portal",
     "recid": "2019",
-    "run_period": [
-      "Run2011A"
-    ],
     "title": "High-Level Trigger path information DST_Physics",
     "type": {
       "primary": "Supplementaries",
@@ -671,9 +551,6 @@
     "collections": [
       "CMS-Trigger-Information"
     ],
-    "collision_information": {
-      "energy": "7TeV"
-    },
     "date_created": [
       "2011"
     ],
@@ -681,9 +558,6 @@
     "experiment": "CMS",
     "publisher": "CERN Open Data Portal",
     "recid": "2020",
-    "run_period": [
-      "Run2011A"
-    ],
     "title": "High-Level Trigger path information EcalCalibrationOutput",
     "type": {
       "primary": "Supplementaries",
@@ -704,9 +578,6 @@
     "collections": [
       "CMS-Trigger-Information"
     ],
-    "collision_information": {
-      "energy": "7TeV"
-    },
     "date_created": [
       "2011"
     ],
@@ -714,9 +585,6 @@
     "experiment": "CMS",
     "publisher": "CERN Open Data Portal",
     "recid": "2021",
-    "run_period": [
-      "Run2011A"
-    ],
     "title": "High-Level Trigger path information ExpressForHIOutput",
     "type": {
       "primary": "Supplementaries",
@@ -737,9 +605,6 @@
     "collections": [
       "CMS-Trigger-Information"
     ],
-    "collision_information": {
-      "energy": "7TeV"
-    },
     "date_created": [
       "2011"
     ],
@@ -747,9 +612,6 @@
     "experiment": "CMS",
     "publisher": "CERN Open Data Portal",
     "recid": "2022",
-    "run_period": [
-      "Run2011A"
-    ],
     "title": "High-Level Trigger path information ExpressOutput",
     "type": {
       "primary": "Supplementaries",
@@ -770,9 +632,6 @@
     "collections": [
       "CMS-Trigger-Information"
     ],
-    "collision_information": {
-      "energy": "7TeV"
-    },
     "date_created": [
       "2011"
     ],
@@ -780,9 +639,6 @@
     "experiment": "CMS",
     "publisher": "CERN Open Data Portal",
     "recid": "2023",
-    "run_period": [
-      "Run2011A"
-    ],
     "title": "High-Level Trigger path information HLTDQMOutput",
     "type": {
       "primary": "Supplementaries",
@@ -803,9 +659,6 @@
     "collections": [
       "CMS-Trigger-Information"
     ],
-    "collision_information": {
-      "energy": "7TeV"
-    },
     "date_created": [
       "2011"
     ],
@@ -813,9 +666,6 @@
     "experiment": "CMS",
     "publisher": "CERN Open Data Portal",
     "recid": "2024",
-    "run_period": [
-      "Run2011A"
-    ],
     "title": "High-Level Trigger path information HLTDQMResultsOutput",
     "type": {
       "primary": "Supplementaries",
@@ -836,9 +686,6 @@
     "collections": [
       "CMS-Trigger-Information"
     ],
-    "collision_information": {
-      "energy": "7TeV"
-    },
     "date_created": [
       "2011"
     ],
@@ -846,9 +693,6 @@
     "experiment": "CMS",
     "publisher": "CERN Open Data Portal",
     "recid": "2025",
-    "run_period": [
-      "Run2011A"
-    ],
     "title": "High-Level Trigger path information HLTMONOutput",
     "type": {
       "primary": "Supplementaries",
@@ -869,9 +713,6 @@
     "collections": [
       "CMS-Trigger-Information"
     ],
-    "collision_information": {
-      "energy": "7TeV"
-    },
     "date_created": [
       "2011"
     ],
@@ -879,9 +720,6 @@
     "experiment": "CMS",
     "publisher": "CERN Open Data Portal",
     "recid": "2026",
-    "run_period": [
-      "Run2011A"
-    ],
     "title": "High-Level Trigger path information HLTOutput",
     "type": {
       "primary": "Supplementaries",
@@ -902,9 +740,6 @@
     "collections": [
       "CMS-Trigger-Information"
     ],
-    "collision_information": {
-      "energy": "7TeV"
-    },
     "date_created": [
       "2011"
     ],
@@ -912,9 +747,6 @@
     "experiment": "CMS",
     "publisher": "CERN Open Data Portal",
     "recid": "2027",
-    "run_period": [
-      "Run2011A"
-    ],
     "title": "High-Level Trigger path information HLT_300Tower0p5 (HighPileUp dataset)",
     "type": {
       "primary": "Supplementaries",
@@ -935,9 +767,6 @@
     "collections": [
       "CMS-Trigger-Information"
     ],
-    "collision_information": {
-      "energy": "7TeV"
-    },
     "date_created": [
       "2011"
     ],
@@ -945,9 +774,6 @@
     "experiment": "CMS",
     "publisher": "CERN Open Data Portal",
     "recid": "2028",
-    "run_period": [
-      "Run2011A"
-    ],
     "title": "High-Level Trigger path information HLT_300Tower0p6 (HighPileUp dataset)",
     "type": {
       "primary": "Supplementaries",
@@ -968,9 +794,6 @@
     "collections": [
       "CMS-Trigger-Information"
     ],
-    "collision_information": {
-      "energy": "7TeV"
-    },
     "date_created": [
       "2011"
     ],
@@ -978,9 +801,6 @@
     "experiment": "CMS",
     "publisher": "CERN Open Data Portal",
     "recid": "2029",
-    "run_period": [
-      "Run2011A"
-    ],
     "title": "High-Level Trigger path information HLT_300Tower0p7 (HighPileUp dataset)",
     "type": {
       "primary": "Supplementaries",
@@ -1001,9 +821,6 @@
     "collections": [
       "CMS-Trigger-Information"
     ],
-    "collision_information": {
-      "energy": "7TeV"
-    },
     "date_created": [
       "2011"
     ],
@@ -1011,9 +828,6 @@
     "experiment": "CMS",
     "publisher": "CERN Open Data Portal",
     "recid": "2030",
-    "run_period": [
-      "Run2011A"
-    ],
     "title": "High-Level Trigger path information HLT_300Tower0p8 (HighPileUp dataset)",
     "type": {
       "primary": "Supplementaries",
@@ -1034,9 +848,6 @@
     "collections": [
       "CMS-Trigger-Information"
     ],
-    "collision_information": {
-      "energy": "7TeV"
-    },
     "date_created": [
       "2011"
     ],
@@ -1044,9 +855,6 @@
     "experiment": "CMS",
     "publisher": "CERN Open Data Portal",
     "recid": "2031",
-    "run_period": [
-      "Run2011A"
-    ],
     "title": "High-Level Trigger path information HLT_600Tower0p5 (HighPileUpHPF dataset)",
     "type": {
       "primary": "Supplementaries",
@@ -1067,9 +875,6 @@
     "collections": [
       "CMS-Trigger-Information"
     ],
-    "collision_information": {
-      "energy": "7TeV"
-    },
     "date_created": [
       "2011"
     ],
@@ -1077,9 +882,6 @@
     "experiment": "CMS",
     "publisher": "CERN Open Data Portal",
     "recid": "2032",
-    "run_period": [
-      "Run2011A"
-    ],
     "title": "High-Level Trigger path information HLT_600Tower0p6 (HighPileUpHPF dataset)",
     "type": {
       "primary": "Supplementaries",
@@ -1100,9 +902,6 @@
     "collections": [
       "CMS-Trigger-Information"
     ],
-    "collision_information": {
-      "energy": "7TeV"
-    },
     "date_created": [
       "2011"
     ],
@@ -1110,9 +909,6 @@
     "experiment": "CMS",
     "publisher": "CERN Open Data Portal",
     "recid": "2033",
-    "run_period": [
-      "Run2011A"
-    ],
     "title": "High-Level Trigger path information HLT_600Tower0p7 (HighPileUpHPF dataset)",
     "type": {
       "primary": "Supplementaries",
@@ -1133,9 +929,6 @@
     "collections": [
       "CMS-Trigger-Information"
     ],
-    "collision_information": {
-      "energy": "7TeV"
-    },
     "date_created": [
       "2011"
     ],
@@ -1143,9 +936,6 @@
     "experiment": "CMS",
     "publisher": "CERN Open Data Portal",
     "recid": "2034",
-    "run_period": [
-      "Run2011A"
-    ],
     "title": "High-Level Trigger path information HLT_600Tower0p8 (HighPileUpHPF dataset)",
     "type": {
       "primary": "Supplementaries",
@@ -1166,9 +956,6 @@
     "collections": [
       "CMS-Trigger-Information"
     ],
-    "collision_information": {
-      "energy": "7TeV"
-    },
     "date_created": [
       "2011"
     ],
@@ -1176,9 +963,6 @@
     "experiment": "CMS",
     "publisher": "CERN Open Data Portal",
     "recid": "2035",
-    "run_period": [
-      "Run2011A"
-    ],
     "title": "High-Level Trigger path information HLT_600Tower0p9 (HighPileUpHPF dataset)",
     "type": {
       "primary": "Supplementaries",
@@ -1199,9 +983,6 @@
     "collections": [
       "CMS-Trigger-Information"
     ],
-    "collision_information": {
-      "energy": "7TeV"
-    },
     "date_created": [
       "2011"
     ],
@@ -1209,9 +990,6 @@
     "experiment": "CMS",
     "publisher": "CERN Open Data Portal",
     "recid": "2036",
-    "run_period": [
-      "Run2011A"
-    ],
     "title": "High-Level Trigger path information HLT_600Tower1p0 (HighPileUpHPF dataset)",
     "type": {
       "primary": "Supplementaries",
@@ -1232,9 +1010,6 @@
     "collections": [
       "CMS-Trigger-Information"
     ],
-    "collision_information": {
-      "energy": "7TeV"
-    },
     "date_created": [
       "2011"
     ],
@@ -1242,9 +1017,6 @@
     "experiment": "CMS",
     "publisher": "CERN Open Data Portal",
     "recid": "2037",
-    "run_period": [
-      "Run2011A"
-    ],
     "title": "High-Level Trigger path information HLT_60Jet10 (MultiJet dataset)",
     "type": {
       "primary": "Supplementaries",
@@ -1265,9 +1037,6 @@
     "collections": [
       "CMS-Trigger-Information"
     ],
-    "collision_information": {
-      "energy": "7TeV"
-    },
     "date_created": [
       "2011"
     ],
@@ -1275,9 +1044,6 @@
     "experiment": "CMS",
     "publisher": "CERN Open Data Portal",
     "recid": "2038",
-    "run_period": [
-      "Run2011A"
-    ],
     "title": "High-Level Trigger path information HLT_70Jet10 (HighPileUp, MultiJet datasets)",
     "type": {
       "primary": "Supplementaries",
@@ -1298,9 +1064,6 @@
     "collections": [
       "CMS-Trigger-Information"
     ],
-    "collision_information": {
-      "energy": "7TeV"
-    },
     "date_created": [
       "2011"
     ],
@@ -1308,9 +1071,6 @@
     "experiment": "CMS",
     "publisher": "CERN Open Data Portal",
     "recid": "2039",
-    "run_period": [
-      "Run2011A"
-    ],
     "title": "High-Level Trigger path information HLT_70Jet13 (HighPileUp, MultiJet datasets)",
     "type": {
       "primary": "Supplementaries",
@@ -1331,9 +1091,6 @@
     "collections": [
       "CMS-Trigger-Information"
     ],
-    "collision_information": {
-      "energy": "7TeV"
-    },
     "date_created": [
       "2011"
     ],
@@ -1341,9 +1098,6 @@
     "experiment": "CMS",
     "publisher": "CERN Open Data Portal",
     "recid": "2040",
-    "run_period": [
-      "Run2011A"
-    ],
     "title": "High-Level Trigger path information HLT_Activity_Ecal_SC7 (Commissioning dataset)",
     "type": {
       "primary": "Supplementaries",
@@ -1364,9 +1118,6 @@
     "collections": [
       "CMS-Trigger-Information"
     ],
-    "collision_information": {
-      "energy": "7TeV"
-    },
     "date_created": [
       "2011"
     ],
@@ -1374,9 +1125,6 @@
     "experiment": "CMS",
     "publisher": "CERN Open Data Portal",
     "recid": "2041",
-    "run_period": [
-      "Run2011A"
-    ],
     "title": "High-Level Trigger path information HLT_BTagMu_DiJet100_Mu9 (METBTag dataset)",
     "type": {
       "primary": "Supplementaries",
@@ -1397,9 +1145,6 @@
     "collections": [
       "CMS-Trigger-Information"
     ],
-    "collision_information": {
-      "energy": "7TeV"
-    },
     "date_created": [
       "2011"
     ],
@@ -1407,9 +1152,6 @@
     "experiment": "CMS",
     "publisher": "CERN Open Data Portal",
     "recid": "2042",
-    "run_period": [
-      "Run2011A"
-    ],
     "title": "High-Level Trigger path information HLT_BTagMu_DiJet110_Mu5 (BTag, METBTag datasets)",
     "type": {
       "primary": "Supplementaries",
@@ -1430,9 +1172,6 @@
     "collections": [
       "CMS-Trigger-Information"
     ],
-    "collision_information": {
-      "energy": "7TeV"
-    },
     "date_created": [
       "2011"
     ],
@@ -1440,9 +1179,6 @@
     "experiment": "CMS",
     "publisher": "CERN Open Data Portal",
     "recid": "2043",
-    "run_period": [
-      "Run2011A"
-    ],
     "title": "High-Level Trigger path information HLT_BTagMu_DiJet20_Mu5 (BTag, METBTag datasets)",
     "type": {
       "primary": "Supplementaries",
@@ -1463,9 +1199,6 @@
     "collections": [
       "CMS-Trigger-Information"
     ],
-    "collision_information": {
-      "energy": "7TeV"
-    },
     "date_created": [
       "2011"
     ],
@@ -1473,9 +1206,6 @@
     "experiment": "CMS",
     "publisher": "CERN Open Data Portal",
     "recid": "2044",
-    "run_period": [
-      "Run2011A"
-    ],
     "title": "High-Level Trigger path information HLT_BTagMu_DiJet40_Mu5 (BTag, METBTag datasets)",
     "type": {
       "primary": "Supplementaries",
@@ -1496,9 +1226,6 @@
     "collections": [
       "CMS-Trigger-Information"
     ],
-    "collision_information": {
-      "energy": "7TeV"
-    },
     "date_created": [
       "2011"
     ],
@@ -1506,9 +1233,6 @@
     "experiment": "CMS",
     "publisher": "CERN Open Data Portal",
     "recid": "2045",
-    "run_period": [
-      "Run2011A"
-    ],
     "title": "High-Level Trigger path information HLT_BTagMu_DiJet60_Mu7 (METBTag dataset)",
     "type": {
       "primary": "Supplementaries",
@@ -1529,9 +1253,6 @@
     "collections": [
       "CMS-Trigger-Information"
     ],
-    "collision_information": {
-      "energy": "7TeV"
-    },
     "date_created": [
       "2011"
     ],
@@ -1539,9 +1260,6 @@
     "experiment": "CMS",
     "publisher": "CERN Open Data Portal",
     "recid": "2046",
-    "run_period": [
-      "Run2011A"
-    ],
     "title": "High-Level Trigger path information HLT_BTagMu_DiJet70_Mu5 (BTag, METBTag datasets)",
     "type": {
       "primary": "Supplementaries",
@@ -1562,9 +1280,6 @@
     "collections": [
       "CMS-Trigger-Information"
     ],
-    "collision_information": {
-      "energy": "7TeV"
-    },
     "date_created": [
       "2011"
     ],
@@ -1572,9 +1287,6 @@
     "experiment": "CMS",
     "publisher": "CERN Open Data Portal",
     "recid": "2047",
-    "run_period": [
-      "Run2011A"
-    ],
     "title": "High-Level Trigger path information HLT_BTagMu_DiJet80_Mu9 (METBTag dataset)",
     "type": {
       "primary": "Supplementaries",
@@ -1595,9 +1307,6 @@
     "collections": [
       "CMS-Trigger-Information"
     ],
-    "collision_information": {
-      "energy": "7TeV"
-    },
     "date_created": [
       "2011"
     ],
@@ -1605,9 +1314,6 @@
     "experiment": "CMS",
     "publisher": "CERN Open Data Portal",
     "recid": "2048",
-    "run_period": [
-      "Run2011A"
-    ],
     "title": "High-Level Trigger path information HLT_BeamGas_BSC (Commissioning dataset)",
     "type": {
       "primary": "Supplementaries",
@@ -1628,9 +1334,6 @@
     "collections": [
       "CMS-Trigger-Information"
     ],
-    "collision_information": {
-      "energy": "7TeV"
-    },
     "date_created": [
       "2011"
     ],
@@ -1638,9 +1341,6 @@
     "experiment": "CMS",
     "publisher": "CERN Open Data Portal",
     "recid": "2049",
-    "run_period": [
-      "Run2011A"
-    ],
     "title": "High-Level Trigger path information HLT_BeamGas_HF (Commissioning dataset)",
     "type": {
       "primary": "Supplementaries",
@@ -1661,9 +1361,6 @@
     "collections": [
       "CMS-Trigger-Information"
     ],
-    "collision_information": {
-      "energy": "7TeV"
-    },
     "date_created": [
       "2011"
     ],
@@ -1671,9 +1368,6 @@
     "experiment": "CMS",
     "publisher": "CERN Open Data Portal",
     "recid": "2050",
-    "run_period": [
-      "Run2011A"
-    ],
     "title": "High-Level Trigger path information HLT_BeamGas_HF_Beam1 (Commissioning dataset)",
     "type": {
       "primary": "Supplementaries",
@@ -1694,9 +1388,6 @@
     "collections": [
       "CMS-Trigger-Information"
     ],
-    "collision_information": {
-      "energy": "7TeV"
-    },
     "date_created": [
       "2011"
     ],
@@ -1704,9 +1395,6 @@
     "experiment": "CMS",
     "publisher": "CERN Open Data Portal",
     "recid": "2051",
-    "run_period": [
-      "Run2011A"
-    ],
     "title": "High-Level Trigger path information HLT_BeamGas_HF_Beam2 (Commissioning dataset)",
     "type": {
       "primary": "Supplementaries",
@@ -1727,9 +1415,6 @@
     "collections": [
       "CMS-Trigger-Information"
     ],
-    "collision_information": {
-      "energy": "7TeV"
-    },
     "date_created": [
       "2011"
     ],
@@ -1737,9 +1422,6 @@
     "experiment": "CMS",
     "publisher": "CERN Open Data Portal",
     "recid": "2052",
-    "run_period": [
-      "Run2011A"
-    ],
     "title": "High-Level Trigger path information HLT_BeamHalo (Cosmics dataset)",
     "type": {
       "primary": "Supplementaries",
@@ -1760,9 +1442,6 @@
     "collections": [
       "CMS-Trigger-Information"
     ],
-    "collision_information": {
-      "energy": "7TeV"
-    },
     "date_created": [
       "2011"
     ],
@@ -1770,9 +1449,6 @@
     "experiment": "CMS",
     "publisher": "CERN Open Data Portal",
     "recid": "2053",
-    "run_period": [
-      "Run2011A"
-    ],
     "title": "High-Level Trigger path information HLT_Calibration",
     "type": {
       "primary": "Supplementaries",
@@ -1793,9 +1469,6 @@
     "collections": [
       "CMS-Trigger-Information"
     ],
-    "collision_information": {
-      "energy": "7TeV"
-    },
     "date_created": [
       "2011"
     ],
@@ -1803,9 +1476,6 @@
     "experiment": "CMS",
     "publisher": "CERN Open Data Portal",
     "recid": "2054",
-    "run_period": [
-      "Run2011A"
-    ],
     "title": "High-Level Trigger path information HLT_CentralJet46_BTagIP3D_CentralJet38_BTagIP3D (MultiJet dataset)",
     "type": {
       "primary": "Supplementaries",
@@ -1826,9 +1496,6 @@
     "collections": [
       "CMS-Trigger-Information"
     ],
-    "collision_information": {
-      "energy": "7TeV"
-    },
     "date_created": [
       "2011"
     ],
@@ -1836,9 +1503,6 @@
     "experiment": "CMS",
     "publisher": "CERN Open Data Portal",
     "recid": "2055",
-    "run_period": [
-      "Run2011A"
-    ],
     "title": "High-Level Trigger path information HLT_CentralJet46_CentralJet38_CentralJet20_DiBTagIP3D (MultiJet dataset)",
     "type": {
       "primary": "Supplementaries",
@@ -1859,9 +1523,6 @@
     "collections": [
       "CMS-Trigger-Information"
     ],
-    "collision_information": {
-      "energy": "7TeV"
-    },
     "date_created": [
       "2011"
     ],
@@ -1869,9 +1530,6 @@
     "experiment": "CMS",
     "publisher": "CERN Open Data Portal",
     "recid": "2056",
-    "run_period": [
-      "Run2011A"
-    ],
     "title": "High-Level Trigger path information HLT_CentralJet46_CentralJet38_DiBTagIP3D (MultiJet dataset)",
     "type": {
       "primary": "Supplementaries",
@@ -1892,9 +1550,6 @@
     "collections": [
       "CMS-Trigger-Information"
     ],
-    "collision_information": {
-      "energy": "7TeV"
-    },
     "date_created": [
       "2011"
     ],
@@ -1902,9 +1557,6 @@
     "experiment": "CMS",
     "publisher": "CERN Open Data Portal",
     "recid": "2057",
-    "run_period": [
-      "Run2011A"
-    ],
     "title": "High-Level Trigger path information HLT_CentralJet60_CentralJet53_DiBTagIP3D (MultiJet dataset)",
     "type": {
       "primary": "Supplementaries",
@@ -1925,9 +1577,6 @@
     "collections": [
       "CMS-Trigger-Information"
     ],
-    "collision_information": {
-      "energy": "7TeV"
-    },
     "date_created": [
       "2011"
     ],
@@ -1935,9 +1584,6 @@
     "experiment": "CMS",
     "publisher": "CERN Open Data Portal",
     "recid": "2058",
-    "run_period": [
-      "Run2011A"
-    ],
     "title": "High-Level Trigger path information HLT_CentralJet80_MET100 (MET, METBTag datasets)",
     "type": {
       "primary": "Supplementaries",
@@ -1958,9 +1604,6 @@
     "collections": [
       "CMS-Trigger-Information"
     ],
-    "collision_information": {
-      "energy": "7TeV"
-    },
     "date_created": [
       "2011"
     ],
@@ -1968,9 +1611,6 @@
     "experiment": "CMS",
     "publisher": "CERN Open Data Portal",
     "recid": "2059",
-    "run_period": [
-      "Run2011A"
-    ],
     "title": "High-Level Trigger path information HLT_CentralJet80_MET110 (MET dataset)",
     "type": {
       "primary": "Supplementaries",
@@ -1991,9 +1631,6 @@
     "collections": [
       "CMS-Trigger-Information"
     ],
-    "collision_information": {
-      "energy": "7TeV"
-    },
     "date_created": [
       "2011"
     ],
@@ -2001,9 +1638,6 @@
     "experiment": "CMS",
     "publisher": "CERN Open Data Portal",
     "recid": "2060",
-    "run_period": [
-      "Run2011A"
-    ],
     "title": "High-Level Trigger path information HLT_CentralJet80_MET160 (MET, METBTag datasets)",
     "type": {
       "primary": "Supplementaries",
@@ -2024,9 +1658,6 @@
     "collections": [
       "CMS-Trigger-Information"
     ],
-    "collision_information": {
-      "energy": "7TeV"
-    },
     "date_created": [
       "2011"
     ],
@@ -2034,9 +1665,6 @@
     "experiment": "CMS",
     "publisher": "CERN Open Data Portal",
     "recid": "2061",
-    "run_period": [
-      "Run2011A"
-    ],
     "title": "High-Level Trigger path information HLT_CentralJet80_MET65 (MET, METBTag datasets)",
     "type": {
       "primary": "Supplementaries",
@@ -2057,9 +1685,6 @@
     "collections": [
       "CMS-Trigger-Information"
     ],
-    "collision_information": {
-      "energy": "7TeV"
-    },
     "date_created": [
       "2011"
     ],
@@ -2067,9 +1692,6 @@
     "experiment": "CMS",
     "publisher": "CERN Open Data Portal",
     "recid": "2062",
-    "run_period": [
-      "Run2011A"
-    ],
     "title": "High-Level Trigger path information HLT_CentralJet80_MET80 (MET, METBTag datasets)",
     "type": {
       "primary": "Supplementaries",
@@ -2090,9 +1712,6 @@
     "collections": [
       "CMS-Trigger-Information"
     ],
-    "collision_information": {
-      "energy": "7TeV"
-    },
     "date_created": [
       "2011"
     ],
@@ -2100,9 +1719,6 @@
     "experiment": "CMS",
     "publisher": "CERN Open Data Portal",
     "recid": "2063",
-    "run_period": [
-      "Run2011A"
-    ],
     "title": "High-Level Trigger path information HLT_CentralJet80_MET80HF (MET dataset)",
     "type": {
       "primary": "Supplementaries",
@@ -2123,9 +1739,6 @@
     "collections": [
       "CMS-Trigger-Information"
     ],
-    "collision_information": {
-      "energy": "7TeV"
-    },
     "date_created": [
       "2011"
     ],
@@ -2133,9 +1746,6 @@
     "experiment": "CMS",
     "publisher": "CERN Open Data Portal",
     "recid": "2064",
-    "run_period": [
-      "Run2011A"
-    ],
     "title": "High-Level Trigger path information HLT_CentralJet80_MET95 (MET dataset)",
     "type": {
       "primary": "Supplementaries",
@@ -2156,9 +1766,6 @@
     "collections": [
       "CMS-Trigger-Information"
     ],
-    "collision_information": {
-      "energy": "7TeV"
-    },
     "date_created": [
       "2011"
     ],
@@ -2166,9 +1773,6 @@
     "experiment": "CMS",
     "publisher": "CERN Open Data Portal",
     "recid": "2065",
-    "run_period": [
-      "Run2011A"
-    ],
     "title": "High-Level Trigger path information HLT_DTCalibration",
     "type": {
       "primary": "Supplementaries",
@@ -2189,9 +1793,6 @@
     "collections": [
       "CMS-Trigger-Information"
     ],
-    "collision_information": {
-      "energy": "7TeV"
-    },
     "date_created": [
       "2011"
     ],
@@ -2199,9 +1800,6 @@
     "experiment": "CMS",
     "publisher": "CERN Open Data Portal",
     "recid": "2066",
-    "run_period": [
-      "Run2011A"
-    ],
     "title": "High-Level Trigger path information HLT_DTErrors (FEDMonitor dataset)",
     "type": {
       "primary": "Supplementaries",
@@ -2222,9 +1820,6 @@
     "collections": [
       "CMS-Trigger-Information"
     ],
-    "collision_information": {
-      "energy": "7TeV"
-    },
     "date_created": [
       "2011"
     ],
@@ -2232,9 +1827,6 @@
     "experiment": "CMS",
     "publisher": "CERN Open Data Portal",
     "recid": "2067",
-    "run_period": [
-      "Run2011A"
-    ],
     "title": "High-Level Trigger path information HLT_DiCentralJet20_BTagIP_MET65 (MET dataset)",
     "type": {
       "primary": "Supplementaries",
@@ -2255,9 +1847,6 @@
     "collections": [
       "CMS-Trigger-Information"
     ],
-    "collision_information": {
-      "energy": "7TeV"
-    },
     "date_created": [
       "2011"
     ],
@@ -2265,9 +1854,6 @@
     "experiment": "CMS",
     "publisher": "CERN Open Data Portal",
     "recid": "2068",
-    "run_period": [
-      "Run2011A"
-    ],
     "title": "High-Level Trigger path information HLT_DiCentralJet20_MET100_HBHENoiseFiltered (MET dataset)",
     "type": {
       "primary": "Supplementaries",
@@ -2288,9 +1874,6 @@
     "collections": [
       "CMS-Trigger-Information"
     ],
-    "collision_information": {
-      "energy": "7TeV"
-    },
     "date_created": [
       "2011"
     ],
@@ -2298,9 +1881,6 @@
     "experiment": "CMS",
     "publisher": "CERN Open Data Portal",
     "recid": "2069",
-    "run_period": [
-      "Run2011A"
-    ],
     "title": "High-Level Trigger path information HLT_DiCentralJet20_MET80 (MET dataset)",
     "type": {
       "primary": "Supplementaries",
@@ -2321,9 +1901,6 @@
     "collections": [
       "CMS-Trigger-Information"
     ],
-    "collision_information": {
-      "energy": "7TeV"
-    },
     "date_created": [
       "2011"
     ],
@@ -2331,9 +1908,6 @@
     "experiment": "CMS",
     "publisher": "CERN Open Data Portal",
     "recid": "2070",
-    "run_period": [
-      "Run2011A"
-    ],
     "title": "High-Level Trigger path information HLT_DiCentralJet36_BTagIP3DLoose (MultiJet dataset)",
     "type": {
       "primary": "Supplementaries",
@@ -2354,9 +1928,6 @@
     "collections": [
       "CMS-Trigger-Information"
     ],
-    "collision_information": {
-      "energy": "7TeV"
-    },
     "date_created": [
       "2011"
     ],
@@ -2364,9 +1935,6 @@
     "experiment": "CMS",
     "publisher": "CERN Open Data Portal",
     "recid": "2071",
-    "run_period": [
-      "Run2011A"
-    ],
     "title": "High-Level Trigger path information HLT_DiCentralPFJet30_PFMHT80 (MET dataset)",
     "type": {
       "primary": "Supplementaries",
@@ -2387,9 +1955,6 @@
     "collections": [
       "CMS-Trigger-Information"
     ],
-    "collision_information": {
-      "energy": "7TeV"
-    },
     "date_created": [
       "2011"
     ],
@@ -2397,9 +1962,6 @@
     "experiment": "CMS",
     "publisher": "CERN Open Data Portal",
     "recid": "2072",
-    "run_period": [
-      "Run2011A"
-    ],
     "title": "High-Level Trigger path information HLT_DiCentralPFJet50_PFMHT80 (MET dataset)",
     "type": {
       "primary": "Supplementaries",
@@ -2420,9 +1982,6 @@
     "collections": [
       "CMS-Trigger-Information"
     ],
-    "collision_information": {
-      "energy": "7TeV"
-    },
     "date_created": [
       "2011"
     ],
@@ -2430,9 +1989,6 @@
     "experiment": "CMS",
     "publisher": "CERN Open Data Portal",
     "recid": "2073",
-    "run_period": [
-      "Run2011A"
-    ],
     "title": "High-Level Trigger path information HLT_DiJet100_PT100 (HT dataset)",
     "type": {
       "primary": "Supplementaries",
@@ -2453,9 +2009,6 @@
     "collections": [
       "CMS-Trigger-Information"
     ],
-    "collision_information": {
-      "energy": "7TeV"
-    },
     "date_created": [
       "2011"
     ],
@@ -2463,9 +2016,6 @@
     "experiment": "CMS",
     "publisher": "CERN Open Data Portal",
     "recid": "2074",
-    "run_period": [
-      "Run2011A"
-    ],
     "title": "High-Level Trigger path information HLT_DiJet130_PT130 (HT dataset)",
     "type": {
       "primary": "Supplementaries",
@@ -2486,9 +2036,6 @@
     "collections": [
       "CMS-Trigger-Information"
     ],
-    "collision_information": {
-      "energy": "7TeV"
-    },
     "date_created": [
       "2011"
     ],
@@ -2496,9 +2043,6 @@
     "experiment": "CMS",
     "publisher": "CERN Open Data Portal",
     "recid": "2075",
-    "run_period": [
-      "Run2011A"
-    ],
     "title": "High-Level Trigger path information HLT_DiJet160_PT160 (HT dataset)",
     "type": {
       "primary": "Supplementaries",
@@ -2519,9 +2063,6 @@
     "collections": [
       "CMS-Trigger-Information"
     ],
-    "collision_information": {
-      "energy": "7TeV"
-    },
     "date_created": [
       "2011"
     ],
@@ -2529,9 +2070,6 @@
     "experiment": "CMS",
     "publisher": "CERN Open Data Portal",
     "recid": "2076",
-    "run_period": [
-      "Run2011A"
-    ],
     "title": "High-Level Trigger path information HLT_DiJet60_MET45 (MET, METBTag datasets)",
     "type": {
       "primary": "Supplementaries",
@@ -2552,9 +2090,6 @@
     "collections": [
       "CMS-Trigger-Information"
     ],
-    "collision_information": {
-      "energy": "7TeV"
-    },
     "date_created": [
       "2011"
     ],
@@ -2562,9 +2097,6 @@
     "experiment": "CMS",
     "publisher": "CERN Open Data Portal",
     "recid": "2077",
-    "run_period": [
-      "Run2011A"
-    ],
     "title": "High-Level Trigger path information HLT_DiJet70_PT70 (HT dataset)",
     "type": {
       "primary": "Supplementaries",
@@ -2585,9 +2117,6 @@
     "collections": [
       "CMS-Trigger-Information"
     ],
-    "collision_information": {
-      "energy": "7TeV"
-    },
     "date_created": [
       "2011"
     ],
@@ -2595,9 +2124,6 @@
     "experiment": "CMS",
     "publisher": "CERN Open Data Portal",
     "recid": "2078",
-    "run_period": [
-      "Run2011A"
-    ],
     "title": "High-Level Trigger path information HLT_DiJetAve100U (Jet dataset)",
     "type": {
       "primary": "Supplementaries",
@@ -2618,9 +2144,6 @@
     "collections": [
       "CMS-Trigger-Information"
     ],
-    "collision_information": {
-      "energy": "7TeV"
-    },
     "date_created": [
       "2011"
     ],
@@ -2628,9 +2151,6 @@
     "experiment": "CMS",
     "publisher": "CERN Open Data Portal",
     "recid": "2079",
-    "run_period": [
-      "Run2011A"
-    ],
     "title": "High-Level Trigger path information HLT_DiJetAve110 (Jet dataset)",
     "type": {
       "primary": "Supplementaries",
@@ -2651,9 +2171,6 @@
     "collections": [
       "CMS-Trigger-Information"
     ],
-    "collision_information": {
-      "energy": "7TeV"
-    },
     "date_created": [
       "2011"
     ],
@@ -2661,9 +2178,6 @@
     "experiment": "CMS",
     "publisher": "CERN Open Data Portal",
     "recid": "2080",
-    "run_period": [
-      "Run2011A"
-    ],
     "title": "High-Level Trigger path information HLT_DiJetAve140U (Jet dataset)",
     "type": {
       "primary": "Supplementaries",
@@ -2684,9 +2198,6 @@
     "collections": [
       "CMS-Trigger-Information"
     ],
-    "collision_information": {
-      "energy": "7TeV"
-    },
     "date_created": [
       "2011"
     ],
@@ -2694,9 +2205,6 @@
     "experiment": "CMS",
     "publisher": "CERN Open Data Portal",
     "recid": "2081",
-    "run_period": [
-      "Run2011A"
-    ],
     "title": "High-Level Trigger path information HLT_DiJetAve150 (Jet dataset)",
     "type": {
       "primary": "Supplementaries",
@@ -2717,9 +2225,6 @@
     "collections": [
       "CMS-Trigger-Information"
     ],
-    "collision_information": {
-      "energy": "7TeV"
-    },
     "date_created": [
       "2011"
     ],
@@ -2727,9 +2232,6 @@
     "experiment": "CMS",
     "publisher": "CERN Open Data Portal",
     "recid": "2082",
-    "run_period": [
-      "Run2011A"
-    ],
     "title": "High-Level Trigger path information HLT_DiJetAve15U (Jet dataset)",
     "type": {
       "primary": "Supplementaries",
@@ -2750,9 +2252,6 @@
     "collections": [
       "CMS-Trigger-Information"
     ],
-    "collision_information": {
-      "energy": "7TeV"
-    },
     "date_created": [
       "2011"
     ],
@@ -2760,9 +2259,6 @@
     "experiment": "CMS",
     "publisher": "CERN Open Data Portal",
     "recid": "2083",
-    "run_period": [
-      "Run2011A"
-    ],
     "title": "High-Level Trigger path information HLT_DiJetAve180U (Jet dataset)",
     "type": {
       "primary": "Supplementaries",
@@ -2783,9 +2279,6 @@
     "collections": [
       "CMS-Trigger-Information"
     ],
-    "collision_information": {
-      "energy": "7TeV"
-    },
     "date_created": [
       "2011"
     ],
@@ -2793,9 +2286,6 @@
     "experiment": "CMS",
     "publisher": "CERN Open Data Portal",
     "recid": "2084",
-    "run_period": [
-      "Run2011A"
-    ],
     "title": "High-Level Trigger path information HLT_DiJetAve190 (Jet dataset)",
     "type": {
       "primary": "Supplementaries",
@@ -2816,9 +2306,6 @@
     "collections": [
       "CMS-Trigger-Information"
     ],
-    "collision_information": {
-      "energy": "7TeV"
-    },
     "date_created": [
       "2011"
     ],
@@ -2826,9 +2313,6 @@
     "experiment": "CMS",
     "publisher": "CERN Open Data Portal",
     "recid": "2085",
-    "run_period": [
-      "Run2011A"
-    ],
     "title": "High-Level Trigger path information HLT_DiJetAve240 (Jet dataset)",
     "type": {
       "primary": "Supplementaries",
@@ -2849,9 +2333,6 @@
     "collections": [
       "CMS-Trigger-Information"
     ],
-    "collision_information": {
-      "energy": "7TeV"
-    },
     "date_created": [
       "2011"
     ],
@@ -2859,9 +2340,6 @@
     "experiment": "CMS",
     "publisher": "CERN Open Data Portal",
     "recid": "2086",
-    "run_period": [
-      "Run2011A"
-    ],
     "title": "High-Level Trigger path information HLT_DiJetAve30 (Jet dataset)",
     "type": {
       "primary": "Supplementaries",
@@ -2882,9 +2360,6 @@
     "collections": [
       "CMS-Trigger-Information"
     ],
-    "collision_information": {
-      "energy": "7TeV"
-    },
     "date_created": [
       "2011"
     ],
@@ -2892,9 +2367,6 @@
     "experiment": "CMS",
     "publisher": "CERN Open Data Portal",
     "recid": "2087",
-    "run_period": [
-      "Run2011A"
-    ],
     "title": "High-Level Trigger path information HLT_DiJetAve300 (Jet dataset)",
     "type": {
       "primary": "Supplementaries",
@@ -2915,9 +2387,6 @@
     "collections": [
       "CMS-Trigger-Information"
     ],
-    "collision_information": {
-      "energy": "7TeV"
-    },
     "date_created": [
       "2011"
     ],
@@ -2925,9 +2394,6 @@
     "experiment": "CMS",
     "publisher": "CERN Open Data Portal",
     "recid": "2088",
-    "run_period": [
-      "Run2011A"
-    ],
     "title": "High-Level Trigger path information HLT_DiJetAve300U (Jet dataset)",
     "type": {
       "primary": "Supplementaries",
@@ -2948,9 +2414,6 @@
     "collections": [
       "CMS-Trigger-Information"
     ],
-    "collision_information": {
-      "energy": "7TeV"
-    },
     "date_created": [
       "2011"
     ],
@@ -2958,9 +2421,6 @@
     "experiment": "CMS",
     "publisher": "CERN Open Data Portal",
     "recid": "2089",
-    "run_period": [
-      "Run2011A"
-    ],
     "title": "High-Level Trigger path information HLT_DiJetAve30U (Jet dataset)",
     "type": {
       "primary": "Supplementaries",
@@ -2981,9 +2441,6 @@
     "collections": [
       "CMS-Trigger-Information"
     ],
-    "collision_information": {
-      "energy": "7TeV"
-    },
     "date_created": [
       "2011"
     ],
@@ -2991,9 +2448,6 @@
     "experiment": "CMS",
     "publisher": "CERN Open Data Portal",
     "recid": "2090",
-    "run_period": [
-      "Run2011A"
-    ],
     "title": "High-Level Trigger path information HLT_DiJetAve370 (Jet dataset)",
     "type": {
       "primary": "Supplementaries",
@@ -3014,9 +2468,6 @@
     "collections": [
       "CMS-Trigger-Information"
     ],
-    "collision_information": {
-      "energy": "7TeV"
-    },
     "date_created": [
       "2011"
     ],
@@ -3024,9 +2475,6 @@
     "experiment": "CMS",
     "publisher": "CERN Open Data Portal",
     "recid": "2091",
-    "run_period": [
-      "Run2011A"
-    ],
     "title": "High-Level Trigger path information HLT_DiJetAve50U (Jet dataset)",
     "type": {
       "primary": "Supplementaries",
@@ -3047,9 +2495,6 @@
     "collections": [
       "CMS-Trigger-Information"
     ],
-    "collision_information": {
-      "energy": "7TeV"
-    },
     "date_created": [
       "2011"
     ],
@@ -3057,9 +2502,6 @@
     "experiment": "CMS",
     "publisher": "CERN Open Data Portal",
     "recid": "2092",
-    "run_period": [
-      "Run2011A"
-    ],
     "title": "High-Level Trigger path information HLT_DiJetAve60 (Jet dataset)",
     "type": {
       "primary": "Supplementaries",
@@ -3080,9 +2522,6 @@
     "collections": [
       "CMS-Trigger-Information"
     ],
-    "collision_information": {
-      "energy": "7TeV"
-    },
     "date_created": [
       "2011"
     ],
@@ -3090,9 +2529,6 @@
     "experiment": "CMS",
     "publisher": "CERN Open Data Portal",
     "recid": "2093",
-    "run_period": [
-      "Run2011A"
-    ],
     "title": "High-Level Trigger path information HLT_DiJetAve70U (Jet dataset)",
     "type": {
       "primary": "Supplementaries",
@@ -3113,9 +2549,6 @@
     "collections": [
       "CMS-Trigger-Information"
     ],
-    "collision_information": {
-      "energy": "7TeV"
-    },
     "date_created": [
       "2011"
     ],
@@ -3123,9 +2556,6 @@
     "experiment": "CMS",
     "publisher": "CERN Open Data Portal",
     "recid": "2094",
-    "run_period": [
-      "Run2011A"
-    ],
     "title": "High-Level Trigger path information HLT_DiJetAve80 (Jet dataset)",
     "type": {
       "primary": "Supplementaries",
@@ -3146,9 +2576,6 @@
     "collections": [
       "CMS-Trigger-Information"
     ],
-    "collision_information": {
-      "energy": "7TeV"
-    },
     "date_created": [
       "2011"
     ],
@@ -3156,9 +2583,6 @@
     "experiment": "CMS",
     "publisher": "CERN Open Data Portal",
     "recid": "2095",
-    "run_period": [
-      "Run2011A"
-    ],
     "title": "High-Level Trigger path information HLT_Dimuon0_Barrel_Upsilon (MuOnia dataset)",
     "type": {
       "primary": "Supplementaries",
@@ -3179,9 +2603,6 @@
     "collections": [
       "CMS-Trigger-Information"
     ],
-    "collision_information": {
-      "energy": "7TeV"
-    },
     "date_created": [
       "2011"
     ],
@@ -3189,9 +2610,6 @@
     "experiment": "CMS",
     "publisher": "CERN Open Data Portal",
     "recid": "2096",
-    "run_period": [
-      "Run2011A"
-    ],
     "title": "High-Level Trigger path information HLT_Dimuon0_Jpsi (MuOnia dataset)",
     "type": {
       "primary": "Supplementaries",
@@ -3212,9 +2630,6 @@
     "collections": [
       "CMS-Trigger-Information"
     ],
-    "collision_information": {
-      "energy": "7TeV"
-    },
     "date_created": [
       "2011"
     ],
@@ -3222,9 +2637,6 @@
     "experiment": "CMS",
     "publisher": "CERN Open Data Portal",
     "recid": "2097",
-    "run_period": [
-      "Run2011A"
-    ],
     "title": "High-Level Trigger path information HLT_Dimuon0_Jpsi_Muon (MuOnia dataset)",
     "type": {
       "primary": "Supplementaries",
@@ -3245,9 +2657,6 @@
     "collections": [
       "CMS-Trigger-Information"
     ],
-    "collision_information": {
-      "energy": "7TeV"
-    },
     "date_created": [
       "2011"
     ],
@@ -3255,9 +2664,6 @@
     "experiment": "CMS",
     "publisher": "CERN Open Data Portal",
     "recid": "2098",
-    "run_period": [
-      "Run2011A"
-    ],
     "title": "High-Level Trigger path information HLT_Dimuon0_Jpsi_NoVertexing (MuOnia dataset)",
     "type": {
       "primary": "Supplementaries",
@@ -3278,9 +2684,6 @@
     "collections": [
       "CMS-Trigger-Information"
     ],
-    "collision_information": {
-      "energy": "7TeV"
-    },
     "date_created": [
       "2011"
     ],
@@ -3288,9 +2691,6 @@
     "experiment": "CMS",
     "publisher": "CERN Open Data Portal",
     "recid": "2099",
-    "run_period": [
-      "Run2011A"
-    ],
     "title": "High-Level Trigger path information HLT_Dimuon0_Omega_Phi (MuOnia dataset)",
     "type": {
       "primary": "Supplementaries",
@@ -3311,9 +2711,6 @@
     "collections": [
       "CMS-Trigger-Information"
     ],
-    "collision_information": {
-      "energy": "7TeV"
-    },
     "date_created": [
       "2011"
     ],
@@ -3321,9 +2718,6 @@
     "experiment": "CMS",
     "publisher": "CERN Open Data Portal",
     "recid": "2100",
-    "run_period": [
-      "Run2011A"
-    ],
     "title": "High-Level Trigger path information HLT_Dimuon0_Upsilon (MuOnia dataset)",
     "type": {
       "primary": "Supplementaries",
@@ -3344,9 +2738,6 @@
     "collections": [
       "CMS-Trigger-Information"
     ],
-    "collision_information": {
-      "energy": "7TeV"
-    },
     "date_created": [
       "2011"
     ],
@@ -3354,9 +2745,6 @@
     "experiment": "CMS",
     "publisher": "CERN Open Data Portal",
     "recid": "2101",
-    "run_period": [
-      "Run2011A"
-    ],
     "title": "High-Level Trigger path information HLT_Dimuon0_Upsilon_Muon (MuOnia dataset)",
     "type": {
       "primary": "Supplementaries",
@@ -3377,9 +2765,6 @@
     "collections": [
       "CMS-Trigger-Information"
     ],
-    "collision_information": {
-      "energy": "7TeV"
-    },
     "date_created": [
       "2011"
     ],
@@ -3387,9 +2772,6 @@
     "experiment": "CMS",
     "publisher": "CERN Open Data Portal",
     "recid": "2102",
-    "run_period": [
-      "Run2011A"
-    ],
     "title": "High-Level Trigger path information HLT_Dimuon10_Jpsi_Barrel (MuOnia dataset)",
     "type": {
       "primary": "Supplementaries",
@@ -3410,9 +2792,6 @@
     "collections": [
       "CMS-Trigger-Information"
     ],
-    "collision_information": {
-      "energy": "7TeV"
-    },
     "date_created": [
       "2011"
     ],
@@ -3420,9 +2799,6 @@
     "experiment": "CMS",
     "publisher": "CERN Open Data Portal",
     "recid": "2103",
-    "run_period": [
-      "Run2011A"
-    ],
     "title": "High-Level Trigger path information HLT_Dimuon11_PsiPrime (MuOnia dataset)",
     "type": {
       "primary": "Supplementaries",
@@ -3443,9 +2819,6 @@
     "collections": [
       "CMS-Trigger-Information"
     ],
-    "collision_information": {
-      "energy": "7TeV"
-    },
     "date_created": [
       "2011"
     ],
@@ -3453,9 +2826,6 @@
     "experiment": "CMS",
     "publisher": "CERN Open Data Portal",
     "recid": "2104",
-    "run_period": [
-      "Run2011A"
-    ],
     "title": "High-Level Trigger path information HLT_Dimuon13_Jpsi_Barrel (MuOnia dataset)",
     "type": {
       "primary": "Supplementaries",
@@ -3476,9 +2846,6 @@
     "collections": [
       "CMS-Trigger-Information"
     ],
-    "collision_information": {
-      "energy": "7TeV"
-    },
     "date_created": [
       "2011"
     ],
@@ -3486,9 +2853,6 @@
     "experiment": "CMS",
     "publisher": "CERN Open Data Portal",
     "recid": "2105",
-    "run_period": [
-      "Run2011A"
-    ],
     "title": "High-Level Trigger path information HLT_Dimuon4_Bs_Barrel (MuOnia dataset)",
     "type": {
       "primary": "Supplementaries",
@@ -3509,9 +2873,6 @@
     "collections": [
       "CMS-Trigger-Information"
     ],
-    "collision_information": {
-      "energy": "7TeV"
-    },
     "date_created": [
       "2011"
     ],
@@ -3519,9 +2880,6 @@
     "experiment": "CMS",
     "publisher": "CERN Open Data Portal",
     "recid": "2106",
-    "run_period": [
-      "Run2011A"
-    ],
     "title": "High-Level Trigger path information HLT_Dimuon5_Upsilon_Barrel (MuOnia dataset)",
     "type": {
       "primary": "Supplementaries",
@@ -3542,9 +2900,6 @@
     "collections": [
       "CMS-Trigger-Information"
     ],
-    "collision_information": {
-      "energy": "7TeV"
-    },
     "date_created": [
       "2011"
     ],
@@ -3552,9 +2907,6 @@
     "experiment": "CMS",
     "publisher": "CERN Open Data Portal",
     "recid": "2107",
-    "run_period": [
-      "Run2011A"
-    ],
     "title": "High-Level Trigger path information HLT_Dimuon6_Bs (MuOnia dataset)",
     "type": {
       "primary": "Supplementaries",
@@ -3575,9 +2927,6 @@
     "collections": [
       "CMS-Trigger-Information"
     ],
-    "collision_information": {
-      "energy": "7TeV"
-    },
     "date_created": [
       "2011"
     ],
@@ -3585,9 +2934,6 @@
     "experiment": "CMS",
     "publisher": "CERN Open Data Portal",
     "recid": "2108",
-    "run_period": [
-      "Run2011A"
-    ],
     "title": "High-Level Trigger path information HLT_Dimuon6_LowMass (MuOnia dataset)",
     "type": {
       "primary": "Supplementaries",
@@ -3608,9 +2954,6 @@
     "collections": [
       "CMS-Trigger-Information"
     ],
-    "collision_information": {
-      "energy": "7TeV"
-    },
     "date_created": [
       "2011"
     ],
@@ -3618,9 +2961,6 @@
     "experiment": "CMS",
     "publisher": "CERN Open Data Portal",
     "recid": "2109",
-    "run_period": [
-      "Run2011A"
-    ],
     "title": "High-Level Trigger path information HLT_Dimuon6p5_Barrel_Jpsi (MuOnia dataset)",
     "type": {
       "primary": "Supplementaries",
@@ -3641,9 +2981,6 @@
     "collections": [
       "CMS-Trigger-Information"
     ],
-    "collision_information": {
-      "energy": "7TeV"
-    },
     "date_created": [
       "2011"
     ],
@@ -3651,9 +2988,6 @@
     "experiment": "CMS",
     "publisher": "CERN Open Data Portal",
     "recid": "2110",
-    "run_period": [
-      "Run2011A"
-    ],
     "title": "High-Level Trigger path information HLT_Dimuon6p5_Barrel_PsiPrime (MuOnia dataset)",
     "type": {
       "primary": "Supplementaries",
@@ -3674,9 +3008,6 @@
     "collections": [
       "CMS-Trigger-Information"
     ],
-    "collision_information": {
-      "energy": "7TeV"
-    },
     "date_created": [
       "2011"
     ],
@@ -3684,9 +3015,6 @@
     "experiment": "CMS",
     "publisher": "CERN Open Data Portal",
     "recid": "2111",
-    "run_period": [
-      "Run2011A"
-    ],
     "title": "High-Level Trigger path information HLT_Dimuon6p5_Jpsi (MuOnia dataset)",
     "type": {
       "primary": "Supplementaries",
@@ -3707,9 +3035,6 @@
     "collections": [
       "CMS-Trigger-Information"
     ],
-    "collision_information": {
-      "energy": "7TeV"
-    },
     "date_created": [
       "2011"
     ],
@@ -3717,9 +3042,6 @@
     "experiment": "CMS",
     "publisher": "CERN Open Data Portal",
     "recid": "2112",
-    "run_period": [
-      "Run2011A"
-    ],
     "title": "High-Level Trigger path information HLT_Dimuon6p5_Jpsi_Displaced (MuOnia dataset)",
     "type": {
       "primary": "Supplementaries",
@@ -3740,9 +3062,6 @@
     "collections": [
       "CMS-Trigger-Information"
     ],
-    "collision_information": {
-      "energy": "7TeV"
-    },
     "date_created": [
       "2011"
     ],
@@ -3750,9 +3069,6 @@
     "experiment": "CMS",
     "publisher": "CERN Open Data Portal",
     "recid": "2113",
-    "run_period": [
-      "Run2011A"
-    ],
     "title": "High-Level Trigger path information HLT_Dimuon6p5_LowMass (MuOnia dataset)",
     "type": {
       "primary": "Supplementaries",
@@ -3773,9 +3089,6 @@
     "collections": [
       "CMS-Trigger-Information"
     ],
-    "collision_information": {
-      "energy": "7TeV"
-    },
     "date_created": [
       "2011"
     ],
@@ -3783,9 +3096,6 @@
     "experiment": "CMS",
     "publisher": "CERN Open Data Portal",
     "recid": "2114",
-    "run_period": [
-      "Run2011A"
-    ],
     "title": "High-Level Trigger path information HLT_Dimuon6p5_LowMass_Displaced (MuOnia dataset)",
     "type": {
       "primary": "Supplementaries",
@@ -3806,9 +3116,6 @@
     "collections": [
       "CMS-Trigger-Information"
     ],
-    "collision_information": {
-      "energy": "7TeV"
-    },
     "date_created": [
       "2011"
     ],
@@ -3816,9 +3123,6 @@
     "experiment": "CMS",
     "publisher": "CERN Open Data Portal",
     "recid": "2115",
-    "run_period": [
-      "Run2011A"
-    ],
     "title": "High-Level Trigger path information HLT_Dimuon7_Jpsi_Displaced (MuOnia dataset)",
     "type": {
       "primary": "Supplementaries",
@@ -3839,9 +3143,6 @@
     "collections": [
       "CMS-Trigger-Information"
     ],
-    "collision_information": {
-      "energy": "7TeV"
-    },
     "date_created": [
       "2011"
     ],
@@ -3849,9 +3150,6 @@
     "experiment": "CMS",
     "publisher": "CERN Open Data Portal",
     "recid": "2116",
-    "run_period": [
-      "Run2011A"
-    ],
     "title": "High-Level Trigger path information HLT_Dimuon7_Jpsi_X_Barrel (MuOnia dataset)",
     "type": {
       "primary": "Supplementaries",
@@ -3872,9 +3170,6 @@
     "collections": [
       "CMS-Trigger-Information"
     ],
-    "collision_information": {
-      "energy": "7TeV"
-    },
     "date_created": [
       "2011"
     ],
@@ -3882,9 +3177,6 @@
     "experiment": "CMS",
     "publisher": "CERN Open Data Portal",
     "recid": "2117",
-    "run_period": [
-      "Run2011A"
-    ],
     "title": "High-Level Trigger path information HLT_Dimuon7_LowMass_Displaced (MuOnia dataset)",
     "type": {
       "primary": "Supplementaries",
@@ -3905,9 +3197,6 @@
     "collections": [
       "CMS-Trigger-Information"
     ],
-    "collision_information": {
-      "energy": "7TeV"
-    },
     "date_created": [
       "2011"
     ],
@@ -3915,9 +3204,6 @@
     "experiment": "CMS",
     "publisher": "CERN Open Data Portal",
     "recid": "2118",
-    "run_period": [
-      "Run2011A"
-    ],
     "title": "High-Level Trigger path information HLT_Dimuon7_PsiPrime (MuOnia dataset)",
     "type": {
       "primary": "Supplementaries",
@@ -3938,9 +3224,6 @@
     "collections": [
       "CMS-Trigger-Information"
     ],
-    "collision_information": {
-      "energy": "7TeV"
-    },
     "date_created": [
       "2011"
     ],
@@ -3948,9 +3231,6 @@
     "experiment": "CMS",
     "publisher": "CERN Open Data Portal",
     "recid": "2119",
-    "run_period": [
-      "Run2011A"
-    ],
     "title": "High-Level Trigger path information HLT_Dimuon7_Upsilon_Barrel (MuOnia dataset)",
     "type": {
       "primary": "Supplementaries",
@@ -3971,9 +3251,6 @@
     "collections": [
       "CMS-Trigger-Information"
     ],
-    "collision_information": {
-      "energy": "7TeV"
-    },
     "date_created": [
       "2011"
     ],
@@ -3981,9 +3258,6 @@
     "experiment": "CMS",
     "publisher": "CERN Open Data Portal",
     "recid": "2120",
-    "run_period": [
-      "Run2011A"
-    ],
     "title": "High-Level Trigger path information HLT_Dimuon9_PsiPrime (MuOnia dataset)",
     "type": {
       "primary": "Supplementaries",
@@ -4004,9 +3278,6 @@
     "collections": [
       "CMS-Trigger-Information"
     ],
-    "collision_information": {
-      "energy": "7TeV"
-    },
     "date_created": [
       "2011"
     ],
@@ -4014,9 +3285,6 @@
     "experiment": "CMS",
     "publisher": "CERN Open Data Portal",
     "recid": "2121",
-    "run_period": [
-      "Run2011A"
-    ],
     "title": "High-Level Trigger path information HLT_Dimuon9_Upsilon_Barrel (MuOnia dataset)",
     "type": {
       "primary": "Supplementaries",
@@ -4037,9 +3305,6 @@
     "collections": [
       "CMS-Trigger-Information"
     ],
-    "collision_information": {
-      "energy": "7TeV"
-    },
     "date_created": [
       "2011"
     ],
@@ -4047,9 +3312,6 @@
     "experiment": "CMS",
     "publisher": "CERN Open Data Portal",
     "recid": "2122",
-    "run_period": [
-      "Run2011A"
-    ],
     "title": "High-Level Trigger path information HLT_DoubleEle10_CaloIdL_TrkIdVL_Ele10 (DoubleElectron dataset)",
     "type": {
       "primary": "Supplementaries",
@@ -4070,9 +3332,6 @@
     "collections": [
       "CMS-Trigger-Information"
     ],
-    "collision_information": {
-      "energy": "7TeV"
-    },
     "date_created": [
       "2011"
     ],
@@ -4080,9 +3339,6 @@
     "experiment": "CMS",
     "publisher": "CERN Open Data Portal",
     "recid": "2123",
-    "run_period": [
-      "Run2011A"
-    ],
     "title": "High-Level Trigger path information HLT_DoubleEle10_CaloIdL_TrkIdVL_Ele10_CaloIdT_TrkIdVL (DoubleElectron dataset)",
     "type": {
       "primary": "Supplementaries",
@@ -4103,9 +3359,6 @@
     "collections": [
       "CMS-Trigger-Information"
     ],
-    "collision_information": {
-      "energy": "7TeV"
-    },
     "date_created": [
       "2011"
     ],
@@ -4113,9 +3366,6 @@
     "experiment": "CMS",
     "publisher": "CERN Open Data Portal",
     "recid": "2124",
-    "run_period": [
-      "Run2011A"
-    ],
     "title": "High-Level Trigger path information HLT_DoubleEle33 (Photon dataset)",
     "type": {
       "primary": "Supplementaries",
@@ -4136,9 +3386,6 @@
     "collections": [
       "CMS-Trigger-Information"
     ],
-    "collision_information": {
-      "energy": "7TeV"
-    },
     "date_created": [
       "2011"
     ],
@@ -4146,9 +3393,6 @@
     "experiment": "CMS",
     "publisher": "CERN Open Data Portal",
     "recid": "2125",
-    "run_period": [
-      "Run2011A"
-    ],
     "title": "High-Level Trigger path information HLT_DoubleEle33_CaloIdL (Photon dataset)",
     "type": {
       "primary": "Supplementaries",
@@ -4169,9 +3413,6 @@
     "collections": [
       "CMS-Trigger-Information"
     ],
-    "collision_information": {
-      "energy": "7TeV"
-    },
     "date_created": [
       "2011"
     ],
@@ -4179,9 +3420,6 @@
     "experiment": "CMS",
     "publisher": "CERN Open Data Portal",
     "recid": "2126",
-    "run_period": [
-      "Run2011A"
-    ],
     "title": "High-Level Trigger path information HLT_DoubleEle33_CaloIdL_CaloIsoT (Photon dataset)",
     "type": {
       "primary": "Supplementaries",
@@ -4202,9 +3440,6 @@
     "collections": [
       "CMS-Trigger-Information"
     ],
-    "collision_information": {
-      "energy": "7TeV"
-    },
     "date_created": [
       "2011"
     ],
@@ -4212,9 +3447,6 @@
     "experiment": "CMS",
     "publisher": "CERN Open Data Portal",
     "recid": "2127",
-    "run_period": [
-      "Run2011A"
-    ],
     "title": "High-Level Trigger path information HLT_DoubleEle33_CaloIdT (Photon dataset)",
     "type": {
       "primary": "Supplementaries",
@@ -4235,9 +3467,6 @@
     "collections": [
       "CMS-Trigger-Information"
     ],
-    "collision_information": {
-      "energy": "7TeV"
-    },
     "date_created": [
       "2011"
     ],
@@ -4245,9 +3474,6 @@
     "experiment": "CMS",
     "publisher": "CERN Open Data Portal",
     "recid": "2128",
-    "run_period": [
-      "Run2011A"
-    ],
     "title": "High-Level Trigger path information HLT_DoubleEle45_CaloIdL (DoubleElectron, Photon datasets)",
     "type": {
       "primary": "Supplementaries",
@@ -4268,9 +3494,6 @@
     "collections": [
       "CMS-Trigger-Information"
     ],
-    "collision_information": {
-      "energy": "7TeV"
-    },
     "date_created": [
       "2011"
     ],
@@ -4278,9 +3501,6 @@
     "experiment": "CMS",
     "publisher": "CERN Open Data Portal",
     "recid": "2129",
-    "run_period": [
-      "Run2011A"
-    ],
     "title": "High-Level Trigger path information HLT_DoubleEle8_CaloIdL_TrkIdVL (ElectronHad dataset)",
     "type": {
       "primary": "Supplementaries",
@@ -4301,9 +3521,6 @@
     "collections": [
       "CMS-Trigger-Information"
     ],
-    "collision_information": {
-      "energy": "7TeV"
-    },
     "date_created": [
       "2011"
     ],
@@ -4311,9 +3528,6 @@
     "experiment": "CMS",
     "publisher": "CERN Open Data Portal",
     "recid": "2130",
-    "run_period": [
-      "Run2011A"
-    ],
     "title": "High-Level Trigger path information HLT_DoubleEle8_CaloIdL_TrkIdVL_HT150 (ElectronHad dataset)",
     "type": {
       "primary": "Supplementaries",
@@ -4334,9 +3548,6 @@
     "collections": [
       "CMS-Trigger-Information"
     ],
-    "collision_information": {
-      "energy": "7TeV"
-    },
     "date_created": [
       "2011"
     ],
@@ -4344,9 +3555,6 @@
     "experiment": "CMS",
     "publisher": "CERN Open Data Portal",
     "recid": "2131",
-    "run_period": [
-      "Run2011A"
-    ],
     "title": "High-Level Trigger path information HLT_DoubleEle8_CaloIdL_TrkIdVL_HT160 (ElectronHad dataset)",
     "type": {
       "primary": "Supplementaries",
@@ -4367,9 +3575,6 @@
     "collections": [
       "CMS-Trigger-Information"
     ],
-    "collision_information": {
-      "energy": "7TeV"
-    },
     "date_created": [
       "2011"
     ],
@@ -4377,9 +3582,6 @@
     "experiment": "CMS",
     "publisher": "CERN Open Data Portal",
     "recid": "2132",
-    "run_period": [
-      "Run2011A"
-    ],
     "title": "High-Level Trigger path information HLT_DoubleEle8_CaloIdT_TrkIdVL (ElectronHad dataset)",
     "type": {
       "primary": "Supplementaries",
@@ -4400,9 +3602,6 @@
     "collections": [
       "CMS-Trigger-Information"
     ],
-    "collision_information": {
-      "energy": "7TeV"
-    },
     "date_created": [
       "2011"
     ],
@@ -4410,9 +3609,6 @@
     "experiment": "CMS",
     "publisher": "CERN Open Data Portal",
     "recid": "2133",
-    "run_period": [
-      "Run2011A"
-    ],
     "title": "High-Level Trigger path information HLT_DoubleEle8_CaloIdT_TrkIdVL_HT150 (ElectronHad dataset)",
     "type": {
       "primary": "Supplementaries",
@@ -4433,9 +3629,6 @@
     "collections": [
       "CMS-Trigger-Information"
     ],
-    "collision_information": {
-      "energy": "7TeV"
-    },
     "date_created": [
       "2011"
     ],
@@ -4443,9 +3636,6 @@
     "experiment": "CMS",
     "publisher": "CERN Open Data Portal",
     "recid": "2134",
-    "run_period": [
-      "Run2011A"
-    ],
     "title": "High-Level Trigger path information HLT_DoubleEle8_CaloIdT_TrkIdVL_HT160 (ElectronHad dataset)",
     "type": {
       "primary": "Supplementaries",
@@ -4466,9 +3656,6 @@
     "collections": [
       "CMS-Trigger-Information"
     ],
-    "collision_information": {
-      "energy": "7TeV"
-    },
     "date_created": [
       "2011"
     ],
@@ -4476,9 +3663,6 @@
     "experiment": "CMS",
     "publisher": "CERN Open Data Portal",
     "recid": "2135",
-    "run_period": [
-      "Run2011A"
-    ],
     "title": "High-Level Trigger path information HLT_DoubleEle8_CaloIdT_TrkIdVL_Mass4_HT150 (ElectronHad dataset)",
     "type": {
       "primary": "Supplementaries",
@@ -4499,9 +3683,6 @@
     "collections": [
       "CMS-Trigger-Information"
     ],
-    "collision_information": {
-      "energy": "7TeV"
-    },
     "date_created": [
       "2011"
     ],
@@ -4509,9 +3690,6 @@
     "experiment": "CMS",
     "publisher": "CERN Open Data Portal",
     "recid": "2136",
-    "run_period": [
-      "Run2011A"
-    ],
     "title": "High-Level Trigger path information HLT_DoubleEle8_CaloIdT_TrkIdVL_Mass8_HT150 (ElectronHad dataset)",
     "type": {
       "primary": "Supplementaries",
@@ -4532,9 +3710,6 @@
     "collections": [
       "CMS-Trigger-Information"
     ],
-    "collision_information": {
-      "energy": "7TeV"
-    },
     "date_created": [
       "2011"
     ],
@@ -4542,9 +3717,6 @@
     "experiment": "CMS",
     "publisher": "CERN Open Data Portal",
     "recid": "2137",
-    "run_period": [
-      "Run2011A"
-    ],
     "title": "High-Level Trigger path information HLT_DoubleEle8_CaloIdT_TrkIdVL_Mass8_HT200 (ElectronHad dataset)",
     "type": {
       "primary": "Supplementaries",
@@ -4565,9 +3737,6 @@
     "collections": [
       "CMS-Trigger-Information"
     ],
-    "collision_information": {
-      "energy": "7TeV"
-    },
     "date_created": [
       "2011"
     ],
@@ -4575,9 +3744,6 @@
     "experiment": "CMS",
     "publisher": "CERN Open Data Portal",
     "recid": "2138",
-    "run_period": [
-      "Run2011A"
-    ],
     "title": "High-Level Trigger path information HLT_DoubleIsoPFTau20_Trk5 (Tau dataset)",
     "type": {
       "primary": "Supplementaries",
@@ -4598,9 +3764,6 @@
     "collections": [
       "CMS-Trigger-Information"
     ],
-    "collision_information": {
-      "energy": "7TeV"
-    },
     "date_created": [
       "2011"
     ],
@@ -4608,9 +3771,6 @@
     "experiment": "CMS",
     "publisher": "CERN Open Data Portal",
     "recid": "2139",
-    "run_period": [
-      "Run2011A"
-    ],
     "title": "High-Level Trigger path information HLT_DoubleIsoPFTau25_Trk5_eta2p1 (Tau dataset)",
     "type": {
       "primary": "Supplementaries",
@@ -4631,9 +3791,6 @@
     "collections": [
       "CMS-Trigger-Information"
     ],
-    "collision_information": {
-      "energy": "7TeV"
-    },
     "date_created": [
       "2011"
     ],
@@ -4641,9 +3798,6 @@
     "experiment": "CMS",
     "publisher": "CERN Open Data Portal",
     "recid": "2140",
-    "run_period": [
-      "Run2011A"
-    ],
     "title": "High-Level Trigger path information HLT_DoubleIsoPFTau35_Trk5_eta2p1 (Tau dataset)",
     "type": {
       "primary": "Supplementaries",
@@ -4664,9 +3818,6 @@
     "collections": [
       "CMS-Trigger-Information"
     ],
-    "collision_information": {
-      "energy": "7TeV"
-    },
     "date_created": [
       "2011"
     ],
@@ -4674,9 +3825,6 @@
     "experiment": "CMS",
     "publisher": "CERN Open Data Portal",
     "recid": "2141",
-    "run_period": [
-      "Run2011A"
-    ],
     "title": "High-Level Trigger path information HLT_DoubleIsoPFTau40_Trk5_eta2p1 (Tau dataset)",
     "type": {
       "primary": "Supplementaries",
@@ -4697,9 +3845,6 @@
     "collections": [
       "CMS-Trigger-Information"
     ],
-    "collision_information": {
-      "energy": "7TeV"
-    },
     "date_created": [
       "2011"
     ],
@@ -4707,9 +3852,6 @@
     "experiment": "CMS",
     "publisher": "CERN Open Data Portal",
     "recid": "2142",
-    "run_period": [
-      "Run2011A"
-    ],
     "title": "High-Level Trigger path information HLT_DoubleIsoPFTau45_Trk5_eta2p1 (Tau dataset)",
     "type": {
       "primary": "Supplementaries",
@@ -4730,9 +3872,6 @@
     "collections": [
       "CMS-Trigger-Information"
     ],
-    "collision_information": {
-      "energy": "7TeV"
-    },
     "date_created": [
       "2011"
     ],
@@ -4740,9 +3879,6 @@
     "experiment": "CMS",
     "publisher": "CERN Open Data Portal",
     "recid": "2143",
-    "run_period": [
-      "Run2011A"
-    ],
     "title": "High-Level Trigger path information HLT_DoubleIsoPFTau55_Trk5_eta2p1 (Tau dataset)",
     "type": {
       "primary": "Supplementaries",
@@ -4763,9 +3899,6 @@
     "collections": [
       "CMS-Trigger-Information"
     ],
-    "collision_information": {
-      "energy": "7TeV"
-    },
     "date_created": [
       "2011"
     ],
@@ -4773,9 +3906,6 @@
     "experiment": "CMS",
     "publisher": "CERN Open Data Portal",
     "recid": "2144",
-    "run_period": [
-      "Run2011A"
-    ],
     "title": "High-Level Trigger path information HLT_DoubleJet30_ForwardBackward (MultiJet dataset)",
     "type": {
       "primary": "Supplementaries",
@@ -4796,9 +3926,6 @@
     "collections": [
       "CMS-Trigger-Information"
     ],
-    "collision_information": {
-      "energy": "7TeV"
-    },
     "date_created": [
       "2011"
     ],
@@ -4806,9 +3933,6 @@
     "experiment": "CMS",
     "publisher": "CERN Open Data Portal",
     "recid": "2145",
-    "run_period": [
-      "Run2011A"
-    ],
     "title": "High-Level Trigger path information HLT_DoubleJet60_ForwardBackward (MultiJet dataset)",
     "type": {
       "primary": "Supplementaries",
@@ -4829,9 +3953,6 @@
     "collections": [
       "CMS-Trigger-Information"
     ],
-    "collision_information": {
-      "energy": "7TeV"
-    },
     "date_created": [
       "2011"
     ],
@@ -4839,9 +3960,6 @@
     "experiment": "CMS",
     "publisher": "CERN Open Data Portal",
     "recid": "2146",
-    "run_period": [
-      "Run2011A"
-    ],
     "title": "High-Level Trigger path information HLT_DoubleJet70_ForwardBackward (MultiJet dataset)",
     "type": {
       "primary": "Supplementaries",
@@ -4862,9 +3980,6 @@
     "collections": [
       "CMS-Trigger-Information"
     ],
-    "collision_information": {
-      "energy": "7TeV"
-    },
     "date_created": [
       "2011"
     ],
@@ -4872,9 +3987,6 @@
     "experiment": "CMS",
     "publisher": "CERN Open Data Portal",
     "recid": "2147",
-    "run_period": [
-      "Run2011A"
-    ],
     "title": "High-Level Trigger path information HLT_DoubleJet80_ForwardBackward (MultiJet dataset)",
     "type": {
       "primary": "Supplementaries",
@@ -4895,9 +4007,6 @@
     "collections": [
       "CMS-Trigger-Information"
     ],
-    "collision_information": {
-      "energy": "7TeV"
-    },
     "date_created": [
       "2011"
     ],
@@ -4905,9 +4014,6 @@
     "experiment": "CMS",
     "publisher": "CERN Open Data Portal",
     "recid": "2148",
-    "run_period": [
-      "Run2011A"
-    ],
     "title": "High-Level Trigger path information HLT_DoubleMu2_Bs (MuOnia dataset)",
     "type": {
       "primary": "Supplementaries",
@@ -4928,9 +4034,6 @@
     "collections": [
       "CMS-Trigger-Information"
     ],
-    "collision_information": {
-      "energy": "7TeV"
-    },
     "date_created": [
       "2011"
     ],
@@ -4938,9 +4041,6 @@
     "experiment": "CMS",
     "publisher": "CERN Open Data Portal",
     "recid": "2149",
-    "run_period": [
-      "Run2011A"
-    ],
     "title": "High-Level Trigger path information HLT_DoubleMu3 (DoubleMu dataset)",
     "type": {
       "primary": "Supplementaries",
@@ -4961,9 +4061,6 @@
     "collections": [
       "CMS-Trigger-Information"
     ],
-    "collision_information": {
-      "energy": "7TeV"
-    },
     "date_created": [
       "2011"
     ],
@@ -4971,9 +4068,6 @@
     "experiment": "CMS",
     "publisher": "CERN Open Data Portal",
     "recid": "2150",
-    "run_period": [
-      "Run2011A"
-    ],
     "title": "High-Level Trigger path information HLT_DoubleMu3_Bs (MuOnia dataset)",
     "type": {
       "primary": "Supplementaries",
@@ -4994,9 +4088,6 @@
     "collections": [
       "CMS-Trigger-Information"
     ],
-    "collision_information": {
-      "energy": "7TeV"
-    },
     "date_created": [
       "2011"
     ],
@@ -5004,9 +4095,6 @@
     "experiment": "CMS",
     "publisher": "CERN Open Data Portal",
     "recid": "2151",
-    "run_period": [
-      "Run2011A"
-    ],
     "title": "High-Level Trigger path information HLT_DoubleMu3_HT150 (MuHad dataset)",
     "type": {
       "primary": "Supplementaries",
@@ -5027,9 +4115,6 @@
     "collections": [
       "CMS-Trigger-Information"
     ],
-    "collision_information": {
-      "energy": "7TeV"
-    },
     "date_created": [
       "2011"
     ],
@@ -5037,9 +4122,6 @@
     "experiment": "CMS",
     "publisher": "CERN Open Data Portal",
     "recid": "2152",
-    "run_period": [
-      "Run2011A"
-    ],
     "title": "High-Level Trigger path information HLT_DoubleMu3_HT160 (MuHad dataset)",
     "type": {
       "primary": "Supplementaries",
@@ -5060,9 +4142,6 @@
     "collections": [
       "CMS-Trigger-Information"
     ],
-    "collision_information": {
-      "energy": "7TeV"
-    },
     "date_created": [
       "2011"
     ],
@@ -5070,9 +4149,6 @@
     "experiment": "CMS",
     "publisher": "CERN Open Data Portal",
     "recid": "2153",
-    "run_period": [
-      "Run2011A"
-    ],
     "title": "High-Level Trigger path information HLT_DoubleMu3_HT200 (MuHad dataset)",
     "type": {
       "primary": "Supplementaries",
@@ -5093,9 +4169,6 @@
     "collections": [
       "CMS-Trigger-Information"
     ],
-    "collision_information": {
-      "energy": "7TeV"
-    },
     "date_created": [
       "2011"
     ],
@@ -5103,9 +4176,6 @@
     "experiment": "CMS",
     "publisher": "CERN Open Data Portal",
     "recid": "2154",
-    "run_period": [
-      "Run2011A"
-    ],
     "title": "High-Level Trigger path information HLT_DoubleMu3_Jpsi (MuOnia dataset)",
     "type": {
       "primary": "Supplementaries",
@@ -5126,9 +4196,6 @@
     "collections": [
       "CMS-Trigger-Information"
     ],
-    "collision_information": {
-      "energy": "7TeV"
-    },
     "date_created": [
       "2011"
     ],
@@ -5136,9 +4203,6 @@
     "experiment": "CMS",
     "publisher": "CERN Open Data Portal",
     "recid": "2155",
-    "run_period": [
-      "Run2011A"
-    ],
     "title": "High-Level Trigger path information HLT_DoubleMu3_LowMass (MuOnia dataset)",
     "type": {
       "primary": "Supplementaries",
@@ -5159,9 +4223,6 @@
     "collections": [
       "CMS-Trigger-Information"
     ],
-    "collision_information": {
-      "energy": "7TeV"
-    },
     "date_created": [
       "2011"
     ],
@@ -5169,9 +4230,6 @@
     "experiment": "CMS",
     "publisher": "CERN Open Data Portal",
     "recid": "2156",
-    "run_period": [
-      "Run2011A"
-    ],
     "title": "High-Level Trigger path information HLT_DoubleMu3_Mass4_HT150 (MuHad dataset)",
     "type": {
       "primary": "Supplementaries",
@@ -5192,9 +4250,6 @@
     "collections": [
       "CMS-Trigger-Information"
     ],
-    "collision_information": {
-      "energy": "7TeV"
-    },
     "date_created": [
       "2011"
     ],
@@ -5202,9 +4257,6 @@
     "experiment": "CMS",
     "publisher": "CERN Open Data Portal",
     "recid": "2157",
-    "run_period": [
-      "Run2011A"
-    ],
     "title": "High-Level Trigger path information HLT_DoubleMu3_Quarkonium (MuOnia dataset)",
     "type": {
       "primary": "Supplementaries",
@@ -5225,9 +4277,6 @@
     "collections": [
       "CMS-Trigger-Information"
     ],
-    "collision_information": {
-      "energy": "7TeV"
-    },
     "date_created": [
       "2011"
     ],
@@ -5235,9 +4284,6 @@
     "experiment": "CMS",
     "publisher": "CERN Open Data Portal",
     "recid": "2158",
-    "run_period": [
-      "Run2011A"
-    ],
     "title": "High-Level Trigger path information HLT_DoubleMu3_Upsilon (MuOnia dataset)",
     "type": {
       "primary": "Supplementaries",
@@ -5258,9 +4304,6 @@
     "collections": [
       "CMS-Trigger-Information"
     ],
-    "collision_information": {
-      "energy": "7TeV"
-    },
     "date_created": [
       "2011"
     ],
@@ -5268,9 +4311,6 @@
     "experiment": "CMS",
     "publisher": "CERN Open Data Portal",
     "recid": "2159",
-    "run_period": [
-      "Run2011A"
-    ],
     "title": "High-Level Trigger path information HLT_DoubleMu3p5_Jpsi_Displaced (MuOnia dataset)",
     "type": {
       "primary": "Supplementaries",
@@ -5291,9 +4331,6 @@
     "collections": [
       "CMS-Trigger-Information"
     ],
-    "collision_information": {
-      "energy": "7TeV"
-    },
     "date_created": [
       "2011"
     ],
@@ -5301,9 +4338,6 @@
     "experiment": "CMS",
     "publisher": "CERN Open Data Portal",
     "recid": "2160",
-    "run_period": [
-      "Run2011A"
-    ],
     "title": "High-Level Trigger path information HLT_DoubleMu45 (DoubleMu dataset)",
     "type": {
       "primary": "Supplementaries",
@@ -5324,9 +4358,6 @@
     "collections": [
       "CMS-Trigger-Information"
     ],
-    "collision_information": {
-      "energy": "7TeV"
-    },
     "date_created": [
       "2011"
     ],
@@ -5334,9 +4365,6 @@
     "experiment": "CMS",
     "publisher": "CERN Open Data Portal",
     "recid": "2161",
-    "run_period": [
-      "Run2011A"
-    ],
     "title": "High-Level Trigger path information HLT_DoubleMu4_Acoplanarity03 (DoubleMu dataset)",
     "type": {
       "primary": "Supplementaries",
@@ -5357,9 +4385,6 @@
     "collections": [
       "CMS-Trigger-Information"
     ],
-    "collision_information": {
-      "energy": "7TeV"
-    },
     "date_created": [
       "2011"
     ],
@@ -5367,9 +4392,6 @@
     "experiment": "CMS",
     "publisher": "CERN Open Data Portal",
     "recid": "2162",
-    "run_period": [
-      "Run2011A"
-    ],
     "title": "High-Level Trigger path information HLT_DoubleMu4_Dimuon4_Bs_Barrel (MuOnia dataset)",
     "type": {
       "primary": "Supplementaries",
@@ -5390,9 +4412,6 @@
     "collections": [
       "CMS-Trigger-Information"
     ],
-    "collision_information": {
-      "energy": "7TeV"
-    },
     "date_created": [
       "2011"
     ],
@@ -5400,9 +4419,6 @@
     "experiment": "CMS",
     "publisher": "CERN Open Data Portal",
     "recid": "2163",
-    "run_period": [
-      "Run2011A"
-    ],
     "title": "High-Level Trigger path information HLT_DoubleMu4_Dimuon6_Bs (MuOnia dataset)",
     "type": {
       "primary": "Supplementaries",
@@ -5423,9 +4439,6 @@
     "collections": [
       "CMS-Trigger-Information"
     ],
-    "collision_information": {
-      "energy": "7TeV"
-    },
     "date_created": [
       "2011"
     ],
@@ -5433,9 +4446,6 @@
     "experiment": "CMS",
     "publisher": "CERN Open Data Portal",
     "recid": "2164",
-    "run_period": [
-      "Run2011A"
-    ],
     "title": "High-Level Trigger path information HLT_DoubleMu4_Jpsi_Displaced (MuOnia dataset)",
     "type": {
       "primary": "Supplementaries",
@@ -5456,9 +4466,6 @@
     "collections": [
       "CMS-Trigger-Information"
     ],
-    "collision_information": {
-      "energy": "7TeV"
-    },
     "date_created": [
       "2011"
     ],
@@ -5466,9 +4473,6 @@
     "experiment": "CMS",
     "publisher": "CERN Open Data Portal",
     "recid": "2165",
-    "run_period": [
-      "Run2011A"
-    ],
     "title": "High-Level Trigger path information HLT_DoubleMu4_LowMass_Displaced (MuOnia dataset)",
     "type": {
       "primary": "Supplementaries",
@@ -5489,9 +4493,6 @@
     "collections": [
       "CMS-Trigger-Information"
     ],
-    "collision_information": {
-      "energy": "7TeV"
-    },
     "date_created": [
       "2011"
     ],
@@ -5499,9 +4500,6 @@
     "experiment": "CMS",
     "publisher": "CERN Open Data Portal",
     "recid": "2166",
-    "run_period": [
-      "Run2011A"
-    ],
     "title": "High-Level Trigger path information HLT_DoubleMu4p5_LowMass_Displaced (MuOnia dataset)",
     "type": {
       "primary": "Supplementaries",
@@ -5522,9 +4520,6 @@
     "collections": [
       "CMS-Trigger-Information"
     ],
-    "collision_information": {
-      "energy": "7TeV"
-    },
     "date_created": [
       "2011"
     ],
@@ -5532,9 +4527,6 @@
     "experiment": "CMS",
     "publisher": "CERN Open Data Portal",
     "recid": "2167",
-    "run_period": [
-      "Run2011A"
-    ],
     "title": "High-Level Trigger path information HLT_DoubleMu5 (DoubleMu dataset)",
     "type": {
       "primary": "Supplementaries",
@@ -5555,9 +4547,6 @@
     "collections": [
       "CMS-Trigger-Information"
     ],
-    "collision_information": {
-      "energy": "7TeV"
-    },
     "date_created": [
       "2011"
     ],
@@ -5565,9 +4554,6 @@
     "experiment": "CMS",
     "publisher": "CERN Open Data Portal",
     "recid": "2168",
-    "run_period": [
-      "Run2011A"
-    ],
     "title": "High-Level Trigger path information HLT_DoubleMu5_Acoplanarity03 (DoubleMu dataset)",
     "type": {
       "primary": "Supplementaries",
@@ -5588,9 +4574,6 @@
     "collections": [
       "CMS-Trigger-Information"
     ],
-    "collision_information": {
-      "energy": "7TeV"
-    },
     "date_created": [
       "2011"
     ],
@@ -5598,9 +4581,6 @@
     "experiment": "CMS",
     "publisher": "CERN Open Data Portal",
     "recid": "2169",
-    "run_period": [
-      "Run2011A"
-    ],
     "title": "High-Level Trigger path information HLT_DoubleMu5_Ele8 (MuEG dataset)",
     "type": {
       "primary": "Supplementaries",
@@ -5621,9 +4601,6 @@
     "collections": [
       "CMS-Trigger-Information"
     ],
-    "collision_information": {
-      "energy": "7TeV"
-    },
     "date_created": [
       "2011"
     ],
@@ -5631,9 +4608,6 @@
     "experiment": "CMS",
     "publisher": "CERN Open Data Portal",
     "recid": "2170",
-    "run_period": [
-      "Run2011A"
-    ],
     "title": "High-Level Trigger path information HLT_DoubleMu5_Ele8_CaloIdL_TrkIdVL (MuEG dataset)",
     "type": {
       "primary": "Supplementaries",
@@ -5654,9 +4628,6 @@
     "collections": [
       "CMS-Trigger-Information"
     ],
-    "collision_information": {
-      "energy": "7TeV"
-    },
     "date_created": [
       "2011"
     ],
@@ -5664,9 +4635,6 @@
     "experiment": "CMS",
     "publisher": "CERN Open Data Portal",
     "recid": "2171",
-    "run_period": [
-      "Run2011A"
-    ],
     "title": "High-Level Trigger path information HLT_DoubleMu5_Ele8_CaloIdT_TrkIdT (MuEG dataset)",
     "type": {
       "primary": "Supplementaries",
@@ -5687,9 +4655,6 @@
     "collections": [
       "CMS-Trigger-Information"
     ],
-    "collision_information": {
-      "energy": "7TeV"
-    },
     "date_created": [
       "2011"
     ],
@@ -5697,9 +4662,6 @@
     "experiment": "CMS",
     "publisher": "CERN Open Data Portal",
     "recid": "2172",
-    "run_period": [
-      "Run2011A"
-    ],
     "title": "High-Level Trigger path information HLT_DoubleMu5_Ele8_CaloIdT_TrkIdVL (MuEG dataset)",
     "type": {
       "primary": "Supplementaries",
@@ -5720,9 +4682,6 @@
     "collections": [
       "CMS-Trigger-Information"
     ],
-    "collision_information": {
-      "energy": "7TeV"
-    },
     "date_created": [
       "2011"
     ],
@@ -5730,9 +4689,6 @@
     "experiment": "CMS",
     "publisher": "CERN Open Data Portal",
     "recid": "2173",
-    "run_period": [
-      "Run2011A"
-    ],
     "title": "High-Level Trigger path information HLT_DoubleMu5_HT150 (MuHad dataset)",
     "type": {
       "primary": "Supplementaries",
@@ -5753,9 +4709,6 @@
     "collections": [
       "CMS-Trigger-Information"
     ],
-    "collision_information": {
-      "energy": "7TeV"
-    },
     "date_created": [
       "2011"
     ],
@@ -5763,9 +4716,6 @@
     "experiment": "CMS",
     "publisher": "CERN Open Data Portal",
     "recid": "2174",
-    "run_period": [
-      "Run2011A"
-    ],
     "title": "High-Level Trigger path information HLT_DoubleMu5_IsoMu5 (DoubleMu dataset)",
     "type": {
       "primary": "Supplementaries",
@@ -5786,9 +4736,6 @@
     "collections": [
       "CMS-Trigger-Information"
     ],
-    "collision_information": {
-      "energy": "7TeV"
-    },
     "date_created": [
       "2011"
     ],
@@ -5796,9 +4743,6 @@
     "experiment": "CMS",
     "publisher": "CERN Open Data Portal",
     "recid": "2175",
-    "run_period": [
-      "Run2011A"
-    ],
     "title": "High-Level Trigger path information HLT_DoubleMu5_Jpsi_Displaced (MuOnia dataset)",
     "type": {
       "primary": "Supplementaries",
@@ -5819,9 +4763,6 @@
     "collections": [
       "CMS-Trigger-Information"
     ],
-    "collision_information": {
-      "energy": "7TeV"
-    },
     "date_created": [
       "2011"
     ],
@@ -5829,9 +4770,6 @@
     "experiment": "CMS",
     "publisher": "CERN Open Data Portal",
     "recid": "2176",
-    "run_period": [
-      "Run2011A"
-    ],
     "title": "High-Level Trigger path information HLT_DoubleMu5_LowMass_Displaced (MuOnia dataset)",
     "type": {
       "primary": "Supplementaries",
@@ -5852,9 +4790,6 @@
     "collections": [
       "CMS-Trigger-Information"
     ],
-    "collision_information": {
-      "energy": "7TeV"
-    },
     "date_created": [
       "2011"
     ],
@@ -5862,9 +4797,6 @@
     "experiment": "CMS",
     "publisher": "CERN Open Data Portal",
     "recid": "2177",
-    "run_period": [
-      "Run2011A"
-    ],
     "title": "High-Level Trigger path information HLT_DoubleMu5_Mass4_HT150 (MuHad dataset)",
     "type": {
       "primary": "Supplementaries",
@@ -5885,9 +4817,6 @@
     "collections": [
       "CMS-Trigger-Information"
     ],
-    "collision_information": {
-      "energy": "7TeV"
-    },
     "date_created": [
       "2011"
     ],
@@ -5895,9 +4824,6 @@
     "experiment": "CMS",
     "publisher": "CERN Open Data Portal",
     "recid": "2178",
-    "run_period": [
-      "Run2011A"
-    ],
     "title": "High-Level Trigger path information HLT_DoubleMu5_Mass8_HT150 (MuHad dataset)",
     "type": {
       "primary": "Supplementaries",
@@ -5918,9 +4844,6 @@
     "collections": [
       "CMS-Trigger-Information"
     ],
-    "collision_information": {
-      "energy": "7TeV"
-    },
     "date_created": [
       "2011"
     ],
@@ -5928,9 +4851,6 @@
     "experiment": "CMS",
     "publisher": "CERN Open Data Portal",
     "recid": "2179",
-    "run_period": [
-      "Run2011A"
-    ],
     "title": "High-Level Trigger path information HLT_DoubleMu6 (DoubleMu dataset)",
     "type": {
       "primary": "Supplementaries",
@@ -5951,9 +4871,6 @@
     "collections": [
       "CMS-Trigger-Information"
     ],
-    "collision_information": {
-      "energy": "7TeV"
-    },
     "date_created": [
       "2011"
     ],
@@ -5961,9 +4878,6 @@
     "experiment": "CMS",
     "publisher": "CERN Open Data Portal",
     "recid": "2180",
-    "run_period": [
-      "Run2011A"
-    ],
     "title": "High-Level Trigger path information HLT_DoubleMu6_Acoplanarity03 (DoubleMu dataset)",
     "type": {
       "primary": "Supplementaries",
@@ -5984,9 +4898,6 @@
     "collections": [
       "CMS-Trigger-Information"
     ],
-    "collision_information": {
-      "energy": "7TeV"
-    },
     "date_created": [
       "2011"
     ],
@@ -5994,9 +4905,6 @@
     "experiment": "CMS",
     "publisher": "CERN Open Data Portal",
     "recid": "2181",
-    "run_period": [
-      "Run2011A"
-    ],
     "title": "High-Level Trigger path information HLT_DoubleMu7 (DoubleMu dataset)",
     "type": {
       "primary": "Supplementaries",
@@ -6017,9 +4925,6 @@
     "collections": [
       "CMS-Trigger-Information"
     ],
-    "collision_information": {
-      "energy": "7TeV"
-    },
     "date_created": [
       "2011"
     ],
@@ -6027,9 +4932,6 @@
     "experiment": "CMS",
     "publisher": "CERN Open Data Portal",
     "recid": "2182",
-    "run_period": [
-      "Run2011A"
-    ],
     "title": "High-Level Trigger path information HLT_DoubleMu7_Acoplanarity03 (DoubleMu dataset)",
     "type": {
       "primary": "Supplementaries",
@@ -6050,9 +4952,6 @@
     "collections": [
       "CMS-Trigger-Information"
     ],
-    "collision_information": {
-      "energy": "7TeV"
-    },
     "date_created": [
       "2011"
     ],
@@ -6060,9 +4959,6 @@
     "experiment": "CMS",
     "publisher": "CERN Open Data Portal",
     "recid": "2183",
-    "run_period": [
-      "Run2011A"
-    ],
     "title": "High-Level Trigger path information HLT_DoubleMu8_Mass8_HT150 (MuHad dataset)",
     "type": {
       "primary": "Supplementaries",
@@ -6083,9 +4979,6 @@
     "collections": [
       "CMS-Trigger-Information"
     ],
-    "collision_information": {
-      "energy": "7TeV"
-    },
     "date_created": [
       "2011"
     ],
@@ -6093,9 +4986,6 @@
     "experiment": "CMS",
     "publisher": "CERN Open Data Portal",
     "recid": "2184",
-    "run_period": [
-      "Run2011A"
-    ],
     "title": "High-Level Trigger path information HLT_DoubleMu8_Mass8_HT200 (MuHad dataset)",
     "type": {
       "primary": "Supplementaries",
@@ -6116,9 +5006,6 @@
     "collections": [
       "CMS-Trigger-Information"
     ],
-    "collision_information": {
-      "energy": "7TeV"
-    },
     "date_created": [
       "2011"
     ],
@@ -6126,9 +5013,6 @@
     "experiment": "CMS",
     "publisher": "CERN Open Data Portal",
     "recid": "2185",
-    "run_period": [
-      "Run2011A"
-    ],
     "title": "High-Level Trigger path information HLT_DoublePhoton33 (Photon dataset)",
     "type": {
       "primary": "Supplementaries",
@@ -6149,9 +5033,6 @@
     "collections": [
       "CMS-Trigger-Information"
     ],
-    "collision_information": {
-      "energy": "7TeV"
-    },
     "date_created": [
       "2011"
     ],
@@ -6159,9 +5040,6 @@
     "experiment": "CMS",
     "publisher": "CERN Open Data Portal",
     "recid": "2186",
-    "run_period": [
-      "Run2011A"
-    ],
     "title": "High-Level Trigger path information HLT_DoublePhoton33_HEVT (Photon dataset)",
     "type": {
       "primary": "Supplementaries",
@@ -6182,9 +5060,6 @@
     "collections": [
       "CMS-Trigger-Information"
     ],
-    "collision_information": {
-      "energy": "7TeV"
-    },
     "date_created": [
       "2011"
     ],
@@ -6192,9 +5067,6 @@
     "experiment": "CMS",
     "publisher": "CERN Open Data Portal",
     "recid": "2187",
-    "run_period": [
-      "Run2011A"
-    ],
     "title": "High-Level Trigger path information HLT_DoublePhoton38_HEVT (Photon dataset)",
     "type": {
       "primary": "Supplementaries",
@@ -6215,9 +5087,6 @@
     "collections": [
       "CMS-Trigger-Information"
     ],
-    "collision_information": {
-      "energy": "7TeV"
-    },
     "date_created": [
       "2011"
     ],
@@ -6225,9 +5094,6 @@
     "experiment": "CMS",
     "publisher": "CERN Open Data Portal",
     "recid": "2188",
-    "run_period": [
-      "Run2011A"
-    ],
     "title": "High-Level Trigger path information HLT_DoublePhoton40_CaloIdL_MR150 (Photon dataset)",
     "type": {
       "primary": "Supplementaries",
@@ -6248,9 +5114,6 @@
     "collections": [
       "CMS-Trigger-Information"
     ],
-    "collision_information": {
-      "energy": "7TeV"
-    },
     "date_created": [
       "2011"
     ],
@@ -6258,9 +5121,6 @@
     "experiment": "CMS",
     "publisher": "CERN Open Data Portal",
     "recid": "2189",
-    "run_period": [
-      "Run2011A"
-    ],
     "title": "High-Level Trigger path information HLT_DoublePhoton40_CaloIdL_R014_MR150 (Photon dataset)",
     "type": {
       "primary": "Supplementaries",
@@ -6281,9 +5141,6 @@
     "collections": [
       "CMS-Trigger-Information"
     ],
-    "collision_information": {
-      "energy": "7TeV"
-    },
     "date_created": [
       "2011"
     ],
@@ -6291,9 +5148,6 @@
     "experiment": "CMS",
     "publisher": "CERN Open Data Portal",
     "recid": "2190",
-    "run_period": [
-      "Run2011A"
-    ],
     "title": "High-Level Trigger path information HLT_DoublePhoton40_MR150 (Photon dataset)",
     "type": {
       "primary": "Supplementaries",
@@ -6314,9 +5168,6 @@
     "collections": [
       "CMS-Trigger-Information"
     ],
-    "collision_information": {
-      "energy": "7TeV"
-    },
     "date_created": [
       "2011"
     ],
@@ -6324,9 +5175,6 @@
     "experiment": "CMS",
     "publisher": "CERN Open Data Portal",
     "recid": "2191",
-    "run_period": [
-      "Run2011A"
-    ],
     "title": "High-Level Trigger path information HLT_DoublePhoton40_R014_MR150 (Photon dataset)",
     "type": {
       "primary": "Supplementaries",
@@ -6347,9 +5195,6 @@
     "collections": [
       "CMS-Trigger-Information"
     ],
-    "collision_information": {
-      "energy": "7TeV"
-    },
     "date_created": [
       "2011"
     ],
@@ -6357,9 +5202,6 @@
     "experiment": "CMS",
     "publisher": "CERN Open Data Portal",
     "recid": "2192",
-    "run_period": [
-      "Run2011A"
-    ],
     "title": "High-Level Trigger path information HLT_DoublePhoton43_HEVT (Photon dataset)",
     "type": {
       "primary": "Supplementaries",
@@ -6380,9 +5222,6 @@
     "collections": [
       "CMS-Trigger-Information"
     ],
-    "collision_information": {
-      "energy": "7TeV"
-    },
     "date_created": [
       "2011"
     ],
@@ -6390,9 +5229,6 @@
     "experiment": "CMS",
     "publisher": "CERN Open Data Portal",
     "recid": "2193",
-    "run_period": [
-      "Run2011A"
-    ],
     "title": "High-Level Trigger path information HLT_DoublePhoton48_HEVT (Photon dataset)",
     "type": {
       "primary": "Supplementaries",
@@ -6413,9 +5249,6 @@
     "collections": [
       "CMS-Trigger-Information"
     ],
-    "collision_information": {
-      "energy": "7TeV"
-    },
     "date_created": [
       "2011"
     ],
@@ -6423,9 +5256,6 @@
     "experiment": "CMS",
     "publisher": "CERN Open Data Portal",
     "recid": "2194",
-    "run_period": [
-      "Run2011A"
-    ],
     "title": "High-Level Trigger path information HLT_DoublePhoton50 (Photon dataset)",
     "type": {
       "primary": "Supplementaries",
@@ -6446,9 +5276,6 @@
     "collections": [
       "CMS-Trigger-Information"
     ],
-    "collision_information": {
-      "energy": "7TeV"
-    },
     "date_created": [
       "2011"
     ],
@@ -6456,9 +5283,6 @@
     "experiment": "CMS",
     "publisher": "CERN Open Data Portal",
     "recid": "2195",
-    "run_period": [
-      "Run2011A"
-    ],
     "title": "High-Level Trigger path information HLT_DoublePhoton5_IsoVL_CEP (Photon dataset)",
     "type": {
       "primary": "Supplementaries",
@@ -6479,9 +5303,6 @@
     "collections": [
       "CMS-Trigger-Information"
     ],
-    "collision_information": {
-      "energy": "7TeV"
-    },
     "date_created": [
       "2011"
     ],
@@ -6489,9 +5310,6 @@
     "experiment": "CMS",
     "publisher": "CERN Open Data Portal",
     "recid": "2196",
-    "run_period": [
-      "Run2011A"
-    ],
     "title": "High-Level Trigger path information HLT_DoublePhoton60 (Photon dataset)",
     "type": {
       "primary": "Supplementaries",
@@ -6512,9 +5330,6 @@
     "collections": [
       "CMS-Trigger-Information"
     ],
-    "collision_information": {
-      "energy": "7TeV"
-    },
     "date_created": [
       "2011"
     ],
@@ -6522,9 +5337,6 @@
     "experiment": "CMS",
     "publisher": "CERN Open Data Portal",
     "recid": "2197",
-    "run_period": [
-      "Run2011A"
-    ],
     "title": "High-Level Trigger path information HLT_DoublePhoton70 (Photon dataset)",
     "type": {
       "primary": "Supplementaries",
@@ -6545,9 +5357,6 @@
     "collections": [
       "CMS-Trigger-Information"
     ],
-    "collision_information": {
-      "energy": "7TeV"
-    },
     "date_created": [
       "2011"
     ],
@@ -6555,9 +5364,6 @@
     "experiment": "CMS",
     "publisher": "CERN Open Data Portal",
     "recid": "2198",
-    "run_period": [
-      "Run2011A"
-    ],
     "title": "High-Level Trigger path information HLT_DoublePhoton80 (Photon dataset)",
     "type": {
       "primary": "Supplementaries",
@@ -6578,9 +5384,6 @@
     "collections": [
       "CMS-Trigger-Information"
     ],
-    "collision_information": {
-      "energy": "7TeV"
-    },
     "date_created": [
       "2011"
     ],
@@ -6588,9 +5391,6 @@
     "experiment": "CMS",
     "publisher": "CERN Open Data Portal",
     "recid": "2199",
-    "run_period": [
-      "Run2011A"
-    ],
     "title": "High-Level Trigger path information HLT_DoubleTkIso10Mu5_Mass8_HT150 (MuHad dataset)",
     "type": {
       "primary": "Supplementaries",
@@ -6611,9 +5411,6 @@
     "collections": [
       "CMS-Trigger-Information"
     ],
-    "collision_information": {
-      "energy": "7TeV"
-    },
     "date_created": [
       "2011"
     ],
@@ -6621,9 +5418,6 @@
     "experiment": "CMS",
     "publisher": "CERN Open Data Portal",
     "recid": "2200",
-    "run_period": [
-      "Run2011A"
-    ],
     "title": "High-Level Trigger path information HLT_DoubleTkIso10Mu5_Mass8_HT200 (MuHad dataset)",
     "type": {
       "primary": "Supplementaries",
@@ -6644,9 +5438,6 @@
     "collections": [
       "CMS-Trigger-Information"
     ],
-    "collision_information": {
-      "energy": "7TeV"
-    },
     "date_created": [
       "2011"
     ],
@@ -6654,9 +5445,6 @@
     "experiment": "CMS",
     "publisher": "CERN Open Data Portal",
     "recid": "2201",
-    "run_period": [
-      "Run2011A"
-    ],
     "title": "High-Level Trigger path information HLT_EcalCalibration",
     "type": {
       "primary": "Supplementaries",
@@ -6677,9 +5465,6 @@
     "collections": [
       "CMS-Trigger-Information"
     ],
-    "collision_information": {
-      "energy": "7TeV"
-    },
     "date_created": [
       "2011"
     ],
@@ -6687,9 +5472,6 @@
     "experiment": "CMS",
     "publisher": "CERN Open Data Portal",
     "recid": "2202",
-    "run_period": [
-      "Run2011A"
-    ],
     "title": "High-Level Trigger path information HLT_EightJet120 (MultiJet dataset)",
     "type": {
       "primary": "Supplementaries",
@@ -6710,9 +5492,6 @@
     "collections": [
       "CMS-Trigger-Information"
     ],
-    "collision_information": {
-      "energy": "7TeV"
-    },
     "date_created": [
       "2011"
     ],
@@ -6720,9 +5499,6 @@
     "experiment": "CMS",
     "publisher": "CERN Open Data Portal",
     "recid": "2203",
-    "run_period": [
-      "Run2011A"
-    ],
     "title": "High-Level Trigger path information HLT_EightJet35 (MultiJet dataset)",
     "type": {
       "primary": "Supplementaries",
@@ -6743,9 +5519,6 @@
     "collections": [
       "CMS-Trigger-Information"
     ],
-    "collision_information": {
-      "energy": "7TeV"
-    },
     "date_created": [
       "2011"
     ],
@@ -6753,9 +5526,6 @@
     "experiment": "CMS",
     "publisher": "CERN Open Data Portal",
     "recid": "2204",
-    "run_period": [
-      "Run2011A"
-    ],
     "title": "High-Level Trigger path information HLT_EightJet35_L1FastJet (MultiJet dataset)",
     "type": {
       "primary": "Supplementaries",
@@ -6776,9 +5546,6 @@
     "collections": [
       "CMS-Trigger-Information"
     ],
-    "collision_information": {
-      "energy": "7TeV"
-    },
     "date_created": [
       "2011"
     ],
@@ -6786,9 +5553,6 @@
     "experiment": "CMS",
     "publisher": "CERN Open Data Portal",
     "recid": "2205",
-    "run_period": [
-      "Run2011A"
-    ],
     "title": "High-Level Trigger path information HLT_EightJet40 (MultiJet dataset)",
     "type": {
       "primary": "Supplementaries",
@@ -6809,9 +5573,6 @@
     "collections": [
       "CMS-Trigger-Information"
     ],
-    "collision_information": {
-      "energy": "7TeV"
-    },
     "date_created": [
       "2011"
     ],
@@ -6819,9 +5580,6 @@
     "experiment": "CMS",
     "publisher": "CERN Open Data Portal",
     "recid": "2206",
-    "run_period": [
-      "Run2011A"
-    ],
     "title": "High-Level Trigger path information HLT_EightJet40_L1FastJet (MultiJet dataset)",
     "type": {
       "primary": "Supplementaries",
@@ -6842,9 +5600,6 @@
     "collections": [
       "CMS-Trigger-Information"
     ],
-    "collision_information": {
-      "energy": "7TeV"
-    },
     "date_created": [
       "2011"
     ],
@@ -6852,9 +5607,6 @@
     "experiment": "CMS",
     "publisher": "CERN Open Data Portal",
     "recid": "2207",
-    "run_period": [
-      "Run2011A"
-    ],
     "title": "High-Level Trigger path information HLT_Ele100_CaloIdVL_CaloIsoVL_TrkIdVL_TrkIsoVL (SingleElectron dataset)",
     "type": {
       "primary": "Supplementaries",
@@ -6875,9 +5627,6 @@
     "collections": [
       "CMS-Trigger-Information"
     ],
-    "collision_information": {
-      "energy": "7TeV"
-    },
     "date_created": [
       "2011"
     ],
@@ -6885,9 +5634,6 @@
     "experiment": "CMS",
     "publisher": "CERN Open Data Portal",
     "recid": "2208",
-    "run_period": [
-      "Run2011A"
-    ],
     "title": "High-Level Trigger path information HLT_Ele100_CaloIdVT_TrkIdT (SingleElectron dataset)",
     "type": {
       "primary": "Supplementaries",
@@ -6908,9 +5654,6 @@
     "collections": [
       "CMS-Trigger-Information"
     ],
-    "collision_information": {
-      "energy": "7TeV"
-    },
     "date_created": [
       "2011"
     ],
@@ -6918,9 +5661,6 @@
     "experiment": "CMS",
     "publisher": "CERN Open Data Portal",
     "recid": "2209",
-    "run_period": [
-      "Run2011A"
-    ],
     "title": "High-Level Trigger path information HLT_Ele10_CaloIdL_CaloIsoVL_TrkIdVL_TrkIsoVL_HT200 (ElectronHad dataset)",
     "type": {
       "primary": "Supplementaries",
@@ -6941,9 +5681,6 @@
     "collections": [
       "CMS-Trigger-Information"
     ],
-    "collision_information": {
-      "energy": "7TeV"
-    },
     "date_created": [
       "2011"
     ],
@@ -6951,9 +5688,6 @@
     "experiment": "CMS",
     "publisher": "CERN Open Data Portal",
     "recid": "2210",
-    "run_period": [
-      "Run2011A"
-    ],
     "title": "High-Level Trigger path information HLT_Ele10_CaloIdL_CaloIsoVL_TrkIdVL_TrkIsoVL_R005_MR200 (ElectronHad dataset)",
     "type": {
       "primary": "Supplementaries",
@@ -6974,9 +5708,6 @@
     "collections": [
       "CMS-Trigger-Information"
     ],
-    "collision_information": {
-      "energy": "7TeV"
-    },
     "date_created": [
       "2011"
     ],
@@ -6984,9 +5715,6 @@
     "experiment": "CMS",
     "publisher": "CERN Open Data Portal",
     "recid": "2211",
-    "run_period": [
-      "Run2011A"
-    ],
     "title": "High-Level Trigger path information HLT_Ele10_CaloIdL_CaloIsoVL_TrkIdVL_TrkIsoVL_R025_MR200 (ElectronHad dataset)",
     "type": {
       "primary": "Supplementaries",
@@ -7007,9 +5735,6 @@
     "collections": [
       "CMS-Trigger-Information"
     ],
-    "collision_information": {
-      "energy": "7TeV"
-    },
     "date_created": [
       "2011"
     ],
@@ -7017,9 +5742,6 @@
     "experiment": "CMS",
     "publisher": "CERN Open Data Portal",
     "recid": "2212",
-    "run_period": [
-      "Run2011A"
-    ],
     "title": "High-Level Trigger path information HLT_Ele10_CaloIdL_CaloIsoVL_TrkIdVL_TrkIsoVL_R029_MR200 (ElectronHad dataset)",
     "type": {
       "primary": "Supplementaries",
@@ -7040,9 +5762,6 @@
     "collections": [
       "CMS-Trigger-Information"
     ],
-    "collision_information": {
-      "energy": "7TeV"
-    },
     "date_created": [
       "2011"
     ],
@@ -7050,9 +5769,6 @@
     "experiment": "CMS",
     "publisher": "CERN Open Data Portal",
     "recid": "2213",
-    "run_period": [
-      "Run2011A"
-    ],
     "title": "High-Level Trigger path information HLT_Ele10_CaloIdL_TrkIdVL_CaloIsoVL_TrkIsoVL_R005_MR200 (ElectronHad dataset)",
     "type": {
       "primary": "Supplementaries",
@@ -7073,9 +5789,6 @@
     "collections": [
       "CMS-Trigger-Information"
     ],
-    "collision_information": {
-      "energy": "7TeV"
-    },
     "date_created": [
       "2011"
     ],
@@ -7083,9 +5796,6 @@
     "experiment": "CMS",
     "publisher": "CERN Open Data Portal",
     "recid": "2214",
-    "run_period": [
-      "Run2011A"
-    ],
     "title": "High-Level Trigger path information HLT_Ele10_CaloIdL_TrkIdVL_CaloIsoVL_TrkIsoVL_R020_MR200 (ElectronHad dataset)",
     "type": {
       "primary": "Supplementaries",
@@ -7106,9 +5816,6 @@
     "collections": [
       "CMS-Trigger-Information"
     ],
-    "collision_information": {
-      "energy": "7TeV"
-    },
     "date_created": [
       "2011"
     ],
@@ -7116,9 +5823,6 @@
     "experiment": "CMS",
     "publisher": "CERN Open Data Portal",
     "recid": "2215",
-    "run_period": [
-      "Run2011A"
-    ],
     "title": "High-Level Trigger path information HLT_Ele10_CaloIdL_TrkIdVL_CaloIsoVL_TrkIsoVL_R025_MR200 (ElectronHad dataset)",
     "type": {
       "primary": "Supplementaries",
@@ -7139,9 +5843,6 @@
     "collections": [
       "CMS-Trigger-Information"
     ],
-    "collision_information": {
-      "energy": "7TeV"
-    },
     "date_created": [
       "2011"
     ],
@@ -7149,9 +5850,6 @@
     "experiment": "CMS",
     "publisher": "CERN Open Data Portal",
     "recid": "2216",
-    "run_period": [
-      "Run2011A"
-    ],
     "title": "High-Level Trigger path information HLT_Ele10_CaloIdT_CaloIsoVL_TrkIdT_TrkIsoVL_HT200 (ElectronHad dataset)",
     "type": {
       "primary": "Supplementaries",
@@ -7172,9 +5870,6 @@
     "collections": [
       "CMS-Trigger-Information"
     ],
-    "collision_information": {
-      "energy": "7TeV"
-    },
     "date_created": [
       "2011"
     ],
@@ -7182,9 +5877,6 @@
     "experiment": "CMS",
     "publisher": "CERN Open Data Portal",
     "recid": "2217",
-    "run_period": [
-      "Run2011A"
-    ],
     "title": "High-Level Trigger path information HLT_Ele10_CaloIdT_TrkIdVL_CaloIsoVL_TrkIsoVL_R020_MR200 (ElectronHad dataset)",
     "type": {
       "primary": "Supplementaries",
@@ -7205,9 +5897,6 @@
     "collections": [
       "CMS-Trigger-Information"
     ],
-    "collision_information": {
-      "energy": "7TeV"
-    },
     "date_created": [
       "2011"
     ],
@@ -7215,9 +5904,6 @@
     "experiment": "CMS",
     "publisher": "CERN Open Data Portal",
     "recid": "2218",
-    "run_period": [
-      "Run2011A"
-    ],
     "title": "High-Level Trigger path information HLT_Ele12_CaloIdL_CaloIsoVL_TrkIdVL_TrkIsoVL_R005_MR200 (ElectronHad dataset)",
     "type": {
       "primary": "Supplementaries",
@@ -7238,9 +5924,6 @@
     "collections": [
       "CMS-Trigger-Information"
     ],
-    "collision_information": {
-      "energy": "7TeV"
-    },
     "date_created": [
       "2011"
     ],
@@ -7248,9 +5931,6 @@
     "experiment": "CMS",
     "publisher": "CERN Open Data Portal",
     "recid": "2219",
-    "run_period": [
-      "Run2011A"
-    ],
     "title": "High-Level Trigger path information HLT_Ele12_CaloIdL_CaloIsoVL_TrkIdVL_TrkIsoVL_R014_MR200 (ElectronHad dataset)",
     "type": {
       "primary": "Supplementaries",
@@ -7271,9 +5951,6 @@
     "collections": [
       "CMS-Trigger-Information"
     ],
-    "collision_information": {
-      "energy": "7TeV"
-    },
     "date_created": [
       "2011"
     ],
@@ -7281,9 +5958,6 @@
     "experiment": "CMS",
     "publisher": "CERN Open Data Portal",
     "recid": "2220",
-    "run_period": [
-      "Run2011A"
-    ],
     "title": "High-Level Trigger path information HLT_Ele12_CaloIdL_CaloIsoVL_TrkIdVL_TrkIsoVL_R025_MR200 (ElectronHad dataset)",
     "type": {
       "primary": "Supplementaries",
@@ -7304,9 +5978,6 @@
     "collections": [
       "CMS-Trigger-Information"
     ],
-    "collision_information": {
-      "energy": "7TeV"
-    },
     "date_created": [
       "2011"
     ],
@@ -7314,9 +5985,6 @@
     "experiment": "CMS",
     "publisher": "CERN Open Data Portal",
     "recid": "2221",
-    "run_period": [
-      "Run2011A"
-    ],
     "title": "High-Level Trigger path information HLT_Ele12_CaloIdL_CaloIsoVL_TrkIdVL_TrkIsoVL_R029_MR200 (ElectronHad dataset)",
     "type": {
       "primary": "Supplementaries",
@@ -7337,9 +6005,6 @@
     "collections": [
       "CMS-Trigger-Information"
     ],
-    "collision_information": {
-      "energy": "7TeV"
-    },
     "date_created": [
       "2011"
     ],
@@ -7347,9 +6012,6 @@
     "experiment": "CMS",
     "publisher": "CERN Open Data Portal",
     "recid": "2222",
-    "run_period": [
-      "Run2011A"
-    ],
     "title": "High-Level Trigger path information HLT_Ele12_CaloIdL_CaloIsoVL_TrkIdVL_TrkIsoVL_R033_MR200 (ElectronHad dataset)",
     "type": {
       "primary": "Supplementaries",
@@ -7370,9 +6032,6 @@
     "collections": [
       "CMS-Trigger-Information"
     ],
-    "collision_information": {
-      "energy": "7TeV"
-    },
     "date_created": [
       "2011"
     ],
@@ -7380,9 +6039,6 @@
     "experiment": "CMS",
     "publisher": "CERN Open Data Portal",
     "recid": "2223",
-    "run_period": [
-      "Run2011A"
-    ],
     "title": "High-Level Trigger path information HLT_Ele15_CaloIdT_CaloIsoVL_TrkIdT_TrkIsoVL (ElectronHad dataset)",
     "type": {
       "primary": "Supplementaries",
@@ -7403,9 +6059,6 @@
     "collections": [
       "CMS-Trigger-Information"
     ],
-    "collision_information": {
-      "energy": "7TeV"
-    },
     "date_created": [
       "2011"
     ],
@@ -7413,9 +6066,6 @@
     "experiment": "CMS",
     "publisher": "CERN Open Data Portal",
     "recid": "2224",
-    "run_period": [
-      "Run2011A"
-    ],
     "title": "High-Level Trigger path information HLT_Ele15_CaloIdT_CaloIsoVL_TrkIdT_TrkIsoVL_HT200 (ElectronHad dataset)",
     "type": {
       "primary": "Supplementaries",
@@ -7436,9 +6086,6 @@
     "collections": [
       "CMS-Trigger-Information"
     ],
-    "collision_information": {
-      "energy": "7TeV"
-    },
     "date_created": [
       "2011"
     ],
@@ -7446,9 +6093,6 @@
     "experiment": "CMS",
     "publisher": "CERN Open Data Portal",
     "recid": "2225",
-    "run_period": [
-      "Run2011A"
-    ],
     "title": "High-Level Trigger path information HLT_Ele15_CaloIdT_CaloIsoVL_TrkIdT_TrkIsoVL_HT250 (ElectronHad dataset)",
     "type": {
       "primary": "Supplementaries",
@@ -7469,9 +6113,6 @@
     "collections": [
       "CMS-Trigger-Information"
     ],
-    "collision_information": {
-      "energy": "7TeV"
-    },
     "date_created": [
       "2011"
     ],
@@ -7479,9 +6120,6 @@
     "experiment": "CMS",
     "publisher": "CERN Open Data Portal",
     "recid": "2226",
-    "run_period": [
-      "Run2011A"
-    ],
     "title": "High-Level Trigger path information HLT_Ele15_CaloIdT_CaloIsoVL_TrkIdT_TrkIsoVL_HT250_PFMHT25 (ElectronHad dataset)",
     "type": {
       "primary": "Supplementaries",
@@ -7502,9 +6140,6 @@
     "collections": [
       "CMS-Trigger-Information"
     ],
-    "collision_information": {
-      "energy": "7TeV"
-    },
     "date_created": [
       "2011"
     ],
@@ -7512,9 +6147,6 @@
     "experiment": "CMS",
     "publisher": "CERN Open Data Portal",
     "recid": "2227",
-    "run_period": [
-      "Run2011A"
-    ],
     "title": "High-Level Trigger path information HLT_Ele15_CaloIdT_CaloIsoVL_TrkIdT_TrkIsoVL_HT250_PFMHT40 (ElectronHad dataset)",
     "type": {
       "primary": "Supplementaries",
@@ -7535,9 +6167,6 @@
     "collections": [
       "CMS-Trigger-Information"
     ],
-    "collision_information": {
-      "energy": "7TeV"
-    },
     "date_created": [
       "2011"
     ],
@@ -7545,9 +6174,6 @@
     "experiment": "CMS",
     "publisher": "CERN Open Data Portal",
     "recid": "2228",
-    "run_period": [
-      "Run2011A"
-    ],
     "title": "High-Level Trigger path information HLT_Ele15_CaloIdT_CaloIsoVL_TrkIdT_TrkIsoVL_HT250_PFMHT50 (ElectronHad dataset)",
     "type": {
       "primary": "Supplementaries",
@@ -7568,9 +6194,6 @@
     "collections": [
       "CMS-Trigger-Information"
     ],
-    "collision_information": {
-      "energy": "7TeV"
-    },
     "date_created": [
       "2011"
     ],
@@ -7578,9 +6201,6 @@
     "experiment": "CMS",
     "publisher": "CERN Open Data Portal",
     "recid": "2229",
-    "run_period": [
-      "Run2011A"
-    ],
     "title": "High-Level Trigger path information HLT_Ele15_CaloIdVT_CaloIsoT_TrkIdT_TrkIsoT (TauPlusX dataset)",
     "type": {
       "primary": "Supplementaries",
@@ -7601,9 +6221,6 @@
     "collections": [
       "CMS-Trigger-Information"
     ],
-    "collision_information": {
-      "energy": "7TeV"
-    },
     "date_created": [
       "2011"
     ],
@@ -7611,9 +6228,6 @@
     "experiment": "CMS",
     "publisher": "CERN Open Data Portal",
     "recid": "2230",
-    "run_period": [
-      "Run2011A"
-    ],
     "title": "High-Level Trigger path information HLT_Ele15_CaloIdVT_CaloIsoT_TrkIdT_TrkIsoT_Jet35_Jet25_Deta2 (ElectronHad dataset)",
     "type": {
       "primary": "Supplementaries",
@@ -7634,9 +6248,6 @@
     "collections": [
       "CMS-Trigger-Information"
     ],
-    "collision_information": {
-      "energy": "7TeV"
-    },
     "date_created": [
       "2011"
     ],
@@ -7644,9 +6255,6 @@
     "experiment": "CMS",
     "publisher": "CERN Open Data Portal",
     "recid": "2231",
-    "run_period": [
-      "Run2011A"
-    ],
     "title": "High-Level Trigger path information HLT_Ele15_CaloIdVT_CaloIsoT_TrkIdT_TrkIsoT_Jet35_Jet25_Deta3 (ElectronHad dataset)",
     "type": {
       "primary": "Supplementaries",
@@ -7667,9 +6275,6 @@
     "collections": [
       "CMS-Trigger-Information"
     ],
-    "collision_information": {
-      "energy": "7TeV"
-    },
     "date_created": [
       "2011"
     ],
@@ -7677,9 +6282,6 @@
     "experiment": "CMS",
     "publisher": "CERN Open Data Portal",
     "recid": "2232",
-    "run_period": [
-      "Run2011A"
-    ],
     "title": "High-Level Trigger path information HLT_Ele15_CaloIdVT_CaloIsoT_TrkIdT_TrkIsoT_Jet35_Jet25_Deta3_Jet20 (ElectronHad dataset)",
     "type": {
       "primary": "Supplementaries",
@@ -7700,9 +6302,6 @@
     "collections": [
       "CMS-Trigger-Information"
     ],
-    "collision_information": {
-      "energy": "7TeV"
-    },
     "date_created": [
       "2011"
     ],
@@ -7710,9 +6309,6 @@
     "experiment": "CMS",
     "publisher": "CERN Open Data Portal",
     "recid": "2233",
-    "run_period": [
-      "Run2011A"
-    ],
     "title": "High-Level Trigger path information HLT_Ele15_CaloIdVT_CaloIsoT_TrkIdT_TrkIsoT_LooseIsoPFTau15 (TauPlusX dataset)",
     "type": {
       "primary": "Supplementaries",
@@ -7733,9 +6329,6 @@
     "collections": [
       "CMS-Trigger-Information"
     ],
-    "collision_information": {
-      "energy": "7TeV"
-    },
     "date_created": [
       "2011"
     ],
@@ -7743,9 +6336,6 @@
     "experiment": "CMS",
     "publisher": "CERN Open Data Portal",
     "recid": "2234",
-    "run_period": [
-      "Run2011A"
-    ],
     "title": "High-Level Trigger path information HLT_Ele15_CaloIdVT_CaloIsoT_TrkIdT_TrkIsoT_LooseIsoPFTau20 (TauPlusX dataset)",
     "type": {
       "primary": "Supplementaries",
@@ -7766,9 +6356,6 @@
     "collections": [
       "CMS-Trigger-Information"
     ],
-    "collision_information": {
-      "energy": "7TeV"
-    },
     "date_created": [
       "2011"
     ],
@@ -7776,9 +6363,6 @@
     "experiment": "CMS",
     "publisher": "CERN Open Data Portal",
     "recid": "2235",
-    "run_period": [
-      "Run2011A"
-    ],
     "title": "High-Level Trigger path information HLT_Ele15_CaloIdVT_CaloIsoT_TrkIdT_TrkIsoT_TightIsoPFTau20 (TauPlusX dataset)",
     "type": {
       "primary": "Supplementaries",
@@ -7799,9 +6383,6 @@
     "collections": [
       "CMS-Trigger-Information"
     ],
-    "collision_information": {
-      "energy": "7TeV"
-    },
     "date_created": [
       "2011"
     ],
@@ -7809,9 +6390,6 @@
     "experiment": "CMS",
     "publisher": "CERN Open Data Portal",
     "recid": "2236",
-    "run_period": [
-      "Run2011A"
-    ],
     "title": "High-Level Trigger path information HLT_Ele15_CaloIdVT_TrkIdT_Jet35_Jet25_Deta2 (ElectronHad dataset)",
     "type": {
       "primary": "Supplementaries",
@@ -7832,9 +6410,6 @@
     "collections": [
       "CMS-Trigger-Information"
     ],
-    "collision_information": {
-      "energy": "7TeV"
-    },
     "date_created": [
       "2011"
     ],
@@ -7842,9 +6417,6 @@
     "experiment": "CMS",
     "publisher": "CERN Open Data Portal",
     "recid": "2237",
-    "run_period": [
-      "Run2011A"
-    ],
     "title": "High-Level Trigger path information HLT_Ele15_CaloIdVT_TrkIdT_Jet35_Jet25_Deta3_Jet20 (ElectronHad dataset)",
     "type": {
       "primary": "Supplementaries",
@@ -7865,9 +6437,6 @@
     "collections": [
       "CMS-Trigger-Information"
     ],
-    "collision_information": {
-      "energy": "7TeV"
-    },
     "date_created": [
       "2011"
     ],
@@ -7875,9 +6444,6 @@
     "experiment": "CMS",
     "publisher": "CERN Open Data Portal",
     "recid": "2238",
-    "run_period": [
-      "Run2011A"
-    ],
     "title": "High-Level Trigger path information HLT_Ele15_CaloIdVT_TrkIdT_LooseIsoPFTau15 (TauPlusX dataset)",
     "type": {
       "primary": "Supplementaries",
@@ -7898,9 +6464,6 @@
     "collections": [
       "CMS-Trigger-Information"
     ],
-    "collision_information": {
-      "energy": "7TeV"
-    },
     "date_created": [
       "2011"
     ],
@@ -7908,9 +6471,6 @@
     "experiment": "CMS",
     "publisher": "CERN Open Data Portal",
     "recid": "2239",
-    "run_period": [
-      "Run2011A"
-    ],
     "title": "High-Level Trigger path information HLT_Ele15_CaloIdVT_TrkIdT_LooseIsoPFTau20 (TauPlusX dataset)",
     "type": {
       "primary": "Supplementaries",
@@ -7931,9 +6491,6 @@
     "collections": [
       "CMS-Trigger-Information"
     ],
-    "collision_information": {
-      "energy": "7TeV"
-    },
     "date_created": [
       "2011"
     ],
@@ -7941,9 +6498,6 @@
     "experiment": "CMS",
     "publisher": "CERN Open Data Portal",
     "recid": "2240",
-    "run_period": [
-      "Run2011A"
-    ],
     "title": "High-Level Trigger path information HLT_Ele15_CaloIdVT_TrkIdT_TightIsoPFTau20 (TauPlusX dataset)",
     "type": {
       "primary": "Supplementaries",
@@ -7964,9 +6518,6 @@
     "collections": [
       "CMS-Trigger-Information"
     ],
-    "collision_information": {
-      "energy": "7TeV"
-    },
     "date_created": [
       "2011"
     ],
@@ -7974,9 +6525,6 @@
     "experiment": "CMS",
     "publisher": "CERN Open Data Portal",
     "recid": "2241",
-    "run_period": [
-      "Run2011A"
-    ],
     "title": "High-Level Trigger path information HLT_Ele17_CaloIdL_CaloIsoVL (DoubleElectron dataset)",
     "type": {
       "primary": "Supplementaries",
@@ -7997,9 +6545,6 @@
     "collections": [
       "CMS-Trigger-Information"
     ],
-    "collision_information": {
-      "energy": "7TeV"
-    },
     "date_created": [
       "2011"
     ],
@@ -8007,9 +6552,6 @@
     "experiment": "CMS",
     "publisher": "CERN Open Data Portal",
     "recid": "2242",
-    "run_period": [
-      "Run2011A"
-    ],
     "title": "High-Level Trigger path information HLT_Ele17_CaloIdL_CaloIsoVL_Ele15_HFL (DoubleElectron dataset)",
     "type": {
       "primary": "Supplementaries",
@@ -8030,9 +6572,6 @@
     "collections": [
       "CMS-Trigger-Information"
     ],
-    "collision_information": {
-      "energy": "7TeV"
-    },
     "date_created": [
       "2011"
     ],
@@ -8040,9 +6579,6 @@
     "experiment": "CMS",
     "publisher": "CERN Open Data Portal",
     "recid": "2243",
-    "run_period": [
-      "Run2011A"
-    ],
     "title": "High-Level Trigger path information HLT_Ele17_CaloIdL_CaloIsoVL_Ele15_HFT (DoubleElectron dataset)",
     "type": {
       "primary": "Supplementaries",
@@ -8063,9 +6599,6 @@
     "collections": [
       "CMS-Trigger-Information"
     ],
-    "collision_information": {
-      "energy": "7TeV"
-    },
     "date_created": [
       "2011"
     ],
@@ -8073,9 +6606,6 @@
     "experiment": "CMS",
     "publisher": "CERN Open Data Portal",
     "recid": "2244",
-    "run_period": [
-      "Run2011A"
-    ],
     "title": "High-Level Trigger path information HLT_Ele17_CaloIdL_CaloIsoVL_Ele8_CaloIdL_CaloIsoVL (DoubleElectron dataset)",
     "type": {
       "primary": "Supplementaries",
@@ -8096,9 +6626,6 @@
     "collections": [
       "CMS-Trigger-Information"
     ],
-    "collision_information": {
-      "energy": "7TeV"
-    },
     "date_created": [
       "2011"
     ],
@@ -8106,9 +6633,6 @@
     "experiment": "CMS",
     "publisher": "CERN Open Data Portal",
     "recid": "2245",
-    "run_period": [
-      "Run2011A"
-    ],
     "title": "High-Level Trigger path information HLT_Ele17_CaloIdT_CaloIsoVL_TrkIdVL_TrkIsoVL_Ele8_CaloIdT_CaloIsoVL_TrkIdVL_TrkIsoVL (DoubleElectron dataset)",
     "type": {
       "primary": "Supplementaries",
@@ -8129,9 +6653,6 @@
     "collections": [
       "CMS-Trigger-Information"
     ],
-    "collision_information": {
-      "energy": "7TeV"
-    },
     "date_created": [
       "2011"
     ],
@@ -8139,9 +6660,6 @@
     "experiment": "CMS",
     "publisher": "CERN Open Data Portal",
     "recid": "2246",
-    "run_period": [
-      "Run2011A"
-    ],
     "title": "High-Level Trigger path information HLT_Ele17_CaloIdT_TrkIdVL_CaloIsoVL_TrkIsoVL_Ele8_CaloIdT_TrkIdVL_CaloIsoVL_TrkIsoVL (DoubleElectron, SingleElectron datasets)",
     "type": {
       "primary": "Supplementaries",
@@ -8162,9 +6680,6 @@
     "collections": [
       "CMS-Trigger-Information"
     ],
-    "collision_information": {
-      "energy": "7TeV"
-    },
     "date_created": [
       "2011"
     ],
@@ -8172,9 +6687,6 @@
     "experiment": "CMS",
     "publisher": "CERN Open Data Portal",
     "recid": "2247",
-    "run_period": [
-      "Run2011A"
-    ],
     "title": "High-Level Trigger path information HLT_Ele17_CaloIdVT_CaloIsoT_TrkIdT_TrkIsoT_CentralJet30_CentralJet25_PFMHT15 (ElectronHad dataset)",
     "type": {
       "primary": "Supplementaries",
@@ -8195,9 +6707,6 @@
     "collections": [
       "CMS-Trigger-Information"
     ],
-    "collision_information": {
-      "energy": "7TeV"
-    },
     "date_created": [
       "2011"
     ],
@@ -8205,9 +6714,6 @@
     "experiment": "CMS",
     "publisher": "CERN Open Data Portal",
     "recid": "2248",
-    "run_period": [
-      "Run2011A"
-    ],
     "title": "High-Level Trigger path information HLT_Ele17_CaloIdVT_CaloIsoT_TrkIdT_TrkIsoT_Jet35_Jet25_Deta3p5_Jet25 (ElectronHad dataset)",
     "type": {
       "primary": "Supplementaries",
@@ -8228,9 +6734,6 @@
     "collections": [
       "CMS-Trigger-Information"
     ],
-    "collision_information": {
-      "energy": "7TeV"
-    },
     "date_created": [
       "2011"
     ],
@@ -8238,9 +6741,6 @@
     "experiment": "CMS",
     "publisher": "CERN Open Data Portal",
     "recid": "2249",
-    "run_period": [
-      "Run2011A"
-    ],
     "title": "High-Level Trigger path information HLT_Ele17_CaloIdVT_CaloIsoVT_TrkIdT_TrkIsoVT_Ele8_Mass30 (DoubleElectron dataset)",
     "type": {
       "primary": "Supplementaries",
@@ -8261,9 +6761,6 @@
     "collections": [
       "CMS-Trigger-Information"
     ],
-    "collision_information": {
-      "energy": "7TeV"
-    },
     "date_created": [
       "2011"
     ],
@@ -8271,9 +6768,6 @@
     "experiment": "CMS",
     "publisher": "CERN Open Data Portal",
     "recid": "2250",
-    "run_period": [
-      "Run2011A"
-    ],
     "title": "High-Level Trigger path information HLT_Ele17_CaloIdVT_CaloIsoVT_TrkIdT_TrkIsoVT_SC8_Mass30 (DoubleElectron dataset)",
     "type": {
       "primary": "Supplementaries",
@@ -8294,9 +6788,6 @@
     "collections": [
       "CMS-Trigger-Information"
     ],
-    "collision_information": {
-      "energy": "7TeV"
-    },
     "date_created": [
       "2011"
     ],
@@ -8304,9 +6795,6 @@
     "experiment": "CMS",
     "publisher": "CERN Open Data Portal",
     "recid": "2251",
-    "run_period": [
-      "Run2011A"
-    ],
     "title": "High-Level Trigger path information HLT_Ele17_CaloIdVT_TrkIdT_CentralJet30_CentralJet25 (ElectronHad dataset)",
     "type": {
       "primary": "Supplementaries",
@@ -8327,9 +6815,6 @@
     "collections": [
       "CMS-Trigger-Information"
     ],
-    "collision_information": {
-      "energy": "7TeV"
-    },
     "date_created": [
       "2011"
     ],
@@ -8337,9 +6822,6 @@
     "experiment": "CMS",
     "publisher": "CERN Open Data Portal",
     "recid": "2252",
-    "run_period": [
-      "Run2011A"
-    ],
     "title": "High-Level Trigger path information HLT_Ele18_CaloIdVT_CaloIsoT_TrkIdT_TrkIsoT_LooseIsoPFTau20 (TauPlusX dataset)",
     "type": {
       "primary": "Supplementaries",
@@ -8360,9 +6842,6 @@
     "collections": [
       "CMS-Trigger-Information"
     ],
-    "collision_information": {
-      "energy": "7TeV"
-    },
     "date_created": [
       "2011"
     ],
@@ -8370,9 +6849,6 @@
     "experiment": "CMS",
     "publisher": "CERN Open Data Portal",
     "recid": "2253",
-    "run_period": [
-      "Run2011A"
-    ],
     "title": "High-Level Trigger path information HLT_Ele18_CaloIdVT_CaloIsoT_TrkIdT_TrkIsoT_MediumIsoPFTau20 (TauPlusX dataset)",
     "type": {
       "primary": "Supplementaries",
@@ -8393,9 +6869,6 @@
     "collections": [
       "CMS-Trigger-Information"
     ],
-    "collision_information": {
-      "energy": "7TeV"
-    },
     "date_created": [
       "2011"
     ],
@@ -8403,9 +6876,6 @@
     "experiment": "CMS",
     "publisher": "CERN Open Data Portal",
     "recid": "2254",
-    "run_period": [
-      "Run2011A"
-    ],
     "title": "High-Level Trigger path information HLT_Ele18_CaloIdVT_CaloIsoT_TrkIdT_TrkIsoT_TightIsoPFTau20 (TauPlusX dataset)",
     "type": {
       "primary": "Supplementaries",
@@ -8426,9 +6896,6 @@
     "collections": [
       "CMS-Trigger-Information"
     ],
-    "collision_information": {
-      "energy": "7TeV"
-    },
     "date_created": [
       "2011"
     ],
@@ -8436,9 +6903,6 @@
     "experiment": "CMS",
     "publisher": "CERN Open Data Portal",
     "recid": "2255",
-    "run_period": [
-      "Run2011A"
-    ],
     "title": "High-Level Trigger path information HLT_Ele18_CaloIdVT_TrkIdT_MediumIsoPFTau20 (TauPlusX dataset)",
     "type": {
       "primary": "Supplementaries",
@@ -8459,9 +6923,6 @@
     "collections": [
       "CMS-Trigger-Information"
     ],
-    "collision_information": {
-      "energy": "7TeV"
-    },
     "date_created": [
       "2011"
     ],
@@ -8469,9 +6930,6 @@
     "experiment": "CMS",
     "publisher": "CERN Open Data Portal",
     "recid": "2256",
-    "run_period": [
-      "Run2011A"
-    ],
     "title": "High-Level Trigger path information HLT_Ele20_CaloIdVT_CaloIsoT_TrkIdT_TrkIsoT_Jet35_Jet25_Deta3_Jet20 (ElectronHad dataset)",
     "type": {
       "primary": "Supplementaries",
@@ -8492,9 +6950,6 @@
     "collections": [
       "CMS-Trigger-Information"
     ],
-    "collision_information": {
-      "energy": "7TeV"
-    },
     "date_created": [
       "2011"
     ],
@@ -8502,9 +6957,6 @@
     "experiment": "CMS",
     "publisher": "CERN Open Data Portal",
     "recid": "2257",
-    "run_period": [
-      "Run2011A"
-    ],
     "title": "High-Level Trigger path information HLT_Ele20_CaloIdVT_CaloIsoT_TrkIdT_TrkIsoT_MediumIsoPFTau20 (TauPlusX dataset)",
     "type": {
       "primary": "Supplementaries",
@@ -8525,9 +6977,6 @@
     "collections": [
       "CMS-Trigger-Information"
     ],
-    "collision_information": {
-      "energy": "7TeV"
-    },
     "date_created": [
       "2011"
     ],
@@ -8535,9 +6984,6 @@
     "experiment": "CMS",
     "publisher": "CERN Open Data Portal",
     "recid": "2258",
-    "run_period": [
-      "Run2011A"
-    ],
     "title": "High-Level Trigger path information HLT_Ele22_CaloIdL_CaloIsoVL_Ele15_HFT (DoubleElectron dataset)",
     "type": {
       "primary": "Supplementaries",
@@ -8558,9 +7004,6 @@
     "collections": [
       "CMS-Trigger-Information"
     ],
-    "collision_information": {
-      "energy": "7TeV"
-    },
     "date_created": [
       "2011"
     ],
@@ -8568,9 +7011,6 @@
     "experiment": "CMS",
     "publisher": "CERN Open Data Portal",
     "recid": "2259",
-    "run_period": [
-      "Run2011A"
-    ],
     "title": "High-Level Trigger path information HLT_Ele22_CaloIdVT_CaloIsoT_TrkIdT_TrkIsoT_CentralJet30_CentralJet25 (ElectronHad dataset)",
     "type": {
       "primary": "Supplementaries",
@@ -8591,9 +7031,6 @@
     "collections": [
       "CMS-Trigger-Information"
     ],
-    "collision_information": {
-      "energy": "7TeV"
-    },
     "date_created": [
       "2011"
     ],
@@ -8601,9 +7038,6 @@
     "experiment": "CMS",
     "publisher": "CERN Open Data Portal",
     "recid": "2260",
-    "run_period": [
-      "Run2011A"
-    ],
     "title": "High-Level Trigger path information HLT_Ele22_CaloIdVT_CaloIsoT_TrkIdT_TrkIsoT_CentralJet30_CentralJet25_PFMHT20 (ElectronHad dataset)",
     "type": {
       "primary": "Supplementaries",
@@ -8624,9 +7058,6 @@
     "collections": [
       "CMS-Trigger-Information"
     ],
-    "collision_information": {
-      "energy": "7TeV"
-    },
     "date_created": [
       "2011"
     ],
@@ -8634,9 +7065,6 @@
     "experiment": "CMS",
     "publisher": "CERN Open Data Portal",
     "recid": "2261",
-    "run_period": [
-      "Run2011A"
-    ],
     "title": "High-Level Trigger path information HLT_Ele22_CaloIdVT_TrkIdT_CentralJet30_CentralJet25 (ElectronHad dataset)",
     "type": {
       "primary": "Supplementaries",
@@ -8657,9 +7085,6 @@
     "collections": [
       "CMS-Trigger-Information"
     ],
-    "collision_information": {
-      "energy": "7TeV"
-    },
     "date_created": [
       "2011"
     ],
@@ -8667,9 +7092,6 @@
     "experiment": "CMS",
     "publisher": "CERN Open Data Portal",
     "recid": "2262",
-    "run_period": [
-      "Run2011A"
-    ],
     "title": "High-Level Trigger path information HLT_Ele25_CaloIdL_CaloIsoVL_TrkIdVL_TrkIsoVL (SingleElectron dataset)",
     "type": {
       "primary": "Supplementaries",
@@ -8690,9 +7112,6 @@
     "collections": [
       "CMS-Trigger-Information"
     ],
-    "collision_information": {
-      "energy": "7TeV"
-    },
     "date_created": [
       "2011"
     ],
@@ -8700,9 +7119,6 @@
     "experiment": "CMS",
     "publisher": "CERN Open Data Portal",
     "recid": "2263",
-    "run_period": [
-      "Run2011A"
-    ],
     "title": "High-Level Trigger path information HLT_Ele25_CaloIdVT_CaloIsoT_TrkIdT_TrkIsoT_CentralJet30 (ElectronHad dataset)",
     "type": {
       "primary": "Supplementaries",
@@ -8723,9 +7139,6 @@
     "collections": [
       "CMS-Trigger-Information"
     ],
-    "collision_information": {
-      "energy": "7TeV"
-    },
     "date_created": [
       "2011"
     ],
@@ -8733,9 +7146,6 @@
     "experiment": "CMS",
     "publisher": "CERN Open Data Portal",
     "recid": "2264",
-    "run_period": [
-      "Run2011A"
-    ],
     "title": "High-Level Trigger path information HLT_Ele25_CaloIdVT_CaloIsoT_TrkIdT_TrkIsoT_CentralJet30_BTagIP (ElectronHad dataset)",
     "type": {
       "primary": "Supplementaries",
@@ -8756,9 +7166,6 @@
     "collections": [
       "CMS-Trigger-Information"
     ],
-    "collision_information": {
-      "energy": "7TeV"
-    },
     "date_created": [
       "2011"
     ],
@@ -8766,9 +7173,6 @@
     "experiment": "CMS",
     "publisher": "CERN Open Data Portal",
     "recid": "2265",
-    "run_period": [
-      "Run2011A"
-    ],
     "title": "High-Level Trigger path information HLT_Ele25_CaloIdVT_CaloIsoT_TrkIdT_TrkIsoT_CentralJet30_CentralJet25_PFMHT20 (ElectronHad dataset)",
     "type": {
       "primary": "Supplementaries",
@@ -8789,9 +7193,6 @@
     "collections": [
       "CMS-Trigger-Information"
     ],
-    "collision_information": {
-      "energy": "7TeV"
-    },
     "date_created": [
       "2011"
     ],
@@ -8799,9 +7200,6 @@
     "experiment": "CMS",
     "publisher": "CERN Open Data Portal",
     "recid": "2266",
-    "run_period": [
-      "Run2011A"
-    ],
     "title": "High-Level Trigger path information HLT_Ele25_CaloIdVT_CaloIsoT_TrkIdT_TrkIsoT_CentralPFJet30 (ElectronHad dataset)",
     "type": {
       "primary": "Supplementaries",
@@ -8822,9 +7220,6 @@
     "collections": [
       "CMS-Trigger-Information"
     ],
-    "collision_information": {
-      "energy": "7TeV"
-    },
     "date_created": [
       "2011"
     ],
@@ -8832,9 +7227,6 @@
     "experiment": "CMS",
     "publisher": "CERN Open Data Portal",
     "recid": "2267",
-    "run_period": [
-      "Run2011A"
-    ],
     "title": "High-Level Trigger path information HLT_Ele25_CaloIdVT_CaloIsoT_TrkIdT_TrkIsoT_DiCentralJet30 (ElectronHad dataset)",
     "type": {
       "primary": "Supplementaries",
@@ -8855,9 +7247,6 @@
     "collections": [
       "CMS-Trigger-Information"
     ],
-    "collision_information": {
-      "energy": "7TeV"
-    },
     "date_created": [
       "2011"
     ],
@@ -8865,9 +7254,6 @@
     "experiment": "CMS",
     "publisher": "CERN Open Data Portal",
     "recid": "2268",
-    "run_period": [
-      "Run2011A"
-    ],
     "title": "High-Level Trigger path information HLT_Ele25_CaloIdVT_CaloIsoT_TrkIdT_TrkIsoT_DiCentralJet30_PFMHT25 (ElectronHad dataset)",
     "type": {
       "primary": "Supplementaries",
@@ -8888,9 +7274,6 @@
     "collections": [
       "CMS-Trigger-Information"
     ],
-    "collision_information": {
-      "energy": "7TeV"
-    },
     "date_created": [
       "2011"
     ],
@@ -8898,9 +7281,6 @@
     "experiment": "CMS",
     "publisher": "CERN Open Data Portal",
     "recid": "2269",
-    "run_period": [
-      "Run2011A"
-    ],
     "title": "High-Level Trigger path information HLT_Ele25_CaloIdVT_CaloIsoT_TrkIdT_TrkIsoT_DiCentralPFJet30 (ElectronHad dataset)",
     "type": {
       "primary": "Supplementaries",
@@ -8921,9 +7301,6 @@
     "collections": [
       "CMS-Trigger-Information"
     ],
-    "collision_information": {
-      "energy": "7TeV"
-    },
     "date_created": [
       "2011"
     ],
@@ -8931,9 +7308,6 @@
     "experiment": "CMS",
     "publisher": "CERN Open Data Portal",
     "recid": "2270",
-    "run_period": [
-      "Run2011A"
-    ],
     "title": "High-Level Trigger path information HLT_Ele25_CaloIdVT_CaloIsoT_TrkIdT_TrkIsoT_MediumIsoPFTau25 (TauPlusX dataset)",
     "type": {
       "primary": "Supplementaries",
@@ -8954,9 +7328,6 @@
     "collections": [
       "CMS-Trigger-Information"
     ],
-    "collision_information": {
-      "energy": "7TeV"
-    },
     "date_created": [
       "2011"
     ],
@@ -8964,9 +7335,6 @@
     "experiment": "CMS",
     "publisher": "CERN Open Data Portal",
     "recid": "2271",
-    "run_period": [
-      "Run2011A"
-    ],
     "title": "High-Level Trigger path information HLT_Ele25_CaloIdVT_CaloIsoT_TrkIdT_TrkIsoT_QuadCentralJet30 (ElectronHad dataset)",
     "type": {
       "primary": "Supplementaries",
@@ -8987,9 +7355,6 @@
     "collections": [
       "CMS-Trigger-Information"
     ],
-    "collision_information": {
-      "energy": "7TeV"
-    },
     "date_created": [
       "2011"
     ],
@@ -8997,9 +7362,6 @@
     "experiment": "CMS",
     "publisher": "CERN Open Data Portal",
     "recid": "2272",
-    "run_period": [
-      "Run2011A"
-    ],
     "title": "High-Level Trigger path information HLT_Ele25_CaloIdVT_CaloIsoT_TrkIdT_TrkIsoT_QuadCentralPFJet30 (ElectronHad dataset)",
     "type": {
       "primary": "Supplementaries",
@@ -9020,9 +7382,6 @@
     "collections": [
       "CMS-Trigger-Information"
     ],
-    "collision_information": {
-      "energy": "7TeV"
-    },
     "date_created": [
       "2011"
     ],
@@ -9030,9 +7389,6 @@
     "experiment": "CMS",
     "publisher": "CERN Open Data Portal",
     "recid": "2273",
-    "run_period": [
-      "Run2011A"
-    ],
     "title": "High-Level Trigger path information HLT_Ele25_CaloIdVT_CaloIsoT_TrkIdT_TrkIsoT_TriCentralJet30 (ElectronHad dataset)",
     "type": {
       "primary": "Supplementaries",
@@ -9053,9 +7409,6 @@
     "collections": [
       "CMS-Trigger-Information"
     ],
-    "collision_information": {
-      "energy": "7TeV"
-    },
     "date_created": [
       "2011"
     ],
@@ -9063,9 +7416,6 @@
     "experiment": "CMS",
     "publisher": "CERN Open Data Portal",
     "recid": "2274",
-    "run_period": [
-      "Run2011A"
-    ],
     "title": "High-Level Trigger path information HLT_Ele25_CaloIdVT_CaloIsoT_TrkIdT_TrkIsoT_TriCentralPFJet30 (ElectronHad dataset)",
     "type": {
       "primary": "Supplementaries",
@@ -9086,9 +7436,6 @@
     "collections": [
       "CMS-Trigger-Information"
     ],
-    "collision_information": {
-      "energy": "7TeV"
-    },
     "date_created": [
       "2011"
     ],
@@ -9096,9 +7443,6 @@
     "experiment": "CMS",
     "publisher": "CERN Open Data Portal",
     "recid": "2275",
-    "run_period": [
-      "Run2011A"
-    ],
     "title": "High-Level Trigger path information HLT_Ele25_CaloIdVT_TrkIdT_CentralDiJet30 (ElectronHad dataset)",
     "type": {
       "primary": "Supplementaries",
@@ -9119,9 +7463,6 @@
     "collections": [
       "CMS-Trigger-Information"
     ],
-    "collision_information": {
-      "energy": "7TeV"
-    },
     "date_created": [
       "2011"
     ],
@@ -9129,9 +7470,6 @@
     "experiment": "CMS",
     "publisher": "CERN Open Data Portal",
     "recid": "2276",
-    "run_period": [
-      "Run2011A"
-    ],
     "title": "High-Level Trigger path information HLT_Ele25_CaloIdVT_TrkIdT_CentralJet30 (ElectronHad dataset)",
     "type": {
       "primary": "Supplementaries",
@@ -9152,9 +7490,6 @@
     "collections": [
       "CMS-Trigger-Information"
     ],
-    "collision_information": {
-      "energy": "7TeV"
-    },
     "date_created": [
       "2011"
     ],
@@ -9162,9 +7497,6 @@
     "experiment": "CMS",
     "publisher": "CERN Open Data Portal",
     "recid": "2277",
-    "run_period": [
-      "Run2011A"
-    ],
     "title": "High-Level Trigger path information HLT_Ele25_CaloIdVT_TrkIdT_CentralJet30_BTagIP (ElectronHad dataset)",
     "type": {
       "primary": "Supplementaries",
@@ -9185,9 +7517,6 @@
     "collections": [
       "CMS-Trigger-Information"
     ],
-    "collision_information": {
-      "energy": "7TeV"
-    },
     "date_created": [
       "2011"
     ],
@@ -9195,9 +7524,6 @@
     "experiment": "CMS",
     "publisher": "CERN Open Data Portal",
     "recid": "2278",
-    "run_period": [
-      "Run2011A"
-    ],
     "title": "High-Level Trigger path information HLT_Ele25_CaloIdVT_TrkIdT_CentralJet40_BTagIP (ElectronHad dataset)",
     "type": {
       "primary": "Supplementaries",
@@ -9218,9 +7544,6 @@
     "collections": [
       "CMS-Trigger-Information"
     ],
-    "collision_information": {
-      "energy": "7TeV"
-    },
     "date_created": [
       "2011"
     ],
@@ -9228,9 +7551,6 @@
     "experiment": "CMS",
     "publisher": "CERN Open Data Portal",
     "recid": "2279",
-    "run_period": [
-      "Run2011A"
-    ],
     "title": "High-Level Trigger path information HLT_Ele25_CaloIdVT_TrkIdT_CentralPFJet30 (ElectronHad dataset)",
     "type": {
       "primary": "Supplementaries",
@@ -9251,9 +7571,6 @@
     "collections": [
       "CMS-Trigger-Information"
     ],
-    "collision_information": {
-      "energy": "7TeV"
-    },
     "date_created": [
       "2011"
     ],
@@ -9261,9 +7578,6 @@
     "experiment": "CMS",
     "publisher": "CERN Open Data Portal",
     "recid": "2280",
-    "run_period": [
-      "Run2011A"
-    ],
     "title": "High-Level Trigger path information HLT_Ele25_CaloIdVT_TrkIdT_CentralTriJet30 (ElectronHad dataset)",
     "type": {
       "primary": "Supplementaries",
@@ -9284,9 +7598,6 @@
     "collections": [
       "CMS-Trigger-Information"
     ],
-    "collision_information": {
-      "energy": "7TeV"
-    },
     "date_created": [
       "2011"
     ],
@@ -9294,9 +7605,6 @@
     "experiment": "CMS",
     "publisher": "CERN Open Data Portal",
     "recid": "2281",
-    "run_period": [
-      "Run2011A"
-    ],
     "title": "High-Level Trigger path information HLT_Ele25_CaloIdVT_TrkIdT_DiCentralJet30 (ElectronHad dataset)",
     "type": {
       "primary": "Supplementaries",
@@ -9317,9 +7625,6 @@
     "collections": [
       "CMS-Trigger-Information"
     ],
-    "collision_information": {
-      "energy": "7TeV"
-    },
     "date_created": [
       "2011"
     ],
@@ -9327,9 +7632,6 @@
     "experiment": "CMS",
     "publisher": "CERN Open Data Portal",
     "recid": "2282",
-    "run_period": [
-      "Run2011A"
-    ],
     "title": "High-Level Trigger path information HLT_Ele25_CaloIdVT_TrkIdT_DiCentralPFJet30 (ElectronHad dataset)",
     "type": {
       "primary": "Supplementaries",
@@ -9350,9 +7652,6 @@
     "collections": [
       "CMS-Trigger-Information"
     ],
-    "collision_information": {
-      "energy": "7TeV"
-    },
     "date_created": [
       "2011"
     ],
@@ -9360,9 +7659,6 @@
     "experiment": "CMS",
     "publisher": "CERN Open Data Portal",
     "recid": "2283",
-    "run_period": [
-      "Run2011A"
-    ],
     "title": "High-Level Trigger path information HLT_Ele25_CaloIdVT_TrkIdT_QuadCentralJet30 (ElectronHad dataset)",
     "type": {
       "primary": "Supplementaries",
@@ -9383,9 +7679,6 @@
     "collections": [
       "CMS-Trigger-Information"
     ],
-    "collision_information": {
-      "energy": "7TeV"
-    },
     "date_created": [
       "2011"
     ],
@@ -9393,9 +7686,6 @@
     "experiment": "CMS",
     "publisher": "CERN Open Data Portal",
     "recid": "2284",
-    "run_period": [
-      "Run2011A"
-    ],
     "title": "High-Level Trigger path information HLT_Ele25_CaloIdVT_TrkIdT_QuadCentralPFJet30 (ElectronHad dataset)",
     "type": {
       "primary": "Supplementaries",
@@ -9416,9 +7706,6 @@
     "collections": [
       "CMS-Trigger-Information"
     ],
-    "collision_information": {
-      "energy": "7TeV"
-    },
     "date_created": [
       "2011"
     ],
@@ -9426,9 +7713,6 @@
     "experiment": "CMS",
     "publisher": "CERN Open Data Portal",
     "recid": "2285",
-    "run_period": [
-      "Run2011A"
-    ],
     "title": "High-Level Trigger path information HLT_Ele25_CaloIdVT_TrkIdT_TriCentralJet30 (ElectronHad dataset)",
     "type": {
       "primary": "Supplementaries",
@@ -9449,9 +7733,6 @@
     "collections": [
       "CMS-Trigger-Information"
     ],
-    "collision_information": {
-      "energy": "7TeV"
-    },
     "date_created": [
       "2011"
     ],
@@ -9459,9 +7740,6 @@
     "experiment": "CMS",
     "publisher": "CERN Open Data Portal",
     "recid": "2286",
-    "run_period": [
-      "Run2011A"
-    ],
     "title": "High-Level Trigger path information HLT_Ele25_CaloIdVT_TrkIdT_TriCentralPFJet30 (ElectronHad dataset)",
     "type": {
       "primary": "Supplementaries",
@@ -9482,9 +7760,6 @@
     "collections": [
       "CMS-Trigger-Information"
     ],
-    "collision_information": {
-      "energy": "7TeV"
-    },
     "date_created": [
       "2011"
     ],
@@ -9492,9 +7767,6 @@
     "experiment": "CMS",
     "publisher": "CERN Open Data Portal",
     "recid": "2287",
-    "run_period": [
-      "Run2011A"
-    ],
     "title": "High-Level Trigger path information HLT_Ele25_WP80_PFMT40 (SingleElectron dataset)",
     "type": {
       "primary": "Supplementaries",
@@ -9515,9 +7787,6 @@
     "collections": [
       "CMS-Trigger-Information"
     ],
-    "collision_information": {
-      "energy": "7TeV"
-    },
     "date_created": [
       "2011"
     ],
@@ -9525,9 +7794,6 @@
     "experiment": "CMS",
     "publisher": "CERN Open Data Portal",
     "recid": "2288",
-    "run_period": [
-      "Run2011A"
-    ],
     "title": "High-Level Trigger path information HLT_Ele27_CaloIdL_CaloIsoVL_TrkIdVL_TrkIsoVL (SingleElectron dataset)",
     "type": {
       "primary": "Supplementaries",
@@ -9548,9 +7814,6 @@
     "collections": [
       "CMS-Trigger-Information"
     ],
-    "collision_information": {
-      "energy": "7TeV"
-    },
     "date_created": [
       "2011"
     ],
@@ -9558,9 +7821,6 @@
     "experiment": "CMS",
     "publisher": "CERN Open Data Portal",
     "recid": "2289",
-    "run_period": [
-      "Run2011A"
-    ],
     "title": "High-Level Trigger path information HLT_Ele27_CaloIdVT_CaloIsoT_TrkIdT_TrkIsoT (SingleElectron dataset)",
     "type": {
       "primary": "Supplementaries",
@@ -9581,9 +7841,6 @@
     "collections": [
       "CMS-Trigger-Information"
     ],
-    "collision_information": {
-      "energy": "7TeV"
-    },
     "date_created": [
       "2011"
     ],
@@ -9591,9 +7848,6 @@
     "experiment": "CMS",
     "publisher": "CERN Open Data Portal",
     "recid": "2290",
-    "run_period": [
-      "Run2011A"
-    ],
     "title": "High-Level Trigger path information HLT_Ele27_CaloIdVT_CaloIsoT_TrkIdT_TrkIsoT_CentralJet30_CentralJet25 (ElectronHad dataset)",
     "type": {
       "primary": "Supplementaries",
@@ -9614,9 +7868,6 @@
     "collections": [
       "CMS-Trigger-Information"
     ],
-    "collision_information": {
-      "energy": "7TeV"
-    },
     "date_created": [
       "2011"
     ],
@@ -9624,9 +7875,6 @@
     "experiment": "CMS",
     "publisher": "CERN Open Data Portal",
     "recid": "2291",
-    "run_period": [
-      "Run2011A"
-    ],
     "title": "High-Level Trigger path information HLT_Ele27_CaloIdVT_CaloIsoT_TrkIdT_TrkIsoT_CentralJet30_CentralJet25_PFMHT20 (ElectronHad dataset)",
     "type": {
       "primary": "Supplementaries",
@@ -9647,9 +7895,6 @@
     "collections": [
       "CMS-Trigger-Information"
     ],
-    "collision_information": {
-      "energy": "7TeV"
-    },
     "date_created": [
       "2011"
     ],
@@ -9657,9 +7902,6 @@
     "experiment": "CMS",
     "publisher": "CERN Open Data Portal",
     "recid": "2292",
-    "run_period": [
-      "Run2011A"
-    ],
     "title": "High-Level Trigger path information HLT_Ele27_CaloIdVT_CaloIsoT_TrkIdT_TrkIsoT_Jet35_Jet25_Deta3_Jet20 (ElectronHad dataset)",
     "type": {
       "primary": "Supplementaries",
@@ -9680,9 +7922,6 @@
     "collections": [
       "CMS-Trigger-Information"
     ],
-    "collision_information": {
-      "energy": "7TeV"
-    },
     "date_created": [
       "2011"
     ],
@@ -9690,9 +7929,6 @@
     "experiment": "CMS",
     "publisher": "CERN Open Data Portal",
     "recid": "2293",
-    "run_period": [
-      "Run2011A"
-    ],
     "title": "High-Level Trigger path information HLT_Ele27_CaloIdVT_TrkIdT_CentralJet30_CentralJet25 (ElectronHad dataset)",
     "type": {
       "primary": "Supplementaries",
@@ -9713,9 +7949,6 @@
     "collections": [
       "CMS-Trigger-Information"
     ],
-    "collision_information": {
-      "energy": "7TeV"
-    },
     "date_created": [
       "2011"
     ],
@@ -9723,9 +7956,6 @@
     "experiment": "CMS",
     "publisher": "CERN Open Data Portal",
     "recid": "2294",
-    "run_period": [
-      "Run2011A"
-    ],
     "title": "High-Level Trigger path information HLT_Ele27_CaloIdVT_TrkIdT_DiCentralPFJet25 (ElectronHad dataset)",
     "type": {
       "primary": "Supplementaries",
@@ -9746,9 +7976,6 @@
     "collections": [
       "CMS-Trigger-Information"
     ],
-    "collision_information": {
-      "energy": "7TeV"
-    },
     "date_created": [
       "2011"
     ],
@@ -9756,9 +7983,6 @@
     "experiment": "CMS",
     "publisher": "CERN Open Data Portal",
     "recid": "2295",
-    "run_period": [
-      "Run2011A"
-    ],
     "title": "High-Level Trigger path information HLT_Ele27_CaloIdVT_TrkIdT_DiPFJet25_Deta3 (ElectronHad dataset)",
     "type": {
       "primary": "Supplementaries",
@@ -9779,9 +8003,6 @@
     "collections": [
       "CMS-Trigger-Information"
     ],
-    "collision_information": {
-      "energy": "7TeV"
-    },
     "date_created": [
       "2011"
     ],
@@ -9789,9 +8010,6 @@
     "experiment": "CMS",
     "publisher": "CERN Open Data Portal",
     "recid": "2296",
-    "run_period": [
-      "Run2011A"
-    ],
     "title": "High-Level Trigger path information HLT_Ele27_CaloIdVT_TrkIdT_Jet35_Jet25_Deta3_Jet20 (ElectronHad dataset)",
     "type": {
       "primary": "Supplementaries",
@@ -9812,9 +8030,6 @@
     "collections": [
       "CMS-Trigger-Information"
     ],
-    "collision_information": {
-      "energy": "7TeV"
-    },
     "date_created": [
       "2011"
     ],
@@ -9822,9 +8037,6 @@
     "experiment": "CMS",
     "publisher": "CERN Open Data Portal",
     "recid": "2297",
-    "run_period": [
-      "Run2011A"
-    ],
     "title": "High-Level Trigger path information HLT_Ele27_WP70_PFMT40_PFMHT20 (SingleElectron dataset)",
     "type": {
       "primary": "Supplementaries",
@@ -9845,9 +8057,6 @@
     "collections": [
       "CMS-Trigger-Information"
     ],
-    "collision_information": {
-      "energy": "7TeV"
-    },
     "date_created": [
       "2011"
     ],
@@ -9855,9 +8064,6 @@
     "experiment": "CMS",
     "publisher": "CERN Open Data Portal",
     "recid": "2298",
-    "run_period": [
-      "Run2011A"
-    ],
     "title": "High-Level Trigger path information HLT_Ele27_WP80 (SingleElectron dataset)",
     "type": {
       "primary": "Supplementaries",
@@ -9878,9 +8084,6 @@
     "collections": [
       "CMS-Trigger-Information"
     ],
-    "collision_information": {
-      "energy": "7TeV"
-    },
     "date_created": [
       "2011"
     ],
@@ -9888,9 +8091,6 @@
     "experiment": "CMS",
     "publisher": "CERN Open Data Portal",
     "recid": "2299",
-    "run_period": [
-      "Run2011A"
-    ],
     "title": "High-Level Trigger path information HLT_Ele27_WP80_DiCentralPFJet25 (ElectronHad dataset)",
     "type": {
       "primary": "Supplementaries",
@@ -9911,9 +8111,6 @@
     "collections": [
       "CMS-Trigger-Information"
     ],
-    "collision_information": {
-      "energy": "7TeV"
-    },
     "date_created": [
       "2011"
     ],
@@ -9921,9 +8118,6 @@
     "experiment": "CMS",
     "publisher": "CERN Open Data Portal",
     "recid": "2300",
-    "run_period": [
-      "Run2011A"
-    ],
     "title": "High-Level Trigger path information HLT_Ele27_WP80_DiCentralPFJet25_PFMHT15 (ElectronHad dataset)",
     "type": {
       "primary": "Supplementaries",
@@ -9944,9 +8138,6 @@
     "collections": [
       "CMS-Trigger-Information"
     ],
-    "collision_information": {
-      "energy": "7TeV"
-    },
     "date_created": [
       "2011"
     ],
@@ -9954,9 +8145,6 @@
     "experiment": "CMS",
     "publisher": "CERN Open Data Portal",
     "recid": "2301",
-    "run_period": [
-      "Run2011A"
-    ],
     "title": "High-Level Trigger path information HLT_Ele27_WP80_DiPFJet25_Deta3 (ElectronHad dataset)",
     "type": {
       "primary": "Supplementaries",
@@ -9977,9 +8165,6 @@
     "collections": [
       "CMS-Trigger-Information"
     ],
-    "collision_information": {
-      "energy": "7TeV"
-    },
     "date_created": [
       "2011"
     ],
@@ -9987,9 +8172,6 @@
     "experiment": "CMS",
     "publisher": "CERN Open Data Portal",
     "recid": "2302",
-    "run_period": [
-      "Run2011A"
-    ],
     "title": "High-Level Trigger path information HLT_Ele27_WP80_PFMT50 (SingleElectron dataset)",
     "type": {
       "primary": "Supplementaries",
@@ -10010,9 +8192,6 @@
     "collections": [
       "CMS-Trigger-Information"
     ],
-    "collision_information": {
-      "energy": "7TeV"
-    },
     "date_created": [
       "2011"
     ],
@@ -10020,9 +8199,6 @@
     "experiment": "CMS",
     "publisher": "CERN Open Data Portal",
     "recid": "2303",
-    "run_period": [
-      "Run2011A"
-    ],
     "title": "High-Level Trigger path information HLT_Ele30_CaloIdVT_CaloIsoT_TrkIdT_TrkIsoT_DiCentralJet30_PFMHT25 (ElectronHad dataset)",
     "type": {
       "primary": "Supplementaries",
@@ -10043,9 +8219,6 @@
     "collections": [
       "CMS-Trigger-Information"
     ],
-    "collision_information": {
-      "energy": "7TeV"
-    },
     "date_created": [
       "2011"
     ],
@@ -10053,9 +8226,6 @@
     "experiment": "CMS",
     "publisher": "CERN Open Data Portal",
     "recid": "2304",
-    "run_period": [
-      "Run2011A"
-    ],
     "title": "High-Level Trigger path information HLT_Ele30_CaloIdVT_CaloIsoT_TrkIdT_TrkIsoT_Jet35_Jet25_Deta3p5_Jet25 (ElectronHad dataset)",
     "type": {
       "primary": "Supplementaries",
@@ -10076,9 +8246,6 @@
     "collections": [
       "CMS-Trigger-Information"
     ],
-    "collision_information": {
-      "energy": "7TeV"
-    },
     "date_created": [
       "2011"
     ],
@@ -10086,9 +8253,6 @@
     "experiment": "CMS",
     "publisher": "CERN Open Data Portal",
     "recid": "2305",
-    "run_period": [
-      "Run2011A"
-    ],
     "title": "High-Level Trigger path information HLT_Ele32_CaloIdL_CaloIsoVL_SC17 (DoubleElectron dataset)",
     "type": {
       "primary": "Supplementaries",
@@ -10109,9 +8273,6 @@
     "collections": [
       "CMS-Trigger-Information"
     ],
-    "collision_information": {
-      "energy": "7TeV"
-    },
     "date_created": [
       "2011"
     ],
@@ -10119,9 +8280,6 @@
     "experiment": "CMS",
     "publisher": "CERN Open Data Portal",
     "recid": "2306",
-    "run_period": [
-      "Run2011A"
-    ],
     "title": "High-Level Trigger path information HLT_Ele32_CaloIdL_CaloIsoVL_TrkIdVL_TrkIsoVL (SingleElectron dataset)",
     "type": {
       "primary": "Supplementaries",
@@ -10142,9 +8300,6 @@
     "collections": [
       "CMS-Trigger-Information"
     ],
-    "collision_information": {
-      "energy": "7TeV"
-    },
     "date_created": [
       "2011"
     ],
@@ -10152,9 +8307,6 @@
     "experiment": "CMS",
     "publisher": "CERN Open Data Portal",
     "recid": "2307",
-    "run_period": [
-      "Run2011A"
-    ],
     "title": "High-Level Trigger path information HLT_Ele32_CaloIdT_CaloIsoT_TrkIdT_TrkIsoT_Ele17 (DoubleElectron dataset)",
     "type": {
       "primary": "Supplementaries",
@@ -10175,9 +8327,6 @@
     "collections": [
       "CMS-Trigger-Information"
     ],
-    "collision_information": {
-      "energy": "7TeV"
-    },
     "date_created": [
       "2011"
     ],
@@ -10185,9 +8334,6 @@
     "experiment": "CMS",
     "publisher": "CERN Open Data Portal",
     "recid": "2308",
-    "run_period": [
-      "Run2011A"
-    ],
     "title": "High-Level Trigger path information HLT_Ele32_CaloIdT_CaloIsoT_TrkIdT_TrkIsoT_SC17 (DoubleElectron dataset)",
     "type": {
       "primary": "Supplementaries",
@@ -10208,9 +8354,6 @@
     "collections": [
       "CMS-Trigger-Information"
     ],
-    "collision_information": {
-      "energy": "7TeV"
-    },
     "date_created": [
       "2011"
     ],
@@ -10218,9 +8361,6 @@
     "experiment": "CMS",
     "publisher": "CERN Open Data Portal",
     "recid": "2309",
-    "run_period": [
-      "Run2011A"
-    ],
     "title": "High-Level Trigger path information HLT_Ele32_CaloIdVL_CaloIsoVL_TrkIdVL_TrkIsoVL (SingleElectron dataset)",
     "type": {
       "primary": "Supplementaries",
@@ -10241,9 +8381,6 @@
     "collections": [
       "CMS-Trigger-Information"
     ],
-    "collision_information": {
-      "energy": "7TeV"
-    },
     "date_created": [
       "2011"
     ],
@@ -10251,9 +8388,6 @@
     "experiment": "CMS",
     "publisher": "CERN Open Data Portal",
     "recid": "2310",
-    "run_period": [
-      "Run2011A"
-    ],
     "title": "High-Level Trigger path information HLT_Ele32_CaloIdVT_CaloIsoT_TrkIdT_TrkIsoT (SingleElectron dataset)",
     "type": {
       "primary": "Supplementaries",
@@ -10274,9 +8408,6 @@
     "collections": [
       "CMS-Trigger-Information"
     ],
-    "collision_information": {
-      "energy": "7TeV"
-    },
     "date_created": [
       "2011"
     ],
@@ -10284,9 +8415,6 @@
     "experiment": "CMS",
     "publisher": "CERN Open Data Portal",
     "recid": "2311",
-    "run_period": [
-      "Run2011A"
-    ],
     "title": "High-Level Trigger path information HLT_Ele32_WP70 (SingleElectron dataset)",
     "type": {
       "primary": "Supplementaries",
@@ -10307,9 +8435,6 @@
     "collections": [
       "CMS-Trigger-Information"
     ],
-    "collision_information": {
-      "energy": "7TeV"
-    },
     "date_created": [
       "2011"
     ],
@@ -10317,9 +8442,6 @@
     "experiment": "CMS",
     "publisher": "CERN Open Data Portal",
     "recid": "2312",
-    "run_period": [
-      "Run2011A"
-    ],
     "title": "High-Level Trigger path information HLT_Ele32_WP70_PFMT50 (SingleElectron dataset)",
     "type": {
       "primary": "Supplementaries",
@@ -10340,9 +8462,6 @@
     "collections": [
       "CMS-Trigger-Information"
     ],
-    "collision_information": {
-      "energy": "7TeV"
-    },
     "date_created": [
       "2011"
     ],
@@ -10350,9 +8469,6 @@
     "experiment": "CMS",
     "publisher": "CERN Open Data Portal",
     "recid": "2313",
-    "run_period": [
-      "Run2011A"
-    ],
     "title": "High-Level Trigger path information HLT_Ele32_WP80_DiCentralPFJet25_PFMHT25 (ElectronHad dataset)",
     "type": {
       "primary": "Supplementaries",
@@ -10373,9 +8489,6 @@
     "collections": [
       "CMS-Trigger-Information"
     ],
-    "collision_information": {
-      "energy": "7TeV"
-    },
     "date_created": [
       "2011"
     ],
@@ -10383,9 +8496,6 @@
     "experiment": "CMS",
     "publisher": "CERN Open Data Portal",
     "recid": "2314",
-    "run_period": [
-      "Run2011A"
-    ],
     "title": "High-Level Trigger path information HLT_Ele32_WP80_DiPFJet25_Deta3p5 (ElectronHad dataset)",
     "type": {
       "primary": "Supplementaries",
@@ -10406,9 +8516,6 @@
     "collections": [
       "CMS-Trigger-Information"
     ],
-    "collision_information": {
-      "energy": "7TeV"
-    },
     "date_created": [
       "2011"
     ],
@@ -10416,9 +8523,6 @@
     "experiment": "CMS",
     "publisher": "CERN Open Data Portal",
     "recid": "2315",
-    "run_period": [
-      "Run2011A"
-    ],
     "title": "High-Level Trigger path information HLT_Ele42_CaloIdVL_CaloIsoVL_TrkIdVL_TrkIsoVL (SingleElectron dataset)",
     "type": {
       "primary": "Supplementaries",
@@ -10439,9 +8543,6 @@
     "collections": [
       "CMS-Trigger-Information"
     ],
-    "collision_information": {
-      "energy": "7TeV"
-    },
     "date_created": [
       "2011"
     ],
@@ -10449,9 +8550,6 @@
     "experiment": "CMS",
     "publisher": "CERN Open Data Portal",
     "recid": "2316",
-    "run_period": [
-      "Run2011A"
-    ],
     "title": "High-Level Trigger path information HLT_Ele42_CaloIdVT_CaloIsoT_TrkIdT_TrkIsoT (SingleElectron dataset)",
     "type": {
       "primary": "Supplementaries",
@@ -10472,9 +8570,6 @@
     "collections": [
       "CMS-Trigger-Information"
     ],
-    "collision_information": {
-      "energy": "7TeV"
-    },
     "date_created": [
       "2011"
     ],
@@ -10482,9 +8577,6 @@
     "experiment": "CMS",
     "publisher": "CERN Open Data Portal",
     "recid": "2317",
-    "run_period": [
-      "Run2011A"
-    ],
     "title": "High-Level Trigger path information HLT_Ele45_CaloIdVT_TrkIdT (SingleElectron dataset)",
     "type": {
       "primary": "Supplementaries",
@@ -10505,9 +8597,6 @@
     "collections": [
       "CMS-Trigger-Information"
     ],
-    "collision_information": {
-      "energy": "7TeV"
-    },
     "date_created": [
       "2011"
     ],
@@ -10515,9 +8604,6 @@
     "experiment": "CMS",
     "publisher": "CERN Open Data Portal",
     "recid": "2318",
-    "run_period": [
-      "Run2011A"
-    ],
     "title": "High-Level Trigger path information HLT_Ele52_CaloIdVT_TrkIdT (SingleElectron dataset)",
     "type": {
       "primary": "Supplementaries",
@@ -10538,9 +8624,6 @@
     "collections": [
       "CMS-Trigger-Information"
     ],
-    "collision_information": {
-      "energy": "7TeV"
-    },
     "date_created": [
       "2011"
     ],
@@ -10548,9 +8631,6 @@
     "experiment": "CMS",
     "publisher": "CERN Open Data Portal",
     "recid": "2319",
-    "run_period": [
-      "Run2011A"
-    ],
     "title": "High-Level Trigger path information HLT_Ele65_CaloIdVT_TrkIdT (SingleElectron dataset)",
     "type": {
       "primary": "Supplementaries",
@@ -10571,9 +8651,6 @@
     "collections": [
       "CMS-Trigger-Information"
     ],
-    "collision_information": {
-      "energy": "7TeV"
-    },
     "date_created": [
       "2011"
     ],
@@ -10581,9 +8658,6 @@
     "experiment": "CMS",
     "publisher": "CERN Open Data Portal",
     "recid": "2320",
-    "run_period": [
-      "Run2011A"
-    ],
     "title": "High-Level Trigger path information HLT_Ele8 (DoubleElectron dataset)",
     "type": {
       "primary": "Supplementaries",
@@ -10604,9 +8678,6 @@
     "collections": [
       "CMS-Trigger-Information"
     ],
-    "collision_information": {
-      "energy": "7TeV"
-    },
     "date_created": [
       "2011"
     ],
@@ -10614,9 +8685,6 @@
     "experiment": "CMS",
     "publisher": "CERN Open Data Portal",
     "recid": "2321",
-    "run_period": [
-      "Run2011A"
-    ],
     "title": "High-Level Trigger path information HLT_Ele80_CaloIdVT_TrkIdT (SingleElectron dataset)",
     "type": {
       "primary": "Supplementaries",
@@ -10637,9 +8705,6 @@
     "collections": [
       "CMS-Trigger-Information"
     ],
-    "collision_information": {
-      "energy": "7TeV"
-    },
     "date_created": [
       "2011"
     ],
@@ -10647,9 +8712,6 @@
     "experiment": "CMS",
     "publisher": "CERN Open Data Portal",
     "recid": "2322",
-    "run_period": [
-      "Run2011A"
-    ],
     "title": "High-Level Trigger path information HLT_Ele8_CaloIdL_CaloIsoVL (DoubleElectron dataset)",
     "type": {
       "primary": "Supplementaries",
@@ -10670,9 +8732,6 @@
     "collections": [
       "CMS-Trigger-Information"
     ],
-    "collision_information": {
-      "energy": "7TeV"
-    },
     "date_created": [
       "2011"
     ],
@@ -10680,9 +8739,6 @@
     "experiment": "CMS",
     "publisher": "CERN Open Data Portal",
     "recid": "2323",
-    "run_period": [
-      "Run2011A"
-    ],
     "title": "High-Level Trigger path information HLT_Ele8_CaloIdL_CaloIsoVL_Jet40 (DoubleElectron dataset)",
     "type": {
       "primary": "Supplementaries",
@@ -10703,9 +8759,6 @@
     "collections": [
       "CMS-Trigger-Information"
     ],
-    "collision_information": {
-      "energy": "7TeV"
-    },
     "date_created": [
       "2011"
     ],
@@ -10713,9 +8766,6 @@
     "experiment": "CMS",
     "publisher": "CERN Open Data Portal",
     "recid": "2324",
-    "run_period": [
-      "Run2011A"
-    ],
     "title": "High-Level Trigger path information HLT_Ele8_CaloIdL_TrkIdVL (DoubleElectron dataset)",
     "type": {
       "primary": "Supplementaries",
@@ -10736,9 +8786,6 @@
     "collections": [
       "CMS-Trigger-Information"
     ],
-    "collision_information": {
-      "energy": "7TeV"
-    },
     "date_created": [
       "2011"
     ],
@@ -10746,9 +8793,6 @@
     "experiment": "CMS",
     "publisher": "CERN Open Data Portal",
     "recid": "2325",
-    "run_period": [
-      "Run2011A"
-    ],
     "title": "High-Level Trigger path information HLT_Ele8_CaloIdT_CaloIsoVL_TrkIdVL_TrkIsoVL (DoubleElectron dataset)",
     "type": {
       "primary": "Supplementaries",
@@ -10769,9 +8813,6 @@
     "collections": [
       "CMS-Trigger-Information"
     ],
-    "collision_information": {
-      "energy": "7TeV"
-    },
     "date_created": [
       "2011"
     ],
@@ -10779,9 +8820,6 @@
     "experiment": "CMS",
     "publisher": "CERN Open Data Portal",
     "recid": "2326",
-    "run_period": [
-      "Run2011A"
-    ],
     "title": "High-Level Trigger path information HLT_Ele8_CaloIdT_TrkIdT_DiJet30 (ElectronHad dataset)",
     "type": {
       "primary": "Supplementaries",
@@ -10802,9 +8840,6 @@
     "collections": [
       "CMS-Trigger-Information"
     ],
-    "collision_information": {
-      "energy": "7TeV"
-    },
     "date_created": [
       "2011"
     ],
@@ -10812,9 +8847,6 @@
     "experiment": "CMS",
     "publisher": "CERN Open Data Portal",
     "recid": "2327",
-    "run_period": [
-      "Run2011A"
-    ],
     "title": "High-Level Trigger path information HLT_Ele8_CaloIdT_TrkIdT_QuadJet30 (ElectronHad dataset)",
     "type": {
       "primary": "Supplementaries",
@@ -10835,9 +8867,6 @@
     "collections": [
       "CMS-Trigger-Information"
     ],
-    "collision_information": {
-      "energy": "7TeV"
-    },
     "date_created": [
       "2011"
     ],
@@ -10845,9 +8874,6 @@
     "experiment": "CMS",
     "publisher": "CERN Open Data Portal",
     "recid": "2328",
-    "run_period": [
-      "Run2011A"
-    ],
     "title": "High-Level Trigger path information HLT_Ele8_CaloIdT_TrkIdT_TriJet30 (ElectronHad dataset)",
     "type": {
       "primary": "Supplementaries",
@@ -10868,9 +8894,6 @@
     "collections": [
       "CMS-Trigger-Information"
     ],
-    "collision_information": {
-      "energy": "7TeV"
-    },
     "date_created": [
       "2011"
     ],
@@ -10878,9 +8901,6 @@
     "experiment": "CMS",
     "publisher": "CERN Open Data Portal",
     "recid": "2329",
-    "run_period": [
-      "Run2011A"
-    ],
     "title": "High-Level Trigger path information HLT_Ele8_CaloIdT_TrkIdVL_CaloIsoVL_TrkIsoVL (DoubleElectron dataset)",
     "type": {
       "primary": "Supplementaries",
@@ -10901,9 +8921,6 @@
     "collections": [
       "CMS-Trigger-Information"
     ],
-    "collision_information": {
-      "energy": "7TeV"
-    },
     "date_created": [
       "2011"
     ],
@@ -10911,9 +8928,6 @@
     "experiment": "CMS",
     "publisher": "CERN Open Data Portal",
     "recid": "2330",
-    "run_period": [
-      "Run2011A"
-    ],
     "title": "High-Level Trigger path information HLT_Ele90_NoSpikeFilter (SingleElectron dataset)",
     "type": {
       "primary": "Supplementaries",
@@ -10934,9 +8948,6 @@
     "collections": [
       "CMS-Trigger-Information"
     ],
-    "collision_information": {
-      "energy": "7TeV"
-    },
     "date_created": [
       "2011"
     ],
@@ -10944,9 +8955,6 @@
     "experiment": "CMS",
     "publisher": "CERN Open Data Portal",
     "recid": "2331",
-    "run_period": [
-      "Run2011A"
-    ],
     "title": "High-Level Trigger path information HLT_ExclDiJet60_HFAND (MultiJet dataset)",
     "type": {
       "primary": "Supplementaries",
@@ -10967,9 +8975,6 @@
     "collections": [
       "CMS-Trigger-Information"
     ],
-    "collision_information": {
-      "energy": "7TeV"
-    },
     "date_created": [
       "2011"
     ],
@@ -10977,9 +8982,6 @@
     "experiment": "CMS",
     "publisher": "CERN Open Data Portal",
     "recid": "2332",
-    "run_period": [
-      "Run2011A"
-    ],
     "title": "High-Level Trigger path information HLT_ExclDiJet60_HFOR (MultiJet dataset)",
     "type": {
       "primary": "Supplementaries",
@@ -11000,9 +9002,6 @@
     "collections": [
       "CMS-Trigger-Information"
     ],
-    "collision_information": {
-      "energy": "7TeV"
-    },
     "date_created": [
       "2011"
     ],
@@ -11010,9 +9009,6 @@
     "experiment": "CMS",
     "publisher": "CERN Open Data Portal",
     "recid": "2333",
-    "run_period": [
-      "Run2011A"
-    ],
     "title": "High-Level Trigger path information HLT_FatJetMass300_DR1p1_Deta2p0_CentralJet30_BTagIP (HT dataset)",
     "type": {
       "primary": "Supplementaries",
@@ -11033,9 +9029,6 @@
     "collections": [
       "CMS-Trigger-Information"
     ],
-    "collision_information": {
-      "energy": "7TeV"
-    },
     "date_created": [
       "2011"
     ],
@@ -11043,9 +9036,6 @@
     "experiment": "CMS",
     "publisher": "CERN Open Data Portal",
     "recid": "2334",
-    "run_period": [
-      "Run2011A"
-    ],
     "title": "High-Level Trigger path information HLT_FatJetMass350_DR1p1_Deta2p0_CentralJet30_BTagIP (HT dataset)",
     "type": {
       "primary": "Supplementaries",
@@ -11066,9 +9056,6 @@
     "collections": [
       "CMS-Trigger-Information"
     ],
-    "collision_information": {
-      "energy": "7TeV"
-    },
     "date_created": [
       "2011"
     ],
@@ -11076,9 +9063,6 @@
     "experiment": "CMS",
     "publisher": "CERN Open Data Portal",
     "recid": "2335",
-    "run_period": [
-      "Run2011A"
-    ],
     "title": "High-Level Trigger path information HLT_FatJetMass750_DR1p1_Deta2p0 (HT dataset)",
     "type": {
       "primary": "Supplementaries",
@@ -11099,9 +9083,6 @@
     "collections": [
       "CMS-Trigger-Information"
     ],
-    "collision_information": {
-      "energy": "7TeV"
-    },
     "date_created": [
       "2011"
     ],
@@ -11109,9 +9090,6 @@
     "experiment": "CMS",
     "publisher": "CERN Open Data Portal",
     "recid": "2336",
-    "run_period": [
-      "Run2011A"
-    ],
     "title": "High-Level Trigger path information HLT_FatJetMass850_DR1p1_Deta2p0 (HT dataset)",
     "type": {
       "primary": "Supplementaries",
@@ -11132,9 +9110,6 @@
     "collections": [
       "CMS-Trigger-Information"
     ],
-    "collision_information": {
-      "energy": "7TeV"
-    },
     "date_created": [
       "2011"
     ],
@@ -11142,9 +9117,6 @@
     "experiment": "CMS",
     "publisher": "CERN Open Data Portal",
     "recid": "2337",
-    "run_period": [
-      "Run2011A"
-    ],
     "title": "High-Level Trigger path information HLT_GlobalRunHPDNoise (HcalHPDNoise dataset)",
     "type": {
       "primary": "Supplementaries",
@@ -11165,9 +9137,6 @@
     "collections": [
       "CMS-Trigger-Information"
     ],
-    "collision_information": {
-      "energy": "7TeV"
-    },
     "date_created": [
       "2011"
     ],
@@ -11175,9 +9144,6 @@
     "experiment": "CMS",
     "publisher": "CERN Open Data Portal",
     "recid": "2338",
-    "run_period": [
-      "Run2011A"
-    ],
     "title": "High-Level Trigger path information HLT_HIActivityHF_Coincidence3",
     "type": {
       "primary": "Supplementaries",
@@ -11198,9 +9164,6 @@
     "collections": [
       "CMS-Trigger-Information"
     ],
-    "collision_information": {
-      "energy": "7TeV"
-    },
     "date_created": [
       "2011"
     ],
@@ -11208,9 +9171,6 @@
     "experiment": "CMS",
     "publisher": "CERN Open Data Portal",
     "recid": "2339",
-    "run_period": [
-      "Run2011A"
-    ],
     "title": "High-Level Trigger path information HLT_HIActivityHF_Single3",
     "type": {
       "primary": "Supplementaries",
@@ -11231,9 +9191,6 @@
     "collections": [
       "CMS-Trigger-Information"
     ],
-    "collision_information": {
-      "energy": "7TeV"
-    },
     "date_created": [
       "2011"
     ],
@@ -11241,9 +9198,6 @@
     "experiment": "CMS",
     "publisher": "CERN Open Data Portal",
     "recid": "2340",
-    "run_period": [
-      "Run2011A"
-    ],
     "title": "High-Level Trigger path information HLT_HIBptxXOR (HIMinBiasUPC dataset)",
     "type": {
       "primary": "Supplementaries",
@@ -11264,9 +9218,6 @@
     "collections": [
       "CMS-Trigger-Information"
     ],
-    "collision_information": {
-      "energy": "7TeV"
-    },
     "date_created": [
       "2011"
     ],
@@ -11274,9 +9225,6 @@
     "experiment": "CMS",
     "publisher": "CERN Open Data Portal",
     "recid": "2341",
-    "run_period": [
-      "Run2011A"
-    ],
     "title": "High-Level Trigger path information HLT_HICentral10 (HIMinBiasUPC dataset)",
     "type": {
       "primary": "Supplementaries",
@@ -11297,9 +9245,6 @@
     "collections": [
       "CMS-Trigger-Information"
     ],
-    "collision_information": {
-      "energy": "7TeV"
-    },
     "date_created": [
       "2011"
     ],
@@ -11307,9 +9252,6 @@
     "experiment": "CMS",
     "publisher": "CERN Open Data Portal",
     "recid": "2342",
-    "run_period": [
-      "Run2011A"
-    ],
     "title": "High-Level Trigger path information HLT_HICentralityVeto (HIMinBiasUPC dataset)",
     "type": {
       "primary": "Supplementaries",
@@ -11330,9 +9272,6 @@
     "collections": [
       "CMS-Trigger-Information"
     ],
-    "collision_information": {
-      "energy": "7TeV"
-    },
     "date_created": [
       "2011"
     ],
@@ -11340,9 +9279,6 @@
     "experiment": "CMS",
     "publisher": "CERN Open Data Portal",
     "recid": "2343",
-    "run_period": [
-      "Run2011A"
-    ],
     "title": "High-Level Trigger path information HLT_HIClusterVertexCompatibility",
     "type": {
       "primary": "Supplementaries",
@@ -11363,9 +9299,6 @@
     "collections": [
       "CMS-Trigger-Information"
     ],
-    "collision_information": {
-      "energy": "7TeV"
-    },
     "date_created": [
       "2011"
     ],
@@ -11373,9 +9306,6 @@
     "experiment": "CMS",
     "publisher": "CERN Open Data Portal",
     "recid": "2344",
-    "run_period": [
-      "Run2011A"
-    ],
     "title": "High-Level Trigger path information HLT_HIDTCalibration",
     "type": {
       "primary": "Supplementaries",
@@ -11396,9 +9326,6 @@
     "collections": [
       "CMS-Trigger-Information"
     ],
-    "collision_information": {
-      "energy": "7TeV"
-    },
     "date_created": [
       "2011"
     ],
@@ -11406,9 +9333,6 @@
     "experiment": "CMS",
     "publisher": "CERN Open Data Portal",
     "recid": "2345",
-    "run_period": [
-      "Run2011A"
-    ],
     "title": "High-Level Trigger path information HLT_HIDiJet55 (HIHighPt dataset)",
     "type": {
       "primary": "Supplementaries",
@@ -11429,9 +9353,6 @@
     "collections": [
       "CMS-Trigger-Information"
     ],
-    "collision_information": {
-      "energy": "7TeV"
-    },
     "date_created": [
       "2011"
     ],
@@ -11439,9 +9360,6 @@
     "experiment": "CMS",
     "publisher": "CERN Open Data Portal",
     "recid": "2346",
-    "run_period": [
-      "Run2011A"
-    ],
     "title": "High-Level Trigger path information HLT_HIDoublePhoton10 (HIHighPt dataset)",
     "type": {
       "primary": "Supplementaries",
@@ -11462,9 +9380,6 @@
     "collections": [
       "CMS-Trigger-Information"
     ],
-    "collision_information": {
-      "energy": "7TeV"
-    },
     "date_created": [
       "2011"
     ],
@@ -11472,9 +9387,6 @@
     "experiment": "CMS",
     "publisher": "CERN Open Data Portal",
     "recid": "2347",
-    "run_period": [
-      "Run2011A"
-    ],
     "title": "High-Level Trigger path information HLT_HIDoublePhoton15 (HIHighPt dataset)",
     "type": {
       "primary": "Supplementaries",
@@ -11495,9 +9407,6 @@
     "collections": [
       "CMS-Trigger-Information"
     ],
-    "collision_information": {
-      "energy": "7TeV"
-    },
     "date_created": [
       "2011"
     ],
@@ -11505,9 +9414,6 @@
     "experiment": "CMS",
     "publisher": "CERN Open Data Portal",
     "recid": "2348",
-    "run_period": [
-      "Run2011A"
-    ],
     "title": "High-Level Trigger path information HLT_HIDoublePhoton20 (HIHighPt dataset)",
     "type": {
       "primary": "Supplementaries",
@@ -11528,9 +9434,6 @@
     "collections": [
       "CMS-Trigger-Information"
     ],
-    "collision_information": {
-      "energy": "7TeV"
-    },
     "date_created": [
       "2011"
     ],
@@ -11538,9 +9441,6 @@
     "experiment": "CMS",
     "publisher": "CERN Open Data Portal",
     "recid": "2349",
-    "run_period": [
-      "Run2011A"
-    ],
     "title": "High-Level Trigger path information HLT_HIEcalCalibration",
     "type": {
       "primary": "Supplementaries",
@@ -11561,9 +9461,6 @@
     "collections": [
       "CMS-Trigger-Information"
     ],
-    "collision_information": {
-      "energy": "7TeV"
-    },
     "date_created": [
       "2011"
     ],
@@ -11571,9 +9468,6 @@
     "experiment": "CMS",
     "publisher": "CERN Open Data Portal",
     "recid": "2350",
-    "run_period": [
-      "Run2011A"
-    ],
     "title": "High-Level Trigger path information HLT_HIFullTrack12_L1Central (HIHighPt dataset)",
     "type": {
       "primary": "Supplementaries",
@@ -11594,9 +9488,6 @@
     "collections": [
       "CMS-Trigger-Information"
     ],
-    "collision_information": {
-      "energy": "7TeV"
-    },
     "date_created": [
       "2011"
     ],
@@ -11604,9 +9495,6 @@
     "experiment": "CMS",
     "publisher": "CERN Open Data Portal",
     "recid": "2351",
-    "run_period": [
-      "Run2011A"
-    ],
     "title": "High-Level Trigger path information HLT_HIFullTrack12_L1Peripheral (HIHighPt dataset)",
     "type": {
       "primary": "Supplementaries",
@@ -11627,9 +9515,6 @@
     "collections": [
       "CMS-Trigger-Information"
     ],
-    "collision_information": {
-      "energy": "7TeV"
-    },
     "date_created": [
       "2011"
     ],
@@ -11637,9 +9522,6 @@
     "experiment": "CMS",
     "publisher": "CERN Open Data Portal",
     "recid": "2352",
-    "run_period": [
-      "Run2011A"
-    ],
     "title": "High-Level Trigger path information HLT_HIFullTrack14_L1Central (HIHighPt dataset)",
     "type": {
       "primary": "Supplementaries",
@@ -11660,9 +9542,6 @@
     "collections": [
       "CMS-Trigger-Information"
     ],
-    "collision_information": {
-      "energy": "7TeV"
-    },
     "date_created": [
       "2011"
     ],
@@ -11670,9 +9549,6 @@
     "experiment": "CMS",
     "publisher": "CERN Open Data Portal",
     "recid": "2353",
-    "run_period": [
-      "Run2011A"
-    ],
     "title": "High-Level Trigger path information HLT_HIFullTrack14_L1Peripheral (HIHighPt dataset)",
     "type": {
       "primary": "Supplementaries",
@@ -11693,9 +9569,6 @@
     "collections": [
       "CMS-Trigger-Information"
     ],
-    "collision_information": {
-      "energy": "7TeV"
-    },
     "date_created": [
       "2011"
     ],
@@ -11703,9 +9576,6 @@
     "experiment": "CMS",
     "publisher": "CERN Open Data Portal",
     "recid": "2354",
-    "run_period": [
-      "Run2011A"
-    ],
     "title": "High-Level Trigger path information HLT_HIFullTrack20_L1Central (HIHighPt dataset)",
     "type": {
       "primary": "Supplementaries",
@@ -11726,9 +9596,6 @@
     "collections": [
       "CMS-Trigger-Information"
     ],
-    "collision_information": {
-      "energy": "7TeV"
-    },
     "date_created": [
       "2011"
     ],
@@ -11736,9 +9603,6 @@
     "experiment": "CMS",
     "publisher": "CERN Open Data Portal",
     "recid": "2355",
-    "run_period": [
-      "Run2011A"
-    ],
     "title": "High-Level Trigger path information HLT_HIFullTrack20_L1Peripheral (HIHighPt dataset)",
     "type": {
       "primary": "Supplementaries",
@@ -11759,9 +9623,6 @@
     "collections": [
       "CMS-Trigger-Information"
     ],
-    "collision_information": {
-      "energy": "7TeV"
-    },
     "date_created": [
       "2011"
     ],
@@ -11769,9 +9630,6 @@
     "experiment": "CMS",
     "publisher": "CERN Open Data Portal",
     "recid": "2356",
-    "run_period": [
-      "Run2011A"
-    ],
     "title": "High-Level Trigger path information HLT_HIFullTrack25_L1Central (HIHighPt dataset)",
     "type": {
       "primary": "Supplementaries",
@@ -11792,9 +9650,6 @@
     "collections": [
       "CMS-Trigger-Information"
     ],
-    "collision_information": {
-      "energy": "7TeV"
-    },
     "date_created": [
       "2011"
     ],
@@ -11802,9 +9657,6 @@
     "experiment": "CMS",
     "publisher": "CERN Open Data Portal",
     "recid": "2357",
-    "run_period": [
-      "Run2011A"
-    ],
     "title": "High-Level Trigger path information HLT_HIFullTrack25_L1Peripheral (HIHighPt dataset)",
     "type": {
       "primary": "Supplementaries",
@@ -11825,9 +9677,6 @@
     "collections": [
       "CMS-Trigger-Information"
     ],
-    "collision_information": {
-      "energy": "7TeV"
-    },
     "date_created": [
       "2011"
     ],
@@ -11835,9 +9684,6 @@
     "experiment": "CMS",
     "publisher": "CERN Open Data Portal",
     "recid": "2358",
-    "run_period": [
-      "Run2011A"
-    ],
     "title": "High-Level Trigger path information HLT_HIHcalCalibration",
     "type": {
       "primary": "Supplementaries",
@@ -11858,9 +9704,6 @@
     "collections": [
       "CMS-Trigger-Information"
     ],
-    "collision_information": {
-      "energy": "7TeV"
-    },
     "date_created": [
       "2011"
     ],
@@ -11868,9 +9711,6 @@
     "experiment": "CMS",
     "publisher": "CERN Open Data Portal",
     "recid": "2359",
-    "run_period": [
-      "Run2011A"
-    ],
     "title": "High-Level Trigger path information HLT_HIJet55 (HIHighPt dataset)",
     "type": {
       "primary": "Supplementaries",
@@ -11891,9 +9731,6 @@
     "collections": [
       "CMS-Trigger-Information"
     ],
-    "collision_information": {
-      "energy": "7TeV"
-    },
     "date_created": [
       "2011"
     ],
@@ -11901,9 +9738,6 @@
     "experiment": "CMS",
     "publisher": "CERN Open Data Portal",
     "recid": "2360",
-    "run_period": [
-      "Run2011A"
-    ],
     "title": "High-Level Trigger path information HLT_HIJet65 (HIHighPt dataset)",
     "type": {
       "primary": "Supplementaries",
@@ -11924,9 +9758,6 @@
     "collections": [
       "CMS-Trigger-Information"
     ],
-    "collision_information": {
-      "energy": "7TeV"
-    },
     "date_created": [
       "2011"
     ],
@@ -11934,9 +9765,6 @@
     "experiment": "CMS",
     "publisher": "CERN Open Data Portal",
     "recid": "2361",
-    "run_period": [
-      "Run2011A"
-    ],
     "title": "High-Level Trigger path information HLT_HIJet65_Jet55 (HIHighPt dataset)",
     "type": {
       "primary": "Supplementaries",
@@ -11957,9 +9785,6 @@
     "collections": [
       "CMS-Trigger-Information"
     ],
-    "collision_information": {
-      "energy": "7TeV"
-    },
     "date_created": [
       "2011"
     ],
@@ -11967,9 +9792,6 @@
     "experiment": "CMS",
     "publisher": "CERN Open Data Portal",
     "recid": "2362",
-    "run_period": [
-      "Run2011A"
-    ],
     "title": "High-Level Trigger path information HLT_HIJet80 (HIHighPt dataset)",
     "type": {
       "primary": "Supplementaries",
@@ -11990,9 +9812,6 @@
     "collections": [
       "CMS-Trigger-Information"
     ],
-    "collision_information": {
-      "energy": "7TeV"
-    },
     "date_created": [
       "2011"
     ],
@@ -12000,9 +9819,6 @@
     "experiment": "CMS",
     "publisher": "CERN Open Data Portal",
     "recid": "2363",
-    "run_period": [
-      "Run2011A"
-    ],
     "title": "High-Level Trigger path information HLT_HIJet95 (HIHighPt dataset)",
     "type": {
       "primary": "Supplementaries",
@@ -12023,9 +9839,6 @@
     "collections": [
       "CMS-Trigger-Information"
     ],
-    "collision_information": {
-      "energy": "7TeV"
-    },
     "date_created": [
       "2011"
     ],
@@ -12033,9 +9846,6 @@
     "experiment": "CMS",
     "publisher": "CERN Open Data Portal",
     "recid": "2364",
-    "run_period": [
-      "Run2011A"
-    ],
     "title": "High-Level Trigger path information HLT_HIJetE30_NoBPTX (HIHighPt dataset)",
     "type": {
       "primary": "Supplementaries",
@@ -12056,9 +9866,6 @@
     "collections": [
       "CMS-Trigger-Information"
     ],
-    "collision_information": {
-      "energy": "7TeV"
-    },
     "date_created": [
       "2011"
     ],
@@ -12066,9 +9873,6 @@
     "experiment": "CMS",
     "publisher": "CERN Open Data Portal",
     "recid": "2365",
-    "run_period": [
-      "Run2011A"
-    ],
     "title": "High-Level Trigger path information HLT_HIJetE50_NoBPTX3BX_NoHalo (HIHighPt dataset)",
     "type": {
       "primary": "Supplementaries",
@@ -12089,9 +9893,6 @@
     "collections": [
       "CMS-Trigger-Information"
     ],
-    "collision_information": {
-      "energy": "7TeV"
-    },
     "date_created": [
       "2011"
     ],
@@ -12099,9 +9900,6 @@
     "experiment": "CMS",
     "publisher": "CERN Open Data Portal",
     "recid": "2366",
-    "run_period": [
-      "Run2011A"
-    ],
     "title": "High-Level Trigger path information HLT_HIL1Algo_BptxXOR_BSC_OR (HIMinBiasUPC dataset)",
     "type": {
       "primary": "Supplementaries",
@@ -12122,9 +9920,6 @@
     "collections": [
       "CMS-Trigger-Information"
     ],
-    "collision_information": {
-      "energy": "7TeV"
-    },
     "date_created": [
       "2011"
     ],
@@ -12132,9 +9927,6 @@
     "experiment": "CMS",
     "publisher": "CERN Open Data Portal",
     "recid": "2367",
-    "run_period": [
-      "Run2011A"
-    ],
     "title": "High-Level Trigger path information HLT_HIL1CaloMonitor (HIMinBiasUPC dataset)",
     "type": {
       "primary": "Supplementaries",
@@ -12155,9 +9947,6 @@
     "collections": [
       "CMS-Trigger-Information"
     ],
-    "collision_information": {
-      "energy": "7TeV"
-    },
     "date_created": [
       "2011"
     ],
@@ -12165,9 +9954,6 @@
     "experiment": "CMS",
     "publisher": "CERN Open Data Portal",
     "recid": "2368",
-    "run_period": [
-      "Run2011A"
-    ],
     "title": "High-Level Trigger path information HLT_HIL1DoubleMu0_HighQ (HIDiMuon dataset)",
     "type": {
       "primary": "Supplementaries",
@@ -12188,9 +9974,6 @@
     "collections": [
       "CMS-Trigger-Information"
     ],
-    "collision_information": {
-      "energy": "7TeV"
-    },
     "date_created": [
       "2011"
     ],
@@ -12198,9 +9981,6 @@
     "experiment": "CMS",
     "publisher": "CERN Open Data Portal",
     "recid": "2369",
-    "run_period": [
-      "Run2011A"
-    ],
     "title": "High-Level Trigger path information HLT_HIL1DoubleMuOpen (HIDiMuon dataset)",
     "type": {
       "primary": "Supplementaries",
@@ -12221,9 +10001,6 @@
     "collections": [
       "CMS-Trigger-Information"
     ],
-    "collision_information": {
-      "energy": "7TeV"
-    },
     "date_created": [
       "2011"
     ],
@@ -12231,9 +10008,6 @@
     "experiment": "CMS",
     "publisher": "CERN Open Data Portal",
     "recid": "2370",
-    "run_period": [
-      "Run2011A"
-    ],
     "title": "High-Level Trigger path information HLT_HIL2DoubleMu0 (HIDiMuon dataset)",
     "type": {
       "primary": "Supplementaries",
@@ -12254,9 +10028,6 @@
     "collections": [
       "CMS-Trigger-Information"
     ],
-    "collision_information": {
-      "energy": "7TeV"
-    },
     "date_created": [
       "2011"
     ],
@@ -12264,9 +10035,6 @@
     "experiment": "CMS",
     "publisher": "CERN Open Data Portal",
     "recid": "2371",
-    "run_period": [
-      "Run2011A"
-    ],
     "title": "High-Level Trigger path information HLT_HIL2DoubleMu0_L1HighQL2NHitQ (HIDiMuon dataset)",
     "type": {
       "primary": "Supplementaries",
@@ -12287,9 +10055,6 @@
     "collections": [
       "CMS-Trigger-Information"
     ],
-    "collision_information": {
-      "energy": "7TeV"
-    },
     "date_created": [
       "2011"
     ],
@@ -12297,9 +10062,6 @@
     "experiment": "CMS",
     "publisher": "CERN Open Data Portal",
     "recid": "2372",
-    "run_period": [
-      "Run2011A"
-    ],
     "title": "High-Level Trigger path information HLT_HIL2DoubleMu0_NHitQ (HIDiMuon dataset)",
     "type": {
       "primary": "Supplementaries",
@@ -12320,9 +10082,6 @@
     "collections": [
       "CMS-Trigger-Information"
     ],
-    "collision_information": {
-      "energy": "7TeV"
-    },
     "date_created": [
       "2011"
     ],
@@ -12330,9 +10089,6 @@
     "experiment": "CMS",
     "publisher": "CERN Open Data Portal",
     "recid": "2373",
-    "run_period": [
-      "Run2011A"
-    ],
     "title": "High-Level Trigger path information HLT_HIL2DoubleMu3 (HIDiMuon dataset)",
     "type": {
       "primary": "Supplementaries",
@@ -12353,9 +10109,6 @@
     "collections": [
       "CMS-Trigger-Information"
     ],
-    "collision_information": {
-      "energy": "7TeV"
-    },
     "date_created": [
       "2011"
     ],
@@ -12363,9 +10116,6 @@
     "experiment": "CMS",
     "publisher": "CERN Open Data Portal",
     "recid": "2374",
-    "run_period": [
-      "Run2011A"
-    ],
     "title": "High-Level Trigger path information HLT_HIL2Mu15 (HIDiMuon dataset)",
     "type": {
       "primary": "Supplementaries",
@@ -12386,9 +10136,6 @@
     "collections": [
       "CMS-Trigger-Information"
     ],
-    "collision_information": {
-      "energy": "7TeV"
-    },
     "date_created": [
       "2011"
     ],
@@ -12396,9 +10143,6 @@
     "experiment": "CMS",
     "publisher": "CERN Open Data Portal",
     "recid": "2375",
-    "run_period": [
-      "Run2011A"
-    ],
     "title": "High-Level Trigger path information HLT_HIL2Mu3 (HIDiMuon dataset)",
     "type": {
       "primary": "Supplementaries",
@@ -12419,9 +10163,6 @@
     "collections": [
       "CMS-Trigger-Information"
     ],
-    "collision_information": {
-      "energy": "7TeV"
-    },
     "date_created": [
       "2011"
     ],
@@ -12429,9 +10170,6 @@
     "experiment": "CMS",
     "publisher": "CERN Open Data Portal",
     "recid": "2376",
-    "run_period": [
-      "Run2011A"
-    ],
     "title": "High-Level Trigger path information HLT_HIL2Mu3_NHitQ (HIDiMuon dataset)",
     "type": {
       "primary": "Supplementaries",
@@ -12452,9 +10190,6 @@
     "collections": [
       "CMS-Trigger-Information"
     ],
-    "collision_information": {
-      "energy": "7TeV"
-    },
     "date_created": [
       "2011"
     ],
@@ -12462,9 +10197,6 @@
     "experiment": "CMS",
     "publisher": "CERN Open Data Portal",
     "recid": "2377",
-    "run_period": [
-      "Run2011A"
-    ],
     "title": "High-Level Trigger path information HLT_HIL2Mu7 (HIDiMuon dataset)",
     "type": {
       "primary": "Supplementaries",
@@ -12485,9 +10217,6 @@
     "collections": [
       "CMS-Trigger-Information"
     ],
-    "collision_information": {
-      "energy": "7TeV"
-    },
     "date_created": [
       "2011"
     ],
@@ -12495,9 +10224,6 @@
     "experiment": "CMS",
     "publisher": "CERN Open Data Portal",
     "recid": "2378",
-    "run_period": [
-      "Run2011A"
-    ],
     "title": "High-Level Trigger path information HLT_HIL3DoubleMuOpen (HIDiMuon dataset)",
     "type": {
       "primary": "Supplementaries",
@@ -12518,9 +10244,6 @@
     "collections": [
       "CMS-Trigger-Information"
     ],
-    "collision_information": {
-      "energy": "7TeV"
-    },
     "date_created": [
       "2011"
     ],
@@ -12528,9 +10251,6 @@
     "experiment": "CMS",
     "publisher": "CERN Open Data Portal",
     "recid": "2379",
-    "run_period": [
-      "Run2011A"
-    ],
     "title": "High-Level Trigger path information HLT_HIL3DoubleMuOpen_Mgt2 (HIDiMuon dataset)",
     "type": {
       "primary": "Supplementaries",
@@ -12551,9 +10271,6 @@
     "collections": [
       "CMS-Trigger-Information"
     ],
-    "collision_information": {
-      "energy": "7TeV"
-    },
     "date_created": [
       "2011"
     ],
@@ -12561,9 +10278,6 @@
     "experiment": "CMS",
     "publisher": "CERN Open Data Portal",
     "recid": "2380",
-    "run_period": [
-      "Run2011A"
-    ],
     "title": "High-Level Trigger path information HLT_HIL3DoubleMuOpen_Mgt2_OS (HIDiMuon dataset)",
     "type": {
       "primary": "Supplementaries",
@@ -12584,9 +10298,6 @@
     "collections": [
       "CMS-Trigger-Information"
     ],
-    "collision_information": {
-      "energy": "7TeV"
-    },
     "date_created": [
       "2011"
     ],
@@ -12594,9 +10305,6 @@
     "experiment": "CMS",
     "publisher": "CERN Open Data Portal",
     "recid": "2381",
-    "run_period": [
-      "Run2011A"
-    ],
     "title": "High-Level Trigger path information HLT_HIL3DoubleMuOpen_Mgt2_OS_NoCowboy (HIDiMuon dataset)",
     "type": {
       "primary": "Supplementaries",
@@ -12617,9 +10325,6 @@
     "collections": [
       "CMS-Trigger-Information"
     ],
-    "collision_information": {
-      "energy": "7TeV"
-    },
     "date_created": [
       "2011"
     ],
@@ -12627,9 +10332,6 @@
     "experiment": "CMS",
     "publisher": "CERN Open Data Portal",
     "recid": "2382",
-    "run_period": [
-      "Run2011A"
-    ],
     "title": "High-Level Trigger path information HLT_HIL3DoubleMuOpen_Mgt2_SS (HIDiMuon dataset)",
     "type": {
       "primary": "Supplementaries",
@@ -12650,9 +10352,6 @@
     "collections": [
       "CMS-Trigger-Information"
     ],
-    "collision_information": {
-      "energy": "7TeV"
-    },
     "date_created": [
       "2011"
     ],
@@ -12660,9 +10359,6 @@
     "experiment": "CMS",
     "publisher": "CERN Open Data Portal",
     "recid": "2383",
-    "run_period": [
-      "Run2011A"
-    ],
     "title": "High-Level Trigger path information HLT_HIL3Mu3 (HIDiMuon dataset)",
     "type": {
       "primary": "Supplementaries",
@@ -12683,9 +10379,6 @@
     "collections": [
       "CMS-Trigger-Information"
     ],
-    "collision_information": {
-      "energy": "7TeV"
-    },
     "date_created": [
       "2011"
     ],
@@ -12693,9 +10386,6 @@
     "experiment": "CMS",
     "publisher": "CERN Open Data Portal",
     "recid": "2384",
-    "run_period": [
-      "Run2011A"
-    ],
     "title": "High-Level Trigger path information HLT_HIMET120 (HIHighPt dataset)",
     "type": {
       "primary": "Supplementaries",
@@ -12716,9 +10406,6 @@
     "collections": [
       "CMS-Trigger-Information"
     ],
-    "collision_information": {
-      "energy": "7TeV"
-    },
     "date_created": [
       "2011"
     ],
@@ -12726,9 +10413,6 @@
     "experiment": "CMS",
     "publisher": "CERN Open Data Portal",
     "recid": "2385",
-    "run_period": [
-      "Run2011A"
-    ],
     "title": "High-Level Trigger path information HLT_HIMET200 (HIHighPt dataset)",
     "type": {
       "primary": "Supplementaries",
@@ -12749,9 +10433,6 @@
     "collections": [
       "CMS-Trigger-Information"
     ],
-    "collision_information": {
-      "energy": "7TeV"
-    },
     "date_created": [
       "2011"
     ],
@@ -12759,9 +10440,6 @@
     "experiment": "CMS",
     "publisher": "CERN Open Data Portal",
     "recid": "2386",
-    "run_period": [
-      "Run2011A"
-    ],
     "title": "High-Level Trigger path information HLT_HIMET220 (HIHighPt dataset)",
     "type": {
       "primary": "Supplementaries",
@@ -12782,9 +10460,6 @@
     "collections": [
       "CMS-Trigger-Information"
     ],
-    "collision_information": {
-      "energy": "7TeV"
-    },
     "date_created": [
       "2011"
     ],
@@ -12792,9 +10467,6 @@
     "experiment": "CMS",
     "publisher": "CERN Open Data Portal",
     "recid": "2387",
-    "run_period": [
-      "Run2011A"
-    ],
     "title": "High-Level Trigger path information HLT_HIMinBiasBSC (HIMinBiasUPC dataset)",
     "type": {
       "primary": "Supplementaries",
@@ -12815,9 +10487,6 @@
     "collections": [
       "CMS-Trigger-Information"
     ],
-    "collision_information": {
-      "energy": "7TeV"
-    },
     "date_created": [
       "2011"
     ],
@@ -12825,9 +10494,6 @@
     "experiment": "CMS",
     "publisher": "CERN Open Data Portal",
     "recid": "2388",
-    "run_period": [
-      "Run2011A"
-    ],
     "title": "High-Level Trigger path information HLT_HIMinBiasBSC_OR (HIMinBiasUPC dataset)",
     "type": {
       "primary": "Supplementaries",
@@ -12848,9 +10514,6 @@
     "collections": [
       "CMS-Trigger-Information"
     ],
-    "collision_information": {
-      "energy": "7TeV"
-    },
     "date_created": [
       "2011"
     ],
@@ -12858,9 +10521,6 @@
     "experiment": "CMS",
     "publisher": "CERN Open Data Portal",
     "recid": "2389",
-    "run_period": [
-      "Run2011A"
-    ],
     "title": "High-Level Trigger path information HLT_HIMinBiasHF (HIMinBiasUPC dataset)",
     "type": {
       "primary": "Supplementaries",
@@ -12881,9 +10541,6 @@
     "collections": [
       "CMS-Trigger-Information"
     ],
-    "collision_information": {
-      "energy": "7TeV"
-    },
     "date_created": [
       "2011"
     ],
@@ -12891,9 +10548,6 @@
     "experiment": "CMS",
     "publisher": "CERN Open Data Portal",
     "recid": "2390",
-    "run_period": [
-      "Run2011A"
-    ],
     "title": "High-Level Trigger path information HLT_HIMinBiasHfOrBSC (HIMinBiasUPC dataset)",
     "type": {
       "primary": "Supplementaries",
@@ -12914,9 +10568,6 @@
     "collections": [
       "CMS-Trigger-Information"
     ],
-    "collision_information": {
-      "energy": "7TeV"
-    },
     "date_created": [
       "2011"
     ],
@@ -12924,9 +10575,6 @@
     "experiment": "CMS",
     "publisher": "CERN Open Data Portal",
     "recid": "2391",
-    "run_period": [
-      "Run2011A"
-    ],
     "title": "High-Level Trigger path information HLT_HIMinBiasHf_OR (HIMinBiasUPC dataset)",
     "type": {
       "primary": "Supplementaries",
@@ -12947,9 +10595,6 @@
     "collections": [
       "CMS-Trigger-Information"
     ],
-    "collision_information": {
-      "energy": "7TeV"
-    },
     "date_created": [
       "2011"
     ],
@@ -12957,9 +10602,6 @@
     "experiment": "CMS",
     "publisher": "CERN Open Data Portal",
     "recid": "2392",
-    "run_period": [
-      "Run2011A"
-    ],
     "title": "High-Level Trigger path information HLT_HIMinBiasPixel_SingleTrack (HIMinBiasUPC dataset)",
     "type": {
       "primary": "Supplementaries",
@@ -12980,9 +10622,6 @@
     "collections": [
       "CMS-Trigger-Information"
     ],
-    "collision_information": {
-      "energy": "7TeV"
-    },
     "date_created": [
       "2011"
     ],
@@ -12990,9 +10629,6 @@
     "experiment": "CMS",
     "publisher": "CERN Open Data Portal",
     "recid": "2393",
-    "run_period": [
-      "Run2011A"
-    ],
     "title": "High-Level Trigger path information HLT_HIMinBiasZDCPixel_SingleTrack (HIMinBiasUPC dataset)",
     "type": {
       "primary": "Supplementaries",
@@ -13013,9 +10649,6 @@
     "collections": [
       "CMS-Trigger-Information"
     ],
-    "collision_information": {
-      "energy": "7TeV"
-    },
     "date_created": [
       "2011"
     ],
@@ -13023,9 +10656,6 @@
     "experiment": "CMS",
     "publisher": "CERN Open Data Portal",
     "recid": "2394",
-    "run_period": [
-      "Run2011A"
-    ],
     "title": "High-Level Trigger path information HLT_HIMinBiasZDC_Calo (HIMinBiasUPC dataset)",
     "type": {
       "primary": "Supplementaries",
@@ -13046,9 +10676,6 @@
     "collections": [
       "CMS-Trigger-Information"
     ],
-    "collision_information": {
-      "energy": "7TeV"
-    },
     "date_created": [
       "2011"
     ],
@@ -13056,9 +10683,6 @@
     "experiment": "CMS",
     "publisher": "CERN Open Data Portal",
     "recid": "2395",
-    "run_period": [
-      "Run2011A"
-    ],
     "title": "High-Level Trigger path information HLT_HIMinBiasZDC_Calo_PlusOrMinus (HIMinBiasUPC dataset)",
     "type": {
       "primary": "Supplementaries",
@@ -13079,9 +10703,6 @@
     "collections": [
       "CMS-Trigger-Information"
     ],
-    "collision_information": {
-      "energy": "7TeV"
-    },
     "date_created": [
       "2011"
     ],
@@ -13089,9 +10710,6 @@
     "experiment": "CMS",
     "publisher": "CERN Open Data Portal",
     "recid": "2396",
-    "run_period": [
-      "Run2011A"
-    ],
     "title": "High-Level Trigger path information HLT_HIMinBiasZDC_PlusOrMinusPixel_SingleTrack (HIMinBiasUPC dataset)",
     "type": {
       "primary": "Supplementaries",
@@ -13112,9 +10730,6 @@
     "collections": [
       "CMS-Trigger-Information"
     ],
-    "collision_information": {
-      "energy": "7TeV"
-    },
     "date_created": [
       "2011"
     ],
@@ -13122,9 +10737,6 @@
     "experiment": "CMS",
     "publisher": "CERN Open Data Portal",
     "recid": "2397",
-    "run_period": [
-      "Run2011A"
-    ],
     "title": "High-Level Trigger path information HLT_HIPhoton10_Photon15 (HIHighPt dataset)",
     "type": {
       "primary": "Supplementaries",
@@ -13145,9 +10757,6 @@
     "collections": [
       "CMS-Trigger-Information"
     ],
-    "collision_information": {
-      "energy": "7TeV"
-    },
     "date_created": [
       "2011"
     ],
@@ -13155,9 +10764,6 @@
     "experiment": "CMS",
     "publisher": "CERN Open Data Portal",
     "recid": "2398",
-    "run_period": [
-      "Run2011A"
-    ],
     "title": "High-Level Trigger path information HLT_HIPhoton15_Photon20 (HIHighPt dataset)",
     "type": {
       "primary": "Supplementaries",
@@ -13178,9 +10784,6 @@
     "collections": [
       "CMS-Trigger-Information"
     ],
-    "collision_information": {
-      "energy": "7TeV"
-    },
     "date_created": [
       "2011"
     ],
@@ -13188,9 +10791,6 @@
     "experiment": "CMS",
     "publisher": "CERN Open Data Portal",
     "recid": "2399",
-    "run_period": [
-      "Run2011A"
-    ],
     "title": "High-Level Trigger path information HLT_HIPhysics (HIMinBiasUPC dataset)",
     "type": {
       "primary": "Supplementaries",
@@ -13211,9 +10811,6 @@
     "collections": [
       "CMS-Trigger-Information"
     ],
-    "collision_information": {
-      "energy": "7TeV"
-    },
     "date_created": [
       "2011"
     ],
@@ -13221,9 +10818,6 @@
     "experiment": "CMS",
     "publisher": "CERN Open Data Portal",
     "recid": "2400",
-    "run_period": [
-      "Run2011A"
-    ],
     "title": "High-Level Trigger path information HLT_HIRandom (HIMinBiasUPC dataset)",
     "type": {
       "primary": "Supplementaries",
@@ -13244,9 +10838,6 @@
     "collections": [
       "CMS-Trigger-Information"
     ],
-    "collision_information": {
-      "energy": "7TeV"
-    },
     "date_created": [
       "2011"
     ],
@@ -13254,9 +10845,6 @@
     "experiment": "CMS",
     "publisher": "CERN Open Data Portal",
     "recid": "2401",
-    "run_period": [
-      "Run2011A"
-    ],
     "title": "High-Level Trigger path information HLT_HISinglePhoton15 (HIHighPt dataset)",
     "type": {
       "primary": "Supplementaries",
@@ -13277,9 +10865,6 @@
     "collections": [
       "CMS-Trigger-Information"
     ],
-    "collision_information": {
-      "energy": "7TeV"
-    },
     "date_created": [
       "2011"
     ],
@@ -13287,9 +10872,6 @@
     "experiment": "CMS",
     "publisher": "CERN Open Data Portal",
     "recid": "2402",
-    "run_period": [
-      "Run2011A"
-    ],
     "title": "High-Level Trigger path information HLT_HISinglePhoton20 (HIHighPt dataset)",
     "type": {
       "primary": "Supplementaries",
@@ -13310,9 +10892,6 @@
     "collections": [
       "CMS-Trigger-Information"
     ],
-    "collision_information": {
-      "energy": "7TeV"
-    },
     "date_created": [
       "2011"
     ],
@@ -13320,9 +10899,6 @@
     "experiment": "CMS",
     "publisher": "CERN Open Data Portal",
     "recid": "2403",
-    "run_period": [
-      "Run2011A"
-    ],
     "title": "High-Level Trigger path information HLT_HISinglePhoton30 (HIHighPt dataset)",
     "type": {
       "primary": "Supplementaries",
@@ -13343,9 +10919,6 @@
     "collections": [
       "CMS-Trigger-Information"
     ],
-    "collision_information": {
-      "energy": "7TeV"
-    },
     "date_created": [
       "2011"
     ],
@@ -13353,9 +10926,6 @@
     "experiment": "CMS",
     "publisher": "CERN Open Data Portal",
     "recid": "2404",
-    "run_period": [
-      "Run2011A"
-    ],
     "title": "High-Level Trigger path information HLT_HISinglePhoton40 (HIHighPt dataset)",
     "type": {
       "primary": "Supplementaries",
@@ -13376,9 +10946,6 @@
     "collections": [
       "CMS-Trigger-Information"
     ],
-    "collision_information": {
-      "energy": "7TeV"
-    },
     "date_created": [
       "2011"
     ],
@@ -13386,9 +10953,6 @@
     "experiment": "CMS",
     "publisher": "CERN Open Data Portal",
     "recid": "2405",
-    "run_period": [
-      "Run2011A"
-    ],
     "title": "High-Level Trigger path information HLT_HIUCC010 (HIMinBiasUPC dataset)",
     "type": {
       "primary": "Supplementaries",
@@ -13409,9 +10973,6 @@
     "collections": [
       "CMS-Trigger-Information"
     ],
-    "collision_information": {
-      "energy": "7TeV"
-    },
     "date_created": [
       "2011"
     ],
@@ -13419,9 +10980,6 @@
     "experiment": "CMS",
     "publisher": "CERN Open Data Portal",
     "recid": "2406",
-    "run_period": [
-      "Run2011A"
-    ],
     "title": "High-Level Trigger path information HLT_HIUCC015 (HIMinBiasUPC dataset)",
     "type": {
       "primary": "Supplementaries",
@@ -13442,9 +11000,6 @@
     "collections": [
       "CMS-Trigger-Information"
     ],
-    "collision_information": {
-      "energy": "7TeV"
-    },
     "date_created": [
       "2011"
     ],
@@ -13452,9 +11007,6 @@
     "experiment": "CMS",
     "publisher": "CERN Open Data Portal",
     "recid": "2407",
-    "run_period": [
-      "Run2011A"
-    ],
     "title": "High-Level Trigger path information HLT_HIUPCNeuEG2Pixel_SingleTrack (HIMinBiasUPC dataset)",
     "type": {
       "primary": "Supplementaries",
@@ -13475,9 +11027,6 @@
     "collections": [
       "CMS-Trigger-Information"
     ],
-    "collision_information": {
-      "energy": "7TeV"
-    },
     "date_created": [
       "2011"
     ],
@@ -13485,9 +11034,6 @@
     "experiment": "CMS",
     "publisher": "CERN Open Data Portal",
     "recid": "2408",
-    "run_period": [
-      "Run2011A"
-    ],
     "title": "High-Level Trigger path information HLT_HIUPCNeuEG5Pixel_SingleTrack (HIMinBiasUPC dataset)",
     "type": {
       "primary": "Supplementaries",
@@ -13508,9 +11054,6 @@
     "collections": [
       "CMS-Trigger-Information"
     ],
-    "collision_information": {
-      "energy": "7TeV"
-    },
     "date_created": [
       "2011"
     ],
@@ -13518,9 +11061,6 @@
     "experiment": "CMS",
     "publisher": "CERN Open Data Portal",
     "recid": "2409",
-    "run_period": [
-      "Run2011A"
-    ],
     "title": "High-Level Trigger path information HLT_HIUPCNeuHcalHfEG2Pixel_SingleTrack (HIMinBiasUPC dataset)",
     "type": {
       "primary": "Supplementaries",
@@ -13541,9 +11081,6 @@
     "collections": [
       "CMS-Trigger-Information"
     ],
-    "collision_information": {
-      "energy": "7TeV"
-    },
     "date_created": [
       "2011"
     ],
@@ -13551,9 +11088,6 @@
     "experiment": "CMS",
     "publisher": "CERN Open Data Portal",
     "recid": "2410",
-    "run_period": [
-      "Run2011A"
-    ],
     "title": "High-Level Trigger path information HLT_HIUPCNeuHcalHfEG5Pixel_SingleTrack (HIMinBiasUPC dataset)",
     "type": {
       "primary": "Supplementaries",
@@ -13574,9 +11108,6 @@
     "collections": [
       "CMS-Trigger-Information"
     ],
-    "collision_information": {
-      "energy": "7TeV"
-    },
     "date_created": [
       "2011"
     ],
@@ -13584,9 +11115,6 @@
     "experiment": "CMS",
     "publisher": "CERN Open Data Portal",
     "recid": "2411",
-    "run_period": [
-      "Run2011A"
-    ],
     "title": "High-Level Trigger path information HLT_HIUPCNeuHcalHfMuPixel_SingleTrack (HIMinBiasUPC dataset)",
     "type": {
       "primary": "Supplementaries",
@@ -13607,9 +11135,6 @@
     "collections": [
       "CMS-Trigger-Information"
     ],
-    "collision_information": {
-      "energy": "7TeV"
-    },
     "date_created": [
       "2011"
     ],
@@ -13617,9 +11142,6 @@
     "experiment": "CMS",
     "publisher": "CERN Open Data Portal",
     "recid": "2412",
-    "run_period": [
-      "Run2011A"
-    ],
     "title": "High-Level Trigger path information HLT_HIUPCNeuMuPixel_SingleTrack (HIMinBiasUPC dataset)",
     "type": {
       "primary": "Supplementaries",
@@ -13640,9 +11162,6 @@
     "collections": [
       "CMS-Trigger-Information"
     ],
-    "collision_information": {
-      "energy": "7TeV"
-    },
     "date_created": [
       "2011"
     ],
@@ -13650,9 +11169,6 @@
     "experiment": "CMS",
     "publisher": "CERN Open Data Portal",
     "recid": "2413",
-    "run_period": [
-      "Run2011A"
-    ],
     "title": "High-Level Trigger path information HLT_HIZeroBias (HIMinBiasUPC dataset)",
     "type": {
       "primary": "Supplementaries",
@@ -13673,9 +11189,6 @@
     "collections": [
       "CMS-Trigger-Information"
     ],
-    "collision_information": {
-      "energy": "7TeV"
-    },
     "date_created": [
       "2011"
     ],
@@ -13683,9 +11196,6 @@
     "experiment": "CMS",
     "publisher": "CERN Open Data Portal",
     "recid": "2414",
-    "run_period": [
-      "Run2011A"
-    ],
     "title": "High-Level Trigger path information HLT_HIZeroBiasPixel_SingleTrack (HIMinBiasUPC dataset)",
     "type": {
       "primary": "Supplementaries",
@@ -13706,9 +11216,6 @@
     "collections": [
       "CMS-Trigger-Information"
     ],
-    "collision_information": {
-      "energy": "7TeV"
-    },
     "date_created": [
       "2011"
     ],
@@ -13716,9 +11223,6 @@
     "experiment": "CMS",
     "publisher": "CERN Open Data Portal",
     "recid": "2415",
-    "run_period": [
-      "Run2011A"
-    ],
     "title": "High-Level Trigger path information HLT_HIZeroBiasXOR (HIMinBiasUPC dataset)",
     "type": {
       "primary": "Supplementaries",
@@ -13739,9 +11243,6 @@
     "collections": [
       "CMS-Trigger-Information"
     ],
-    "collision_information": {
-      "energy": "7TeV"
-    },
     "date_created": [
       "2011"
     ],
@@ -13749,9 +11250,6 @@
     "experiment": "CMS",
     "publisher": "CERN Open Data Portal",
     "recid": "2416",
-    "run_period": [
-      "Run2011A"
-    ],
     "title": "High-Level Trigger path information HLT_HT150 (HT dataset)",
     "type": {
       "primary": "Supplementaries",
@@ -13772,9 +11270,6 @@
     "collections": [
       "CMS-Trigger-Information"
     ],
-    "collision_information": {
-      "energy": "7TeV"
-    },
     "date_created": [
       "2011"
     ],
@@ -13782,9 +11277,6 @@
     "experiment": "CMS",
     "publisher": "CERN Open Data Portal",
     "recid": "2417",
-    "run_period": [
-      "Run2011A"
-    ],
     "title": "High-Level Trigger path information HLT_HT150_AlphaT0p60 (HT dataset)",
     "type": {
       "primary": "Supplementaries",
@@ -13805,9 +11297,6 @@
     "collections": [
       "CMS-Trigger-Information"
     ],
-    "collision_information": {
-      "energy": "7TeV"
-    },
     "date_created": [
       "2011"
     ],
@@ -13815,9 +11304,6 @@
     "experiment": "CMS",
     "publisher": "CERN Open Data Portal",
     "recid": "2418",
-    "run_period": [
-      "Run2011A"
-    ],
     "title": "High-Level Trigger path information HLT_HT150_AlphaT0p70 (HT dataset)",
     "type": {
       "primary": "Supplementaries",
@@ -13838,9 +11324,6 @@
     "collections": [
       "CMS-Trigger-Information"
     ],
-    "collision_information": {
-      "energy": "7TeV"
-    },
     "date_created": [
       "2011"
     ],
@@ -13848,9 +11331,6 @@
     "experiment": "CMS",
     "publisher": "CERN Open Data Portal",
     "recid": "2419",
-    "run_period": [
-      "Run2011A"
-    ],
     "title": "High-Level Trigger path information HLT_HT160 (HT dataset)",
     "type": {
       "primary": "Supplementaries",
@@ -13871,9 +11351,6 @@
     "collections": [
       "CMS-Trigger-Information"
     ],
-    "collision_information": {
-      "energy": "7TeV"
-    },
     "date_created": [
       "2011"
     ],
@@ -13881,9 +11358,6 @@
     "experiment": "CMS",
     "publisher": "CERN Open Data Portal",
     "recid": "2420",
-    "run_period": [
-      "Run2011A"
-    ],
     "title": "High-Level Trigger path information HLT_HT200 (HT dataset)",
     "type": {
       "primary": "Supplementaries",
@@ -13904,9 +11378,6 @@
     "collections": [
       "CMS-Trigger-Information"
     ],
-    "collision_information": {
-      "energy": "7TeV"
-    },
     "date_created": [
       "2011"
     ],
@@ -13914,9 +11385,6 @@
     "experiment": "CMS",
     "publisher": "CERN Open Data Portal",
     "recid": "2421",
-    "run_period": [
-      "Run2011A"
-    ],
     "title": "High-Level Trigger path information HLT_HT2000 (HT dataset)",
     "type": {
       "primary": "Supplementaries",
@@ -13937,9 +11405,6 @@
     "collections": [
       "CMS-Trigger-Information"
     ],
-    "collision_information": {
-      "energy": "7TeV"
-    },
     "date_created": [
       "2011"
     ],
@@ -13947,9 +11412,6 @@
     "experiment": "CMS",
     "publisher": "CERN Open Data Portal",
     "recid": "2422",
-    "run_period": [
-      "Run2011A"
-    ],
     "title": "High-Level Trigger path information HLT_HT200_AlphaT0p53 (HT dataset)",
     "type": {
       "primary": "Supplementaries",
@@ -13970,9 +11432,6 @@
     "collections": [
       "CMS-Trigger-Information"
     ],
-    "collision_information": {
-      "energy": "7TeV"
-    },
     "date_created": [
       "2011"
     ],
@@ -13980,9 +11439,6 @@
     "experiment": "CMS",
     "publisher": "CERN Open Data Portal",
     "recid": "2423",
-    "run_period": [
-      "Run2011A"
-    ],
     "title": "High-Level Trigger path information HLT_HT200_AlphaT0p55 (HT dataset)",
     "type": {
       "primary": "Supplementaries",
@@ -14003,9 +11459,6 @@
     "collections": [
       "CMS-Trigger-Information"
     ],
-    "collision_information": {
-      "energy": "7TeV"
-    },
     "date_created": [
       "2011"
     ],
@@ -14013,9 +11466,6 @@
     "experiment": "CMS",
     "publisher": "CERN Open Data Portal",
     "recid": "2424",
-    "run_period": [
-      "Run2011A"
-    ],
     "title": "High-Level Trigger path information HLT_HT200_AlphaT0p60 (HT dataset)",
     "type": {
       "primary": "Supplementaries",
@@ -14036,9 +11486,6 @@
     "collections": [
       "CMS-Trigger-Information"
     ],
-    "collision_information": {
-      "energy": "7TeV"
-    },
     "date_created": [
       "2011"
     ],
@@ -14046,9 +11493,6 @@
     "experiment": "CMS",
     "publisher": "CERN Open Data Portal",
     "recid": "2425",
-    "run_period": [
-      "Run2011A"
-    ],
     "title": "High-Level Trigger path information HLT_HT200_AlphaT0p65 (HT dataset)",
     "type": {
       "primary": "Supplementaries",
@@ -14069,9 +11513,6 @@
     "collections": [
       "CMS-Trigger-Information"
     ],
-    "collision_information": {
-      "energy": "7TeV"
-    },
     "date_created": [
       "2011"
     ],
@@ -14079,9 +11520,6 @@
     "experiment": "CMS",
     "publisher": "CERN Open Data Portal",
     "recid": "2426",
-    "run_period": [
-      "Run2011A"
-    ],
     "title": "High-Level Trigger path information HLT_HT200_DoubleEle5_CaloIdVL_MassJPsi (ElectronHad dataset)",
     "type": {
       "primary": "Supplementaries",
@@ -14102,9 +11540,6 @@
     "collections": [
       "CMS-Trigger-Information"
     ],
-    "collision_information": {
-      "energy": "7TeV"
-    },
     "date_created": [
       "2011"
     ],
@@ -14112,9 +11547,6 @@
     "experiment": "CMS",
     "publisher": "CERN Open Data Portal",
     "recid": "2427",
-    "run_period": [
-      "Run2011A"
-    ],
     "title": "High-Level Trigger path information HLT_HT200_DoubleLooseIsoPFTau10_Trk3_PFMHT35 (TauPlusX dataset)",
     "type": {
       "primary": "Supplementaries",
@@ -14135,9 +11567,6 @@
     "collections": [
       "CMS-Trigger-Information"
     ],
-    "collision_information": {
-      "energy": "7TeV"
-    },
     "date_created": [
       "2011"
     ],
@@ -14145,9 +11574,6 @@
     "experiment": "CMS",
     "publisher": "CERN Open Data Portal",
     "recid": "2428",
-    "run_period": [
-      "Run2011A"
-    ],
     "title": "High-Level Trigger path information HLT_HT200_Ele5_CaloIdVL_TrkIdVL_CaloIsoVL_TrkIsoVL_PFMHT35 (ElectronHad dataset)",
     "type": {
       "primary": "Supplementaries",
@@ -14168,9 +11594,6 @@
     "collections": [
       "CMS-Trigger-Information"
     ],
-    "collision_information": {
-      "energy": "7TeV"
-    },
     "date_created": [
       "2011"
     ],
@@ -14178,9 +11601,6 @@
     "experiment": "CMS",
     "publisher": "CERN Open Data Portal",
     "recid": "2429",
-    "run_period": [
-      "Run2011A"
-    ],
     "title": "High-Level Trigger path information HLT_HT200_Mu5_PFMHT35 (MuHad dataset)",
     "type": {
       "primary": "Supplementaries",
@@ -14201,9 +11621,6 @@
     "collections": [
       "CMS-Trigger-Information"
     ],
-    "collision_information": {
-      "energy": "7TeV"
-    },
     "date_created": [
       "2011"
     ],
@@ -14211,9 +11628,6 @@
     "experiment": "CMS",
     "publisher": "CERN Open Data Portal",
     "recid": "2430",
-    "run_period": [
-      "Run2011A"
-    ],
     "title": "High-Level Trigger path information HLT_HT240 (HT dataset)",
     "type": {
       "primary": "Supplementaries",
@@ -14234,9 +11648,6 @@
     "collections": [
       "CMS-Trigger-Information"
     ],
-    "collision_information": {
-      "energy": "7TeV"
-    },
     "date_created": [
       "2011"
     ],
@@ -14244,9 +11655,6 @@
     "experiment": "CMS",
     "publisher": "CERN Open Data Portal",
     "recid": "2431",
-    "run_period": [
-      "Run2011A"
-    ],
     "title": "High-Level Trigger path information HLT_HT250 (HT dataset)",
     "type": {
       "primary": "Supplementaries",
@@ -14267,9 +11675,6 @@
     "collections": [
       "CMS-Trigger-Information"
     ],
-    "collision_information": {
-      "energy": "7TeV"
-    },
     "date_created": [
       "2011"
     ],
@@ -14277,9 +11682,6 @@
     "experiment": "CMS",
     "publisher": "CERN Open Data Portal",
     "recid": "2432",
-    "run_period": [
-      "Run2011A"
-    ],
     "title": "High-Level Trigger path information HLT_HT250_AlphaT0p53 (HT dataset)",
     "type": {
       "primary": "Supplementaries",
@@ -14300,9 +11702,6 @@
     "collections": [
       "CMS-Trigger-Information"
     ],
-    "collision_information": {
-      "energy": "7TeV"
-    },
     "date_created": [
       "2011"
     ],
@@ -14310,9 +11709,6 @@
     "experiment": "CMS",
     "publisher": "CERN Open Data Portal",
     "recid": "2433",
-    "run_period": [
-      "Run2011A"
-    ],
     "title": "High-Level Trigger path information HLT_HT250_AlphaT0p54 (HT dataset)",
     "type": {
       "primary": "Supplementaries",
@@ -14333,9 +11729,6 @@
     "collections": [
       "CMS-Trigger-Information"
     ],
-    "collision_information": {
-      "energy": "7TeV"
-    },
     "date_created": [
       "2011"
     ],
@@ -14343,9 +11736,6 @@
     "experiment": "CMS",
     "publisher": "CERN Open Data Portal",
     "recid": "2434",
-    "run_period": [
-      "Run2011A"
-    ],
     "title": "High-Level Trigger path information HLT_HT250_AlphaT0p55 (HT dataset)",
     "type": {
       "primary": "Supplementaries",
@@ -14366,9 +11756,6 @@
     "collections": [
       "CMS-Trigger-Information"
     ],
-    "collision_information": {
-      "energy": "7TeV"
-    },
     "date_created": [
       "2011"
     ],
@@ -14376,9 +11763,6 @@
     "experiment": "CMS",
     "publisher": "CERN Open Data Portal",
     "recid": "2435",
-    "run_period": [
-      "Run2011A"
-    ],
     "title": "High-Level Trigger path information HLT_HT250_AlphaT0p58 (HT dataset)",
     "type": {
       "primary": "Supplementaries",
@@ -14399,9 +11783,6 @@
     "collections": [
       "CMS-Trigger-Information"
     ],
-    "collision_information": {
-      "energy": "7TeV"
-    },
     "date_created": [
       "2011"
     ],
@@ -14409,9 +11790,6 @@
     "experiment": "CMS",
     "publisher": "CERN Open Data Portal",
     "recid": "2436",
-    "run_period": [
-      "Run2011A"
-    ],
     "title": "High-Level Trigger path information HLT_HT250_AlphaT0p60 (HT dataset)",
     "type": {
       "primary": "Supplementaries",
@@ -14432,9 +11810,6 @@
     "collections": [
       "CMS-Trigger-Information"
     ],
-    "collision_information": {
-      "energy": "7TeV"
-    },
     "date_created": [
       "2011"
     ],
@@ -14442,9 +11817,6 @@
     "experiment": "CMS",
     "publisher": "CERN Open Data Portal",
     "recid": "2437",
-    "run_period": [
-      "Run2011A"
-    ],
     "title": "High-Level Trigger path information HLT_HT250_AlphaT0p62 (HT dataset)",
     "type": {
       "primary": "Supplementaries",
@@ -14465,9 +11837,6 @@
     "collections": [
       "CMS-Trigger-Information"
     ],
-    "collision_information": {
-      "energy": "7TeV"
-    },
     "date_created": [
       "2011"
     ],
@@ -14475,9 +11844,6 @@
     "experiment": "CMS",
     "publisher": "CERN Open Data Portal",
     "recid": "2438",
-    "run_period": [
-      "Run2011A"
-    ],
     "title": "High-Level Trigger path information HLT_HT250_AlphaT0p65 (HT dataset)",
     "type": {
       "primary": "Supplementaries",
@@ -14498,9 +11864,6 @@
     "collections": [
       "CMS-Trigger-Information"
     ],
-    "collision_information": {
-      "energy": "7TeV"
-    },
     "date_created": [
       "2011"
     ],
@@ -14508,9 +11871,6 @@
     "experiment": "CMS",
     "publisher": "CERN Open Data Portal",
     "recid": "2439",
-    "run_period": [
-      "Run2011A"
-    ],
     "title": "High-Level Trigger path information HLT_HT250_DoubleDisplacedJet60 (HT dataset)",
     "type": {
       "primary": "Supplementaries",
@@ -14531,9 +11891,6 @@
     "collections": [
       "CMS-Trigger-Information"
     ],
-    "collision_information": {
-      "energy": "7TeV"
-    },
     "date_created": [
       "2011"
     ],
@@ -14541,9 +11898,6 @@
     "experiment": "CMS",
     "publisher": "CERN Open Data Portal",
     "recid": "2440",
-    "run_period": [
-      "Run2011A"
-    ],
     "title": "High-Level Trigger path information HLT_HT250_DoubleDisplacedJet60_PromptTrack (HT dataset)",
     "type": {
       "primary": "Supplementaries",
@@ -14564,9 +11918,6 @@
     "collections": [
       "CMS-Trigger-Information"
     ],
-    "collision_information": {
-      "energy": "7TeV"
-    },
     "date_created": [
       "2011"
     ],
@@ -14574,9 +11925,6 @@
     "experiment": "CMS",
     "publisher": "CERN Open Data Portal",
     "recid": "2441",
-    "run_period": [
-      "Run2011A"
-    ],
     "title": "High-Level Trigger path information HLT_HT250_DoubleIsoPFTau10_Trk3_PFMHT35 (TauPlusX dataset)",
     "type": {
       "primary": "Supplementaries",
@@ -14597,9 +11945,6 @@
     "collections": [
       "CMS-Trigger-Information"
     ],
-    "collision_information": {
-      "energy": "7TeV"
-    },
     "date_created": [
       "2011"
     ],
@@ -14607,9 +11952,6 @@
     "experiment": "CMS",
     "publisher": "CERN Open Data Portal",
     "recid": "2442",
-    "run_period": [
-      "Run2011A"
-    ],
     "title": "High-Level Trigger path information HLT_HT250_DoubleLooseIsoPFTau10_Trk3_PFMHT35 (TauPlusX dataset)",
     "type": {
       "primary": "Supplementaries",
@@ -14630,9 +11972,6 @@
     "collections": [
       "CMS-Trigger-Information"
     ],
-    "collision_information": {
-      "energy": "7TeV"
-    },
     "date_created": [
       "2011"
     ],
@@ -14640,9 +11979,6 @@
     "experiment": "CMS",
     "publisher": "CERN Open Data Portal",
     "recid": "2443",
-    "run_period": [
-      "Run2011A"
-    ],
     "title": "High-Level Trigger path information HLT_HT250_Ele5_CaloIdVL_TrkIdVL_CaloIsoVL_TrkIsoVL_PFMHT35 (ElectronHad dataset)",
     "type": {
       "primary": "Supplementaries",
@@ -14663,9 +11999,6 @@
     "collections": [
       "CMS-Trigger-Information"
     ],
-    "collision_information": {
-      "energy": "7TeV"
-    },
     "date_created": [
       "2011"
     ],
@@ -14673,9 +12006,6 @@
     "experiment": "CMS",
     "publisher": "CERN Open Data Portal",
     "recid": "2444",
-    "run_period": [
-      "Run2011A"
-    ],
     "title": "High-Level Trigger path information HLT_HT250_MHT100 (HT dataset)",
     "type": {
       "primary": "Supplementaries",
@@ -14696,9 +12026,6 @@
     "collections": [
       "CMS-Trigger-Information"
     ],
-    "collision_information": {
-      "energy": "7TeV"
-    },
     "date_created": [
       "2011"
     ],
@@ -14706,9 +12033,6 @@
     "experiment": "CMS",
     "publisher": "CERN Open Data Portal",
     "recid": "2445",
-    "run_period": [
-      "Run2011A"
-    ],
     "title": "High-Level Trigger path information HLT_HT250_MHT60 (HT dataset)",
     "type": {
       "primary": "Supplementaries",
@@ -14729,9 +12053,6 @@
     "collections": [
       "CMS-Trigger-Information"
     ],
-    "collision_information": {
-      "energy": "7TeV"
-    },
     "date_created": [
       "2011"
     ],
@@ -14739,9 +12060,6 @@
     "experiment": "CMS",
     "publisher": "CERN Open Data Portal",
     "recid": "2446",
-    "run_period": [
-      "Run2011A"
-    ],
     "title": "High-Level Trigger path information HLT_HT250_MHT70 (HT dataset)",
     "type": {
       "primary": "Supplementaries",
@@ -14762,9 +12080,6 @@
     "collections": [
       "CMS-Trigger-Information"
     ],
-    "collision_information": {
-      "energy": "7TeV"
-    },
     "date_created": [
       "2011"
     ],
@@ -14772,9 +12087,6 @@
     "experiment": "CMS",
     "publisher": "CERN Open Data Portal",
     "recid": "2447",
-    "run_period": [
-      "Run2011A"
-    ],
     "title": "High-Level Trigger path information HLT_HT250_MHT80 (HT dataset)",
     "type": {
       "primary": "Supplementaries",
@@ -14795,9 +12107,6 @@
     "collections": [
       "CMS-Trigger-Information"
     ],
-    "collision_information": {
-      "energy": "7TeV"
-    },
     "date_created": [
       "2011"
     ],
@@ -14805,9 +12114,6 @@
     "experiment": "CMS",
     "publisher": "CERN Open Data Portal",
     "recid": "2448",
-    "run_period": [
-      "Run2011A"
-    ],
     "title": "High-Level Trigger path information HLT_HT250_MHT90 (HT dataset)",
     "type": {
       "primary": "Supplementaries",
@@ -14828,9 +12134,6 @@
     "collections": [
       "CMS-Trigger-Information"
     ],
-    "collision_information": {
-      "energy": "7TeV"
-    },
     "date_created": [
       "2011"
     ],
@@ -14838,9 +12141,6 @@
     "experiment": "CMS",
     "publisher": "CERN Open Data Portal",
     "recid": "2449",
-    "run_period": [
-      "Run2011A"
-    ],
     "title": "High-Level Trigger path information HLT_HT250_Mu15_PFMHT20 (MuHad dataset)",
     "type": {
       "primary": "Supplementaries",
@@ -14861,9 +12161,6 @@
     "collections": [
       "CMS-Trigger-Information"
     ],
-    "collision_information": {
-      "energy": "7TeV"
-    },
     "date_created": [
       "2011"
     ],
@@ -14871,9 +12168,6 @@
     "experiment": "CMS",
     "publisher": "CERN Open Data Portal",
     "recid": "2450",
-    "run_period": [
-      "Run2011A"
-    ],
     "title": "High-Level Trigger path information HLT_HT250_Mu15_PFMHT40 (MuHad dataset)",
     "type": {
       "primary": "Supplementaries",
@@ -14894,9 +12188,6 @@
     "collections": [
       "CMS-Trigger-Information"
     ],
-    "collision_information": {
-      "energy": "7TeV"
-    },
     "date_created": [
       "2011"
     ],
@@ -14904,9 +12195,6 @@
     "experiment": "CMS",
     "publisher": "CERN Open Data Portal",
     "recid": "2451",
-    "run_period": [
-      "Run2011A"
-    ],
     "title": "High-Level Trigger path information HLT_HT250_Mu5_PFMHT35 (MuHad dataset)",
     "type": {
       "primary": "Supplementaries",
@@ -14927,9 +12215,6 @@
     "collections": [
       "CMS-Trigger-Information"
     ],
-    "collision_information": {
-      "energy": "7TeV"
-    },
     "date_created": [
       "2011"
     ],
@@ -14937,9 +12222,6 @@
     "experiment": "CMS",
     "publisher": "CERN Open Data Portal",
     "recid": "2452",
-    "run_period": [
-      "Run2011A"
-    ],
     "title": "High-Level Trigger path information HLT_HT260 (HT dataset)",
     "type": {
       "primary": "Supplementaries",
@@ -14960,9 +12242,6 @@
     "collections": [
       "CMS-Trigger-Information"
     ],
-    "collision_information": {
-      "energy": "7TeV"
-    },
     "date_created": [
       "2011"
     ],
@@ -14970,9 +12249,6 @@
     "experiment": "CMS",
     "publisher": "CERN Open Data Portal",
     "recid": "2453",
-    "run_period": [
-      "Run2011A"
-    ],
     "title": "High-Level Trigger path information HLT_HT260_MHT60 (HT dataset)",
     "type": {
       "primary": "Supplementaries",
@@ -14993,9 +12269,6 @@
     "collections": [
       "CMS-Trigger-Information"
     ],
-    "collision_information": {
-      "energy": "7TeV"
-    },
     "date_created": [
       "2011"
     ],
@@ -15003,9 +12276,6 @@
     "experiment": "CMS",
     "publisher": "CERN Open Data Portal",
     "recid": "2454",
-    "run_period": [
-      "Run2011A"
-    ],
     "title": "High-Level Trigger path information HLT_HT300 (HT dataset)",
     "type": {
       "primary": "Supplementaries",
@@ -15026,9 +12296,6 @@
     "collections": [
       "CMS-Trigger-Information"
     ],
-    "collision_information": {
-      "energy": "7TeV"
-    },
     "date_created": [
       "2011"
     ],
@@ -15036,9 +12303,6 @@
     "experiment": "CMS",
     "publisher": "CERN Open Data Portal",
     "recid": "2455",
-    "run_period": [
-      "Run2011A"
-    ],
     "title": "High-Level Trigger path information HLT_HT300_AlphaT0p52 (HT dataset)",
     "type": {
       "primary": "Supplementaries",
@@ -15059,9 +12323,6 @@
     "collections": [
       "CMS-Trigger-Information"
     ],
-    "collision_information": {
-      "energy": "7TeV"
-    },
     "date_created": [
       "2011"
     ],
@@ -15069,9 +12330,6 @@
     "experiment": "CMS",
     "publisher": "CERN Open Data Portal",
     "recid": "2456",
-    "run_period": [
-      "Run2011A"
-    ],
     "title": "High-Level Trigger path information HLT_HT300_AlphaT0p53 (HT dataset)",
     "type": {
       "primary": "Supplementaries",
@@ -15092,9 +12350,6 @@
     "collections": [
       "CMS-Trigger-Information"
     ],
-    "collision_information": {
-      "energy": "7TeV"
-    },
     "date_created": [
       "2011"
     ],
@@ -15102,9 +12357,6 @@
     "experiment": "CMS",
     "publisher": "CERN Open Data Portal",
     "recid": "2457",
-    "run_period": [
-      "Run2011A"
-    ],
     "title": "High-Level Trigger path information HLT_HT300_AlphaT0p54 (HT dataset)",
     "type": {
       "primary": "Supplementaries",
@@ -15125,9 +12377,6 @@
     "collections": [
       "CMS-Trigger-Information"
     ],
-    "collision_information": {
-      "energy": "7TeV"
-    },
     "date_created": [
       "2011"
     ],
@@ -15135,9 +12384,6 @@
     "experiment": "CMS",
     "publisher": "CERN Open Data Portal",
     "recid": "2458",
-    "run_period": [
-      "Run2011A"
-    ],
     "title": "High-Level Trigger path information HLT_HT300_AlphaT0p55 (HT dataset)",
     "type": {
       "primary": "Supplementaries",
@@ -15158,9 +12404,6 @@
     "collections": [
       "CMS-Trigger-Information"
     ],
-    "collision_information": {
-      "energy": "7TeV"
-    },
     "date_created": [
       "2011"
     ],
@@ -15168,9 +12411,6 @@
     "experiment": "CMS",
     "publisher": "CERN Open Data Portal",
     "recid": "2459",
-    "run_period": [
-      "Run2011A"
-    ],
     "title": "High-Level Trigger path information HLT_HT300_AlphaT0p60 (HT dataset)",
     "type": {
       "primary": "Supplementaries",
@@ -15191,9 +12431,6 @@
     "collections": [
       "CMS-Trigger-Information"
     ],
-    "collision_information": {
-      "energy": "7TeV"
-    },
     "date_created": [
       "2011"
     ],
@@ -15201,9 +12438,6 @@
     "experiment": "CMS",
     "publisher": "CERN Open Data Portal",
     "recid": "2460",
-    "run_period": [
-      "Run2011A"
-    ],
     "title": "High-Level Trigger path information HLT_HT300_CentralJet30_BTagIP (HT dataset)",
     "type": {
       "primary": "Supplementaries",
@@ -15224,9 +12458,6 @@
     "collections": [
       "CMS-Trigger-Information"
     ],
-    "collision_information": {
-      "energy": "7TeV"
-    },
     "date_created": [
       "2011"
     ],
@@ -15234,9 +12465,6 @@
     "experiment": "CMS",
     "publisher": "CERN Open Data Portal",
     "recid": "2461",
-    "run_period": [
-      "Run2011A"
-    ],
     "title": "High-Level Trigger path information HLT_HT300_CentralJet30_BTagIP_PFMHT55 (HT dataset)",
     "type": {
       "primary": "Supplementaries",
@@ -15257,9 +12485,6 @@
     "collections": [
       "CMS-Trigger-Information"
     ],
-    "collision_information": {
-      "energy": "7TeV"
-    },
     "date_created": [
       "2011"
     ],
@@ -15267,9 +12492,6 @@
     "experiment": "CMS",
     "publisher": "CERN Open Data Portal",
     "recid": "2462",
-    "run_period": [
-      "Run2011A"
-    ],
     "title": "High-Level Trigger path information HLT_HT300_CentralJet30_BTagIP_PFMHT65 (HT dataset)",
     "type": {
       "primary": "Supplementaries",
@@ -15290,9 +12512,6 @@
     "collections": [
       "CMS-Trigger-Information"
     ],
-    "collision_information": {
-      "energy": "7TeV"
-    },
     "date_created": [
       "2011"
     ],
@@ -15300,9 +12519,6 @@
     "experiment": "CMS",
     "publisher": "CERN Open Data Portal",
     "recid": "2463",
-    "run_period": [
-      "Run2011A"
-    ],
     "title": "High-Level Trigger path information HLT_HT300_CentralJet30_BTagIP_PFMHT75 (HT dataset)",
     "type": {
       "primary": "Supplementaries",
@@ -15323,9 +12539,6 @@
     "collections": [
       "CMS-Trigger-Information"
     ],
-    "collision_information": {
-      "energy": "7TeV"
-    },
     "date_created": [
       "2011"
     ],
@@ -15333,9 +12546,6 @@
     "experiment": "CMS",
     "publisher": "CERN Open Data Portal",
     "recid": "2464",
-    "run_period": [
-      "Run2011A"
-    ],
     "title": "High-Level Trigger path information HLT_HT300_DoubleIsoPFTau10_Trk3_PFMHT40 (TauPlusX dataset)",
     "type": {
       "primary": "Supplementaries",
@@ -15356,9 +12566,6 @@
     "collections": [
       "CMS-Trigger-Information"
     ],
-    "collision_information": {
-      "energy": "7TeV"
-    },
     "date_created": [
       "2011"
     ],
@@ -15366,9 +12573,6 @@
     "experiment": "CMS",
     "publisher": "CERN Open Data Portal",
     "recid": "2465",
-    "run_period": [
-      "Run2011A"
-    ],
     "title": "High-Level Trigger path information HLT_HT300_Ele5_CaloIdVL_CaloIsoVL_TrkIdVL_TrkIsoVL_PFMHT40 (ElectronHad dataset)",
     "type": {
       "primary": "Supplementaries",
@@ -15389,9 +12593,6 @@
     "collections": [
       "CMS-Trigger-Information"
     ],
-    "collision_information": {
-      "energy": "7TeV"
-    },
     "date_created": [
       "2011"
     ],
@@ -15399,9 +12600,6 @@
     "experiment": "CMS",
     "publisher": "CERN Open Data Portal",
     "recid": "2466",
-    "run_period": [
-      "Run2011A"
-    ],
     "title": "High-Level Trigger path information HLT_HT300_Ele5_CaloIdVL_TrkIdVL_CaloIsoVL_TrkIsoVL_PFMHT40 (ElectronHad dataset)",
     "type": {
       "primary": "Supplementaries",
@@ -15422,9 +12620,6 @@
     "collections": [
       "CMS-Trigger-Information"
     ],
-    "collision_information": {
-      "energy": "7TeV"
-    },
     "date_created": [
       "2011"
     ],
@@ -15432,9 +12627,6 @@
     "experiment": "CMS",
     "publisher": "CERN Open Data Portal",
     "recid": "2467",
-    "run_period": [
-      "Run2011A"
-    ],
     "title": "High-Level Trigger path information HLT_HT300_MHT75 (HT dataset)",
     "type": {
       "primary": "Supplementaries",
@@ -15455,9 +12647,6 @@
     "collections": [
       "CMS-Trigger-Information"
     ],
-    "collision_information": {
-      "energy": "7TeV"
-    },
     "date_created": [
       "2011"
     ],
@@ -15465,9 +12654,6 @@
     "experiment": "CMS",
     "publisher": "CERN Open Data Portal",
     "recid": "2468",
-    "run_period": [
-      "Run2011A"
-    ],
     "title": "High-Level Trigger path information HLT_HT300_MHT80 (HT dataset)",
     "type": {
       "primary": "Supplementaries",
@@ -15488,9 +12674,6 @@
     "collections": [
       "CMS-Trigger-Information"
     ],
-    "collision_information": {
-      "energy": "7TeV"
-    },
     "date_created": [
       "2011"
     ],
@@ -15498,9 +12681,6 @@
     "experiment": "CMS",
     "publisher": "CERN Open Data Portal",
     "recid": "2469",
-    "run_period": [
-      "Run2011A"
-    ],
     "title": "High-Level Trigger path information HLT_HT300_MHT90 (HT dataset)",
     "type": {
       "primary": "Supplementaries",
@@ -15521,9 +12701,6 @@
     "collections": [
       "CMS-Trigger-Information"
     ],
-    "collision_information": {
-      "energy": "7TeV"
-    },
     "date_created": [
       "2011"
     ],
@@ -15531,9 +12708,6 @@
     "experiment": "CMS",
     "publisher": "CERN Open Data Portal",
     "recid": "2470",
-    "run_period": [
-      "Run2011A"
-    ],
     "title": "High-Level Trigger path information HLT_HT300_Mu15_PFMHT40 (MuHad dataset)",
     "type": {
       "primary": "Supplementaries",
@@ -15554,9 +12728,6 @@
     "collections": [
       "CMS-Trigger-Information"
     ],
-    "collision_information": {
-      "energy": "7TeV"
-    },
     "date_created": [
       "2011"
     ],
@@ -15564,9 +12735,6 @@
     "experiment": "CMS",
     "publisher": "CERN Open Data Portal",
     "recid": "2471",
-    "run_period": [
-      "Run2011A"
-    ],
     "title": "High-Level Trigger path information HLT_HT300_Mu15_PFMHT50 (MuHad dataset)",
     "type": {
       "primary": "Supplementaries",
@@ -15587,9 +12755,6 @@
     "collections": [
       "CMS-Trigger-Information"
     ],
-    "collision_information": {
-      "energy": "7TeV"
-    },
     "date_created": [
       "2011"
     ],
@@ -15597,9 +12762,6 @@
     "experiment": "CMS",
     "publisher": "CERN Open Data Portal",
     "recid": "2472",
-    "run_period": [
-      "Run2011A"
-    ],
     "title": "High-Level Trigger path information HLT_HT300_Mu5_PFMHT40 (MuHad dataset)",
     "type": {
       "primary": "Supplementaries",
@@ -15620,9 +12782,6 @@
     "collections": [
       "CMS-Trigger-Information"
     ],
-    "collision_information": {
-      "energy": "7TeV"
-    },
     "date_created": [
       "2011"
     ],
@@ -15630,9 +12789,6 @@
     "experiment": "CMS",
     "publisher": "CERN Open Data Portal",
     "recid": "2473",
-    "run_period": [
-      "Run2011A"
-    ],
     "title": "High-Level Trigger path information HLT_HT300_PFMHT55 (HT dataset)",
     "type": {
       "primary": "Supplementaries",
@@ -15653,9 +12809,6 @@
     "collections": [
       "CMS-Trigger-Information"
     ],
-    "collision_information": {
-      "energy": "7TeV"
-    },
     "date_created": [
       "2011"
     ],
@@ -15663,9 +12816,6 @@
     "experiment": "CMS",
     "publisher": "CERN Open Data Portal",
     "recid": "2474",
-    "run_period": [
-      "Run2011A"
-    ],
     "title": "High-Level Trigger path information HLT_HT300_PFMHT65 (HT dataset)",
     "type": {
       "primary": "Supplementaries",
@@ -15686,9 +12836,6 @@
     "collections": [
       "CMS-Trigger-Information"
     ],
-    "collision_information": {
-      "energy": "7TeV"
-    },
     "date_created": [
       "2011"
     ],
@@ -15696,9 +12843,6 @@
     "experiment": "CMS",
     "publisher": "CERN Open Data Portal",
     "recid": "2475",
-    "run_period": [
-      "Run2011A"
-    ],
     "title": "High-Level Trigger path information HLT_HT350 (HT dataset)",
     "type": {
       "primary": "Supplementaries",
@@ -15719,9 +12863,6 @@
     "collections": [
       "CMS-Trigger-Information"
     ],
-    "collision_information": {
-      "energy": "7TeV"
-    },
     "date_created": [
       "2011"
     ],
@@ -15729,9 +12870,6 @@
     "experiment": "CMS",
     "publisher": "CERN Open Data Portal",
     "recid": "2476",
-    "run_period": [
-      "Run2011A"
-    ],
     "title": "High-Level Trigger path information HLT_HT350_AlphaT0p51 (HT dataset)",
     "type": {
       "primary": "Supplementaries",
@@ -15752,9 +12890,6 @@
     "collections": [
       "CMS-Trigger-Information"
     ],
-    "collision_information": {
-      "energy": "7TeV"
-    },
     "date_created": [
       "2011"
     ],
@@ -15762,9 +12897,6 @@
     "experiment": "CMS",
     "publisher": "CERN Open Data Portal",
     "recid": "2477",
-    "run_period": [
-      "Run2011A"
-    ],
     "title": "High-Level Trigger path information HLT_HT350_AlphaT0p52 (HT dataset)",
     "type": {
       "primary": "Supplementaries",
@@ -15785,9 +12917,6 @@
     "collections": [
       "CMS-Trigger-Information"
     ],
-    "collision_information": {
-      "energy": "7TeV"
-    },
     "date_created": [
       "2011"
     ],
@@ -15795,9 +12924,6 @@
     "experiment": "CMS",
     "publisher": "CERN Open Data Portal",
     "recid": "2478",
-    "run_period": [
-      "Run2011A"
-    ],
     "title": "High-Level Trigger path information HLT_HT350_AlphaT0p53 (HT dataset)",
     "type": {
       "primary": "Supplementaries",
@@ -15818,9 +12944,6 @@
     "collections": [
       "CMS-Trigger-Information"
     ],
-    "collision_information": {
-      "energy": "7TeV"
-    },
     "date_created": [
       "2011"
     ],
@@ -15828,9 +12951,6 @@
     "experiment": "CMS",
     "publisher": "CERN Open Data Portal",
     "recid": "2479",
-    "run_period": [
-      "Run2011A"
-    ],
     "title": "High-Level Trigger path information HLT_HT350_DoubleIsoPFTau10_Trk3_PFMHT45 (TauPlusX dataset)",
     "type": {
       "primary": "Supplementaries",
@@ -15851,9 +12971,6 @@
     "collections": [
       "CMS-Trigger-Information"
     ],
-    "collision_information": {
-      "energy": "7TeV"
-    },
     "date_created": [
       "2011"
     ],
@@ -15861,9 +12978,6 @@
     "experiment": "CMS",
     "publisher": "CERN Open Data Portal",
     "recid": "2480",
-    "run_period": [
-      "Run2011A"
-    ],
     "title": "High-Level Trigger path information HLT_HT350_Ele30_CaloIdT_TrkIdT (ElectronHad dataset)",
     "type": {
       "primary": "Supplementaries",
@@ -15884,9 +12998,6 @@
     "collections": [
       "CMS-Trigger-Information"
     ],
-    "collision_information": {
-      "energy": "7TeV"
-    },
     "date_created": [
       "2011"
     ],
@@ -15894,9 +13005,6 @@
     "experiment": "CMS",
     "publisher": "CERN Open Data Portal",
     "recid": "2481",
-    "run_period": [
-      "Run2011A"
-    ],
     "title": "High-Level Trigger path information HLT_HT350_Ele5_CaloIdVL_CaloIsoVL_TrkIdVL_TrkIsoVL_PFMHT45 (ElectronHad dataset)",
     "type": {
       "primary": "Supplementaries",
@@ -15917,9 +13025,6 @@
     "collections": [
       "CMS-Trigger-Information"
     ],
-    "collision_information": {
-      "energy": "7TeV"
-    },
     "date_created": [
       "2011"
     ],
@@ -15927,9 +13032,6 @@
     "experiment": "CMS",
     "publisher": "CERN Open Data Portal",
     "recid": "2482",
-    "run_period": [
-      "Run2011A"
-    ],
     "title": "High-Level Trigger path information HLT_HT350_Ele5_CaloIdVL_TrkIdVL_CaloIsoVL_TrkIsoVL_PFMHT45 (ElectronHad dataset)",
     "type": {
       "primary": "Supplementaries",
@@ -15950,9 +13052,6 @@
     "collections": [
       "CMS-Trigger-Information"
     ],
-    "collision_information": {
-      "energy": "7TeV"
-    },
     "date_created": [
       "2011"
     ],
@@ -15960,9 +13059,6 @@
     "experiment": "CMS",
     "publisher": "CERN Open Data Portal",
     "recid": "2483",
-    "run_period": [
-      "Run2011A"
-    ],
     "title": "High-Level Trigger path information HLT_HT350_L1FastJet (HT dataset)",
     "type": {
       "primary": "Supplementaries",
@@ -15983,9 +13079,6 @@
     "collections": [
       "CMS-Trigger-Information"
     ],
-    "collision_information": {
-      "energy": "7TeV"
-    },
     "date_created": [
       "2011"
     ],
@@ -15993,9 +13086,6 @@
     "experiment": "CMS",
     "publisher": "CERN Open Data Portal",
     "recid": "2484",
-    "run_period": [
-      "Run2011A"
-    ],
     "title": "High-Level Trigger path information HLT_HT350_L1FastJet_MHT100 (HT dataset)",
     "type": {
       "primary": "Supplementaries",
@@ -16016,9 +13106,6 @@
     "collections": [
       "CMS-Trigger-Information"
     ],
-    "collision_information": {
-      "energy": "7TeV"
-    },
     "date_created": [
       "2011"
     ],
@@ -16026,9 +13113,6 @@
     "experiment": "CMS",
     "publisher": "CERN Open Data Portal",
     "recid": "2485",
-    "run_period": [
-      "Run2011A"
-    ],
     "title": "High-Level Trigger path information HLT_HT350_L1FastJet_MHT110 (HT dataset)",
     "type": {
       "primary": "Supplementaries",
@@ -16049,9 +13133,6 @@
     "collections": [
       "CMS-Trigger-Information"
     ],
-    "collision_information": {
-      "energy": "7TeV"
-    },
     "date_created": [
       "2011"
     ],
@@ -16059,9 +13140,6 @@
     "experiment": "CMS",
     "publisher": "CERN Open Data Portal",
     "recid": "2486",
-    "run_period": [
-      "Run2011A"
-    ],
     "title": "High-Level Trigger path information HLT_HT350_MHT100 (HT dataset)",
     "type": {
       "primary": "Supplementaries",
@@ -16082,9 +13160,6 @@
     "collections": [
       "CMS-Trigger-Information"
     ],
-    "collision_information": {
-      "energy": "7TeV"
-    },
     "date_created": [
       "2011"
     ],
@@ -16092,9 +13167,6 @@
     "experiment": "CMS",
     "publisher": "CERN Open Data Portal",
     "recid": "2487",
-    "run_period": [
-      "Run2011A"
-    ],
     "title": "High-Level Trigger path information HLT_HT350_MHT110 (HT dataset)",
     "type": {
       "primary": "Supplementaries",
@@ -16115,9 +13187,6 @@
     "collections": [
       "CMS-Trigger-Information"
     ],
-    "collision_information": {
-      "energy": "7TeV"
-    },
     "date_created": [
       "2011"
     ],
@@ -16125,9 +13194,6 @@
     "experiment": "CMS",
     "publisher": "CERN Open Data Portal",
     "recid": "2488",
-    "run_period": [
-      "Run2011A"
-    ],
     "title": "High-Level Trigger path information HLT_HT350_MHT70 (HT dataset)",
     "type": {
       "primary": "Supplementaries",
@@ -16148,9 +13214,6 @@
     "collections": [
       "CMS-Trigger-Information"
     ],
-    "collision_information": {
-      "energy": "7TeV"
-    },
     "date_created": [
       "2011"
     ],
@@ -16158,9 +13221,6 @@
     "experiment": "CMS",
     "publisher": "CERN Open Data Portal",
     "recid": "2489",
-    "run_period": [
-      "Run2011A"
-    ],
     "title": "High-Level Trigger path information HLT_HT350_MHT80 (HT dataset)",
     "type": {
       "primary": "Supplementaries",
@@ -16181,9 +13241,6 @@
     "collections": [
       "CMS-Trigger-Information"
     ],
-    "collision_information": {
-      "energy": "7TeV"
-    },
     "date_created": [
       "2011"
     ],
@@ -16191,9 +13248,6 @@
     "experiment": "CMS",
     "publisher": "CERN Open Data Portal",
     "recid": "2490",
-    "run_period": [
-      "Run2011A"
-    ],
     "title": "High-Level Trigger path information HLT_HT350_MHT90 (HT dataset)",
     "type": {
       "primary": "Supplementaries",
@@ -16214,9 +13268,6 @@
     "collections": [
       "CMS-Trigger-Information"
     ],
-    "collision_information": {
-      "energy": "7TeV"
-    },
     "date_created": [
       "2011"
     ],
@@ -16224,9 +13275,6 @@
     "experiment": "CMS",
     "publisher": "CERN Open Data Portal",
     "recid": "2491",
-    "run_period": [
-      "Run2011A"
-    ],
     "title": "High-Level Trigger path information HLT_HT350_Mu5_PFMHT45 (MuHad dataset)",
     "type": {
       "primary": "Supplementaries",
@@ -16247,9 +13295,6 @@
     "collections": [
       "CMS-Trigger-Information"
     ],
-    "collision_information": {
-      "energy": "7TeV"
-    },
     "date_created": [
       "2011"
     ],
@@ -16257,9 +13302,6 @@
     "experiment": "CMS",
     "publisher": "CERN Open Data Portal",
     "recid": "2492",
-    "run_period": [
-      "Run2011A"
-    ],
     "title": "High-Level Trigger path information HLT_HT360 (HT dataset)",
     "type": {
       "primary": "Supplementaries",
@@ -16280,9 +13322,6 @@
     "collections": [
       "CMS-Trigger-Information"
     ],
-    "collision_information": {
-      "energy": "7TeV"
-    },
     "date_created": [
       "2011"
     ],
@@ -16290,9 +13329,6 @@
     "experiment": "CMS",
     "publisher": "CERN Open Data Portal",
     "recid": "2493",
-    "run_period": [
-      "Run2011A"
-    ],
     "title": "High-Level Trigger path information HLT_HT400 (HT dataset)",
     "type": {
       "primary": "Supplementaries",
@@ -16313,9 +13349,6 @@
     "collections": [
       "CMS-Trigger-Information"
     ],
-    "collision_information": {
-      "energy": "7TeV"
-    },
     "date_created": [
       "2011"
     ],
@@ -16323,9 +13356,6 @@
     "experiment": "CMS",
     "publisher": "CERN Open Data Portal",
     "recid": "2494",
-    "run_period": [
-      "Run2011A"
-    ],
     "title": "High-Level Trigger path information HLT_HT400_AlphaT0p51 (HT dataset)",
     "type": {
       "primary": "Supplementaries",
@@ -16346,9 +13376,6 @@
     "collections": [
       "CMS-Trigger-Information"
     ],
-    "collision_information": {
-      "energy": "7TeV"
-    },
     "date_created": [
       "2011"
     ],
@@ -16356,9 +13383,6 @@
     "experiment": "CMS",
     "publisher": "CERN Open Data Portal",
     "recid": "2495",
-    "run_period": [
-      "Run2011A"
-    ],
     "title": "High-Level Trigger path information HLT_HT400_AlphaT0p52 (HT dataset)",
     "type": {
       "primary": "Supplementaries",
@@ -16379,9 +13403,6 @@
     "collections": [
       "CMS-Trigger-Information"
     ],
-    "collision_information": {
-      "energy": "7TeV"
-    },
     "date_created": [
       "2011"
     ],
@@ -16389,9 +13410,6 @@
     "experiment": "CMS",
     "publisher": "CERN Open Data Portal",
     "recid": "2496",
-    "run_period": [
-      "Run2011A"
-    ],
     "title": "High-Level Trigger path information HLT_HT400_DoubleIsoPFTau10_Trk3_PFMHT50 (TauPlusX dataset)",
     "type": {
       "primary": "Supplementaries",
@@ -16412,9 +13430,6 @@
     "collections": [
       "CMS-Trigger-Information"
     ],
-    "collision_information": {
-      "energy": "7TeV"
-    },
     "date_created": [
       "2011"
     ],
@@ -16422,9 +13437,6 @@
     "experiment": "CMS",
     "publisher": "CERN Open Data Portal",
     "recid": "2497",
-    "run_period": [
-      "Run2011A"
-    ],
     "title": "High-Level Trigger path information HLT_HT400_Ele5_CaloIdVL_CaloIsoVL_TrkIdVL_TrkIsoVL_PFMHT50 (ElectronHad dataset)",
     "type": {
       "primary": "Supplementaries",
@@ -16445,9 +13457,6 @@
     "collections": [
       "CMS-Trigger-Information"
     ],
-    "collision_information": {
-      "energy": "7TeV"
-    },
     "date_created": [
       "2011"
     ],
@@ -16455,9 +13464,6 @@
     "experiment": "CMS",
     "publisher": "CERN Open Data Portal",
     "recid": "2498",
-    "run_period": [
-      "Run2011A"
-    ],
     "title": "High-Level Trigger path information HLT_HT400_Ele60_CaloIdT_TrkIdT (ElectronHad dataset)",
     "type": {
       "primary": "Supplementaries",
@@ -16478,9 +13484,6 @@
     "collections": [
       "CMS-Trigger-Information"
     ],
-    "collision_information": {
-      "energy": "7TeV"
-    },
     "date_created": [
       "2011"
     ],
@@ -16488,9 +13491,6 @@
     "experiment": "CMS",
     "publisher": "CERN Open Data Portal",
     "recid": "2499",
-    "run_period": [
-      "Run2011A"
-    ],
     "title": "High-Level Trigger path information HLT_HT400_L1FastJet (HT dataset)",
     "type": {
       "primary": "Supplementaries",
@@ -16511,9 +13511,6 @@
     "collections": [
       "CMS-Trigger-Information"
     ],
-    "collision_information": {
-      "energy": "7TeV"
-    },
     "date_created": [
       "2011"
     ],
@@ -16521,9 +13518,6 @@
     "experiment": "CMS",
     "publisher": "CERN Open Data Portal",
     "recid": "2500",
-    "run_period": [
-      "Run2011A"
-    ],
     "title": "High-Level Trigger path information HLT_HT400_L1FastJet_MHT100 (HT dataset)",
     "type": {
       "primary": "Supplementaries",
@@ -16544,9 +13538,6 @@
     "collections": [
       "CMS-Trigger-Information"
     ],
-    "collision_information": {
-      "energy": "7TeV"
-    },
     "date_created": [
       "2011"
     ],
@@ -16554,9 +13545,6 @@
     "experiment": "CMS",
     "publisher": "CERN Open Data Portal",
     "recid": "2501",
-    "run_period": [
-      "Run2011A"
-    ],
     "title": "High-Level Trigger path information HLT_HT400_L1FastJet_MHT90 (HT dataset)",
     "type": {
       "primary": "Supplementaries",
@@ -16577,9 +13565,6 @@
     "collections": [
       "CMS-Trigger-Information"
     ],
-    "collision_information": {
-      "energy": "7TeV"
-    },
     "date_created": [
       "2011"
     ],
@@ -16587,9 +13572,6 @@
     "experiment": "CMS",
     "publisher": "CERN Open Data Portal",
     "recid": "2502",
-    "run_period": [
-      "Run2011A"
-    ],
     "title": "High-Level Trigger path information HLT_HT400_MHT100 (HT dataset)",
     "type": {
       "primary": "Supplementaries",
@@ -16610,9 +13592,6 @@
     "collections": [
       "CMS-Trigger-Information"
     ],
-    "collision_information": {
-      "energy": "7TeV"
-    },
     "date_created": [
       "2011"
     ],
@@ -16620,9 +13599,6 @@
     "experiment": "CMS",
     "publisher": "CERN Open Data Portal",
     "recid": "2503",
-    "run_period": [
-      "Run2011A"
-    ],
     "title": "High-Level Trigger path information HLT_HT400_MHT80 (HT dataset)",
     "type": {
       "primary": "Supplementaries",
@@ -16643,9 +13619,6 @@
     "collections": [
       "CMS-Trigger-Information"
     ],
-    "collision_information": {
-      "energy": "7TeV"
-    },
     "date_created": [
       "2011"
     ],
@@ -16653,9 +13626,6 @@
     "experiment": "CMS",
     "publisher": "CERN Open Data Portal",
     "recid": "2504",
-    "run_period": [
-      "Run2011A"
-    ],
     "title": "High-Level Trigger path information HLT_HT400_MHT90 (HT dataset)",
     "type": {
       "primary": "Supplementaries",
@@ -16676,9 +13646,6 @@
     "collections": [
       "CMS-Trigger-Information"
     ],
-    "collision_information": {
-      "energy": "7TeV"
-    },
     "date_created": [
       "2011"
     ],
@@ -16686,9 +13653,6 @@
     "experiment": "CMS",
     "publisher": "CERN Open Data Portal",
     "recid": "2505",
-    "run_period": [
-      "Run2011A"
-    ],
     "title": "High-Level Trigger path information HLT_HT400_Mu5_PFMHT50 (MuHad dataset)",
     "type": {
       "primary": "Supplementaries",
@@ -16709,9 +13673,6 @@
     "collections": [
       "CMS-Trigger-Information"
     ],
-    "collision_information": {
-      "energy": "7TeV"
-    },
     "date_created": [
       "2011"
     ],
@@ -16719,9 +13680,6 @@
     "experiment": "CMS",
     "publisher": "CERN Open Data Portal",
     "recid": "2506",
-    "run_period": [
-      "Run2011A"
-    ],
     "title": "High-Level Trigger path information HLT_HT440 (HT dataset)",
     "type": {
       "primary": "Supplementaries",
@@ -16742,9 +13700,6 @@
     "collections": [
       "CMS-Trigger-Information"
     ],
-    "collision_information": {
-      "energy": "7TeV"
-    },
     "date_created": [
       "2011"
     ],
@@ -16752,9 +13707,6 @@
     "experiment": "CMS",
     "publisher": "CERN Open Data Portal",
     "recid": "2507",
-    "run_period": [
-      "Run2011A"
-    ],
     "title": "High-Level Trigger path information HLT_HT450 (HT dataset)",
     "type": {
       "primary": "Supplementaries",
@@ -16775,9 +13727,6 @@
     "collections": [
       "CMS-Trigger-Information"
     ],
-    "collision_information": {
-      "energy": "7TeV"
-    },
     "date_created": [
       "2011"
     ],
@@ -16785,9 +13734,6 @@
     "experiment": "CMS",
     "publisher": "CERN Open Data Portal",
     "recid": "2508",
-    "run_period": [
-      "Run2011A"
-    ],
     "title": "High-Level Trigger path information HLT_HT450_AlphaT0p51 (HT dataset)",
     "type": {
       "primary": "Supplementaries",
@@ -16808,9 +13754,6 @@
     "collections": [
       "CMS-Trigger-Information"
     ],
-    "collision_information": {
-      "energy": "7TeV"
-    },
     "date_created": [
       "2011"
     ],
@@ -16818,9 +13761,6 @@
     "experiment": "CMS",
     "publisher": "CERN Open Data Portal",
     "recid": "2509",
-    "run_period": [
-      "Run2011A"
-    ],
     "title": "High-Level Trigger path information HLT_HT450_AlphaT0p52 (HT dataset)",
     "type": {
       "primary": "Supplementaries",
@@ -16841,9 +13781,6 @@
     "collections": [
       "CMS-Trigger-Information"
     ],
-    "collision_information": {
-      "energy": "7TeV"
-    },
     "date_created": [
       "2011"
     ],
@@ -16851,9 +13788,6 @@
     "experiment": "CMS",
     "publisher": "CERN Open Data Portal",
     "recid": "2510",
-    "run_period": [
-      "Run2011A"
-    ],
     "title": "High-Level Trigger path information HLT_HT450_Ele60_CaloIdT_TrkIdT (ElectronHad dataset)",
     "type": {
       "primary": "Supplementaries",
@@ -16874,9 +13808,6 @@
     "collections": [
       "CMS-Trigger-Information"
     ],
-    "collision_information": {
-      "energy": "7TeV"
-    },
     "date_created": [
       "2011"
     ],
@@ -16884,9 +13815,6 @@
     "experiment": "CMS",
     "publisher": "CERN Open Data Portal",
     "recid": "2511",
-    "run_period": [
-      "Run2011A"
-    ],
     "title": "High-Level Trigger path information HLT_HT500 (HT dataset)",
     "type": {
       "primary": "Supplementaries",
@@ -16907,9 +13835,6 @@
     "collections": [
       "CMS-Trigger-Information"
     ],
-    "collision_information": {
-      "energy": "7TeV"
-    },
     "date_created": [
       "2011"
     ],
@@ -16917,9 +13842,6 @@
     "experiment": "CMS",
     "publisher": "CERN Open Data Portal",
     "recid": "2512",
-    "run_period": [
-      "Run2011A"
-    ],
     "title": "High-Level Trigger path information HLT_HT500_JetPt60_DPhi2p94 (HT dataset)",
     "type": {
       "primary": "Supplementaries",
@@ -16940,9 +13862,6 @@
     "collections": [
       "CMS-Trigger-Information"
     ],
-    "collision_information": {
-      "energy": "7TeV"
-    },
     "date_created": [
       "2011"
     ],
@@ -16950,9 +13869,6 @@
     "experiment": "CMS",
     "publisher": "CERN Open Data Portal",
     "recid": "2513",
-    "run_period": [
-      "Run2011A"
-    ],
     "title": "High-Level Trigger path information HLT_HT520 (HT dataset)",
     "type": {
       "primary": "Supplementaries",
@@ -16973,9 +13889,6 @@
     "collections": [
       "CMS-Trigger-Information"
     ],
-    "collision_information": {
-      "energy": "7TeV"
-    },
     "date_created": [
       "2011"
     ],
@@ -16983,9 +13896,6 @@
     "experiment": "CMS",
     "publisher": "CERN Open Data Portal",
     "recid": "2514",
-    "run_period": [
-      "Run2011A"
-    ],
     "title": "High-Level Trigger path information HLT_HT550 (HT dataset)",
     "type": {
       "primary": "Supplementaries",
@@ -17006,9 +13916,6 @@
     "collections": [
       "CMS-Trigger-Information"
     ],
-    "collision_information": {
-      "energy": "7TeV"
-    },
     "date_created": [
       "2011"
     ],
@@ -17016,9 +13923,6 @@
     "experiment": "CMS",
     "publisher": "CERN Open Data Portal",
     "recid": "2515",
-    "run_period": [
-      "Run2011A"
-    ],
     "title": "High-Level Trigger path information HLT_HT550_JetPt60_DPhi2p94 (HT dataset)",
     "type": {
       "primary": "Supplementaries",
@@ -17039,9 +13943,6 @@
     "collections": [
       "CMS-Trigger-Information"
     ],
-    "collision_information": {
-      "energy": "7TeV"
-    },
     "date_created": [
       "2011"
     ],
@@ -17049,9 +13950,6 @@
     "experiment": "CMS",
     "publisher": "CERN Open Data Portal",
     "recid": "2516",
-    "run_period": [
-      "Run2011A"
-    ],
     "title": "High-Level Trigger path information HLT_HT600 (HT dataset)",
     "type": {
       "primary": "Supplementaries",
@@ -17072,9 +13970,6 @@
     "collections": [
       "CMS-Trigger-Information"
     ],
-    "collision_information": {
-      "energy": "7TeV"
-    },
     "date_created": [
       "2011"
     ],
@@ -17082,9 +13977,6 @@
     "experiment": "CMS",
     "publisher": "CERN Open Data Portal",
     "recid": "2517",
-    "run_period": [
-      "Run2011A"
-    ],
     "title": "High-Level Trigger path information HLT_HT600_JetPt60_DPhi2p94 (HT dataset)",
     "type": {
       "primary": "Supplementaries",
@@ -17105,9 +13997,6 @@
     "collections": [
       "CMS-Trigger-Information"
     ],
-    "collision_information": {
-      "energy": "7TeV"
-    },
     "date_created": [
       "2011"
     ],
@@ -17115,9 +14004,6 @@
     "experiment": "CMS",
     "publisher": "CERN Open Data Portal",
     "recid": "2518",
-    "run_period": [
-      "Run2011A"
-    ],
     "title": "High-Level Trigger path information HLT_HT650 (HT dataset)",
     "type": {
       "primary": "Supplementaries",
@@ -17138,9 +14024,6 @@
     "collections": [
       "CMS-Trigger-Information"
     ],
-    "collision_information": {
-      "energy": "7TeV"
-    },
     "date_created": [
       "2011"
     ],
@@ -17148,9 +14031,6 @@
     "experiment": "CMS",
     "publisher": "CERN Open Data Portal",
     "recid": "2519",
-    "run_period": [
-      "Run2011A"
-    ],
     "title": "High-Level Trigger path information HLT_HT700 (HT dataset)",
     "type": {
       "primary": "Supplementaries",
@@ -17171,9 +14051,6 @@
     "collections": [
       "CMS-Trigger-Information"
     ],
-    "collision_information": {
-      "energy": "7TeV"
-    },
     "date_created": [
       "2011"
     ],
@@ -17181,9 +14058,6 @@
     "experiment": "CMS",
     "publisher": "CERN Open Data Portal",
     "recid": "2520",
-    "run_period": [
-      "Run2011A"
-    ],
     "title": "High-Level Trigger path information HLT_HT750 (HT dataset)",
     "type": {
       "primary": "Supplementaries",
@@ -17204,9 +14078,6 @@
     "collections": [
       "CMS-Trigger-Information"
     ],
-    "collision_information": {
-      "energy": "7TeV"
-    },
     "date_created": [
       "2011"
     ],
@@ -17214,9 +14085,6 @@
     "experiment": "CMS",
     "publisher": "CERN Open Data Portal",
     "recid": "2521",
-    "run_period": [
-      "Run2011A"
-    ],
     "title": "High-Level Trigger path information HLT_HT750_L1FastJet (HT dataset)",
     "type": {
       "primary": "Supplementaries",
@@ -17237,9 +14105,6 @@
     "collections": [
       "CMS-Trigger-Information"
     ],
-    "collision_information": {
-      "energy": "7TeV"
-    },
     "date_created": [
       "2011"
     ],
@@ -17247,9 +14112,6 @@
     "experiment": "CMS",
     "publisher": "CERN Open Data Portal",
     "recid": "2522",
-    "run_period": [
-      "Run2011A"
-    ],
     "title": "High-Level Trigger path information HLT_HcalCalibration",
     "type": {
       "primary": "Supplementaries",
@@ -17270,9 +14132,6 @@
     "collections": [
       "CMS-Trigger-Information"
     ],
-    "collision_information": {
-      "energy": "7TeV"
-    },
     "date_created": [
       "2011"
     ],
@@ -17280,9 +14139,6 @@
     "experiment": "CMS",
     "publisher": "CERN Open Data Portal",
     "recid": "2523",
-    "run_period": [
-      "Run2011A"
-    ],
     "title": "High-Level Trigger path information HLT_HcalNZS (HcalNZS dataset)",
     "type": {
       "primary": "Supplementaries",
@@ -17303,9 +14159,6 @@
     "collections": [
       "CMS-Trigger-Information"
     ],
-    "collision_information": {
-      "energy": "7TeV"
-    },
     "date_created": [
       "2011"
     ],
@@ -17313,9 +14166,6 @@
     "experiment": "CMS",
     "publisher": "CERN Open Data Portal",
     "recid": "2524",
-    "run_period": [
-      "Run2011A"
-    ],
     "title": "High-Level Trigger path information HLT_HcalPhiSym (HcalNZS dataset)",
     "type": {
       "primary": "Supplementaries",
@@ -17336,9 +14186,6 @@
     "collections": [
       "CMS-Trigger-Information"
     ],
-    "collision_information": {
-      "energy": "7TeV"
-    },
     "date_created": [
       "2011"
     ],
@@ -17346,9 +14193,6 @@
     "experiment": "CMS",
     "publisher": "CERN Open Data Portal",
     "recid": "2525",
-    "run_period": [
-      "Run2011A"
-    ],
     "title": "High-Level Trigger path information HLT_IsoMu12 (SingleMu dataset)",
     "type": {
       "primary": "Supplementaries",
@@ -17369,9 +14213,6 @@
     "collections": [
       "CMS-Trigger-Information"
     ],
-    "collision_information": {
-      "energy": "7TeV"
-    },
     "date_created": [
       "2011"
     ],
@@ -17379,9 +14220,6 @@
     "experiment": "CMS",
     "publisher": "CERN Open Data Portal",
     "recid": "2526",
-    "run_period": [
-      "Run2011A"
-    ],
     "title": "High-Level Trigger path information HLT_IsoMu12_LooseIsoPFTau10 (TauPlusX dataset)",
     "type": {
       "primary": "Supplementaries",
@@ -17402,9 +14240,6 @@
     "collections": [
       "CMS-Trigger-Information"
     ],
-    "collision_information": {
-      "energy": "7TeV"
-    },
     "date_created": [
       "2011"
     ],
@@ -17412,9 +14247,6 @@
     "experiment": "CMS",
     "publisher": "CERN Open Data Portal",
     "recid": "2527",
-    "run_period": [
-      "Run2011A"
-    ],
     "title": "High-Level Trigger path information HLT_IsoMu15 (SingleMu dataset)",
     "type": {
       "primary": "Supplementaries",
@@ -17435,9 +14267,6 @@
     "collections": [
       "CMS-Trigger-Information"
     ],
-    "collision_information": {
-      "energy": "7TeV"
-    },
     "date_created": [
       "2011"
     ],
@@ -17445,9 +14274,6 @@
     "experiment": "CMS",
     "publisher": "CERN Open Data Portal",
     "recid": "2528",
-    "run_period": [
-      "Run2011A"
-    ],
     "title": "High-Level Trigger path information HLT_IsoMu15_L1ETM20 (MET dataset)",
     "type": {
       "primary": "Supplementaries",
@@ -17468,9 +14294,6 @@
     "collections": [
       "CMS-Trigger-Information"
     ],
-    "collision_information": {
-      "energy": "7TeV"
-    },
     "date_created": [
       "2011"
     ],
@@ -17478,9 +14301,6 @@
     "experiment": "CMS",
     "publisher": "CERN Open Data Portal",
     "recid": "2529",
-    "run_period": [
-      "Run2011A"
-    ],
     "title": "High-Level Trigger path information HLT_IsoMu15_LooseIsoPFTau15 (TauPlusX dataset)",
     "type": {
       "primary": "Supplementaries",
@@ -17501,9 +14321,6 @@
     "collections": [
       "CMS-Trigger-Information"
     ],
-    "collision_information": {
-      "energy": "7TeV"
-    },
     "date_created": [
       "2011"
     ],
@@ -17511,9 +14328,6 @@
     "experiment": "CMS",
     "publisher": "CERN Open Data Portal",
     "recid": "2530",
-    "run_period": [
-      "Run2011A"
-    ],
     "title": "High-Level Trigger path information HLT_IsoMu15_LooseIsoPFTau20 (TauPlusX dataset)",
     "type": {
       "primary": "Supplementaries",
@@ -17534,9 +14348,6 @@
     "collections": [
       "CMS-Trigger-Information"
     ],
-    "collision_information": {
-      "energy": "7TeV"
-    },
     "date_created": [
       "2011"
     ],
@@ -17544,9 +14355,6 @@
     "experiment": "CMS",
     "publisher": "CERN Open Data Portal",
     "recid": "2531",
-    "run_period": [
-      "Run2011A"
-    ],
     "title": "High-Level Trigger path information HLT_IsoMu15_TightIsoPFTau20 (TauPlusX dataset)",
     "type": {
       "primary": "Supplementaries",
@@ -17567,9 +14375,6 @@
     "collections": [
       "CMS-Trigger-Information"
     ],
-    "collision_information": {
-      "energy": "7TeV"
-    },
     "date_created": [
       "2011"
     ],
@@ -17577,9 +14382,6 @@
     "experiment": "CMS",
     "publisher": "CERN Open Data Portal",
     "recid": "2532",
-    "run_period": [
-      "Run2011A"
-    ],
     "title": "High-Level Trigger path information HLT_IsoMu15_eta2p1 (SingleMu dataset)",
     "type": {
       "primary": "Supplementaries",
@@ -17600,9 +14402,6 @@
     "collections": [
       "CMS-Trigger-Information"
     ],
-    "collision_information": {
-      "energy": "7TeV"
-    },
     "date_created": [
       "2011"
     ],
@@ -17610,9 +14409,6 @@
     "experiment": "CMS",
     "publisher": "CERN Open Data Portal",
     "recid": "2533",
-    "run_period": [
-      "Run2011A"
-    ],
     "title": "High-Level Trigger path information HLT_IsoMu15_eta2p1_LooseIsoPFTau20 (TauPlusX dataset)",
     "type": {
       "primary": "Supplementaries",
@@ -17633,9 +14429,6 @@
     "collections": [
       "CMS-Trigger-Information"
     ],
-    "collision_information": {
-      "energy": "7TeV"
-    },
     "date_created": [
       "2011"
     ],
@@ -17643,9 +14436,6 @@
     "experiment": "CMS",
     "publisher": "CERN Open Data Portal",
     "recid": "2534",
-    "run_period": [
-      "Run2011A"
-    ],
     "title": "High-Level Trigger path information HLT_IsoMu15_eta2p1_MediumIsoPFTau20 (TauPlusX dataset)",
     "type": {
       "primary": "Supplementaries",
@@ -17666,9 +14456,6 @@
     "collections": [
       "CMS-Trigger-Information"
     ],
-    "collision_information": {
-      "energy": "7TeV"
-    },
     "date_created": [
       "2011"
     ],
@@ -17676,9 +14463,6 @@
     "experiment": "CMS",
     "publisher": "CERN Open Data Portal",
     "recid": "2535",
-    "run_period": [
-      "Run2011A"
-    ],
     "title": "High-Level Trigger path information HLT_IsoMu15_eta2p1_TightIsoPFTau20 (TauPlusX dataset)",
     "type": {
       "primary": "Supplementaries",
@@ -17699,9 +14483,6 @@
     "collections": [
       "CMS-Trigger-Information"
     ],
-    "collision_information": {
-      "energy": "7TeV"
-    },
     "date_created": [
       "2011"
     ],
@@ -17709,9 +14490,6 @@
     "experiment": "CMS",
     "publisher": "CERN Open Data Portal",
     "recid": "2536",
-    "run_period": [
-      "Run2011A"
-    ],
     "title": "High-Level Trigger path information HLT_IsoMu17 (SingleMu dataset)",
     "type": {
       "primary": "Supplementaries",
@@ -17732,9 +14510,6 @@
     "collections": [
       "CMS-Trigger-Information"
     ],
-    "collision_information": {
-      "energy": "7TeV"
-    },
     "date_created": [
       "2011"
     ],
@@ -17742,9 +14517,6 @@
     "experiment": "CMS",
     "publisher": "CERN Open Data Portal",
     "recid": "2537",
-    "run_period": [
-      "Run2011A"
-    ],
     "title": "High-Level Trigger path information HLT_IsoMu17_CentralJet30 (MuHad dataset)",
     "type": {
       "primary": "Supplementaries",
@@ -17765,9 +14537,6 @@
     "collections": [
       "CMS-Trigger-Information"
     ],
-    "collision_information": {
-      "energy": "7TeV"
-    },
     "date_created": [
       "2011"
     ],
@@ -17775,9 +14544,6 @@
     "experiment": "CMS",
     "publisher": "CERN Open Data Portal",
     "recid": "2538",
-    "run_period": [
-      "Run2011A"
-    ],
     "title": "High-Level Trigger path information HLT_IsoMu17_CentralJet30_BTagIP (MuHad dataset)",
     "type": {
       "primary": "Supplementaries",
@@ -17798,9 +14564,6 @@
     "collections": [
       "CMS-Trigger-Information"
     ],
-    "collision_information": {
-      "energy": "7TeV"
-    },
     "date_created": [
       "2011"
     ],
@@ -17808,9 +14571,6 @@
     "experiment": "CMS",
     "publisher": "CERN Open Data Portal",
     "recid": "2539",
-    "run_period": [
-      "Run2011A"
-    ],
     "title": "High-Level Trigger path information HLT_IsoMu17_CentralJet40_BTagIP (MuHad dataset)",
     "type": {
       "primary": "Supplementaries",
@@ -17831,9 +14591,6 @@
     "collections": [
       "CMS-Trigger-Information"
     ],
-    "collision_information": {
-      "energy": "7TeV"
-    },
     "date_created": [
       "2011"
     ],
@@ -17841,9 +14598,6 @@
     "experiment": "CMS",
     "publisher": "CERN Open Data Portal",
     "recid": "2540",
-    "run_period": [
-      "Run2011A"
-    ],
     "title": "High-Level Trigger path information HLT_IsoMu17_DiCentralJet30 (MuHad dataset)",
     "type": {
       "primary": "Supplementaries",
@@ -17864,9 +14618,6 @@
     "collections": [
       "CMS-Trigger-Information"
     ],
-    "collision_information": {
-      "energy": "7TeV"
-    },
     "date_created": [
       "2011"
     ],
@@ -17874,9 +14625,6 @@
     "experiment": "CMS",
     "publisher": "CERN Open Data Portal",
     "recid": "2541",
-    "run_period": [
-      "Run2011A"
-    ],
     "title": "High-Level Trigger path information HLT_IsoMu17_QuadCentralJet30 (MuHad dataset)",
     "type": {
       "primary": "Supplementaries",
@@ -17897,9 +14645,6 @@
     "collections": [
       "CMS-Trigger-Information"
     ],
-    "collision_information": {
-      "energy": "7TeV"
-    },
     "date_created": [
       "2011"
     ],
@@ -17907,9 +14652,6 @@
     "experiment": "CMS",
     "publisher": "CERN Open Data Portal",
     "recid": "2542",
-    "run_period": [
-      "Run2011A"
-    ],
     "title": "High-Level Trigger path information HLT_IsoMu17_TriCentralJet30 (MuHad dataset)",
     "type": {
       "primary": "Supplementaries",
@@ -17930,9 +14672,6 @@
     "collections": [
       "CMS-Trigger-Information"
     ],
-    "collision_information": {
-      "energy": "7TeV"
-    },
     "date_created": [
       "2011"
     ],
@@ -17940,9 +14679,6 @@
     "experiment": "CMS",
     "publisher": "CERN Open Data Portal",
     "recid": "2543",
-    "run_period": [
-      "Run2011A"
-    ],
     "title": "High-Level Trigger path information HLT_IsoMu17_eta2p1 (SingleMu dataset)",
     "type": {
       "primary": "Supplementaries",
@@ -17963,9 +14699,6 @@
     "collections": [
       "CMS-Trigger-Information"
     ],
-    "collision_information": {
-      "energy": "7TeV"
-    },
     "date_created": [
       "2011"
     ],
@@ -17973,9 +14706,6 @@
     "experiment": "CMS",
     "publisher": "CERN Open Data Portal",
     "recid": "2544",
-    "run_period": [
-      "Run2011A"
-    ],
     "title": "High-Level Trigger path information HLT_IsoMu17_eta2p1_CentralJet30 (MuHad dataset)",
     "type": {
       "primary": "Supplementaries",
@@ -17996,9 +14726,6 @@
     "collections": [
       "CMS-Trigger-Information"
     ],
-    "collision_information": {
-      "energy": "7TeV"
-    },
     "date_created": [
       "2011"
     ],
@@ -18006,9 +14733,6 @@
     "experiment": "CMS",
     "publisher": "CERN Open Data Portal",
     "recid": "2545",
-    "run_period": [
-      "Run2011A"
-    ],
     "title": "High-Level Trigger path information HLT_IsoMu17_eta2p1_CentralJet30_BTagIP (MuHad dataset)",
     "type": {
       "primary": "Supplementaries",
@@ -18029,9 +14753,6 @@
     "collections": [
       "CMS-Trigger-Information"
     ],
-    "collision_information": {
-      "energy": "7TeV"
-    },
     "date_created": [
       "2011"
     ],
@@ -18039,9 +14760,6 @@
     "experiment": "CMS",
     "publisher": "CERN Open Data Portal",
     "recid": "2546",
-    "run_period": [
-      "Run2011A"
-    ],
     "title": "High-Level Trigger path information HLT_IsoMu17_eta2p1_CentralPFJet30 (MuHad dataset)",
     "type": {
       "primary": "Supplementaries",
@@ -18062,9 +14780,6 @@
     "collections": [
       "CMS-Trigger-Information"
     ],
-    "collision_information": {
-      "energy": "7TeV"
-    },
     "date_created": [
       "2011"
     ],
@@ -18072,9 +14787,6 @@
     "experiment": "CMS",
     "publisher": "CERN Open Data Portal",
     "recid": "2547",
-    "run_period": [
-      "Run2011A"
-    ],
     "title": "High-Level Trigger path information HLT_IsoMu17_eta2p1_DiCentralJet30 (MuHad dataset)",
     "type": {
       "primary": "Supplementaries",
@@ -18095,9 +14807,6 @@
     "collections": [
       "CMS-Trigger-Information"
     ],
-    "collision_information": {
-      "energy": "7TeV"
-    },
     "date_created": [
       "2011"
     ],
@@ -18105,9 +14814,6 @@
     "experiment": "CMS",
     "publisher": "CERN Open Data Portal",
     "recid": "2548",
-    "run_period": [
-      "Run2011A"
-    ],
     "title": "High-Level Trigger path information HLT_IsoMu17_eta2p1_DiCentralPFJet25 (MuHad dataset)",
     "type": {
       "primary": "Supplementaries",
@@ -18128,9 +14834,6 @@
     "collections": [
       "CMS-Trigger-Information"
     ],
-    "collision_information": {
-      "energy": "7TeV"
-    },
     "date_created": [
       "2011"
     ],
@@ -18138,9 +14841,6 @@
     "experiment": "CMS",
     "publisher": "CERN Open Data Portal",
     "recid": "2549",
-    "run_period": [
-      "Run2011A"
-    ],
     "title": "High-Level Trigger path information HLT_IsoMu17_eta2p1_DiCentralPFJet25_PFMHT15 (MuHad dataset)",
     "type": {
       "primary": "Supplementaries",
@@ -18161,9 +14861,6 @@
     "collections": [
       "CMS-Trigger-Information"
     ],
-    "collision_information": {
-      "energy": "7TeV"
-    },
     "date_created": [
       "2011"
     ],
@@ -18171,9 +14868,6 @@
     "experiment": "CMS",
     "publisher": "CERN Open Data Portal",
     "recid": "2550",
-    "run_period": [
-      "Run2011A"
-    ],
     "title": "High-Level Trigger path information HLT_IsoMu17_eta2p1_DiCentralPFJet25_PFMHT25 (MuHad dataset)",
     "type": {
       "primary": "Supplementaries",
@@ -18194,9 +14888,6 @@
     "collections": [
       "CMS-Trigger-Information"
     ],
-    "collision_information": {
-      "energy": "7TeV"
-    },
     "date_created": [
       "2011"
     ],
@@ -18204,9 +14895,6 @@
     "experiment": "CMS",
     "publisher": "CERN Open Data Portal",
     "recid": "2551",
-    "run_period": [
-      "Run2011A"
-    ],
     "title": "High-Level Trigger path information HLT_IsoMu17_eta2p1_DiCentralPFJet30 (MuHad dataset)",
     "type": {
       "primary": "Supplementaries",
@@ -18227,9 +14915,6 @@
     "collections": [
       "CMS-Trigger-Information"
     ],
-    "collision_information": {
-      "energy": "7TeV"
-    },
     "date_created": [
       "2011"
     ],
@@ -18237,9 +14922,6 @@
     "experiment": "CMS",
     "publisher": "CERN Open Data Portal",
     "recid": "2552",
-    "run_period": [
-      "Run2011A"
-    ],
     "title": "High-Level Trigger path information HLT_IsoMu17_eta2p1_DiPFJet25_Deta3 (MuHad dataset)",
     "type": {
       "primary": "Supplementaries",
@@ -18260,9 +14942,6 @@
     "collections": [
       "CMS-Trigger-Information"
     ],
-    "collision_information": {
-      "energy": "7TeV"
-    },
     "date_created": [
       "2011"
     ],
@@ -18270,9 +14949,6 @@
     "experiment": "CMS",
     "publisher": "CERN Open Data Portal",
     "recid": "2553",
-    "run_period": [
-      "Run2011A"
-    ],
     "title": "High-Level Trigger path information HLT_IsoMu17_eta2p1_DiPFJet25_Deta3_PFJet25 (MuHad dataset)",
     "type": {
       "primary": "Supplementaries",
@@ -18293,9 +14969,6 @@
     "collections": [
       "CMS-Trigger-Information"
     ],
-    "collision_information": {
-      "energy": "7TeV"
-    },
     "date_created": [
       "2011"
     ],
@@ -18303,9 +14976,6 @@
     "experiment": "CMS",
     "publisher": "CERN Open Data Portal",
     "recid": "2554",
-    "run_period": [
-      "Run2011A"
-    ],
     "title": "High-Level Trigger path information HLT_IsoMu17_eta2p1_QuadCentralJet30 (MuHad dataset)",
     "type": {
       "primary": "Supplementaries",
@@ -18326,9 +14996,6 @@
     "collections": [
       "CMS-Trigger-Information"
     ],
-    "collision_information": {
-      "energy": "7TeV"
-    },
     "date_created": [
       "2011"
     ],
@@ -18336,9 +15003,6 @@
     "experiment": "CMS",
     "publisher": "CERN Open Data Portal",
     "recid": "2555",
-    "run_period": [
-      "Run2011A"
-    ],
     "title": "High-Level Trigger path information HLT_IsoMu17_eta2p1_QuadCentralPFJet30 (MuHad dataset)",
     "type": {
       "primary": "Supplementaries",
@@ -18359,9 +15023,6 @@
     "collections": [
       "CMS-Trigger-Information"
     ],
-    "collision_information": {
-      "energy": "7TeV"
-    },
     "date_created": [
       "2011"
     ],
@@ -18369,9 +15030,6 @@
     "experiment": "CMS",
     "publisher": "CERN Open Data Portal",
     "recid": "2556",
-    "run_period": [
-      "Run2011A"
-    ],
     "title": "High-Level Trigger path information HLT_IsoMu17_eta2p1_TriCentralJet30 (MuHad dataset)",
     "type": {
       "primary": "Supplementaries",
@@ -18392,9 +15050,6 @@
     "collections": [
       "CMS-Trigger-Information"
     ],
-    "collision_information": {
-      "energy": "7TeV"
-    },
     "date_created": [
       "2011"
     ],
@@ -18402,9 +15057,6 @@
     "experiment": "CMS",
     "publisher": "CERN Open Data Portal",
     "recid": "2557",
-    "run_period": [
-      "Run2011A"
-    ],
     "title": "High-Level Trigger path information HLT_IsoMu17_eta2p1_TriCentralPFJet30 (MuHad dataset)",
     "type": {
       "primary": "Supplementaries",
@@ -18425,9 +15077,6 @@
     "collections": [
       "CMS-Trigger-Information"
     ],
-    "collision_information": {
-      "energy": "7TeV"
-    },
     "date_created": [
       "2011"
     ],
@@ -18435,9 +15084,6 @@
     "experiment": "CMS",
     "publisher": "CERN Open Data Portal",
     "recid": "2558",
-    "run_period": [
-      "Run2011A"
-    ],
     "title": "High-Level Trigger path information HLT_IsoMu20 (SingleMu dataset)",
     "type": {
       "primary": "Supplementaries",
@@ -18458,9 +15104,6 @@
     "collections": [
       "CMS-Trigger-Information"
     ],
-    "collision_information": {
-      "energy": "7TeV"
-    },
     "date_created": [
       "2011"
     ],
@@ -18468,9 +15111,6 @@
     "experiment": "CMS",
     "publisher": "CERN Open Data Portal",
     "recid": "2559",
-    "run_period": [
-      "Run2011A"
-    ],
     "title": "High-Level Trigger path information HLT_IsoMu20_DiCentralJet34 (MuHad dataset)",
     "type": {
       "primary": "Supplementaries",
@@ -18491,9 +15131,6 @@
     "collections": [
       "CMS-Trigger-Information"
     ],
-    "collision_information": {
-      "energy": "7TeV"
-    },
     "date_created": [
       "2011"
     ],
@@ -18501,9 +15138,6 @@
     "experiment": "CMS",
     "publisher": "CERN Open Data Portal",
     "recid": "2560",
-    "run_period": [
-      "Run2011A"
-    ],
     "title": "High-Level Trigger path information HLT_IsoMu20_eta2p1 (SingleMu dataset)",
     "type": {
       "primary": "Supplementaries",
@@ -18524,9 +15158,6 @@
     "collections": [
       "CMS-Trigger-Information"
     ],
-    "collision_information": {
-      "energy": "7TeV"
-    },
     "date_created": [
       "2011"
     ],
@@ -18534,9 +15165,6 @@
     "experiment": "CMS",
     "publisher": "CERN Open Data Portal",
     "recid": "2561",
-    "run_period": [
-      "Run2011A"
-    ],
     "title": "High-Level Trigger path information HLT_IsoMu24 (SingleMu dataset)",
     "type": {
       "primary": "Supplementaries",
@@ -18557,9 +15185,6 @@
     "collections": [
       "CMS-Trigger-Information"
     ],
-    "collision_information": {
-      "energy": "7TeV"
-    },
     "date_created": [
       "2011"
     ],
@@ -18567,9 +15192,6 @@
     "experiment": "CMS",
     "publisher": "CERN Open Data Portal",
     "recid": "2562",
-    "run_period": [
-      "Run2011A"
-    ],
     "title": "High-Level Trigger path information HLT_IsoMu24_eta2p1 (SingleMu dataset)",
     "type": {
       "primary": "Supplementaries",
@@ -18590,9 +15212,6 @@
     "collections": [
       "CMS-Trigger-Information"
     ],
-    "collision_information": {
-      "energy": "7TeV"
-    },
     "date_created": [
       "2011"
     ],
@@ -18600,9 +15219,6 @@
     "experiment": "CMS",
     "publisher": "CERN Open Data Portal",
     "recid": "2563",
-    "run_period": [
-      "Run2011A"
-    ],
     "title": "High-Level Trigger path information HLT_IsoMu30 (SingleMu dataset)",
     "type": {
       "primary": "Supplementaries",
@@ -18623,9 +15239,6 @@
     "collections": [
       "CMS-Trigger-Information"
     ],
-    "collision_information": {
-      "energy": "7TeV"
-    },
     "date_created": [
       "2011"
     ],
@@ -18633,9 +15246,6 @@
     "experiment": "CMS",
     "publisher": "CERN Open Data Portal",
     "recid": "2564",
-    "run_period": [
-      "Run2011A"
-    ],
     "title": "High-Level Trigger path information HLT_IsoMu30_eta2p1 (SingleMu dataset)",
     "type": {
       "primary": "Supplementaries",
@@ -18656,9 +15266,6 @@
     "collections": [
       "CMS-Trigger-Information"
     ],
-    "collision_information": {
-      "energy": "7TeV"
-    },
     "date_created": [
       "2011"
     ],
@@ -18666,9 +15273,6 @@
     "experiment": "CMS",
     "publisher": "CERN Open Data Portal",
     "recid": "2565",
-    "run_period": [
-      "Run2011A"
-    ],
     "title": "High-Level Trigger path information HLT_IsoMu34_eta2p1 (SingleMu dataset)",
     "type": {
       "primary": "Supplementaries",
@@ -18689,9 +15293,6 @@
     "collections": [
       "CMS-Trigger-Information"
     ],
-    "collision_information": {
-      "energy": "7TeV"
-    },
     "date_created": [
       "2011"
     ],
@@ -18699,9 +15300,6 @@
     "experiment": "CMS",
     "publisher": "CERN Open Data Portal",
     "recid": "2566",
-    "run_period": [
-      "Run2011A"
-    ],
     "title": "High-Level Trigger path information HLT_IsoMu40_eta2p1 (SingleMu dataset)",
     "type": {
       "primary": "Supplementaries",
@@ -18722,9 +15320,6 @@
     "collections": [
       "CMS-Trigger-Information"
     ],
-    "collision_information": {
-      "energy": "7TeV"
-    },
     "date_created": [
       "2011"
     ],
@@ -18732,9 +15327,6 @@
     "experiment": "CMS",
     "publisher": "CERN Open Data Portal",
     "recid": "2567",
-    "run_period": [
-      "Run2011A"
-    ],
     "title": "High-Level Trigger path information HLT_IsoPFTau35_Trk20 (Tau dataset)",
     "type": {
       "primary": "Supplementaries",
@@ -18755,9 +15347,6 @@
     "collections": [
       "CMS-Trigger-Information"
     ],
-    "collision_information": {
-      "energy": "7TeV"
-    },
     "date_created": [
       "2011"
     ],
@@ -18765,9 +15354,6 @@
     "experiment": "CMS",
     "publisher": "CERN Open Data Portal",
     "recid": "2568",
-    "run_period": [
-      "Run2011A"
-    ],
     "title": "High-Level Trigger path information HLT_IsoPFTau35_Trk20_MET45 (Tau dataset)",
     "type": {
       "primary": "Supplementaries",
@@ -18788,9 +15374,6 @@
     "collections": [
       "CMS-Trigger-Information"
     ],
-    "collision_information": {
-      "energy": "7TeV"
-    },
     "date_created": [
       "2011"
     ],
@@ -18798,9 +15381,6 @@
     "experiment": "CMS",
     "publisher": "CERN Open Data Portal",
     "recid": "2569",
-    "run_period": [
-      "Run2011A"
-    ],
     "title": "High-Level Trigger path information HLT_IsoPFTau35_Trk20_MET60 (Tau dataset)",
     "type": {
       "primary": "Supplementaries",
@@ -18821,9 +15401,6 @@
     "collections": [
       "CMS-Trigger-Information"
     ],
-    "collision_information": {
-      "energy": "7TeV"
-    },
     "date_created": [
       "2011"
     ],
@@ -18831,9 +15408,6 @@
     "experiment": "CMS",
     "publisher": "CERN Open Data Portal",
     "recid": "2570",
-    "run_period": [
-      "Run2011A"
-    ],
     "title": "High-Level Trigger path information HLT_IsoPFTau35_Trk20_MET70 (Tau dataset)",
     "type": {
       "primary": "Supplementaries",
@@ -18854,9 +15428,6 @@
     "collections": [
       "CMS-Trigger-Information"
     ],
-    "collision_information": {
-      "energy": "7TeV"
-    },
     "date_created": [
       "2011"
     ],
@@ -18864,9 +15435,6 @@
     "experiment": "CMS",
     "publisher": "CERN Open Data Portal",
     "recid": "2571",
-    "run_period": [
-      "Run2011A"
-    ],
     "title": "High-Level Trigger path information HLT_IsoPFTau40_IsoPFTau30_Trk5_eta2p1 (Tau dataset)",
     "type": {
       "primary": "Supplementaries",
@@ -18887,9 +15455,6 @@
     "collections": [
       "CMS-Trigger-Information"
     ],
-    "collision_information": {
-      "energy": "7TeV"
-    },
     "date_created": [
       "2011"
     ],
@@ -18897,9 +15462,6 @@
     "experiment": "CMS",
     "publisher": "CERN Open Data Portal",
     "recid": "2572",
-    "run_period": [
-      "Run2011A"
-    ],
     "title": "High-Level Trigger path information HLT_IsoPFTau45_Trk20_MET60 (Tau dataset)",
     "type": {
       "primary": "Supplementaries",
@@ -18920,9 +15482,6 @@
     "collections": [
       "CMS-Trigger-Information"
     ],
-    "collision_information": {
-      "energy": "7TeV"
-    },
     "date_created": [
       "2011"
     ],
@@ -18930,9 +15489,6 @@
     "experiment": "CMS",
     "publisher": "CERN Open Data Portal",
     "recid": "2573",
-    "run_period": [
-      "Run2011A"
-    ],
     "title": "High-Level Trigger path information HLT_IsoTrackHB (Commissioning dataset)",
     "type": {
       "primary": "Supplementaries",
@@ -18953,9 +15509,6 @@
     "collections": [
       "CMS-Trigger-Information"
     ],
-    "collision_information": {
-      "energy": "7TeV"
-    },
     "date_created": [
       "2011"
     ],
@@ -18963,9 +15516,6 @@
     "experiment": "CMS",
     "publisher": "CERN Open Data Portal",
     "recid": "2574",
-    "run_period": [
-      "Run2011A"
-    ],
     "title": "High-Level Trigger path information HLT_IsoTrackHE (Commissioning dataset)",
     "type": {
       "primary": "Supplementaries",
@@ -18986,9 +15536,6 @@
     "collections": [
       "CMS-Trigger-Information"
     ],
-    "collision_information": {
-      "energy": "7TeV"
-    },
     "date_created": [
       "2011"
     ],
@@ -18996,9 +15543,6 @@
     "experiment": "CMS",
     "publisher": "CERN Open Data Portal",
     "recid": "2575",
-    "run_period": [
-      "Run2011A"
-    ],
     "title": "High-Level Trigger path information HLT_Jet110 (Jet dataset)",
     "type": {
       "primary": "Supplementaries",
@@ -19019,9 +15563,6 @@
     "collections": [
       "CMS-Trigger-Information"
     ],
-    "collision_information": {
-      "energy": "7TeV"
-    },
     "date_created": [
       "2011"
     ],
@@ -19029,9 +15570,6 @@
     "experiment": "CMS",
     "publisher": "CERN Open Data Portal",
     "recid": "2576",
-    "run_period": [
-      "Run2011A"
-    ],
     "title": "High-Level Trigger path information HLT_Jet150 (Jet dataset)",
     "type": {
       "primary": "Supplementaries",
@@ -19052,9 +15590,6 @@
     "collections": [
       "CMS-Trigger-Information"
     ],
-    "collision_information": {
-      "energy": "7TeV"
-    },
     "date_created": [
       "2011"
     ],
@@ -19062,9 +15597,6 @@
     "experiment": "CMS",
     "publisher": "CERN Open Data Portal",
     "recid": "2577",
-    "run_period": [
-      "Run2011A"
-    ],
     "title": "High-Level Trigger path information HLT_Jet190 (Jet dataset)",
     "type": {
       "primary": "Supplementaries",
@@ -19085,9 +15617,6 @@
     "collections": [
       "CMS-Trigger-Information"
     ],
-    "collision_information": {
-      "energy": "7TeV"
-    },
     "date_created": [
       "2011"
     ],
@@ -19095,9 +15624,6 @@
     "experiment": "CMS",
     "publisher": "CERN Open Data Portal",
     "recid": "2578",
-    "run_period": [
-      "Run2011A"
-    ],
     "title": "High-Level Trigger path information HLT_Jet20 (AllPhysics2760 dataset)",
     "type": {
       "primary": "Supplementaries",
@@ -19118,9 +15644,6 @@
     "collections": [
       "CMS-Trigger-Information"
     ],
-    "collision_information": {
-      "energy": "7TeV"
-    },
     "date_created": [
       "2011"
     ],
@@ -19128,9 +15651,6 @@
     "experiment": "CMS",
     "publisher": "CERN Open Data Portal",
     "recid": "2579",
-    "run_period": [
-      "Run2011A"
-    ],
     "title": "High-Level Trigger path information HLT_Jet240 (Jet dataset)",
     "type": {
       "primary": "Supplementaries",
@@ -19151,9 +15671,6 @@
     "collections": [
       "CMS-Trigger-Information"
     ],
-    "collision_information": {
-      "energy": "7TeV"
-    },
     "date_created": [
       "2011"
     ],
@@ -19161,9 +15678,6 @@
     "experiment": "CMS",
     "publisher": "CERN Open Data Portal",
     "recid": "2580",
-    "run_period": [
-      "Run2011A"
-    ],
     "title": "High-Level Trigger path information HLT_Jet240_CentralJet30_BTagIP (Jet dataset)",
     "type": {
       "primary": "Supplementaries",
@@ -19184,9 +15698,6 @@
     "collections": [
       "CMS-Trigger-Information"
     ],
-    "collision_information": {
-      "energy": "7TeV"
-    },
     "date_created": [
       "2011"
     ],
@@ -19194,9 +15705,6 @@
     "experiment": "CMS",
     "publisher": "CERN Open Data Portal",
     "recid": "2581",
-    "run_period": [
-      "Run2011A"
-    ],
     "title": "High-Level Trigger path information HLT_Jet240_L1FastJet (Jet dataset)",
     "type": {
       "primary": "Supplementaries",
@@ -19217,9 +15725,6 @@
     "collections": [
       "CMS-Trigger-Information"
     ],
-    "collision_information": {
-      "energy": "7TeV"
-    },
     "date_created": [
       "2011"
     ],
@@ -19227,9 +15732,6 @@
     "experiment": "CMS",
     "publisher": "CERN Open Data Portal",
     "recid": "2582",
-    "run_period": [
-      "Run2011A"
-    ],
     "title": "High-Level Trigger path information HLT_Jet270_CentralJet30_BTagIP (Jet dataset)",
     "type": {
       "primary": "Supplementaries",
@@ -19250,9 +15752,6 @@
     "collections": [
       "CMS-Trigger-Information"
     ],
-    "collision_information": {
-      "energy": "7TeV"
-    },
     "date_created": [
       "2011"
     ],
@@ -19260,9 +15759,6 @@
     "experiment": "CMS",
     "publisher": "CERN Open Data Portal",
     "recid": "2583",
-    "run_period": [
-      "Run2011A"
-    ],
     "title": "High-Level Trigger path information HLT_Jet30 (Jet dataset)",
     "type": {
       "primary": "Supplementaries",
@@ -19283,9 +15779,6 @@
     "collections": [
       "CMS-Trigger-Information"
     ],
-    "collision_information": {
-      "energy": "7TeV"
-    },
     "date_created": [
       "2011"
     ],
@@ -19293,9 +15786,6 @@
     "experiment": "CMS",
     "publisher": "CERN Open Data Portal",
     "recid": "2584",
-    "run_period": [
-      "Run2011A"
-    ],
     "title": "High-Level Trigger path information HLT_Jet300 (Jet dataset)",
     "type": {
       "primary": "Supplementaries",
@@ -19316,9 +15806,6 @@
     "collections": [
       "CMS-Trigger-Information"
     ],
-    "collision_information": {
-      "energy": "7TeV"
-    },
     "date_created": [
       "2011"
     ],
@@ -19326,9 +15813,6 @@
     "experiment": "CMS",
     "publisher": "CERN Open Data Portal",
     "recid": "2585",
-    "run_period": [
-      "Run2011A"
-    ],
     "title": "High-Level Trigger path information HLT_Jet300_L1FastJet (Jet dataset)",
     "type": {
       "primary": "Supplementaries",
@@ -19349,9 +15833,6 @@
     "collections": [
       "CMS-Trigger-Information"
     ],
-    "collision_information": {
-      "energy": "7TeV"
-    },
     "date_created": [
       "2011"
     ],
@@ -19359,9 +15840,6 @@
     "experiment": "CMS",
     "publisher": "CERN Open Data Portal",
     "recid": "2586",
-    "run_period": [
-      "Run2011A"
-    ],
     "title": "High-Level Trigger path information HLT_Jet30_L1FastJet (Jet dataset)",
     "type": {
       "primary": "Supplementaries",
@@ -19382,9 +15860,6 @@
     "collections": [
       "CMS-Trigger-Information"
     ],
-    "collision_information": {
-      "energy": "7TeV"
-    },
     "date_created": [
       "2011"
     ],
@@ -19392,9 +15867,6 @@
     "experiment": "CMS",
     "publisher": "CERN Open Data Portal",
     "recid": "2587",
-    "run_period": [
-      "Run2011A"
-    ],
     "title": "High-Level Trigger path information HLT_Jet370 (Jet dataset)",
     "type": {
       "primary": "Supplementaries",
@@ -19415,9 +15887,6 @@
     "collections": [
       "CMS-Trigger-Information"
     ],
-    "collision_information": {
-      "energy": "7TeV"
-    },
     "date_created": [
       "2011"
     ],
@@ -19425,9 +15894,6 @@
     "experiment": "CMS",
     "publisher": "CERN Open Data Portal",
     "recid": "2588",
-    "run_period": [
-      "Run2011A"
-    ],
     "title": "High-Level Trigger path information HLT_Jet370_L1FastJet (Jet dataset)",
     "type": {
       "primary": "Supplementaries",
@@ -19448,9 +15914,6 @@
     "collections": [
       "CMS-Trigger-Information"
     ],
-    "collision_information": {
-      "energy": "7TeV"
-    },
     "date_created": [
       "2011"
     ],
@@ -19458,9 +15921,6 @@
     "experiment": "CMS",
     "publisher": "CERN Open Data Portal",
     "recid": "2589",
-    "run_period": [
-      "Run2011A"
-    ],
     "title": "High-Level Trigger path information HLT_Jet370_NoJetID (Jet dataset)",
     "type": {
       "primary": "Supplementaries",
@@ -19481,9 +15941,6 @@
     "collections": [
       "CMS-Trigger-Information"
     ],
-    "collision_information": {
-      "energy": "7TeV"
-    },
     "date_created": [
       "2011"
     ],
@@ -19491,9 +15948,6 @@
     "experiment": "CMS",
     "publisher": "CERN Open Data Portal",
     "recid": "2590",
-    "run_period": [
-      "Run2011A"
-    ],
     "title": "High-Level Trigger path information HLT_Jet40 (AllPhysics2760 dataset)",
     "type": {
       "primary": "Supplementaries",
@@ -19514,9 +15968,6 @@
     "collections": [
       "CMS-Trigger-Information"
     ],
-    "collision_information": {
-      "energy": "7TeV"
-    },
     "date_created": [
       "2011"
     ],
@@ -19524,9 +15975,6 @@
     "experiment": "CMS",
     "publisher": "CERN Open Data Portal",
     "recid": "2591",
-    "run_period": [
-      "Run2011A"
-    ],
     "title": "High-Level Trigger path information HLT_Jet60 (Jet dataset)",
     "type": {
       "primary": "Supplementaries",
@@ -19547,9 +15995,6 @@
     "collections": [
       "CMS-Trigger-Information"
     ],
-    "collision_information": {
-      "energy": "7TeV"
-    },
     "date_created": [
       "2011"
     ],
@@ -19557,9 +16002,6 @@
     "experiment": "CMS",
     "publisher": "CERN Open Data Portal",
     "recid": "2592",
-    "run_period": [
-      "Run2011A"
-    ],
     "title": "High-Level Trigger path information HLT_Jet60_L1FastJet (Jet dataset)",
     "type": {
       "primary": "Supplementaries",
@@ -19580,9 +16022,6 @@
     "collections": [
       "CMS-Trigger-Information"
     ],
-    "collision_information": {
-      "energy": "7TeV"
-    },
     "date_created": [
       "2011"
     ],
@@ -19590,9 +16029,6 @@
     "experiment": "CMS",
     "publisher": "CERN Open Data Portal",
     "recid": "2593",
-    "run_period": [
-      "Run2011A"
-    ],
     "title": "High-Level Trigger path information HLT_Jet80 (Jet dataset)",
     "type": {
       "primary": "Supplementaries",
@@ -19613,9 +16049,6 @@
     "collections": [
       "CMS-Trigger-Information"
     ],
-    "collision_information": {
-      "energy": "7TeV"
-    },
     "date_created": [
       "2011"
     ],
@@ -19623,9 +16056,6 @@
     "experiment": "CMS",
     "publisher": "CERN Open Data Portal",
     "recid": "2594",
-    "run_period": [
-      "Run2011A"
-    ],
     "title": "High-Level Trigger path information HLT_Jet800 (Jet dataset)",
     "type": {
       "primary": "Supplementaries",
@@ -19646,9 +16076,6 @@
     "collections": [
       "CMS-Trigger-Information"
     ],
-    "collision_information": {
-      "energy": "7TeV"
-    },
     "date_created": [
       "2011"
     ],
@@ -19656,9 +16083,6 @@
     "experiment": "CMS",
     "publisher": "CERN Open Data Portal",
     "recid": "2595",
-    "run_period": [
-      "Run2011A"
-    ],
     "title": "High-Level Trigger path information HLT_JetE30_NoBPTX (MinimumBias dataset)",
     "type": {
       "primary": "Supplementaries",
@@ -19679,9 +16103,6 @@
     "collections": [
       "CMS-Trigger-Information"
     ],
-    "collision_information": {
-      "energy": "7TeV"
-    },
     "date_created": [
       "2011"
     ],
@@ -19689,9 +16110,6 @@
     "experiment": "CMS",
     "publisher": "CERN Open Data Portal",
     "recid": "2596",
-    "run_period": [
-      "Run2011A"
-    ],
     "title": "High-Level Trigger path information HLT_JetE30_NoBPTX3BX_NoHalo (MinimumBias dataset)",
     "type": {
       "primary": "Supplementaries",
@@ -19712,9 +16130,6 @@
     "collections": [
       "CMS-Trigger-Information"
     ],
-    "collision_information": {
-      "energy": "7TeV"
-    },
     "date_created": [
       "2011"
     ],
@@ -19722,9 +16137,6 @@
     "experiment": "CMS",
     "publisher": "CERN Open Data Portal",
     "recid": "2597",
-    "run_period": [
-      "Run2011A"
-    ],
     "title": "High-Level Trigger path information HLT_JetE30_NoBPTX_NoHalo (MinimumBias dataset)",
     "type": {
       "primary": "Supplementaries",
@@ -19745,9 +16157,6 @@
     "collections": [
       "CMS-Trigger-Information"
     ],
-    "collision_information": {
-      "energy": "7TeV"
-    },
     "date_created": [
       "2011"
     ],
@@ -19755,9 +16164,6 @@
     "experiment": "CMS",
     "publisher": "CERN Open Data Portal",
     "recid": "2598",
-    "run_period": [
-      "Run2011A"
-    ],
     "title": "High-Level Trigger path information HLT_JetE50_NoBPTX3BX_NoHalo (MinimumBias dataset)",
     "type": {
       "primary": "Supplementaries",
@@ -19778,9 +16184,6 @@
     "collections": [
       "CMS-Trigger-Information"
     ],
-    "collision_information": {
-      "energy": "7TeV"
-    },
     "date_created": [
       "2011"
     ],
@@ -19788,9 +16191,6 @@
     "experiment": "CMS",
     "publisher": "CERN Open Data Portal",
     "recid": "2599",
-    "run_period": [
-      "Run2011A"
-    ],
     "title": "High-Level Trigger path information HLT_L1BscMinBiasORBptxPlusANDMinus (AllPhysics2760 dataset)",
     "type": {
       "primary": "Supplementaries",
@@ -19811,9 +16211,6 @@
     "collections": [
       "CMS-Trigger-Information"
     ],
-    "collision_information": {
-      "energy": "7TeV"
-    },
     "date_created": [
       "2011"
     ],
@@ -19821,9 +16218,6 @@
     "experiment": "CMS",
     "publisher": "CERN Open Data Portal",
     "recid": "2600",
-    "run_period": [
-      "Run2011A"
-    ],
     "title": "High-Level Trigger path information HLT_L1DoubleForJet32_EtaOpp (AllPhysics2760 dataset)",
     "type": {
       "primary": "Supplementaries",
@@ -19844,9 +16238,6 @@
     "collections": [
       "CMS-Trigger-Information"
     ],
-    "collision_information": {
-      "energy": "7TeV"
-    },
     "date_created": [
       "2011"
     ],
@@ -19854,9 +16245,6 @@
     "experiment": "CMS",
     "publisher": "CERN Open Data Portal",
     "recid": "2601",
-    "run_period": [
-      "Run2011A"
-    ],
     "title": "High-Level Trigger path information HLT_L1DoubleForJet8_EtaOpp (AllPhysics2760 dataset)",
     "type": {
       "primary": "Supplementaries",
@@ -19877,9 +16265,6 @@
     "collections": [
       "CMS-Trigger-Information"
     ],
-    "collision_information": {
-      "energy": "7TeV"
-    },
     "date_created": [
       "2011"
     ],
@@ -19887,9 +16272,6 @@
     "experiment": "CMS",
     "publisher": "CERN Open Data Portal",
     "recid": "2602",
-    "run_period": [
-      "Run2011A"
-    ],
     "title": "High-Level Trigger path information HLT_L1DoubleJet36Central (MultiJet dataset)",
     "type": {
       "primary": "Supplementaries",
@@ -19910,9 +16292,6 @@
     "collections": [
       "CMS-Trigger-Information"
     ],
-    "collision_information": {
-      "energy": "7TeV"
-    },
     "date_created": [
       "2011"
     ],
@@ -19920,9 +16299,6 @@
     "experiment": "CMS",
     "publisher": "CERN Open Data Portal",
     "recid": "2603",
-    "run_period": [
-      "Run2011A"
-    ],
     "title": "High-Level Trigger path information HLT_L1DoubleMu0 (DoubleMu dataset)",
     "type": {
       "primary": "Supplementaries",
@@ -19943,9 +16319,6 @@
     "collections": [
       "CMS-Trigger-Information"
     ],
-    "collision_information": {
-      "energy": "7TeV"
-    },
     "date_created": [
       "2011"
     ],
@@ -19953,9 +16326,6 @@
     "experiment": "CMS",
     "publisher": "CERN Open Data Portal",
     "recid": "2604",
-    "run_period": [
-      "Run2011A"
-    ],
     "title": "High-Level Trigger path information HLT_L1DoubleMu0_HighQ (L1MuHPF dataset)",
     "type": {
       "primary": "Supplementaries",
@@ -19976,9 +16346,6 @@
     "collections": [
       "CMS-Trigger-Information"
     ],
-    "collision_information": {
-      "energy": "7TeV"
-    },
     "date_created": [
       "2011"
     ],
@@ -19986,9 +16353,6 @@
     "experiment": "CMS",
     "publisher": "CERN Open Data Portal",
     "recid": "2605",
-    "run_period": [
-      "Run2011A"
-    ],
     "title": "High-Level Trigger path information HLT_L1DoubleMu3 (L1MuHPF dataset)",
     "type": {
       "primary": "Supplementaries",
@@ -20009,9 +16373,6 @@
     "collections": [
       "CMS-Trigger-Information"
     ],
-    "collision_information": {
-      "energy": "7TeV"
-    },
     "date_created": [
       "2011"
     ],
@@ -20019,9 +16380,6 @@
     "experiment": "CMS",
     "publisher": "CERN Open Data Portal",
     "recid": "2606",
-    "run_period": [
-      "Run2011A"
-    ],
     "title": "High-Level Trigger path information HLT_L1ETM30 (MultiJet dataset)",
     "type": {
       "primary": "Supplementaries",
@@ -20042,9 +16400,6 @@
     "collections": [
       "CMS-Trigger-Information"
     ],
-    "collision_information": {
-      "energy": "7TeV"
-    },
     "date_created": [
       "2011"
     ],
@@ -20052,9 +16407,6 @@
     "experiment": "CMS",
     "publisher": "CERN Open Data Portal",
     "recid": "2607",
-    "run_period": [
-      "Run2011A"
-    ],
     "title": "High-Level Trigger path information HLT_L1HTT100 (L1JetHPF dataset)",
     "type": {
       "primary": "Supplementaries",
@@ -20075,9 +16427,6 @@
     "collections": [
       "CMS-Trigger-Information"
     ],
-    "collision_information": {
-      "energy": "7TeV"
-    },
     "date_created": [
       "2011"
     ],
@@ -20085,9 +16434,6 @@
     "experiment": "CMS",
     "publisher": "CERN Open Data Portal",
     "recid": "2608",
-    "run_period": [
-      "Run2011A"
-    ],
     "title": "High-Level Trigger path information HLT_L1MuOpen_AntiBPTX (Cosmics dataset)",
     "type": {
       "primary": "Supplementaries",
@@ -20108,9 +16454,6 @@
     "collections": [
       "CMS-Trigger-Information"
     ],
-    "collision_information": {
-      "energy": "7TeV"
-    },
     "date_created": [
       "2011"
     ],
@@ -20118,9 +16461,6 @@
     "experiment": "CMS",
     "publisher": "CERN Open Data Portal",
     "recid": "2609",
-    "run_period": [
-      "Run2011A"
-    ],
     "title": "High-Level Trigger path information HLT_L1MultiJet (MultiJet dataset)",
     "type": {
       "primary": "Supplementaries",
@@ -20141,9 +16481,6 @@
     "collections": [
       "CMS-Trigger-Information"
     ],
-    "collision_information": {
-      "energy": "7TeV"
-    },
     "date_created": [
       "2011"
     ],
@@ -20151,9 +16488,6 @@
     "experiment": "CMS",
     "publisher": "CERN Open Data Portal",
     "recid": "2610",
-    "run_period": [
-      "Run2011A"
-    ],
     "title": "High-Level Trigger path information HLT_L1SingleEG12 (Commissioning dataset)",
     "type": {
       "primary": "Supplementaries",
@@ -20174,9 +16508,6 @@
     "collections": [
       "CMS-Trigger-Information"
     ],
-    "collision_information": {
-      "energy": "7TeV"
-    },
     "date_created": [
       "2011"
     ],
@@ -20184,9 +16515,6 @@
     "experiment": "CMS",
     "publisher": "CERN Open Data Portal",
     "recid": "2611",
-    "run_period": [
-      "Run2011A"
-    ],
     "title": "High-Level Trigger path information HLT_L1SingleEG20 (L1EGHPF dataset)",
     "type": {
       "primary": "Supplementaries",
@@ -20207,9 +16535,6 @@
     "collections": [
       "CMS-Trigger-Information"
     ],
-    "collision_information": {
-      "energy": "7TeV"
-    },
     "date_created": [
       "2011"
     ],
@@ -20217,9 +16542,6 @@
     "experiment": "CMS",
     "publisher": "CERN Open Data Portal",
     "recid": "2612",
-    "run_period": [
-      "Run2011A"
-    ],
     "title": "High-Level Trigger path information HLT_L1SingleEG5 (Commissioning dataset)",
     "type": {
       "primary": "Supplementaries",
@@ -20240,9 +16562,6 @@
     "collections": [
       "CMS-Trigger-Information"
     ],
-    "collision_information": {
-      "energy": "7TeV"
-    },
     "date_created": [
       "2011"
     ],
@@ -20250,9 +16569,6 @@
     "experiment": "CMS",
     "publisher": "CERN Open Data Portal",
     "recid": "2613",
-    "run_period": [
-      "Run2011A"
-    ],
     "title": "High-Level Trigger path information HLT_L1SingleJet128_part0 (MinBias0Tesla0 dataset)",
     "type": {
       "primary": "Supplementaries",
@@ -20273,9 +16589,6 @@
     "collections": [
       "CMS-Trigger-Information"
     ],
-    "collision_information": {
-      "energy": "7TeV"
-    },
     "date_created": [
       "2011"
     ],
@@ -20283,9 +16596,6 @@
     "experiment": "CMS",
     "publisher": "CERN Open Data Portal",
     "recid": "2614",
-    "run_period": [
-      "Run2011A"
-    ],
     "title": "High-Level Trigger path information HLT_L1SingleJet128_part1 (MinBias0Tesla1 dataset)",
     "type": {
       "primary": "Supplementaries",
@@ -20306,9 +16616,6 @@
     "collections": [
       "CMS-Trigger-Information"
     ],
-    "collision_information": {
-      "energy": "7TeV"
-    },
     "date_created": [
       "2011"
     ],
@@ -20316,9 +16623,6 @@
     "experiment": "CMS",
     "publisher": "CERN Open Data Portal",
     "recid": "2615",
-    "run_period": [
-      "Run2011A"
-    ],
     "title": "High-Level Trigger path information HLT_L1SingleJet128_part2 (MinBias0Tesla2 dataset)",
     "type": {
       "primary": "Supplementaries",
@@ -20339,9 +16643,6 @@
     "collections": [
       "CMS-Trigger-Information"
     ],
-    "collision_information": {
-      "energy": "7TeV"
-    },
     "date_created": [
       "2011"
     ],
@@ -20349,9 +16650,6 @@
     "experiment": "CMS",
     "publisher": "CERN Open Data Portal",
     "recid": "2616",
-    "run_period": [
-      "Run2011A"
-    ],
     "title": "High-Level Trigger path information HLT_L1SingleJet16 (Commissioning dataset)",
     "type": {
       "primary": "Supplementaries",
@@ -20372,9 +16670,6 @@
     "collections": [
       "CMS-Trigger-Information"
     ],
-    "collision_information": {
-      "energy": "7TeV"
-    },
     "date_created": [
       "2011"
     ],
@@ -20382,9 +16677,6 @@
     "experiment": "CMS",
     "publisher": "CERN Open Data Portal",
     "recid": "2617",
-    "run_period": [
-      "Run2011A"
-    ],
     "title": "High-Level Trigger path information HLT_L1SingleJet36 (Commissioning dataset)",
     "type": {
       "primary": "Supplementaries",
@@ -20405,9 +16697,6 @@
     "collections": [
       "CMS-Trigger-Information"
     ],
-    "collision_information": {
-      "energy": "7TeV"
-    },
     "date_created": [
       "2011"
     ],
@@ -20415,9 +16704,6 @@
     "experiment": "CMS",
     "publisher": "CERN Open Data Portal",
     "recid": "2618",
-    "run_period": [
-      "Run2011A"
-    ],
     "title": "High-Level Trigger path information HLT_L1SingleJet36_part0 (MinBias0Tesla0 dataset)",
     "type": {
       "primary": "Supplementaries",
@@ -20438,9 +16724,6 @@
     "collections": [
       "CMS-Trigger-Information"
     ],
-    "collision_information": {
-      "energy": "7TeV"
-    },
     "date_created": [
       "2011"
     ],
@@ -20448,9 +16731,6 @@
     "experiment": "CMS",
     "publisher": "CERN Open Data Portal",
     "recid": "2619",
-    "run_period": [
-      "Run2011A"
-    ],
     "title": "High-Level Trigger path information HLT_L1SingleJet36_part1 (MinBias0Tesla1 dataset)",
     "type": {
       "primary": "Supplementaries",
@@ -20471,9 +16751,6 @@
     "collections": [
       "CMS-Trigger-Information"
     ],
-    "collision_information": {
-      "energy": "7TeV"
-    },
     "date_created": [
       "2011"
     ],
@@ -20481,9 +16758,6 @@
     "experiment": "CMS",
     "publisher": "CERN Open Data Portal",
     "recid": "2620",
-    "run_period": [
-      "Run2011A"
-    ],
     "title": "High-Level Trigger path information HLT_L1SingleJet36_part2 (MinBias0Tesla2 dataset)",
     "type": {
       "primary": "Supplementaries",
@@ -20504,9 +16778,6 @@
     "collections": [
       "CMS-Trigger-Information"
     ],
-    "collision_information": {
-      "energy": "7TeV"
-    },
     "date_created": [
       "2011"
     ],
@@ -20514,9 +16785,6 @@
     "experiment": "CMS",
     "publisher": "CERN Open Data Portal",
     "recid": "2621",
-    "run_period": [
-      "Run2011A"
-    ],
     "title": "High-Level Trigger path information HLT_L1SingleJet52 (L1JetHPF dataset)",
     "type": {
       "primary": "Supplementaries",
@@ -20537,9 +16805,6 @@
     "collections": [
       "CMS-Trigger-Information"
     ],
-    "collision_information": {
-      "energy": "7TeV"
-    },
     "date_created": [
       "2011"
     ],
@@ -20547,9 +16812,6 @@
     "experiment": "CMS",
     "publisher": "CERN Open Data Portal",
     "recid": "2622",
-    "run_period": [
-      "Run2011A"
-    ],
     "title": "High-Level Trigger path information HLT_L1SingleJet52_part0 (MinBias0Tesla0 dataset)",
     "type": {
       "primary": "Supplementaries",
@@ -20570,9 +16832,6 @@
     "collections": [
       "CMS-Trigger-Information"
     ],
-    "collision_information": {
-      "energy": "7TeV"
-    },
     "date_created": [
       "2011"
     ],
@@ -20580,9 +16839,6 @@
     "experiment": "CMS",
     "publisher": "CERN Open Data Portal",
     "recid": "2623",
-    "run_period": [
-      "Run2011A"
-    ],
     "title": "High-Level Trigger path information HLT_L1SingleJet52_part1 (MinBias0Tesla1 dataset)",
     "type": {
       "primary": "Supplementaries",
@@ -20603,9 +16859,6 @@
     "collections": [
       "CMS-Trigger-Information"
     ],
-    "collision_information": {
-      "energy": "7TeV"
-    },
     "date_created": [
       "2011"
     ],
@@ -20613,9 +16866,6 @@
     "experiment": "CMS",
     "publisher": "CERN Open Data Portal",
     "recid": "2624",
-    "run_period": [
-      "Run2011A"
-    ],
     "title": "High-Level Trigger path information HLT_L1SingleJet52_part2 (MinBias0Tesla2 dataset)",
     "type": {
       "primary": "Supplementaries",
@@ -20636,9 +16886,6 @@
     "collections": [
       "CMS-Trigger-Information"
     ],
-    "collision_information": {
-      "energy": "7TeV"
-    },
     "date_created": [
       "2011"
     ],
@@ -20646,9 +16893,6 @@
     "experiment": "CMS",
     "publisher": "CERN Open Data Portal",
     "recid": "2625",
-    "run_period": [
-      "Run2011A"
-    ],
     "title": "High-Level Trigger path information HLT_L1SingleJet68 (L1JetHPF dataset)",
     "type": {
       "primary": "Supplementaries",
@@ -20669,9 +16913,6 @@
     "collections": [
       "CMS-Trigger-Information"
     ],
-    "collision_information": {
-      "energy": "7TeV"
-    },
     "date_created": [
       "2011"
     ],
@@ -20679,9 +16920,6 @@
     "experiment": "CMS",
     "publisher": "CERN Open Data Portal",
     "recid": "2626",
-    "run_period": [
-      "Run2011A"
-    ],
     "title": "High-Level Trigger path information HLT_L1SingleJet68_part0 (MinBias0Tesla0 dataset)",
     "type": {
       "primary": "Supplementaries",
@@ -20702,9 +16940,6 @@
     "collections": [
       "CMS-Trigger-Information"
     ],
-    "collision_information": {
-      "energy": "7TeV"
-    },
     "date_created": [
       "2011"
     ],
@@ -20712,9 +16947,6 @@
     "experiment": "CMS",
     "publisher": "CERN Open Data Portal",
     "recid": "2627",
-    "run_period": [
-      "Run2011A"
-    ],
     "title": "High-Level Trigger path information HLT_L1SingleJet68_part1 (MinBias0Tesla1 dataset)",
     "type": {
       "primary": "Supplementaries",
@@ -20735,9 +16967,6 @@
     "collections": [
       "CMS-Trigger-Information"
     ],
-    "collision_information": {
-      "energy": "7TeV"
-    },
     "date_created": [
       "2011"
     ],
@@ -20745,9 +16974,6 @@
     "experiment": "CMS",
     "publisher": "CERN Open Data Portal",
     "recid": "2628",
-    "run_period": [
-      "Run2011A"
-    ],
     "title": "High-Level Trigger path information HLT_L1SingleJet68_part2 (MinBias0Tesla2 dataset)",
     "type": {
       "primary": "Supplementaries",
@@ -20768,9 +16994,6 @@
     "collections": [
       "CMS-Trigger-Information"
     ],
-    "collision_information": {
-      "energy": "7TeV"
-    },
     "date_created": [
       "2011"
     ],
@@ -20778,9 +17001,6 @@
     "experiment": "CMS",
     "publisher": "CERN Open Data Portal",
     "recid": "2629",
-    "run_period": [
-      "Run2011A"
-    ],
     "title": "High-Level Trigger path information HLT_L1SingleJet92 (L1JetHPF dataset)",
     "type": {
       "primary": "Supplementaries",
@@ -20801,9 +17021,6 @@
     "collections": [
       "CMS-Trigger-Information"
     ],
-    "collision_information": {
-      "energy": "7TeV"
-    },
     "date_created": [
       "2011"
     ],
@@ -20811,9 +17028,6 @@
     "experiment": "CMS",
     "publisher": "CERN Open Data Portal",
     "recid": "2630",
-    "run_period": [
-      "Run2011A"
-    ],
     "title": "High-Level Trigger path information HLT_L1SingleJet92_part0 (MinBias0Tesla0 dataset)",
     "type": {
       "primary": "Supplementaries",
@@ -20834,9 +17048,6 @@
     "collections": [
       "CMS-Trigger-Information"
     ],
-    "collision_information": {
-      "energy": "7TeV"
-    },
     "date_created": [
       "2011"
     ],
@@ -20844,9 +17055,6 @@
     "experiment": "CMS",
     "publisher": "CERN Open Data Portal",
     "recid": "2631",
-    "run_period": [
-      "Run2011A"
-    ],
     "title": "High-Level Trigger path information HLT_L1SingleJet92_part1 (MinBias0Tesla1 dataset)",
     "type": {
       "primary": "Supplementaries",
@@ -20867,9 +17075,6 @@
     "collections": [
       "CMS-Trigger-Information"
     ],
-    "collision_information": {
-      "energy": "7TeV"
-    },
     "date_created": [
       "2011"
     ],
@@ -20877,9 +17082,6 @@
     "experiment": "CMS",
     "publisher": "CERN Open Data Portal",
     "recid": "2632",
-    "run_period": [
-      "Run2011A"
-    ],
     "title": "High-Level Trigger path information HLT_L1SingleJet92_part2 (MinBias0Tesla2 dataset)",
     "type": {
       "primary": "Supplementaries",
@@ -20900,9 +17102,6 @@
     "collections": [
       "CMS-Trigger-Information"
     ],
-    "collision_information": {
-      "energy": "7TeV"
-    },
     "date_created": [
       "2011"
     ],
@@ -20910,9 +17109,6 @@
     "experiment": "CMS",
     "publisher": "CERN Open Data Portal",
     "recid": "2633",
-    "run_period": [
-      "Run2011A"
-    ],
     "title": "High-Level Trigger path information HLT_L1SingleMu10 (SingleMu dataset)",
     "type": {
       "primary": "Supplementaries",
@@ -20933,9 +17129,6 @@
     "collections": [
       "CMS-Trigger-Information"
     ],
-    "collision_information": {
-      "energy": "7TeV"
-    },
     "date_created": [
       "2011"
     ],
@@ -20943,9 +17136,6 @@
     "experiment": "CMS",
     "publisher": "CERN Open Data Portal",
     "recid": "2634",
-    "run_period": [
-      "Run2011A"
-    ],
     "title": "High-Level Trigger path information HLT_L1SingleMu20 (SingleMu dataset)",
     "type": {
       "primary": "Supplementaries",
@@ -20966,9 +17156,6 @@
     "collections": [
       "CMS-Trigger-Information"
     ],
-    "collision_information": {
-      "energy": "7TeV"
-    },
     "date_created": [
       "2011"
     ],
@@ -20976,9 +17163,6 @@
     "experiment": "CMS",
     "publisher": "CERN Open Data Portal",
     "recid": "2635",
-    "run_period": [
-      "Run2011A"
-    ],
     "title": "High-Level Trigger path information HLT_L1SingleMu25 (L1MuHPF dataset)",
     "type": {
       "primary": "Supplementaries",
@@ -20999,9 +17183,6 @@
     "collections": [
       "CMS-Trigger-Information"
     ],
-    "collision_information": {
-      "energy": "7TeV"
-    },
     "date_created": [
       "2011"
     ],
@@ -21009,9 +17190,6 @@
     "experiment": "CMS",
     "publisher": "CERN Open Data Portal",
     "recid": "2636",
-    "run_period": [
-      "Run2011A"
-    ],
     "title": "High-Level Trigger path information HLT_L1SingleMu3 (L1MuHPF dataset)",
     "type": {
       "primary": "Supplementaries",
@@ -21032,9 +17210,6 @@
     "collections": [
       "CMS-Trigger-Information"
     ],
-    "collision_information": {
-      "energy": "7TeV"
-    },
     "date_created": [
       "2011"
     ],
@@ -21042,9 +17217,6 @@
     "experiment": "CMS",
     "publisher": "CERN Open Data Portal",
     "recid": "2637",
-    "run_period": [
-      "Run2011A"
-    ],
     "title": "High-Level Trigger path information HLT_L1SingleMu7 (L1MuHPF dataset)",
     "type": {
       "primary": "Supplementaries",
@@ -21065,9 +17237,6 @@
     "collections": [
       "CMS-Trigger-Information"
     ],
-    "collision_information": {
-      "energy": "7TeV"
-    },
     "date_created": [
       "2011"
     ],
@@ -21075,9 +17244,6 @@
     "experiment": "CMS",
     "publisher": "CERN Open Data Portal",
     "recid": "2638",
-    "run_period": [
-      "Run2011A"
-    ],
     "title": "High-Level Trigger path information HLT_L1SingleMuOpen (Commissioning dataset)",
     "type": {
       "primary": "Supplementaries",
@@ -21098,9 +17264,6 @@
     "collections": [
       "CMS-Trigger-Information"
     ],
-    "collision_information": {
-      "energy": "7TeV"
-    },
     "date_created": [
       "2011"
     ],
@@ -21108,9 +17271,6 @@
     "experiment": "CMS",
     "publisher": "CERN Open Data Portal",
     "recid": "2639",
-    "run_period": [
-      "Run2011A"
-    ],
     "title": "High-Level Trigger path information HLT_L1SingleMuOpen_AntiBPTX (Cosmics dataset)",
     "type": {
       "primary": "Supplementaries",
@@ -21131,9 +17291,6 @@
     "collections": [
       "CMS-Trigger-Information"
     ],
-    "collision_information": {
-      "energy": "7TeV"
-    },
     "date_created": [
       "2011"
     ],
@@ -21141,9 +17298,6 @@
     "experiment": "CMS",
     "publisher": "CERN Open Data Portal",
     "recid": "2640",
-    "run_period": [
-      "Run2011A"
-    ],
     "title": "High-Level Trigger path information HLT_L1SingleMuOpen_DT (Commissioning dataset)",
     "type": {
       "primary": "Supplementaries",
@@ -21164,9 +17318,6 @@
     "collections": [
       "CMS-Trigger-Information"
     ],
-    "collision_information": {
-      "energy": "7TeV"
-    },
     "date_created": [
       "2011"
     ],
@@ -21174,9 +17325,6 @@
     "experiment": "CMS",
     "publisher": "CERN Open Data Portal",
     "recid": "2641",
-    "run_period": [
-      "Run2011A"
-    ],
     "title": "High-Level Trigger path information HLT_L1Tech_BSC_halo (Cosmics dataset)",
     "type": {
       "primary": "Supplementaries",
@@ -21197,9 +17345,6 @@
     "collections": [
       "CMS-Trigger-Information"
     ],
-    "collision_information": {
-      "energy": "7TeV"
-    },
     "date_created": [
       "2011"
     ],
@@ -21207,9 +17352,6 @@
     "experiment": "CMS",
     "publisher": "CERN Open Data Portal",
     "recid": "2642",
-    "run_period": [
-      "Run2011A"
-    ],
     "title": "High-Level Trigger path information HLT_L1Tech_BSC_minBias_OR (Interfill dataset)",
     "type": {
       "primary": "Supplementaries",
@@ -21230,9 +17372,6 @@
     "collections": [
       "CMS-Trigger-Information"
     ],
-    "collision_information": {
-      "energy": "7TeV"
-    },
     "date_created": [
       "2011"
     ],
@@ -21240,9 +17379,6 @@
     "experiment": "CMS",
     "publisher": "CERN Open Data Portal",
     "recid": "2643",
-    "run_period": [
-      "Run2011A"
-    ],
     "title": "High-Level Trigger path information HLT_L1Tech_BSC_minBias_threshold1 (MinimumBias dataset)",
     "type": {
       "primary": "Supplementaries",
@@ -21263,9 +17399,6 @@
     "collections": [
       "CMS-Trigger-Information"
     ],
-    "collision_information": {
-      "energy": "7TeV"
-    },
     "date_created": [
       "2011"
     ],
@@ -21273,9 +17406,6 @@
     "experiment": "CMS",
     "publisher": "CERN Open Data Portal",
     "recid": "2644",
-    "run_period": [
-      "Run2011A"
-    ],
     "title": "High-Level Trigger path information HLT_L1Tech_CASTOR_HaloMuon (ForwardTriggers dataset)",
     "type": {
       "primary": "Supplementaries",
@@ -21296,9 +17426,6 @@
     "collections": [
       "CMS-Trigger-Information"
     ],
-    "collision_information": {
-      "energy": "7TeV"
-    },
     "date_created": [
       "2011"
     ],
@@ -21306,9 +17433,6 @@
     "experiment": "CMS",
     "publisher": "CERN Open Data Portal",
     "recid": "2645",
-    "run_period": [
-      "Run2011A"
-    ],
     "title": "High-Level Trigger path information HLT_L1Tech_HBHEHO_totalOR (HcalHPDNoise dataset)",
     "type": {
       "primary": "Supplementaries",
@@ -21329,9 +17453,6 @@
     "collections": [
       "CMS-Trigger-Information"
     ],
-    "collision_information": {
-      "energy": "7TeV"
-    },
     "date_created": [
       "2011"
     ],
@@ -21339,9 +17460,6 @@
     "experiment": "CMS",
     "publisher": "CERN Open Data Portal",
     "recid": "2646",
-    "run_period": [
-      "Run2011A"
-    ],
     "title": "High-Level Trigger path information HLT_L1Tech_HCAL_HF_single_channel (HcalHPDNoise dataset)",
     "type": {
       "primary": "Supplementaries",
@@ -21362,9 +17480,6 @@
     "collections": [
       "CMS-Trigger-Information"
     ],
-    "collision_information": {
-      "energy": "7TeV"
-    },
     "date_created": [
       "2011"
     ],
@@ -21372,9 +17487,6 @@
     "experiment": "CMS",
     "publisher": "CERN Open Data Portal",
     "recid": "2647",
-    "run_period": [
-      "Run2011A"
-    ],
     "title": "High-Level Trigger path information HLT_L1Tech_HF (HcalHPDNoise dataset)",
     "type": {
       "primary": "Supplementaries",
@@ -21395,9 +17507,6 @@
     "collections": [
       "CMS-Trigger-Information"
     ],
-    "collision_information": {
-      "energy": "7TeV"
-    },
     "date_created": [
       "2011"
     ],
@@ -21405,9 +17514,6 @@
     "experiment": "CMS",
     "publisher": "CERN Open Data Portal",
     "recid": "2648",
-    "run_period": [
-      "Run2011A"
-    ],
     "title": "High-Level Trigger path information HLT_L1TrackerCosmics (Cosmics dataset)",
     "type": {
       "primary": "Supplementaries",
@@ -21428,9 +17534,6 @@
     "collections": [
       "CMS-Trigger-Information"
     ],
-    "collision_information": {
-      "energy": "7TeV"
-    },
     "date_created": [
       "2011"
     ],
@@ -21438,9 +17541,6 @@
     "experiment": "CMS",
     "publisher": "CERN Open Data Portal",
     "recid": "2649",
-    "run_period": [
-      "Run2011A"
-    ],
     "title": "High-Level Trigger path information HLT_L1_BeamHalo (Cosmics dataset)",
     "type": {
       "primary": "Supplementaries",
@@ -21461,9 +17561,6 @@
     "collections": [
       "CMS-Trigger-Information"
     ],
-    "collision_information": {
-      "energy": "7TeV"
-    },
     "date_created": [
       "2011"
     ],
@@ -21471,9 +17568,6 @@
     "experiment": "CMS",
     "publisher": "CERN Open Data Portal",
     "recid": "2650",
-    "run_period": [
-      "Run2011A"
-    ],
     "title": "High-Level Trigger path information HLT_L1_Interbunch_BSC (Commissioning dataset)",
     "type": {
       "primary": "Supplementaries",
@@ -21494,9 +17588,6 @@
     "collections": [
       "CMS-Trigger-Information"
     ],
-    "collision_information": {
-      "energy": "7TeV"
-    },
     "date_created": [
       "2011"
     ],
@@ -21504,9 +17595,6 @@
     "experiment": "CMS",
     "publisher": "CERN Open Data Portal",
     "recid": "2651",
-    "run_period": [
-      "Run2011A"
-    ],
     "title": "High-Level Trigger path information HLT_L1_PreCollisions (Commissioning dataset)",
     "type": {
       "primary": "Supplementaries",
@@ -21527,9 +17615,6 @@
     "collections": [
       "CMS-Trigger-Information"
     ],
-    "collision_information": {
-      "energy": "7TeV"
-    },
     "date_created": [
       "2011"
     ],
@@ -21537,9 +17622,6 @@
     "experiment": "CMS",
     "publisher": "CERN Open Data Portal",
     "recid": "2652",
-    "run_period": [
-      "Run2011A"
-    ],
     "title": "High-Level Trigger path information HLT_L2DoubleMu0 (DoubleMu dataset)",
     "type": {
       "primary": "Supplementaries",
@@ -21560,9 +17642,6 @@
     "collections": [
       "CMS-Trigger-Information"
     ],
-    "collision_information": {
-      "energy": "7TeV"
-    },
     "date_created": [
       "2011"
     ],
@@ -21570,9 +17649,6 @@
     "experiment": "CMS",
     "publisher": "CERN Open Data Portal",
     "recid": "2653",
-    "run_period": [
-      "Run2011A"
-    ],
     "title": "High-Level Trigger path information HLT_L2DoubleMu23_NoVertex (DoubleMu dataset)",
     "type": {
       "primary": "Supplementaries",
@@ -21593,9 +17669,6 @@
     "collections": [
       "CMS-Trigger-Information"
     ],
-    "collision_information": {
-      "energy": "7TeV"
-    },
     "date_created": [
       "2011"
     ],
@@ -21603,9 +17676,6 @@
     "experiment": "CMS",
     "publisher": "CERN Open Data Portal",
     "recid": "2654",
-    "run_period": [
-      "Run2011A"
-    ],
     "title": "High-Level Trigger path information HLT_L2DoubleMu30_NoVertex (DoubleMu dataset)",
     "type": {
       "primary": "Supplementaries",
@@ -21626,9 +17696,6 @@
     "collections": [
       "CMS-Trigger-Information"
     ],
-    "collision_information": {
-      "energy": "7TeV"
-    },
     "date_created": [
       "2011"
     ],
@@ -21636,9 +17703,6 @@
     "experiment": "CMS",
     "publisher": "CERN Open Data Portal",
     "recid": "2655",
-    "run_period": [
-      "Run2011A"
-    ],
     "title": "High-Level Trigger path information HLT_L2DoubleMu30_NoVertex_dPhi2p5 (DoubleMu dataset)",
     "type": {
       "primary": "Supplementaries",
@@ -21659,9 +17723,6 @@
     "collections": [
       "CMS-Trigger-Information"
     ],
-    "collision_information": {
-      "energy": "7TeV"
-    },
     "date_created": [
       "2011"
     ],
@@ -21669,9 +17730,6 @@
     "experiment": "CMS",
     "publisher": "CERN Open Data Portal",
     "recid": "2656",
-    "run_period": [
-      "Run2011A"
-    ],
     "title": "High-Level Trigger path information HLT_L2DoubleMu35_NoVertex (DoubleMu dataset)",
     "type": {
       "primary": "Supplementaries",
@@ -21692,9 +17750,6 @@
     "collections": [
       "CMS-Trigger-Information"
     ],
-    "collision_information": {
-      "energy": "7TeV"
-    },
     "date_created": [
       "2011"
     ],
@@ -21702,9 +17757,6 @@
     "experiment": "CMS",
     "publisher": "CERN Open Data Portal",
     "recid": "2657",
-    "run_period": [
-      "Run2011A"
-    ],
     "title": "High-Level Trigger path information HLT_L2DoubleMu45_NoVertex (DoubleMu dataset)",
     "type": {
       "primary": "Supplementaries",
@@ -21725,9 +17777,6 @@
     "collections": [
       "CMS-Trigger-Information"
     ],
-    "collision_information": {
-      "energy": "7TeV"
-    },
     "date_created": [
       "2011"
     ],
@@ -21735,9 +17784,6 @@
     "experiment": "CMS",
     "publisher": "CERN Open Data Portal",
     "recid": "2658",
-    "run_period": [
-      "Run2011A"
-    ],
     "title": "High-Level Trigger path information HLT_L2Mu10 (SingleMu dataset)",
     "type": {
       "primary": "Supplementaries",
@@ -21758,9 +17804,6 @@
     "collections": [
       "CMS-Trigger-Information"
     ],
-    "collision_information": {
-      "energy": "7TeV"
-    },
     "date_created": [
       "2011"
     ],
@@ -21768,9 +17811,6 @@
     "experiment": "CMS",
     "publisher": "CERN Open Data Portal",
     "recid": "2659",
-    "run_period": [
-      "Run2011A"
-    ],
     "title": "High-Level Trigger path information HLT_L2Mu20 (SingleMu dataset)",
     "type": {
       "primary": "Supplementaries",
@@ -21791,9 +17831,6 @@
     "collections": [
       "CMS-Trigger-Information"
     ],
-    "collision_information": {
-      "energy": "7TeV"
-    },
     "date_created": [
       "2011"
     ],
@@ -21801,9 +17838,6 @@
     "experiment": "CMS",
     "publisher": "CERN Open Data Portal",
     "recid": "2660",
-    "run_period": [
-      "Run2011A"
-    ],
     "title": "High-Level Trigger path information HLT_L2Mu60_1Hit_MET40 (MET dataset)",
     "type": {
       "primary": "Supplementaries",
@@ -21824,9 +17858,6 @@
     "collections": [
       "CMS-Trigger-Information"
     ],
-    "collision_information": {
-      "energy": "7TeV"
-    },
     "date_created": [
       "2011"
     ],
@@ -21834,9 +17865,6 @@
     "experiment": "CMS",
     "publisher": "CERN Open Data Portal",
     "recid": "2661",
-    "run_period": [
-      "Run2011A"
-    ],
     "title": "High-Level Trigger path information HLT_L2Mu60_1Hit_MET60 (MET dataset)",
     "type": {
       "primary": "Supplementaries",
@@ -21857,9 +17885,6 @@
     "collections": [
       "CMS-Trigger-Information"
     ],
-    "collision_information": {
-      "energy": "7TeV"
-    },
     "date_created": [
       "2011"
     ],
@@ -21867,9 +17892,6 @@
     "experiment": "CMS",
     "publisher": "CERN Open Data Portal",
     "recid": "2662",
-    "run_period": [
-      "Run2011A"
-    ],
     "title": "High-Level Trigger path information HLT_L2MuOpen_NoVertex (Cosmics dataset)",
     "type": {
       "primary": "Supplementaries",
@@ -21890,9 +17912,6 @@
     "collections": [
       "CMS-Trigger-Information"
     ],
-    "collision_information": {
-      "energy": "7TeV"
-    },
     "date_created": [
       "2011"
     ],
@@ -21900,9 +17919,6 @@
     "experiment": "CMS",
     "publisher": "CERN Open Data Portal",
     "recid": "2663",
-    "run_period": [
-      "Run2011A"
-    ],
     "title": "High-Level Trigger path information HLT_L3MuonsCosmicTracking (Cosmics dataset)",
     "type": {
       "primary": "Supplementaries",
@@ -21923,9 +17939,6 @@
     "collections": [
       "CMS-Trigger-Information"
     ],
-    "collision_information": {
-      "energy": "7TeV"
-    },
     "date_created": [
       "2011"
     ],
@@ -21933,9 +17946,6 @@
     "experiment": "CMS",
     "publisher": "CERN Open Data Portal",
     "recid": "2664",
-    "run_period": [
-      "Run2011A"
-    ],
     "title": "High-Level Trigger path information HLT_LogMonitor (LogMonitor dataset)",
     "type": {
       "primary": "Supplementaries",
@@ -21956,9 +17966,6 @@
     "collections": [
       "CMS-Trigger-Information"
     ],
-    "collision_information": {
-      "energy": "7TeV"
-    },
     "date_created": [
       "2011"
     ],
@@ -21966,9 +17973,6 @@
     "experiment": "CMS",
     "publisher": "CERN Open Data Portal",
     "recid": "2665",
-    "run_period": [
-      "Run2011A"
-    ],
     "title": "High-Level Trigger path information HLT_MET100 (MET, METBTag datasets)",
     "type": {
       "primary": "Supplementaries",
@@ -21989,9 +17993,6 @@
     "collections": [
       "CMS-Trigger-Information"
     ],
-    "collision_information": {
-      "energy": "7TeV"
-    },
     "date_created": [
       "2011"
     ],
@@ -21999,9 +18000,6 @@
     "experiment": "CMS",
     "publisher": "CERN Open Data Portal",
     "recid": "2666",
-    "run_period": [
-      "Run2011A"
-    ],
     "title": "High-Level Trigger path information HLT_MET100_HBHENoiseFiltered (MET dataset)",
     "type": {
       "primary": "Supplementaries",
@@ -22022,9 +18020,6 @@
     "collections": [
       "CMS-Trigger-Information"
     ],
-    "collision_information": {
-      "energy": "7TeV"
-    },
     "date_created": [
       "2011"
     ],
@@ -22032,9 +18027,6 @@
     "experiment": "CMS",
     "publisher": "CERN Open Data Portal",
     "recid": "2667",
-    "run_period": [
-      "Run2011A"
-    ],
     "title": "High-Level Trigger path information HLT_MET120 (MET, METBTag datasets)",
     "type": {
       "primary": "Supplementaries",
@@ -22055,9 +18047,6 @@
     "collections": [
       "CMS-Trigger-Information"
     ],
-    "collision_information": {
-      "energy": "7TeV"
-    },
     "date_created": [
       "2011"
     ],
@@ -22065,9 +18054,6 @@
     "experiment": "CMS",
     "publisher": "CERN Open Data Portal",
     "recid": "2668",
-    "run_period": [
-      "Run2011A"
-    ],
     "title": "High-Level Trigger path information HLT_MET120_HBHENoiseFiltered (MET dataset)",
     "type": {
       "primary": "Supplementaries",
@@ -22088,9 +18074,6 @@
     "collections": [
       "CMS-Trigger-Information"
     ],
-    "collision_information": {
-      "energy": "7TeV"
-    },
     "date_created": [
       "2011"
     ],
@@ -22098,9 +18081,6 @@
     "experiment": "CMS",
     "publisher": "CERN Open Data Portal",
     "recid": "2669",
-    "run_period": [
-      "Run2011A"
-    ],
     "title": "High-Level Trigger path information HLT_MET200 (MET, METBTag datasets)",
     "type": {
       "primary": "Supplementaries",
@@ -22121,9 +18101,6 @@
     "collections": [
       "CMS-Trigger-Information"
     ],
-    "collision_information": {
-      "energy": "7TeV"
-    },
     "date_created": [
       "2011"
     ],
@@ -22131,9 +18108,6 @@
     "experiment": "CMS",
     "publisher": "CERN Open Data Portal",
     "recid": "2670",
-    "run_period": [
-      "Run2011A"
-    ],
     "title": "High-Level Trigger path information HLT_MET200_HBHENoiseFiltered (MET dataset)",
     "type": {
       "primary": "Supplementaries",
@@ -22154,9 +18128,6 @@
     "collections": [
       "CMS-Trigger-Information"
     ],
-    "collision_information": {
-      "energy": "7TeV"
-    },
     "date_created": [
       "2011"
     ],
@@ -22164,9 +18135,6 @@
     "experiment": "CMS",
     "publisher": "CERN Open Data Portal",
     "recid": "2671",
-    "run_period": [
-      "Run2011A"
-    ],
     "title": "High-Level Trigger path information HLT_MET400 (MET dataset)",
     "type": {
       "primary": "Supplementaries",
@@ -22187,9 +18155,6 @@
     "collections": [
       "CMS-Trigger-Information"
     ],
-    "collision_information": {
-      "energy": "7TeV"
-    },
     "date_created": [
       "2011"
     ],
@@ -22197,9 +18162,6 @@
     "experiment": "CMS",
     "publisher": "CERN Open Data Portal",
     "recid": "2672",
-    "run_period": [
-      "Run2011A"
-    ],
     "title": "High-Level Trigger path information HLT_MET65 (MET dataset)",
     "type": {
       "primary": "Supplementaries",
@@ -22220,9 +18182,6 @@
     "collections": [
       "CMS-Trigger-Information"
     ],
-    "collision_information": {
-      "energy": "7TeV"
-    },
     "date_created": [
       "2011"
     ],
@@ -22230,9 +18189,6 @@
     "experiment": "CMS",
     "publisher": "CERN Open Data Portal",
     "recid": "2673",
-    "run_period": [
-      "Run2011A"
-    ],
     "title": "High-Level Trigger path information HLT_MET65_HBHENoiseFiltered (MET dataset)",
     "type": {
       "primary": "Supplementaries",
@@ -22253,9 +18209,6 @@
     "collections": [
       "CMS-Trigger-Information"
     ],
-    "collision_information": {
-      "energy": "7TeV"
-    },
     "date_created": [
       "2011"
     ],
@@ -22263,9 +18216,6 @@
     "experiment": "CMS",
     "publisher": "CERN Open Data Portal",
     "recid": "2674",
-    "run_period": [
-      "Run2011A"
-    ],
     "title": "High-Level Trigger path information HLT_MR100 (HT dataset)",
     "type": {
       "primary": "Supplementaries",
@@ -22286,9 +18236,6 @@
     "collections": [
       "CMS-Trigger-Information"
     ],
-    "collision_information": {
-      "energy": "7TeV"
-    },
     "date_created": [
       "2011"
     ],
@@ -22296,9 +18243,6 @@
     "experiment": "CMS",
     "publisher": "CERN Open Data Portal",
     "recid": "2675",
-    "run_period": [
-      "Run2011A"
-    ],
     "title": "High-Level Trigger path information HLT_MediumIsoPFTau35_Trk20 (Tau dataset)",
     "type": {
       "primary": "Supplementaries",
@@ -22319,9 +18263,6 @@
     "collections": [
       "CMS-Trigger-Information"
     ],
-    "collision_information": {
-      "energy": "7TeV"
-    },
     "date_created": [
       "2011"
     ],
@@ -22329,9 +18270,6 @@
     "experiment": "CMS",
     "publisher": "CERN Open Data Portal",
     "recid": "2676",
-    "run_period": [
-      "Run2011A"
-    ],
     "title": "High-Level Trigger path information HLT_MediumIsoPFTau35_Trk20_MET60 (Tau dataset)",
     "type": {
       "primary": "Supplementaries",
@@ -22352,9 +18290,6 @@
     "collections": [
       "CMS-Trigger-Information"
     ],
-    "collision_information": {
-      "energy": "7TeV"
-    },
     "date_created": [
       "2011"
     ],
@@ -22362,9 +18297,6 @@
     "experiment": "CMS",
     "publisher": "CERN Open Data Portal",
     "recid": "2677",
-    "run_period": [
-      "Run2011A"
-    ],
     "title": "High-Level Trigger path information HLT_MediumIsoPFTau35_Trk20_MET70 (Tau dataset)",
     "type": {
       "primary": "Supplementaries",
@@ -22385,9 +18317,6 @@
     "collections": [
       "CMS-Trigger-Information"
     ],
-    "collision_information": {
-      "energy": "7TeV"
-    },
     "date_created": [
       "2011"
     ],
@@ -22395,9 +18324,6 @@
     "experiment": "CMS",
     "publisher": "CERN Open Data Portal",
     "recid": "2678",
-    "run_period": [
-      "Run2011A"
-    ],
     "title": "High-Level Trigger path information HLT_Meff440 (HT dataset)",
     "type": {
       "primary": "Supplementaries",
@@ -22418,9 +18344,6 @@
     "collections": [
       "CMS-Trigger-Information"
     ],
-    "collision_information": {
-      "energy": "7TeV"
-    },
     "date_created": [
       "2011"
     ],
@@ -22428,9 +18351,6 @@
     "experiment": "CMS",
     "publisher": "CERN Open Data Portal",
     "recid": "2679",
-    "run_period": [
-      "Run2011A"
-    ],
     "title": "High-Level Trigger path information HLT_Meff520 (HT dataset)",
     "type": {
       "primary": "Supplementaries",
@@ -22451,9 +18371,6 @@
     "collections": [
       "CMS-Trigger-Information"
     ],
-    "collision_information": {
-      "energy": "7TeV"
-    },
     "date_created": [
       "2011"
     ],
@@ -22461,9 +18378,6 @@
     "experiment": "CMS",
     "publisher": "CERN Open Data Portal",
     "recid": "2680",
-    "run_period": [
-      "Run2011A"
-    ],
     "title": "High-Level Trigger path information HLT_Meff640 (HT dataset)",
     "type": {
       "primary": "Supplementaries",
@@ -22484,9 +18398,6 @@
     "collections": [
       "CMS-Trigger-Information"
     ],
-    "collision_information": {
-      "energy": "7TeV"
-    },
     "date_created": [
       "2011"
     ],
@@ -22494,9 +18405,6 @@
     "experiment": "CMS",
     "publisher": "CERN Open Data Portal",
     "recid": "2681",
-    "run_period": [
-      "Run2011A"
-    ],
     "title": "High-Level Trigger path information HLT_Mu0 (AllPhysics2760 dataset)",
     "type": {
       "primary": "Supplementaries",
@@ -22517,9 +18425,6 @@
     "collections": [
       "CMS-Trigger-Information"
     ],
-    "collision_information": {
-      "energy": "7TeV"
-    },
     "date_created": [
       "2011"
     ],
@@ -22527,9 +18432,6 @@
     "experiment": "CMS",
     "publisher": "CERN Open Data Portal",
     "recid": "2682",
-    "run_period": [
-      "Run2011A"
-    ],
     "title": "High-Level Trigger path information HLT_Mu100 (SingleMu dataset)",
     "type": {
       "primary": "Supplementaries",
@@ -22550,9 +18452,6 @@
     "collections": [
       "CMS-Trigger-Information"
     ],
-    "collision_information": {
-      "energy": "7TeV"
-    },
     "date_created": [
       "2011"
     ],
@@ -22560,9 +18459,6 @@
     "experiment": "CMS",
     "publisher": "CERN Open Data Portal",
     "recid": "2683",
-    "run_period": [
-      "Run2011A"
-    ],
     "title": "High-Level Trigger path information HLT_Mu100_eta2p1 (SingleMu dataset)",
     "type": {
       "primary": "Supplementaries",
@@ -22583,9 +18479,6 @@
     "collections": [
       "CMS-Trigger-Information"
     ],
-    "collision_information": {
-      "energy": "7TeV"
-    },
     "date_created": [
       "2011"
     ],
@@ -22593,9 +18486,6 @@
     "experiment": "CMS",
     "publisher": "CERN Open Data Portal",
     "recid": "2684",
-    "run_period": [
-      "Run2011A"
-    ],
     "title": "High-Level Trigger path information HLT_Mu10_Ele10_CaloIdL (MuEG dataset)",
     "type": {
       "primary": "Supplementaries",
@@ -22616,9 +18506,6 @@
     "collections": [
       "CMS-Trigger-Information"
     ],
-    "collision_information": {
-      "energy": "7TeV"
-    },
     "date_created": [
       "2011"
     ],
@@ -22626,9 +18513,6 @@
     "experiment": "CMS",
     "publisher": "CERN Open Data Portal",
     "recid": "2685",
-    "run_period": [
-      "Run2011A"
-    ],
     "title": "High-Level Trigger path information HLT_Mu10_R005_MR200 (MuHad dataset)",
     "type": {
       "primary": "Supplementaries",
@@ -22649,9 +18533,6 @@
     "collections": [
       "CMS-Trigger-Information"
     ],
-    "collision_information": {
-      "energy": "7TeV"
-    },
     "date_created": [
       "2011"
     ],
@@ -22659,9 +18540,6 @@
     "experiment": "CMS",
     "publisher": "CERN Open Data Portal",
     "recid": "2686",
-    "run_period": [
-      "Run2011A"
-    ],
     "title": "High-Level Trigger path information HLT_Mu10_R014_MR200 (MuHad dataset)",
     "type": {
       "primary": "Supplementaries",
@@ -22682,9 +18560,6 @@
     "collections": [
       "CMS-Trigger-Information"
     ],
-    "collision_information": {
-      "energy": "7TeV"
-    },
     "date_created": [
       "2011"
     ],
@@ -22692,9 +18567,6 @@
     "experiment": "CMS",
     "publisher": "CERN Open Data Portal",
     "recid": "2687",
-    "run_period": [
-      "Run2011A"
-    ],
     "title": "High-Level Trigger path information HLT_Mu10_R025_MR200 (MuHad dataset)",
     "type": {
       "primary": "Supplementaries",
@@ -22715,9 +18587,6 @@
     "collections": [
       "CMS-Trigger-Information"
     ],
-    "collision_information": {
-      "energy": "7TeV"
-    },
     "date_created": [
       "2011"
     ],
@@ -22725,9 +18594,6 @@
     "experiment": "CMS",
     "publisher": "CERN Open Data Portal",
     "recid": "2688",
-    "run_period": [
-      "Run2011A"
-    ],
     "title": "High-Level Trigger path information HLT_Mu10_R029_MR200 (MuHad dataset)",
     "type": {
       "primary": "Supplementaries",
@@ -22748,9 +18614,6 @@
     "collections": [
       "CMS-Trigger-Information"
     ],
-    "collision_information": {
-      "energy": "7TeV"
-    },
     "date_created": [
       "2011"
     ],
@@ -22758,9 +18621,6 @@
     "experiment": "CMS",
     "publisher": "CERN Open Data Portal",
     "recid": "2689",
-    "run_period": [
-      "Run2011A"
-    ],
     "title": "High-Level Trigger path information HLT_Mu10_R033_MR200 (MuHad dataset)",
     "type": {
       "primary": "Supplementaries",
@@ -22781,9 +18641,6 @@
     "collections": [
       "CMS-Trigger-Information"
     ],
-    "collision_information": {
-      "energy": "7TeV"
-    },
     "date_created": [
       "2011"
     ],
@@ -22791,9 +18648,6 @@
     "experiment": "CMS",
     "publisher": "CERN Open Data Portal",
     "recid": "2690",
-    "run_period": [
-      "Run2011A"
-    ],
     "title": "High-Level Trigger path information HLT_Mu12 (SingleMu dataset)",
     "type": {
       "primary": "Supplementaries",
@@ -22814,9 +18668,6 @@
     "collections": [
       "CMS-Trigger-Information"
     ],
-    "collision_information": {
-      "energy": "7TeV"
-    },
     "date_created": [
       "2011"
     ],
@@ -22824,9 +18675,6 @@
     "experiment": "CMS",
     "publisher": "CERN Open Data Portal",
     "recid": "2691",
-    "run_period": [
-      "Run2011A"
-    ],
     "title": "High-Level Trigger path information HLT_Mu12_CentralJet30_BTagIP (MuHad dataset)",
     "type": {
       "primary": "Supplementaries",
@@ -22847,9 +18695,6 @@
     "collections": [
       "CMS-Trigger-Information"
     ],
-    "collision_information": {
-      "energy": "7TeV"
-    },
     "date_created": [
       "2011"
     ],
@@ -22857,9 +18702,6 @@
     "experiment": "CMS",
     "publisher": "CERN Open Data Portal",
     "recid": "2692",
-    "run_period": [
-      "Run2011A"
-    ],
     "title": "High-Level Trigger path information HLT_Mu12_DiCentralJet20_BTagIP3D1stTrack (MuHad dataset)",
     "type": {
       "primary": "Supplementaries",
@@ -22880,9 +18722,6 @@
     "collections": [
       "CMS-Trigger-Information"
     ],
-    "collision_information": {
-      "energy": "7TeV"
-    },
     "date_created": [
       "2011"
     ],
@@ -22890,9 +18729,6 @@
     "experiment": "CMS",
     "publisher": "CERN Open Data Portal",
     "recid": "2693",
-    "run_period": [
-      "Run2011A"
-    ],
     "title": "High-Level Trigger path information HLT_Mu12_DiCentralJet20_DiBTagIP3D1stTrack (MuHad dataset)",
     "type": {
       "primary": "Supplementaries",
@@ -22913,9 +18749,6 @@
     "collections": [
       "CMS-Trigger-Information"
     ],
-    "collision_information": {
-      "energy": "7TeV"
-    },
     "date_created": [
       "2011"
     ],
@@ -22923,9 +18756,6 @@
     "experiment": "CMS",
     "publisher": "CERN Open Data Portal",
     "recid": "2694",
-    "run_period": [
-      "Run2011A"
-    ],
     "title": "High-Level Trigger path information HLT_Mu12_DiCentralJet30_BTagIP3D (MuHad dataset)",
     "type": {
       "primary": "Supplementaries",
@@ -22946,9 +18776,6 @@
     "collections": [
       "CMS-Trigger-Information"
     ],
-    "collision_information": {
-      "energy": "7TeV"
-    },
     "date_created": [
       "2011"
     ],
@@ -22956,9 +18783,6 @@
     "experiment": "CMS",
     "publisher": "CERN Open Data Portal",
     "recid": "2695",
-    "run_period": [
-      "Run2011A"
-    ],
     "title": "High-Level Trigger path information HLT_Mu12_eta2p1_DiCentralJet20_BTagIP3D1stTrack (MuHad dataset)",
     "type": {
       "primary": "Supplementaries",
@@ -22979,9 +18803,6 @@
     "collections": [
       "CMS-Trigger-Information"
     ],
-    "collision_information": {
-      "energy": "7TeV"
-    },
     "date_created": [
       "2011"
     ],
@@ -22989,9 +18810,6 @@
     "experiment": "CMS",
     "publisher": "CERN Open Data Portal",
     "recid": "2696",
-    "run_period": [
-      "Run2011A"
-    ],
     "title": "High-Level Trigger path information HLT_Mu12_eta2p1_DiCentralJet20_DiBTagIP3D1stTrack (MuHad dataset)",
     "type": {
       "primary": "Supplementaries",
@@ -23012,9 +18830,6 @@
     "collections": [
       "CMS-Trigger-Information"
     ],
-    "collision_information": {
-      "energy": "7TeV"
-    },
     "date_created": [
       "2011"
     ],
@@ -23022,9 +18837,6 @@
     "experiment": "CMS",
     "publisher": "CERN Open Data Portal",
     "recid": "2697",
-    "run_period": [
-      "Run2011A"
-    ],
     "title": "High-Level Trigger path information HLT_Mu12_eta2p1_DiCentralJet30_BTagIP3D (MuHad dataset)",
     "type": {
       "primary": "Supplementaries",
@@ -23045,9 +18857,6 @@
     "collections": [
       "CMS-Trigger-Information"
     ],
-    "collision_information": {
-      "energy": "7TeV"
-    },
     "date_created": [
       "2011"
     ],
@@ -23055,9 +18864,6 @@
     "experiment": "CMS",
     "publisher": "CERN Open Data Portal",
     "recid": "2698",
-    "run_period": [
-      "Run2011A"
-    ],
     "title": "High-Level Trigger path information HLT_Mu13_Mu8 (DoubleMu dataset)",
     "type": {
       "primary": "Supplementaries",
@@ -23078,9 +18884,6 @@
     "collections": [
       "CMS-Trigger-Information"
     ],
-    "collision_information": {
-      "energy": "7TeV"
-    },
     "date_created": [
       "2011"
     ],
@@ -23088,9 +18891,6 @@
     "experiment": "CMS",
     "publisher": "CERN Open Data Portal",
     "recid": "2699",
-    "run_period": [
-      "Run2011A"
-    ],
     "title": "High-Level Trigger path information HLT_Mu15 (SingleMu dataset)",
     "type": {
       "primary": "Supplementaries",
@@ -23111,9 +18911,6 @@
     "collections": [
       "CMS-Trigger-Information"
     ],
-    "collision_information": {
-      "energy": "7TeV"
-    },
     "date_created": [
       "2011"
     ],
@@ -23121,9 +18918,6 @@
     "experiment": "CMS",
     "publisher": "CERN Open Data Portal",
     "recid": "2700",
-    "run_period": [
-      "Run2011A"
-    ],
     "title": "High-Level Trigger path information HLT_Mu15_DoublePhoton15_CaloIdL (MuEG dataset)",
     "type": {
       "primary": "Supplementaries",
@@ -23144,9 +18938,6 @@
     "collections": [
       "CMS-Trigger-Information"
     ],
-    "collision_information": {
-      "energy": "7TeV"
-    },
     "date_created": [
       "2011"
     ],
@@ -23154,9 +18945,6 @@
     "experiment": "CMS",
     "publisher": "CERN Open Data Portal",
     "recid": "2701",
-    "run_period": [
-      "Run2011A"
-    ],
     "title": "High-Level Trigger path information HLT_Mu15_HT200 (MuHad dataset)",
     "type": {
       "primary": "Supplementaries",
@@ -23177,9 +18965,6 @@
     "collections": [
       "CMS-Trigger-Information"
     ],
-    "collision_information": {
-      "energy": "7TeV"
-    },
     "date_created": [
       "2011"
     ],
@@ -23187,9 +18972,6 @@
     "experiment": "CMS",
     "publisher": "CERN Open Data Portal",
     "recid": "2702",
-    "run_period": [
-      "Run2011A"
-    ],
     "title": "High-Level Trigger path information HLT_Mu15_L1ETM20 (MET dataset)",
     "type": {
       "primary": "Supplementaries",
@@ -23210,9 +18992,6 @@
     "collections": [
       "CMS-Trigger-Information"
     ],
-    "collision_information": {
-      "energy": "7TeV"
-    },
     "date_created": [
       "2011"
     ],
@@ -23220,9 +18999,6 @@
     "experiment": "CMS",
     "publisher": "CERN Open Data Portal",
     "recid": "2703",
-    "run_period": [
-      "Run2011A"
-    ],
     "title": "High-Level Trigger path information HLT_Mu15_LooseIsoPFTau15 (TauPlusX dataset)",
     "type": {
       "primary": "Supplementaries",
@@ -23243,9 +19019,6 @@
     "collections": [
       "CMS-Trigger-Information"
     ],
-    "collision_information": {
-      "energy": "7TeV"
-    },
     "date_created": [
       "2011"
     ],
@@ -23253,9 +19026,6 @@
     "experiment": "CMS",
     "publisher": "CERN Open Data Portal",
     "recid": "2704",
-    "run_period": [
-      "Run2011A"
-    ],
     "title": "High-Level Trigger path information HLT_Mu15_LooseIsoPFTau20 (TauPlusX dataset)",
     "type": {
       "primary": "Supplementaries",
@@ -23276,9 +19046,6 @@
     "collections": [
       "CMS-Trigger-Information"
     ],
-    "collision_information": {
-      "energy": "7TeV"
-    },
     "date_created": [
       "2011"
     ],
@@ -23286,9 +19053,6 @@
     "experiment": "CMS",
     "publisher": "CERN Open Data Portal",
     "recid": "2705",
-    "run_period": [
-      "Run2011A"
-    ],
     "title": "High-Level Trigger path information HLT_Mu15_Photon20_CaloIdL (MuEG dataset)",
     "type": {
       "primary": "Supplementaries",
@@ -23309,9 +19073,6 @@
     "collections": [
       "CMS-Trigger-Information"
     ],
-    "collision_information": {
-      "energy": "7TeV"
-    },
     "date_created": [
       "2011"
     ],
@@ -23319,9 +19080,6 @@
     "experiment": "CMS",
     "publisher": "CERN Open Data Portal",
     "recid": "2706",
-    "run_period": [
-      "Run2011A"
-    ],
     "title": "High-Level Trigger path information HLT_Mu17_CentralJet30 (MuHad dataset)",
     "type": {
       "primary": "Supplementaries",
@@ -23342,9 +19100,6 @@
     "collections": [
       "CMS-Trigger-Information"
     ],
-    "collision_information": {
-      "energy": "7TeV"
-    },
     "date_created": [
       "2011"
     ],
@@ -23352,9 +19107,6 @@
     "experiment": "CMS",
     "publisher": "CERN Open Data Portal",
     "recid": "2707",
-    "run_period": [
-      "Run2011A"
-    ],
     "title": "High-Level Trigger path information HLT_Mu17_CentralJet30_BTagIP (MuHad dataset)",
     "type": {
       "primary": "Supplementaries",
@@ -23375,9 +19127,6 @@
     "collections": [
       "CMS-Trigger-Information"
     ],
-    "collision_information": {
-      "energy": "7TeV"
-    },
     "date_created": [
       "2011"
     ],
@@ -23385,9 +19134,6 @@
     "experiment": "CMS",
     "publisher": "CERN Open Data Portal",
     "recid": "2708",
-    "run_period": [
-      "Run2011A"
-    ],
     "title": "High-Level Trigger path information HLT_Mu17_CentralJet40_BTagIP (MuHad dataset)",
     "type": {
       "primary": "Supplementaries",
@@ -23408,9 +19154,6 @@
     "collections": [
       "CMS-Trigger-Information"
     ],
-    "collision_information": {
-      "energy": "7TeV"
-    },
     "date_created": [
       "2011"
     ],
@@ -23418,9 +19161,6 @@
     "experiment": "CMS",
     "publisher": "CERN Open Data Portal",
     "recid": "2709",
-    "run_period": [
-      "Run2011A"
-    ],
     "title": "High-Level Trigger path information HLT_Mu17_DiCentralJet30 (MuHad dataset)",
     "type": {
       "primary": "Supplementaries",
@@ -23441,9 +19181,6 @@
     "collections": [
       "CMS-Trigger-Information"
     ],
-    "collision_information": {
-      "energy": "7TeV"
-    },
     "date_created": [
       "2011"
     ],
@@ -23451,9 +19188,6 @@
     "experiment": "CMS",
     "publisher": "CERN Open Data Portal",
     "recid": "2710",
-    "run_period": [
-      "Run2011A"
-    ],
     "title": "High-Level Trigger path information HLT_Mu17_Ele8_CaloIdL (MuEG dataset)",
     "type": {
       "primary": "Supplementaries",
@@ -23474,9 +19208,6 @@
     "collections": [
       "CMS-Trigger-Information"
     ],
-    "collision_information": {
-      "energy": "7TeV"
-    },
     "date_created": [
       "2011"
     ],
@@ -23484,9 +19215,6 @@
     "experiment": "CMS",
     "publisher": "CERN Open Data Portal",
     "recid": "2711",
-    "run_period": [
-      "Run2011A"
-    ],
     "title": "High-Level Trigger path information HLT_Mu17_Ele8_CaloIdT_CaloIsoVL (MuEG dataset)",
     "type": {
       "primary": "Supplementaries",
@@ -23507,9 +19235,6 @@
     "collections": [
       "CMS-Trigger-Information"
     ],
-    "collision_information": {
-      "energy": "7TeV"
-    },
     "date_created": [
       "2011"
     ],
@@ -23517,9 +19242,6 @@
     "experiment": "CMS",
     "publisher": "CERN Open Data Portal",
     "recid": "2712",
-    "run_period": [
-      "Run2011A"
-    ],
     "title": "High-Level Trigger path information HLT_Mu17_Mu8 (DoubleMu dataset)",
     "type": {
       "primary": "Supplementaries",
@@ -23540,9 +19262,6 @@
     "collections": [
       "CMS-Trigger-Information"
     ],
-    "collision_information": {
-      "energy": "7TeV"
-    },
     "date_created": [
       "2011"
     ],
@@ -23550,9 +19269,6 @@
     "experiment": "CMS",
     "publisher": "CERN Open Data Portal",
     "recid": "2713",
-    "run_period": [
-      "Run2011A"
-    ],
     "title": "High-Level Trigger path information HLT_Mu17_QuadCentralJet30 (MuHad dataset)",
     "type": {
       "primary": "Supplementaries",
@@ -23573,9 +19289,6 @@
     "collections": [
       "CMS-Trigger-Information"
     ],
-    "collision_information": {
-      "energy": "7TeV"
-    },
     "date_created": [
       "2011"
     ],
@@ -23583,9 +19296,6 @@
     "experiment": "CMS",
     "publisher": "CERN Open Data Portal",
     "recid": "2714",
-    "run_period": [
-      "Run2011A"
-    ],
     "title": "High-Level Trigger path information HLT_Mu17_TkMu8 (DoubleMu dataset)",
     "type": {
       "primary": "Supplementaries",
@@ -23606,9 +19316,6 @@
     "collections": [
       "CMS-Trigger-Information"
     ],
-    "collision_information": {
-      "energy": "7TeV"
-    },
     "date_created": [
       "2011"
     ],
@@ -23616,9 +19323,6 @@
     "experiment": "CMS",
     "publisher": "CERN Open Data Portal",
     "recid": "2715",
-    "run_period": [
-      "Run2011A"
-    ],
     "title": "High-Level Trigger path information HLT_Mu17_TriCentralJet30 (MuHad dataset)",
     "type": {
       "primary": "Supplementaries",
@@ -23639,9 +19343,6 @@
     "collections": [
       "CMS-Trigger-Information"
     ],
-    "collision_information": {
-      "energy": "7TeV"
-    },
     "date_created": [
       "2011"
     ],
@@ -23649,9 +19350,6 @@
     "experiment": "CMS",
     "publisher": "CERN Open Data Portal",
     "recid": "2716",
-    "run_period": [
-      "Run2011A"
-    ],
     "title": "High-Level Trigger path information HLT_Mu17_eta2p1_CentralJet30 (MuHad dataset)",
     "type": {
       "primary": "Supplementaries",
@@ -23672,9 +19370,6 @@
     "collections": [
       "CMS-Trigger-Information"
     ],
-    "collision_information": {
-      "energy": "7TeV"
-    },
     "date_created": [
       "2011"
     ],
@@ -23682,9 +19377,6 @@
     "experiment": "CMS",
     "publisher": "CERN Open Data Portal",
     "recid": "2717",
-    "run_period": [
-      "Run2011A"
-    ],
     "title": "High-Level Trigger path information HLT_Mu17_eta2p1_CentralJet30_BTagIP (MuHad dataset)",
     "type": {
       "primary": "Supplementaries",
@@ -23705,9 +19397,6 @@
     "collections": [
       "CMS-Trigger-Information"
     ],
-    "collision_information": {
-      "energy": "7TeV"
-    },
     "date_created": [
       "2011"
     ],
@@ -23715,9 +19404,6 @@
     "experiment": "CMS",
     "publisher": "CERN Open Data Portal",
     "recid": "2718",
-    "run_period": [
-      "Run2011A"
-    ],
     "title": "High-Level Trigger path information HLT_Mu17_eta2p1_CentralPFJet30 (MuHad dataset)",
     "type": {
       "primary": "Supplementaries",
@@ -23738,9 +19424,6 @@
     "collections": [
       "CMS-Trigger-Information"
     ],
-    "collision_information": {
-      "energy": "7TeV"
-    },
     "date_created": [
       "2011"
     ],
@@ -23748,9 +19431,6 @@
     "experiment": "CMS",
     "publisher": "CERN Open Data Portal",
     "recid": "2719",
-    "run_period": [
-      "Run2011A"
-    ],
     "title": "High-Level Trigger path information HLT_Mu17_eta2p1_DiCentralJet30 (MuHad dataset)",
     "type": {
       "primary": "Supplementaries",
@@ -23771,9 +19451,6 @@
     "collections": [
       "CMS-Trigger-Information"
     ],
-    "collision_information": {
-      "energy": "7TeV"
-    },
     "date_created": [
       "2011"
     ],
@@ -23781,9 +19458,6 @@
     "experiment": "CMS",
     "publisher": "CERN Open Data Portal",
     "recid": "2720",
-    "run_period": [
-      "Run2011A"
-    ],
     "title": "High-Level Trigger path information HLT_Mu17_eta2p1_DiCentralPFJet25_PFMHT15 (MuHad dataset)",
     "type": {
       "primary": "Supplementaries",
@@ -23804,9 +19478,6 @@
     "collections": [
       "CMS-Trigger-Information"
     ],
-    "collision_information": {
-      "energy": "7TeV"
-    },
     "date_created": [
       "2011"
     ],
@@ -23814,9 +19485,6 @@
     "experiment": "CMS",
     "publisher": "CERN Open Data Portal",
     "recid": "2721",
-    "run_period": [
-      "Run2011A"
-    ],
     "title": "High-Level Trigger path information HLT_Mu17_eta2p1_DiCentralPFJet30 (MuHad dataset)",
     "type": {
       "primary": "Supplementaries",
@@ -23837,9 +19505,6 @@
     "collections": [
       "CMS-Trigger-Information"
     ],
-    "collision_information": {
-      "energy": "7TeV"
-    },
     "date_created": [
       "2011"
     ],
@@ -23847,9 +19512,6 @@
     "experiment": "CMS",
     "publisher": "CERN Open Data Portal",
     "recid": "2722",
-    "run_period": [
-      "Run2011A"
-    ],
     "title": "High-Level Trigger path information HLT_Mu17_eta2p1_DiPFJet25_Deta3 (MuHad dataset)",
     "type": {
       "primary": "Supplementaries",
@@ -23870,9 +19532,6 @@
     "collections": [
       "CMS-Trigger-Information"
     ],
-    "collision_information": {
-      "energy": "7TeV"
-    },
     "date_created": [
       "2011"
     ],
@@ -23880,9 +19539,6 @@
     "experiment": "CMS",
     "publisher": "CERN Open Data Portal",
     "recid": "2723",
-    "run_period": [
-      "Run2011A"
-    ],
     "title": "High-Level Trigger path information HLT_Mu17_eta2p1_QuadCentralJet30 (MuHad dataset)",
     "type": {
       "primary": "Supplementaries",
@@ -23903,9 +19559,6 @@
     "collections": [
       "CMS-Trigger-Information"
     ],
-    "collision_information": {
-      "energy": "7TeV"
-    },
     "date_created": [
       "2011"
     ],
@@ -23913,9 +19566,6 @@
     "experiment": "CMS",
     "publisher": "CERN Open Data Portal",
     "recid": "2724",
-    "run_period": [
-      "Run2011A"
-    ],
     "title": "High-Level Trigger path information HLT_Mu17_eta2p1_QuadCentralPFJet30 (MuHad dataset)",
     "type": {
       "primary": "Supplementaries",
@@ -23936,9 +19586,6 @@
     "collections": [
       "CMS-Trigger-Information"
     ],
-    "collision_information": {
-      "energy": "7TeV"
-    },
     "date_created": [
       "2011"
     ],
@@ -23946,9 +19593,6 @@
     "experiment": "CMS",
     "publisher": "CERN Open Data Portal",
     "recid": "2725",
-    "run_period": [
-      "Run2011A"
-    ],
     "title": "High-Level Trigger path information HLT_Mu17_eta2p1_TriCentralJet30 (MuHad dataset)",
     "type": {
       "primary": "Supplementaries",
@@ -23969,9 +19613,6 @@
     "collections": [
       "CMS-Trigger-Information"
     ],
-    "collision_information": {
-      "energy": "7TeV"
-    },
     "date_created": [
       "2011"
     ],
@@ -23979,9 +19620,6 @@
     "experiment": "CMS",
     "publisher": "CERN Open Data Portal",
     "recid": "2726",
-    "run_period": [
-      "Run2011A"
-    ],
     "title": "High-Level Trigger path information HLT_Mu17_eta2p1_TriCentralPFJet30 (MuHad dataset)",
     "type": {
       "primary": "Supplementaries",
@@ -24002,9 +19640,6 @@
     "collections": [
       "CMS-Trigger-Information"
     ],
-    "collision_information": {
-      "energy": "7TeV"
-    },
     "date_created": [
       "2011"
     ],
@@ -24012,9 +19647,6 @@
     "experiment": "CMS",
     "publisher": "CERN Open Data Portal",
     "recid": "2727",
-    "run_period": [
-      "Run2011A"
-    ],
     "title": "High-Level Trigger path information HLT_Mu20 (SingleMu dataset)",
     "type": {
       "primary": "Supplementaries",
@@ -24035,9 +19667,6 @@
     "collections": [
       "CMS-Trigger-Information"
     ],
-    "collision_information": {
-      "energy": "7TeV"
-    },
     "date_created": [
       "2011"
     ],
@@ -24045,9 +19674,6 @@
     "experiment": "CMS",
     "publisher": "CERN Open Data Portal",
     "recid": "2728",
-    "run_period": [
-      "Run2011A"
-    ],
     "title": "High-Level Trigger path information HLT_Mu200_eta2p1 (SingleMu dataset)",
     "type": {
       "primary": "Supplementaries",
@@ -24068,9 +19694,6 @@
     "collections": [
       "CMS-Trigger-Information"
     ],
-    "collision_information": {
-      "energy": "7TeV"
-    },
     "date_created": [
       "2011"
     ],
@@ -24078,9 +19701,6 @@
     "experiment": "CMS",
     "publisher": "CERN Open Data Portal",
     "recid": "2729",
-    "run_period": [
-      "Run2011A"
-    ],
     "title": "High-Level Trigger path information HLT_Mu20_HT200 (MuHad dataset)",
     "type": {
       "primary": "Supplementaries",
@@ -24101,9 +19721,6 @@
     "collections": [
       "CMS-Trigger-Information"
     ],
-    "collision_information": {
-      "energy": "7TeV"
-    },
     "date_created": [
       "2011"
     ],
@@ -24111,9 +19728,6 @@
     "experiment": "CMS",
     "publisher": "CERN Open Data Portal",
     "recid": "2730",
-    "run_period": [
-      "Run2011A"
-    ],
     "title": "High-Level Trigger path information HLT_Mu24 (SingleMu dataset)",
     "type": {
       "primary": "Supplementaries",
@@ -24134,9 +19748,6 @@
     "collections": [
       "CMS-Trigger-Information"
     ],
-    "collision_information": {
-      "energy": "7TeV"
-    },
     "date_created": [
       "2011"
     ],
@@ -24144,9 +19755,6 @@
     "experiment": "CMS",
     "publisher": "CERN Open Data Portal",
     "recid": "2731",
-    "run_period": [
-      "Run2011A"
-    ],
     "title": "High-Level Trigger path information HLT_Mu24_eta2p1 (SingleMu dataset)",
     "type": {
       "primary": "Supplementaries",
@@ -24167,9 +19775,6 @@
     "collections": [
       "CMS-Trigger-Information"
     ],
-    "collision_information": {
-      "energy": "7TeV"
-    },
     "date_created": [
       "2011"
     ],
@@ -24177,9 +19782,6 @@
     "experiment": "CMS",
     "publisher": "CERN Open Data Portal",
     "recid": "2732",
-    "run_period": [
-      "Run2011A"
-    ],
     "title": "High-Level Trigger path information HLT_Mu3 (SingleMu dataset)",
     "type": {
       "primary": "Supplementaries",
@@ -24200,9 +19802,6 @@
     "collections": [
       "CMS-Trigger-Information"
     ],
-    "collision_information": {
-      "energy": "7TeV"
-    },
     "date_created": [
       "2011"
     ],
@@ -24210,9 +19809,6 @@
     "experiment": "CMS",
     "publisher": "CERN Open Data Portal",
     "recid": "2733",
-    "run_period": [
-      "Run2011A"
-    ],
     "title": "High-Level Trigger path information HLT_Mu30 (SingleMu dataset)",
     "type": {
       "primary": "Supplementaries",
@@ -24233,9 +19829,6 @@
     "collections": [
       "CMS-Trigger-Information"
     ],
-    "collision_information": {
-      "energy": "7TeV"
-    },
     "date_created": [
       "2011"
     ],
@@ -24243,9 +19836,6 @@
     "experiment": "CMS",
     "publisher": "CERN Open Data Portal",
     "recid": "2734",
-    "run_period": [
-      "Run2011A"
-    ],
     "title": "High-Level Trigger path information HLT_Mu30_HT200 (MuHad dataset)",
     "type": {
       "primary": "Supplementaries",
@@ -24266,9 +19856,6 @@
     "collections": [
       "CMS-Trigger-Information"
     ],
-    "collision_information": {
-      "energy": "7TeV"
-    },
     "date_created": [
       "2011"
     ],
@@ -24276,9 +19863,6 @@
     "experiment": "CMS",
     "publisher": "CERN Open Data Portal",
     "recid": "2735",
-    "run_period": [
-      "Run2011A"
-    ],
     "title": "High-Level Trigger path information HLT_Mu30_eta2p1 (SingleMu dataset)",
     "type": {
       "primary": "Supplementaries",
@@ -24299,9 +19883,6 @@
     "collections": [
       "CMS-Trigger-Information"
     ],
-    "collision_information": {
-      "energy": "7TeV"
-    },
     "date_created": [
       "2011"
     ],
@@ -24309,9 +19890,6 @@
     "experiment": "CMS",
     "publisher": "CERN Open Data Portal",
     "recid": "2736",
-    "run_period": [
-      "Run2011A"
-    ],
     "title": "High-Level Trigger path information HLT_Mu3_DiJet30 (MuHad dataset)",
     "type": {
       "primary": "Supplementaries",
@@ -24332,9 +19910,6 @@
     "collections": [
       "CMS-Trigger-Information"
     ],
-    "collision_information": {
-      "energy": "7TeV"
-    },
     "date_created": [
       "2011"
     ],
@@ -24342,9 +19917,6 @@
     "experiment": "CMS",
     "publisher": "CERN Open Data Portal",
     "recid": "2737",
-    "run_period": [
-      "Run2011A"
-    ],
     "title": "High-Level Trigger path information HLT_Mu3_Ele8_CaloIdL_TrkIdVL_HT150 (MuHad dataset)",
     "type": {
       "primary": "Supplementaries",
@@ -24365,9 +19937,6 @@
     "collections": [
       "CMS-Trigger-Information"
     ],
-    "collision_information": {
-      "energy": "7TeV"
-    },
     "date_created": [
       "2011"
     ],
@@ -24375,9 +19944,6 @@
     "experiment": "CMS",
     "publisher": "CERN Open Data Portal",
     "recid": "2738",
-    "run_period": [
-      "Run2011A"
-    ],
     "title": "High-Level Trigger path information HLT_Mu3_Ele8_CaloIdL_TrkIdVL_HT160 (MuHad dataset)",
     "type": {
       "primary": "Supplementaries",
@@ -24398,9 +19964,6 @@
     "collections": [
       "CMS-Trigger-Information"
     ],
-    "collision_information": {
-      "energy": "7TeV"
-    },
     "date_created": [
       "2011"
     ],
@@ -24408,9 +19971,6 @@
     "experiment": "CMS",
     "publisher": "CERN Open Data Portal",
     "recid": "2739",
-    "run_period": [
-      "Run2011A"
-    ],
     "title": "High-Level Trigger path information HLT_Mu3_Ele8_CaloIdT_CaloIsoVL (MuEG dataset)",
     "type": {
       "primary": "Supplementaries",
@@ -24431,9 +19991,6 @@
     "collections": [
       "CMS-Trigger-Information"
     ],
-    "collision_information": {
-      "energy": "7TeV"
-    },
     "date_created": [
       "2011"
     ],
@@ -24441,9 +19998,6 @@
     "experiment": "CMS",
     "publisher": "CERN Open Data Portal",
     "recid": "2740",
-    "run_period": [
-      "Run2011A"
-    ],
     "title": "High-Level Trigger path information HLT_Mu3_Ele8_CaloIdT_TrkIdVL_HT150 (MuHad dataset)",
     "type": {
       "primary": "Supplementaries",
@@ -24464,9 +20018,6 @@
     "collections": [
       "CMS-Trigger-Information"
     ],
-    "collision_information": {
-      "energy": "7TeV"
-    },
     "date_created": [
       "2011"
     ],
@@ -24474,9 +20025,6 @@
     "experiment": "CMS",
     "publisher": "CERN Open Data Portal",
     "recid": "2741",
-    "run_period": [
-      "Run2011A"
-    ],
     "title": "High-Level Trigger path information HLT_Mu3_Ele8_CaloIdT_TrkIdVL_HT160 (MuHad dataset)",
     "type": {
       "primary": "Supplementaries",
@@ -24497,9 +20045,6 @@
     "collections": [
       "CMS-Trigger-Information"
     ],
-    "collision_information": {
-      "energy": "7TeV"
-    },
     "date_created": [
       "2011"
     ],
@@ -24507,9 +20052,6 @@
     "experiment": "CMS",
     "publisher": "CERN Open Data Portal",
     "recid": "2742",
-    "run_period": [
-      "Run2011A"
-    ],
     "title": "High-Level Trigger path information HLT_Mu3_QuadJet30 (MuHad dataset)",
     "type": {
       "primary": "Supplementaries",
@@ -24530,9 +20072,6 @@
     "collections": [
       "CMS-Trigger-Information"
     ],
-    "collision_information": {
-      "energy": "7TeV"
-    },
     "date_created": [
       "2011"
     ],
@@ -24540,9 +20079,6 @@
     "experiment": "CMS",
     "publisher": "CERN Open Data Portal",
     "recid": "2743",
-    "run_period": [
-      "Run2011A"
-    ],
     "title": "High-Level Trigger path information HLT_Mu3_Track3_Jpsi (MuOnia dataset)",
     "type": {
       "primary": "Supplementaries",
@@ -24563,9 +20099,6 @@
     "collections": [
       "CMS-Trigger-Information"
     ],
-    "collision_information": {
-      "energy": "7TeV"
-    },
     "date_created": [
       "2011"
     ],
@@ -24573,9 +20106,6 @@
     "experiment": "CMS",
     "publisher": "CERN Open Data Portal",
     "recid": "2744",
-    "run_period": [
-      "Run2011A"
-    ],
     "title": "High-Level Trigger path information HLT_Mu3_TriJet30 (MuHad dataset)",
     "type": {
       "primary": "Supplementaries",
@@ -24596,9 +20126,6 @@
     "collections": [
       "CMS-Trigger-Information"
     ],
-    "collision_information": {
-      "energy": "7TeV"
-    },
     "date_created": [
       "2011"
     ],
@@ -24606,9 +20133,6 @@
     "experiment": "CMS",
     "publisher": "CERN Open Data Portal",
     "recid": "2745",
-    "run_period": [
-      "Run2011A"
-    ],
     "title": "High-Level Trigger path information HLT_Mu40 (SingleMu dataset)",
     "type": {
       "primary": "Supplementaries",
@@ -24629,9 +20153,6 @@
     "collections": [
       "CMS-Trigger-Information"
     ],
-    "collision_information": {
-      "energy": "7TeV"
-    },
     "date_created": [
       "2011"
     ],
@@ -24639,9 +20160,6 @@
     "experiment": "CMS",
     "publisher": "CERN Open Data Portal",
     "recid": "2746",
-    "run_period": [
-      "Run2011A"
-    ],
     "title": "High-Level Trigger path information HLT_Mu40_HT200 (MuHad dataset)",
     "type": {
       "primary": "Supplementaries",
@@ -24662,9 +20180,6 @@
     "collections": [
       "CMS-Trigger-Information"
     ],
-    "collision_information": {
-      "energy": "7TeV"
-    },
     "date_created": [
       "2011"
     ],
@@ -24672,9 +20187,6 @@
     "experiment": "CMS",
     "publisher": "CERN Open Data Portal",
     "recid": "2747",
-    "run_period": [
-      "Run2011A"
-    ],
     "title": "High-Level Trigger path information HLT_Mu40_HT300 (MuHad dataset)",
     "type": {
       "primary": "Supplementaries",
@@ -24695,9 +20207,6 @@
     "collections": [
       "CMS-Trigger-Information"
     ],
-    "collision_information": {
-      "energy": "7TeV"
-    },
     "date_created": [
       "2011"
     ],
@@ -24705,9 +20214,6 @@
     "experiment": "CMS",
     "publisher": "CERN Open Data Portal",
     "recid": "2748",
-    "run_period": [
-      "Run2011A"
-    ],
     "title": "High-Level Trigger path information HLT_Mu40_eta2p1 (SingleMu dataset)",
     "type": {
       "primary": "Supplementaries",
@@ -24728,9 +20234,6 @@
     "collections": [
       "CMS-Trigger-Information"
     ],
-    "collision_information": {
-      "energy": "7TeV"
-    },
     "date_created": [
       "2011"
     ],
@@ -24738,9 +20241,6 @@
     "experiment": "CMS",
     "publisher": "CERN Open Data Portal",
     "recid": "2749",
-    "run_period": [
-      "Run2011A"
-    ],
     "title": "High-Level Trigger path information HLT_Mu5 (SingleMu dataset)",
     "type": {
       "primary": "Supplementaries",
@@ -24761,9 +20261,6 @@
     "collections": [
       "CMS-Trigger-Information"
     ],
-    "collision_information": {
-      "energy": "7TeV"
-    },
     "date_created": [
       "2011"
     ],
@@ -24771,9 +20268,6 @@
     "experiment": "CMS",
     "publisher": "CERN Open Data Portal",
     "recid": "2750",
-    "run_period": [
-      "Run2011A"
-    ],
     "title": "High-Level Trigger path information HLT_Mu50_eta2p1 (SingleMu dataset)",
     "type": {
       "primary": "Supplementaries",
@@ -24794,9 +20288,6 @@
     "collections": [
       "CMS-Trigger-Information"
     ],
-    "collision_information": {
-      "energy": "7TeV"
-    },
     "date_created": [
       "2011"
     ],
@@ -24804,9 +20295,6 @@
     "experiment": "CMS",
     "publisher": "CERN Open Data Portal",
     "recid": "2751",
-    "run_period": [
-      "Run2011A"
-    ],
     "title": "High-Level Trigger path information HLT_Mu5_DiJet30 (MuHad dataset)",
     "type": {
       "primary": "Supplementaries",
@@ -24827,9 +20315,6 @@
     "collections": [
       "CMS-Trigger-Information"
     ],
-    "collision_information": {
-      "energy": "7TeV"
-    },
     "date_created": [
       "2011"
     ],
@@ -24837,9 +20322,6 @@
     "experiment": "CMS",
     "publisher": "CERN Open Data Portal",
     "recid": "2752",
-    "run_period": [
-      "Run2011A"
-    ],
     "title": "High-Level Trigger path information HLT_Mu5_DoubleEle8 (MuEG dataset)",
     "type": {
       "primary": "Supplementaries",
@@ -24860,9 +20342,6 @@
     "collections": [
       "CMS-Trigger-Information"
     ],
-    "collision_information": {
-      "energy": "7TeV"
-    },
     "date_created": [
       "2011"
     ],
@@ -24870,9 +20349,6 @@
     "experiment": "CMS",
     "publisher": "CERN Open Data Portal",
     "recid": "2753",
-    "run_period": [
-      "Run2011A"
-    ],
     "title": "High-Level Trigger path information HLT_Mu5_DoubleEle8_CaloIdL_TrkIdVL (MuEG dataset)",
     "type": {
       "primary": "Supplementaries",
@@ -24893,9 +20369,6 @@
     "collections": [
       "CMS-Trigger-Information"
     ],
-    "collision_information": {
-      "energy": "7TeV"
-    },
     "date_created": [
       "2011"
     ],
@@ -24903,9 +20376,6 @@
     "experiment": "CMS",
     "publisher": "CERN Open Data Portal",
     "recid": "2754",
-    "run_period": [
-      "Run2011A"
-    ],
     "title": "High-Level Trigger path information HLT_Mu5_DoubleEle8_CaloIdT_TrkIdVL (MuEG dataset)",
     "type": {
       "primary": "Supplementaries",
@@ -24926,9 +20396,6 @@
     "collections": [
       "CMS-Trigger-Information"
     ],
-    "collision_information": {
-      "energy": "7TeV"
-    },
     "date_created": [
       "2011"
     ],
@@ -24936,9 +20403,6 @@
     "experiment": "CMS",
     "publisher": "CERN Open Data Portal",
     "recid": "2755",
-    "run_period": [
-      "Run2011A"
-    ],
     "title": "High-Level Trigger path information HLT_Mu5_Ele8_CaloIdL_TrkIdVL_Ele8 (MuEG dataset)",
     "type": {
       "primary": "Supplementaries",
@@ -24959,9 +20423,6 @@
     "collections": [
       "CMS-Trigger-Information"
     ],
-    "collision_information": {
-      "energy": "7TeV"
-    },
     "date_created": [
       "2011"
     ],
@@ -24969,9 +20430,6 @@
     "experiment": "CMS",
     "publisher": "CERN Open Data Portal",
     "recid": "2756",
-    "run_period": [
-      "Run2011A"
-    ],
     "title": "High-Level Trigger path information HLT_Mu5_Ele8_CaloIdT_CaloIsoVL (MuEG dataset)",
     "type": {
       "primary": "Supplementaries",
@@ -24992,9 +20450,6 @@
     "collections": [
       "CMS-Trigger-Information"
     ],
-    "collision_information": {
-      "energy": "7TeV"
-    },
     "date_created": [
       "2011"
     ],
@@ -25002,9 +20457,6 @@
     "experiment": "CMS",
     "publisher": "CERN Open Data Portal",
     "recid": "2757",
-    "run_period": [
-      "Run2011A"
-    ],
     "title": "High-Level Trigger path information HLT_Mu5_Ele8_CaloIdT_TrkIdVL_Ele8_CaloIdL_TrkIdVL (MuEG dataset)",
     "type": {
       "primary": "Supplementaries",
@@ -25025,9 +20477,6 @@
     "collections": [
       "CMS-Trigger-Information"
     ],
-    "collision_information": {
-      "energy": "7TeV"
-    },
     "date_created": [
       "2011"
     ],
@@ -25035,9 +20484,6 @@
     "experiment": "CMS",
     "publisher": "CERN Open Data Portal",
     "recid": "2758",
-    "run_period": [
-      "Run2011A"
-    ],
     "title": "High-Level Trigger path information HLT_Mu5_Ele8_CaloIdT_TrkIdVL_HT150 (MuHad dataset)",
     "type": {
       "primary": "Supplementaries",
@@ -25058,9 +20504,6 @@
     "collections": [
       "CMS-Trigger-Information"
     ],
-    "collision_information": {
-      "energy": "7TeV"
-    },
     "date_created": [
       "2011"
     ],
@@ -25068,9 +20511,6 @@
     "experiment": "CMS",
     "publisher": "CERN Open Data Portal",
     "recid": "2759",
-    "run_period": [
-      "Run2011A"
-    ],
     "title": "High-Level Trigger path information HLT_Mu5_Ele8_CaloIdT_TrkIdVL_Mass4_HT150 (MuHad dataset)",
     "type": {
       "primary": "Supplementaries",
@@ -25091,9 +20531,6 @@
     "collections": [
       "CMS-Trigger-Information"
     ],
-    "collision_information": {
-      "energy": "7TeV"
-    },
     "date_created": [
       "2011"
     ],
@@ -25101,9 +20538,6 @@
     "experiment": "CMS",
     "publisher": "CERN Open Data Portal",
     "recid": "2760",
-    "run_period": [
-      "Run2011A"
-    ],
     "title": "High-Level Trigger path information HLT_Mu5_Ele8_CaloIdT_TrkIdVL_Mass8_HT150 (MuHad dataset)",
     "type": {
       "primary": "Supplementaries",
@@ -25124,9 +20558,6 @@
     "collections": [
       "CMS-Trigger-Information"
     ],
-    "collision_information": {
-      "energy": "7TeV"
-    },
     "date_created": [
       "2011"
     ],
@@ -25134,9 +20565,6 @@
     "experiment": "CMS",
     "publisher": "CERN Open Data Portal",
     "recid": "2761",
-    "run_period": [
-      "Run2011A"
-    ],
     "title": "High-Level Trigger path information HLT_Mu5_HT200 (MuHad dataset)",
     "type": {
       "primary": "Supplementaries",
@@ -25157,9 +20585,6 @@
     "collections": [
       "CMS-Trigger-Information"
     ],
-    "collision_information": {
-      "energy": "7TeV"
-    },
     "date_created": [
       "2011"
     ],
@@ -25167,9 +20592,6 @@
     "experiment": "CMS",
     "publisher": "CERN Open Data Portal",
     "recid": "2762",
-    "run_period": [
-      "Run2011A"
-    ],
     "title": "High-Level Trigger path information HLT_Mu5_L2Mu2 (MuOnia dataset)",
     "type": {
       "primary": "Supplementaries",
@@ -25190,9 +20612,6 @@
     "collections": [
       "CMS-Trigger-Information"
     ],
-    "collision_information": {
-      "energy": "7TeV"
-    },
     "date_created": [
       "2011"
     ],
@@ -25200,9 +20619,6 @@
     "experiment": "CMS",
     "publisher": "CERN Open Data Portal",
     "recid": "2763",
-    "run_period": [
-      "Run2011A"
-    ],
     "title": "High-Level Trigger path information HLT_Mu5_L2Mu2_Jpsi (MuOnia dataset)",
     "type": {
       "primary": "Supplementaries",
@@ -25223,9 +20639,6 @@
     "collections": [
       "CMS-Trigger-Information"
     ],
-    "collision_information": {
-      "energy": "7TeV"
-    },
     "date_created": [
       "2011"
     ],
@@ -25233,9 +20646,6 @@
     "experiment": "CMS",
     "publisher": "CERN Open Data Portal",
     "recid": "2764",
-    "run_period": [
-      "Run2011A"
-    ],
     "title": "High-Level Trigger path information HLT_Mu5_QuadJet30 (MuHad dataset)",
     "type": {
       "primary": "Supplementaries",
@@ -25256,9 +20666,6 @@
     "collections": [
       "CMS-Trigger-Information"
     ],
-    "collision_information": {
-      "energy": "7TeV"
-    },
     "date_created": [
       "2011"
     ],
@@ -25266,9 +20673,6 @@
     "experiment": "CMS",
     "publisher": "CERN Open Data Portal",
     "recid": "2765",
-    "run_period": [
-      "Run2011A"
-    ],
     "title": "High-Level Trigger path information HLT_Mu5_TkMu0_OST_Jpsi_Tight_B5Q7 (Commissioning dataset)",
     "type": {
       "primary": "Supplementaries",
@@ -25289,9 +20693,6 @@
     "collections": [
       "CMS-Trigger-Information"
     ],
-    "collision_information": {
-      "energy": "7TeV"
-    },
     "date_created": [
       "2011"
     ],
@@ -25299,9 +20700,6 @@
     "experiment": "CMS",
     "publisher": "CERN Open Data Portal",
     "recid": "2766",
-    "run_period": [
-      "Run2011A"
-    ],
     "title": "High-Level Trigger path information HLT_Mu5_Track2_Jpsi (MuOnia dataset)",
     "type": {
       "primary": "Supplementaries",
@@ -25322,9 +20720,6 @@
     "collections": [
       "CMS-Trigger-Information"
     ],
-    "collision_information": {
-      "energy": "7TeV"
-    },
     "date_created": [
       "2011"
     ],
@@ -25332,9 +20727,6 @@
     "experiment": "CMS",
     "publisher": "CERN Open Data Portal",
     "recid": "2767",
-    "run_period": [
-      "Run2011A"
-    ],
     "title": "High-Level Trigger path information HLT_Mu5_TriJet30 (MuHad dataset)",
     "type": {
       "primary": "Supplementaries",
@@ -25355,9 +20747,6 @@
     "collections": [
       "CMS-Trigger-Information"
     ],
-    "collision_information": {
-      "energy": "7TeV"
-    },
     "date_created": [
       "2011"
     ],
@@ -25365,9 +20754,6 @@
     "experiment": "CMS",
     "publisher": "CERN Open Data Portal",
     "recid": "2768",
-    "run_period": [
-      "Run2011A"
-    ],
     "title": "High-Level Trigger path information HLT_Mu60 (SingleMu dataset)",
     "type": {
       "primary": "Supplementaries",
@@ -25388,9 +20774,6 @@
     "collections": [
       "CMS-Trigger-Information"
     ],
-    "collision_information": {
-      "energy": "7TeV"
-    },
     "date_created": [
       "2011"
     ],
@@ -25398,9 +20781,6 @@
     "experiment": "CMS",
     "publisher": "CERN Open Data Portal",
     "recid": "2769",
-    "run_period": [
-      "Run2011A"
-    ],
     "title": "High-Level Trigger path information HLT_Mu60_HT200 (MuHad dataset)",
     "type": {
       "primary": "Supplementaries",
@@ -25421,9 +20801,6 @@
     "collections": [
       "CMS-Trigger-Information"
     ],
-    "collision_information": {
-      "energy": "7TeV"
-    },
     "date_created": [
       "2011"
     ],
@@ -25431,9 +20808,6 @@
     "experiment": "CMS",
     "publisher": "CERN Open Data Portal",
     "recid": "2770",
-    "run_period": [
-      "Run2011A"
-    ],
     "title": "High-Level Trigger path information HLT_Mu60_HT300 (MuHad dataset)",
     "type": {
       "primary": "Supplementaries",
@@ -25454,9 +20828,6 @@
     "collections": [
       "CMS-Trigger-Information"
     ],
-    "collision_information": {
-      "energy": "7TeV"
-    },
     "date_created": [
       "2011"
     ],
@@ -25464,9 +20835,6 @@
     "experiment": "CMS",
     "publisher": "CERN Open Data Portal",
     "recid": "2771",
-    "run_period": [
-      "Run2011A"
-    ],
     "title": "High-Level Trigger path information HLT_Mu60_eta2p1 (SingleMu dataset)",
     "type": {
       "primary": "Supplementaries",
@@ -25487,9 +20855,6 @@
     "collections": [
       "CMS-Trigger-Information"
     ],
-    "collision_information": {
-      "energy": "7TeV"
-    },
     "date_created": [
       "2011"
     ],
@@ -25497,9 +20862,6 @@
     "experiment": "CMS",
     "publisher": "CERN Open Data Portal",
     "recid": "2772",
-    "run_period": [
-      "Run2011A"
-    ],
     "title": "High-Level Trigger path information HLT_Mu7_Track5_Jpsi (MuOnia dataset)",
     "type": {
       "primary": "Supplementaries",
@@ -25520,9 +20882,6 @@
     "collections": [
       "CMS-Trigger-Information"
     ],
-    "collision_information": {
-      "energy": "7TeV"
-    },
     "date_created": [
       "2011"
     ],
@@ -25530,9 +20889,6 @@
     "experiment": "CMS",
     "publisher": "CERN Open Data Portal",
     "recid": "2773",
-    "run_period": [
-      "Run2011A"
-    ],
     "title": "High-Level Trigger path information HLT_Mu7_Track7_Jpsi (MuOnia dataset)",
     "type": {
       "primary": "Supplementaries",
@@ -25553,9 +20909,6 @@
     "collections": [
       "CMS-Trigger-Information"
     ],
-    "collision_information": {
-      "energy": "7TeV"
-    },
     "date_created": [
       "2011"
     ],
@@ -25563,9 +20916,6 @@
     "experiment": "CMS",
     "publisher": "CERN Open Data Portal",
     "recid": "2774",
-    "run_period": [
-      "Run2011A"
-    ],
     "title": "High-Level Trigger path information HLT_Mu8 (SingleMu dataset)",
     "type": {
       "primary": "Supplementaries",
@@ -25586,9 +20936,6 @@
     "collections": [
       "CMS-Trigger-Information"
     ],
-    "collision_information": {
-      "energy": "7TeV"
-    },
     "date_created": [
       "2011"
     ],
@@ -25596,9 +20943,6 @@
     "experiment": "CMS",
     "publisher": "CERN Open Data Portal",
     "recid": "2775",
-    "run_period": [
-      "Run2011A"
-    ],
     "title": "High-Level Trigger path information HLT_Mu8_Ele17_CaloIdL (MuEG dataset)",
     "type": {
       "primary": "Supplementaries",
@@ -25619,9 +20963,6 @@
     "collections": [
       "CMS-Trigger-Information"
     ],
-    "collision_information": {
-      "energy": "7TeV"
-    },
     "date_created": [
       "2011"
     ],
@@ -25629,9 +20970,6 @@
     "experiment": "CMS",
     "publisher": "CERN Open Data Portal",
     "recid": "2776",
-    "run_period": [
-      "Run2011A"
-    ],
     "title": "High-Level Trigger path information HLT_Mu8_Ele17_CaloIdT_CaloIsoVL (MuEG dataset)",
     "type": {
       "primary": "Supplementaries",
@@ -25652,9 +20990,6 @@
     "collections": [
       "CMS-Trigger-Information"
     ],
-    "collision_information": {
-      "energy": "7TeV"
-    },
     "date_created": [
       "2011"
     ],
@@ -25662,9 +20997,6 @@
     "experiment": "CMS",
     "publisher": "CERN Open Data Portal",
     "recid": "2777",
-    "run_period": [
-      "Run2011A"
-    ],
     "title": "High-Level Trigger path information HLT_Mu8_Ele8_CaloIdT_TrkIdVL_Mass8_HT150 (MuHad dataset)",
     "type": {
       "primary": "Supplementaries",
@@ -25685,9 +21017,6 @@
     "collections": [
       "CMS-Trigger-Information"
     ],
-    "collision_information": {
-      "energy": "7TeV"
-    },
     "date_created": [
       "2011"
     ],
@@ -25695,9 +21024,6 @@
     "experiment": "CMS",
     "publisher": "CERN Open Data Portal",
     "recid": "2778",
-    "run_period": [
-      "Run2011A"
-    ],
     "title": "High-Level Trigger path information HLT_Mu8_Ele8_CaloIdT_TrkIdVL_Mass8_HT200 (MuHad dataset)",
     "type": {
       "primary": "Supplementaries",
@@ -25718,9 +21044,6 @@
     "collections": [
       "CMS-Trigger-Information"
     ],
-    "collision_information": {
-      "energy": "7TeV"
-    },
     "date_created": [
       "2011"
     ],
@@ -25728,9 +21051,6 @@
     "experiment": "CMS",
     "publisher": "CERN Open Data Portal",
     "recid": "2779",
-    "run_period": [
-      "Run2011A"
-    ],
     "title": "High-Level Trigger path information HLT_Mu8_HT200 (MuHad dataset)",
     "type": {
       "primary": "Supplementaries",
@@ -25751,9 +21071,6 @@
     "collections": [
       "CMS-Trigger-Information"
     ],
-    "collision_information": {
-      "energy": "7TeV"
-    },
     "date_created": [
       "2011"
     ],
@@ -25761,9 +21078,6 @@
     "experiment": "CMS",
     "publisher": "CERN Open Data Portal",
     "recid": "2780",
-    "run_period": [
-      "Run2011A"
-    ],
     "title": "High-Level Trigger path information HLT_Mu8_Jet40 (DoubleMu dataset)",
     "type": {
       "primary": "Supplementaries",
@@ -25784,9 +21098,6 @@
     "collections": [
       "CMS-Trigger-Information"
     ],
-    "collision_information": {
-      "energy": "7TeV"
-    },
     "date_created": [
       "2011"
     ],
@@ -25794,9 +21105,6 @@
     "experiment": "CMS",
     "publisher": "CERN Open Data Portal",
     "recid": "2781",
-    "run_period": [
-      "Run2011A"
-    ],
     "title": "High-Level Trigger path information HLT_Mu8_Photon20_CaloIdVT_IsoT (MuEG dataset)",
     "type": {
       "primary": "Supplementaries",
@@ -25817,9 +21125,6 @@
     "collections": [
       "CMS-Trigger-Information"
     ],
-    "collision_information": {
-      "energy": "7TeV"
-    },
     "date_created": [
       "2011"
     ],
@@ -25827,9 +21132,6 @@
     "experiment": "CMS",
     "publisher": "CERN Open Data Portal",
     "recid": "2782",
-    "run_period": [
-      "Run2011A"
-    ],
     "title": "High-Level Trigger path information HLT_Mu8_R005_MR200 (MuHad dataset)",
     "type": {
       "primary": "Supplementaries",
@@ -25850,9 +21152,6 @@
     "collections": [
       "CMS-Trigger-Information"
     ],
-    "collision_information": {
-      "energy": "7TeV"
-    },
     "date_created": [
       "2011"
     ],
@@ -25860,9 +21159,6 @@
     "experiment": "CMS",
     "publisher": "CERN Open Data Portal",
     "recid": "2783",
-    "run_period": [
-      "Run2011A"
-    ],
     "title": "High-Level Trigger path information HLT_Mu8_R020_MR200 (MuHad dataset)",
     "type": {
       "primary": "Supplementaries",
@@ -25883,9 +21179,6 @@
     "collections": [
       "CMS-Trigger-Information"
     ],
-    "collision_information": {
-      "energy": "7TeV"
-    },
     "date_created": [
       "2011"
     ],
@@ -25893,9 +21186,6 @@
     "experiment": "CMS",
     "publisher": "CERN Open Data Portal",
     "recid": "2784",
-    "run_period": [
-      "Run2011A"
-    ],
     "title": "High-Level Trigger path information HLT_Mu8_R025_MR200 (MuHad dataset)",
     "type": {
       "primary": "Supplementaries",
@@ -25916,9 +21206,6 @@
     "collections": [
       "CMS-Trigger-Information"
     ],
-    "collision_information": {
-      "energy": "7TeV"
-    },
     "date_created": [
       "2011"
     ],
@@ -25926,9 +21213,6 @@
     "experiment": "CMS",
     "publisher": "CERN Open Data Portal",
     "recid": "2785",
-    "run_period": [
-      "Run2011A"
-    ],
     "title": "High-Level Trigger path information HLT_Mu8_R029_MR200 (MuHad dataset)",
     "type": {
       "primary": "Supplementaries",
@@ -25949,9 +21233,6 @@
     "collections": [
       "CMS-Trigger-Information"
     ],
-    "collision_information": {
-      "energy": "7TeV"
-    },
     "date_created": [
       "2011"
     ],
@@ -25959,9 +21240,6 @@
     "experiment": "CMS",
     "publisher": "CERN Open Data Portal",
     "recid": "2786",
-    "run_period": [
-      "Run2011A"
-    ],
     "title": "High-Level Trigger path information HLT_PFHT350_PFMHT100 (HT dataset)",
     "type": {
       "primary": "Supplementaries",
@@ -25982,9 +21260,6 @@
     "collections": [
       "CMS-Trigger-Information"
     ],
-    "collision_information": {
-      "energy": "7TeV"
-    },
     "date_created": [
       "2011"
     ],
@@ -25992,9 +21267,6 @@
     "experiment": "CMS",
     "publisher": "CERN Open Data Portal",
     "recid": "2787",
-    "run_period": [
-      "Run2011A"
-    ],
     "title": "High-Level Trigger path information HLT_PFHT350_PFMHT90 (HT dataset)",
     "type": {
       "primary": "Supplementaries",
@@ -26015,9 +21287,6 @@
     "collections": [
       "CMS-Trigger-Information"
     ],
-    "collision_information": {
-      "energy": "7TeV"
-    },
     "date_created": [
       "2011"
     ],
@@ -26025,9 +21294,6 @@
     "experiment": "CMS",
     "publisher": "CERN Open Data Portal",
     "recid": "2788",
-    "run_period": [
-      "Run2011A"
-    ],
     "title": "High-Level Trigger path information HLT_PFHT400_PFMHT80 (HT dataset)",
     "type": {
       "primary": "Supplementaries",
@@ -26048,9 +21314,6 @@
     "collections": [
       "CMS-Trigger-Information"
     ],
-    "collision_information": {
-      "energy": "7TeV"
-    },
     "date_created": [
       "2011"
     ],
@@ -26058,9 +21321,6 @@
     "experiment": "CMS",
     "publisher": "CERN Open Data Portal",
     "recid": "2789",
-    "run_period": [
-      "Run2011A"
-    ],
     "title": "High-Level Trigger path information HLT_PFHT400_PFMHT90 (HT dataset)",
     "type": {
       "primary": "Supplementaries",
@@ -26081,9 +21341,6 @@
     "collections": [
       "CMS-Trigger-Information"
     ],
-    "collision_information": {
-      "energy": "7TeV"
-    },
     "date_created": [
       "2011"
     ],
@@ -26091,9 +21348,6 @@
     "experiment": "CMS",
     "publisher": "CERN Open Data Portal",
     "recid": "2790",
-    "run_period": [
-      "Run2011A"
-    ],
     "title": "High-Level Trigger path information HLT_PFHT650 (HT dataset)",
     "type": {
       "primary": "Supplementaries",
@@ -26114,9 +21368,6 @@
     "collections": [
       "CMS-Trigger-Information"
     ],
-    "collision_information": {
-      "energy": "7TeV"
-    },
     "date_created": [
       "2011"
     ],
@@ -26124,9 +21375,6 @@
     "experiment": "CMS",
     "publisher": "CERN Open Data Portal",
     "recid": "2791",
-    "run_period": [
-      "Run2011A"
-    ],
     "title": "High-Level Trigger path information HLT_PFMHT150 (MET, METBTag datasets)",
     "type": {
       "primary": "Supplementaries",
@@ -26147,9 +21395,6 @@
     "collections": [
       "CMS-Trigger-Information"
     ],
-    "collision_information": {
-      "energy": "7TeV"
-    },
     "date_created": [
       "2011"
     ],
@@ -26157,9 +21402,6 @@
     "experiment": "CMS",
     "publisher": "CERN Open Data Portal",
     "recid": "2792",
-    "run_period": [
-      "Run2011A"
-    ],
     "title": "High-Level Trigger path information HLT_Photon10_CaloIdVL (AllPhysics2760 dataset)",
     "type": {
       "primary": "Supplementaries",
@@ -26180,9 +21422,6 @@
     "collections": [
       "CMS-Trigger-Information"
     ],
-    "collision_information": {
-      "energy": "7TeV"
-    },
     "date_created": [
       "2011"
     ],
@@ -26190,9 +21429,6 @@
     "experiment": "CMS",
     "publisher": "CERN Open Data Portal",
     "recid": "2793",
-    "run_period": [
-      "Run2011A"
-    ],
     "title": "High-Level Trigger path information HLT_Photon125 (Photon dataset)",
     "type": {
       "primary": "Supplementaries",
@@ -26213,9 +21449,6 @@
     "collections": [
       "CMS-Trigger-Information"
     ],
-    "collision_information": {
-      "energy": "7TeV"
-    },
     "date_created": [
       "2011"
     ],
@@ -26223,9 +21456,6 @@
     "experiment": "CMS",
     "publisher": "CERN Open Data Portal",
     "recid": "2794",
-    "run_period": [
-      "Run2011A"
-    ],
     "title": "High-Level Trigger path information HLT_Photon125_NoSpikeFilter (Photon dataset)",
     "type": {
       "primary": "Supplementaries",
@@ -26246,9 +21476,6 @@
     "collections": [
       "CMS-Trigger-Information"
     ],
-    "collision_information": {
-      "energy": "7TeV"
-    },
     "date_created": [
       "2011"
     ],
@@ -26256,9 +21483,6 @@
     "experiment": "CMS",
     "publisher": "CERN Open Data Portal",
     "recid": "2795",
-    "run_period": [
-      "Run2011A"
-    ],
     "title": "High-Level Trigger path information HLT_Photon135 (Photon dataset)",
     "type": {
       "primary": "Supplementaries",
@@ -26279,9 +21503,6 @@
     "collections": [
       "CMS-Trigger-Information"
     ],
-    "collision_information": {
-      "energy": "7TeV"
-    },
     "date_created": [
       "2011"
     ],
@@ -26289,9 +21510,6 @@
     "experiment": "CMS",
     "publisher": "CERN Open Data Portal",
     "recid": "2796",
-    "run_period": [
-      "Run2011A"
-    ],
     "title": "High-Level Trigger path information HLT_Photon15_CaloIdVL (AllPhysics2760 dataset)",
     "type": {
       "primary": "Supplementaries",
@@ -26312,9 +21530,6 @@
     "collections": [
       "CMS-Trigger-Information"
     ],
-    "collision_information": {
-      "energy": "7TeV"
-    },
     "date_created": [
       "2011"
     ],
@@ -26322,9 +21537,6 @@
     "experiment": "CMS",
     "publisher": "CERN Open Data Portal",
     "recid": "2797",
-    "run_period": [
-      "Run2011A"
-    ],
     "title": "High-Level Trigger path information HLT_Photon200_NoHE (Photon dataset)",
     "type": {
       "primary": "Supplementaries",
@@ -26345,9 +21557,6 @@
     "collections": [
       "CMS-Trigger-Information"
     ],
-    "collision_information": {
-      "energy": "7TeV"
-    },
     "date_created": [
       "2011"
     ],
@@ -26355,9 +21564,6 @@
     "experiment": "CMS",
     "publisher": "CERN Open Data Portal",
     "recid": "2798",
-    "run_period": [
-      "Run2011A"
-    ],
     "title": "High-Level Trigger path information HLT_Photon20_CaloIdVL_IsoL (Photon dataset)",
     "type": {
       "primary": "Supplementaries",
@@ -26378,9 +21584,6 @@
     "collections": [
       "CMS-Trigger-Information"
     ],
-    "collision_information": {
-      "energy": "7TeV"
-    },
     "date_created": [
       "2011"
     ],
@@ -26388,9 +21591,6 @@
     "experiment": "CMS",
     "publisher": "CERN Open Data Portal",
     "recid": "2799",
-    "run_period": [
-      "Run2011A"
-    ],
     "title": "High-Level Trigger path information HLT_Photon20_CaloIdVT_IsoT_Ele8_CaloIdL_CaloIsoVL (DoubleElectron dataset)",
     "type": {
       "primary": "Supplementaries",
@@ -26411,9 +21611,6 @@
     "collections": [
       "CMS-Trigger-Information"
     ],
-    "collision_information": {
-      "energy": "7TeV"
-    },
     "date_created": [
       "2011"
     ],
@@ -26421,9 +21618,6 @@
     "experiment": "CMS",
     "publisher": "CERN Open Data Portal",
     "recid": "2800",
-    "run_period": [
-      "Run2011A"
-    ],
     "title": "High-Level Trigger path information HLT_Photon20_EBOnly_NoSpikeFilter (Commissioning dataset)",
     "type": {
       "primary": "Supplementaries",
@@ -26444,9 +21638,6 @@
     "collections": [
       "CMS-Trigger-Information"
     ],
-    "collision_information": {
-      "energy": "7TeV"
-    },
     "date_created": [
       "2011"
     ],
@@ -26454,9 +21645,6 @@
     "experiment": "CMS",
     "publisher": "CERN Open Data Portal",
     "recid": "2801",
-    "run_period": [
-      "Run2011A"
-    ],
     "title": "High-Level Trigger path information HLT_Photon20_NoSpikeFilter (Commissioning dataset)",
     "type": {
       "primary": "Supplementaries",
@@ -26477,9 +21665,6 @@
     "collections": [
       "CMS-Trigger-Information"
     ],
-    "collision_information": {
-      "energy": "7TeV"
-    },
     "date_created": [
       "2011"
     ],
@@ -26487,9 +21672,6 @@
     "experiment": "CMS",
     "publisher": "CERN Open Data Portal",
     "recid": "2802",
-    "run_period": [
-      "Run2011A"
-    ],
     "title": "High-Level Trigger path information HLT_Photon20_R9Id_Photon18_R9Id (Photon dataset)",
     "type": {
       "primary": "Supplementaries",
@@ -26510,9 +21692,6 @@
     "collections": [
       "CMS-Trigger-Information"
     ],
-    "collision_information": {
-      "energy": "7TeV"
-    },
     "date_created": [
       "2011"
     ],
@@ -26520,9 +21699,6 @@
     "experiment": "CMS",
     "publisher": "CERN Open Data Portal",
     "recid": "2803",
-    "run_period": [
-      "Run2011A"
-    ],
     "title": "High-Level Trigger path information HLT_Photon225_NoHE (Photon dataset)",
     "type": {
       "primary": "Supplementaries",
@@ -26543,9 +21719,6 @@
     "collections": [
       "CMS-Trigger-Information"
     ],
-    "collision_information": {
-      "energy": "7TeV"
-    },
     "date_created": [
       "2011"
     ],
@@ -26553,9 +21726,6 @@
     "experiment": "CMS",
     "publisher": "CERN Open Data Portal",
     "recid": "2804",
-    "run_period": [
-      "Run2011A"
-    ],
     "title": "High-Level Trigger path information HLT_Photon26_CaloIdL_IsoVL_Photon18 (Photon dataset)",
     "type": {
       "primary": "Supplementaries",
@@ -26576,9 +21746,6 @@
     "collections": [
       "CMS-Trigger-Information"
     ],
-    "collision_information": {
-      "energy": "7TeV"
-    },
     "date_created": [
       "2011"
     ],
@@ -26586,9 +21753,6 @@
     "experiment": "CMS",
     "publisher": "CERN Open Data Portal",
     "recid": "2805",
-    "run_period": [
-      "Run2011A"
-    ],
     "title": "High-Level Trigger path information HLT_Photon26_CaloIdL_IsoVL_Photon18_CaloIdL_IsoVL (Photon dataset)",
     "type": {
       "primary": "Supplementaries",
@@ -26609,9 +21773,6 @@
     "collections": [
       "CMS-Trigger-Information"
     ],
-    "collision_information": {
-      "energy": "7TeV"
-    },
     "date_created": [
       "2011"
     ],
@@ -26619,9 +21780,6 @@
     "experiment": "CMS",
     "publisher": "CERN Open Data Portal",
     "recid": "2806",
-    "run_period": [
-      "Run2011A"
-    ],
     "title": "High-Level Trigger path information HLT_Photon26_CaloIdL_IsoVL_Photon18_R9Id (Photon dataset)",
     "type": {
       "primary": "Supplementaries",
@@ -26642,9 +21800,6 @@
     "collections": [
       "CMS-Trigger-Information"
     ],
-    "collision_information": {
-      "energy": "7TeV"
-    },
     "date_created": [
       "2011"
     ],
@@ -26652,9 +21807,6 @@
     "experiment": "CMS",
     "publisher": "CERN Open Data Portal",
     "recid": "2807",
-    "run_period": [
-      "Run2011A"
-    ],
     "title": "High-Level Trigger path information HLT_Photon26_CaloIdXL_IsoXL_Photon18 (Photon dataset)",
     "type": {
       "primary": "Supplementaries",
@@ -26675,9 +21827,6 @@
     "collections": [
       "CMS-Trigger-Information"
     ],
-    "collision_information": {
-      "energy": "7TeV"
-    },
     "date_created": [
       "2011"
     ],
@@ -26685,9 +21834,6 @@
     "experiment": "CMS",
     "publisher": "CERN Open Data Portal",
     "recid": "2808",
-    "run_period": [
-      "Run2011A"
-    ],
     "title": "High-Level Trigger path information HLT_Photon26_CaloIdXL_IsoXL_Photon18_CaloIdXL_IsoXL (Photon dataset)",
     "type": {
       "primary": "Supplementaries",
@@ -26708,9 +21854,6 @@
     "collections": [
       "CMS-Trigger-Information"
     ],
-    "collision_information": {
-      "energy": "7TeV"
-    },
     "date_created": [
       "2011"
     ],
@@ -26718,9 +21861,6 @@
     "experiment": "CMS",
     "publisher": "CERN Open Data Portal",
     "recid": "2809",
-    "run_period": [
-      "Run2011A"
-    ],
     "title": "High-Level Trigger path information HLT_Photon26_CaloIdXL_IsoXL_Photon18_CaloIdXL_IsoXL_Mass60 (Photon dataset)",
     "type": {
       "primary": "Supplementaries",
@@ -26741,9 +21881,6 @@
     "collections": [
       "CMS-Trigger-Information"
     ],
-    "collision_information": {
-      "energy": "7TeV"
-    },
     "date_created": [
       "2011"
     ],
@@ -26751,9 +21888,6 @@
     "experiment": "CMS",
     "publisher": "CERN Open Data Portal",
     "recid": "2810",
-    "run_period": [
-      "Run2011A"
-    ],
     "title": "High-Level Trigger path information HLT_Photon26_CaloIdXL_IsoXL_Photon18_R9Id (Photon dataset)",
     "type": {
       "primary": "Supplementaries",
@@ -26774,9 +21908,6 @@
     "collections": [
       "CMS-Trigger-Information"
     ],
-    "collision_information": {
-      "energy": "7TeV"
-    },
     "date_created": [
       "2011"
     ],
@@ -26784,9 +21915,6 @@
     "experiment": "CMS",
     "publisher": "CERN Open Data Portal",
     "recid": "2811",
-    "run_period": [
-      "Run2011A"
-    ],
     "title": "High-Level Trigger path information HLT_Photon26_CaloIdXL_IsoXL_Photon18_R9IdT_Mass60 (Photon dataset)",
     "type": {
       "primary": "Supplementaries",
@@ -26807,9 +21935,6 @@
     "collections": [
       "CMS-Trigger-Information"
     ],
-    "collision_information": {
-      "energy": "7TeV"
-    },
     "date_created": [
       "2011"
     ],
@@ -26817,9 +21942,6 @@
     "experiment": "CMS",
     "publisher": "CERN Open Data Portal",
     "recid": "2812",
-    "run_period": [
-      "Run2011A"
-    ],
     "title": "High-Level Trigger path information HLT_Photon26_IsoVL_Photon18 (Photon dataset)",
     "type": {
       "primary": "Supplementaries",
@@ -26840,9 +21962,6 @@
     "collections": [
       "CMS-Trigger-Information"
     ],
-    "collision_information": {
-      "energy": "7TeV"
-    },
     "date_created": [
       "2011"
     ],
@@ -26850,9 +21969,6 @@
     "experiment": "CMS",
     "publisher": "CERN Open Data Portal",
     "recid": "2813",
-    "run_period": [
-      "Run2011A"
-    ],
     "title": "High-Level Trigger path information HLT_Photon26_IsoVL_Photon18_IsoVL (Photon dataset)",
     "type": {
       "primary": "Supplementaries",
@@ -26873,9 +21989,6 @@
     "collections": [
       "CMS-Trigger-Information"
     ],
-    "collision_information": {
-      "energy": "7TeV"
-    },
     "date_created": [
       "2011"
     ],
@@ -26883,9 +21996,6 @@
     "experiment": "CMS",
     "publisher": "CERN Open Data Portal",
     "recid": "2814",
-    "run_period": [
-      "Run2011A"
-    ],
     "title": "High-Level Trigger path information HLT_Photon26_Photon18 (Photon dataset)",
     "type": {
       "primary": "Supplementaries",
@@ -26906,9 +22016,6 @@
     "collections": [
       "CMS-Trigger-Information"
     ],
-    "collision_information": {
-      "energy": "7TeV"
-    },
     "date_created": [
       "2011"
     ],
@@ -26916,9 +22023,6 @@
     "experiment": "CMS",
     "publisher": "CERN Open Data Portal",
     "recid": "2815",
-    "run_period": [
-      "Run2011A"
-    ],
     "title": "High-Level Trigger path information HLT_Photon26_R9IdT_Photon18_CaloIdXL_IsoXL_Mass60 (Photon dataset)",
     "type": {
       "primary": "Supplementaries",
@@ -26939,9 +22043,6 @@
     "collections": [
       "CMS-Trigger-Information"
     ],
-    "collision_information": {
-      "energy": "7TeV"
-    },
     "date_created": [
       "2011"
     ],
@@ -26949,9 +22050,6 @@
     "experiment": "CMS",
     "publisher": "CERN Open Data Portal",
     "recid": "2816",
-    "run_period": [
-      "Run2011A"
-    ],
     "title": "High-Level Trigger path information HLT_Photon26_R9IdT_Photon18_R9IdT_Mass60 (Photon dataset)",
     "type": {
       "primary": "Supplementaries",
@@ -26972,9 +22070,6 @@
     "collections": [
       "CMS-Trigger-Information"
     ],
-    "collision_information": {
-      "energy": "7TeV"
-    },
     "date_created": [
       "2011"
     ],
@@ -26982,9 +22077,6 @@
     "experiment": "CMS",
     "publisher": "CERN Open Data Portal",
     "recid": "2817",
-    "run_period": [
-      "Run2011A"
-    ],
     "title": "High-Level Trigger path information HLT_Photon26_R9Id_Photon18_CaloIdL_IsoVL (Photon dataset)",
     "type": {
       "primary": "Supplementaries",
@@ -27005,9 +22097,6 @@
     "collections": [
       "CMS-Trigger-Information"
     ],
-    "collision_information": {
-      "energy": "7TeV"
-    },
     "date_created": [
       "2011"
     ],
@@ -27015,9 +22104,6 @@
     "experiment": "CMS",
     "publisher": "CERN Open Data Portal",
     "recid": "2818",
-    "run_period": [
-      "Run2011A"
-    ],
     "title": "High-Level Trigger path information HLT_Photon26_R9Id_Photon18_CaloIdXL_IsoXL (Photon dataset)",
     "type": {
       "primary": "Supplementaries",
@@ -27038,9 +22124,6 @@
     "collections": [
       "CMS-Trigger-Information"
     ],
-    "collision_information": {
-      "energy": "7TeV"
-    },
     "date_created": [
       "2011"
     ],
@@ -27048,9 +22131,6 @@
     "experiment": "CMS",
     "publisher": "CERN Open Data Portal",
     "recid": "2819",
-    "run_period": [
-      "Run2011A"
-    ],
     "title": "High-Level Trigger path information HLT_Photon26_R9Id_Photon18_R9Id (Photon dataset)",
     "type": {
       "primary": "Supplementaries",
@@ -27071,9 +22151,6 @@
     "collections": [
       "CMS-Trigger-Information"
     ],
-    "collision_information": {
-      "energy": "7TeV"
-    },
     "date_created": [
       "2011"
     ],
@@ -27081,9 +22158,6 @@
     "experiment": "CMS",
     "publisher": "CERN Open Data Portal",
     "recid": "2820",
-    "run_period": [
-      "Run2011A"
-    ],
     "title": "High-Level Trigger path information HLT_Photon30_CaloIdVL (Photon dataset)",
     "type": {
       "primary": "Supplementaries",
@@ -27104,9 +22178,6 @@
     "collections": [
       "CMS-Trigger-Information"
     ],
-    "collision_information": {
-      "energy": "7TeV"
-    },
     "date_created": [
       "2011"
     ],
@@ -27114,9 +22185,6 @@
     "experiment": "CMS",
     "publisher": "CERN Open Data Portal",
     "recid": "2821",
-    "run_period": [
-      "Run2011A"
-    ],
     "title": "High-Level Trigger path information HLT_Photon30_CaloIdVL_IsoL (Photon dataset)",
     "type": {
       "primary": "Supplementaries",
@@ -27137,9 +22205,6 @@
     "collections": [
       "CMS-Trigger-Information"
     ],
-    "collision_information": {
-      "energy": "7TeV"
-    },
     "date_created": [
       "2011"
     ],
@@ -27147,9 +22212,6 @@
     "experiment": "CMS",
     "publisher": "CERN Open Data Portal",
     "recid": "2822",
-    "run_period": [
-      "Run2011A"
-    ],
     "title": "High-Level Trigger path information HLT_Photon30_CaloIdVT_CentralJet20_BTagIP (PhotonHad dataset)",
     "type": {
       "primary": "Supplementaries",
@@ -27170,9 +22232,6 @@
     "collections": [
       "CMS-Trigger-Information"
     ],
-    "collision_information": {
-      "energy": "7TeV"
-    },
     "date_created": [
       "2011"
     ],
@@ -27180,9 +22239,6 @@
     "experiment": "CMS",
     "publisher": "CERN Open Data Portal",
     "recid": "2823",
-    "run_period": [
-      "Run2011A"
-    ],
     "title": "High-Level Trigger path information HLT_Photon32_CaloIdL_Photon26_CaloIdL (Photon dataset)",
     "type": {
       "primary": "Supplementaries",
@@ -27203,9 +22259,6 @@
     "collections": [
       "CMS-Trigger-Information"
     ],
-    "collision_information": {
-      "energy": "7TeV"
-    },
     "date_created": [
       "2011"
     ],
@@ -27213,9 +22266,6 @@
     "experiment": "CMS",
     "publisher": "CERN Open Data Portal",
     "recid": "2824",
-    "run_period": [
-      "Run2011A"
-    ],
     "title": "High-Level Trigger path information HLT_Photon36_CaloIdL_IsoVL_Photon22 (Photon dataset)",
     "type": {
       "primary": "Supplementaries",
@@ -27236,9 +22286,6 @@
     "collections": [
       "CMS-Trigger-Information"
     ],
-    "collision_information": {
-      "energy": "7TeV"
-    },
     "date_created": [
       "2011"
     ],
@@ -27246,9 +22293,6 @@
     "experiment": "CMS",
     "publisher": "CERN Open Data Portal",
     "recid": "2825",
-    "run_period": [
-      "Run2011A"
-    ],
     "title": "High-Level Trigger path information HLT_Photon36_CaloIdL_IsoVL_Photon22_CaloIdL (Photon dataset)",
     "type": {
       "primary": "Supplementaries",
@@ -27269,9 +22313,6 @@
     "collections": [
       "CMS-Trigger-Information"
     ],
-    "collision_information": {
-      "energy": "7TeV"
-    },
     "date_created": [
       "2011"
     ],
@@ -27279,9 +22320,6 @@
     "experiment": "CMS",
     "publisher": "CERN Open Data Portal",
     "recid": "2826",
-    "run_period": [
-      "Run2011A"
-    ],
     "title": "High-Level Trigger path information HLT_Photon36_CaloIdL_IsoVL_Photon22_CaloIdL_IsoVL (Photon dataset)",
     "type": {
       "primary": "Supplementaries",
@@ -27302,9 +22340,6 @@
     "collections": [
       "CMS-Trigger-Information"
     ],
-    "collision_information": {
-      "energy": "7TeV"
-    },
     "date_created": [
       "2011"
     ],
@@ -27312,9 +22347,6 @@
     "experiment": "CMS",
     "publisher": "CERN Open Data Portal",
     "recid": "2827",
-    "run_period": [
-      "Run2011A"
-    ],
     "title": "High-Level Trigger path information HLT_Photon36_CaloIdL_IsoVL_Photon22_R9Id (Photon dataset)",
     "type": {
       "primary": "Supplementaries",
@@ -27335,9 +22367,6 @@
     "collections": [
       "CMS-Trigger-Information"
     ],
-    "collision_information": {
-      "energy": "7TeV"
-    },
     "date_created": [
       "2011"
     ],
@@ -27345,9 +22374,6 @@
     "experiment": "CMS",
     "publisher": "CERN Open Data Portal",
     "recid": "2828",
-    "run_period": [
-      "Run2011A"
-    ],
     "title": "High-Level Trigger path information HLT_Photon36_CaloIdL_Photon22_CaloIdL (Photon dataset)",
     "type": {
       "primary": "Supplementaries",
@@ -27368,9 +22394,6 @@
     "collections": [
       "CMS-Trigger-Information"
     ],
-    "collision_information": {
-      "energy": "7TeV"
-    },
     "date_created": [
       "2011"
     ],
@@ -27378,9 +22401,6 @@
     "experiment": "CMS",
     "publisher": "CERN Open Data Portal",
     "recid": "2829",
-    "run_period": [
-      "Run2011A"
-    ],
     "title": "High-Level Trigger path information HLT_Photon36_CaloIdVL_Photon22_CaloIdVL (Photon dataset)",
     "type": {
       "primary": "Supplementaries",
@@ -27401,9 +22421,6 @@
     "collections": [
       "CMS-Trigger-Information"
     ],
-    "collision_information": {
-      "energy": "7TeV"
-    },
     "date_created": [
       "2011"
     ],
@@ -27411,9 +22428,6 @@
     "experiment": "CMS",
     "publisher": "CERN Open Data Portal",
     "recid": "2830",
-    "run_period": [
-      "Run2011A"
-    ],
     "title": "High-Level Trigger path information HLT_Photon36_CaloId_IsoVL_Photon22_R9Id (Photon dataset)",
     "type": {
       "primary": "Supplementaries",
@@ -27434,9 +22448,6 @@
     "collections": [
       "CMS-Trigger-Information"
     ],
-    "collision_information": {
-      "energy": "7TeV"
-    },
     "date_created": [
       "2011"
     ],
@@ -27444,9 +22455,6 @@
     "experiment": "CMS",
     "publisher": "CERN Open Data Portal",
     "recid": "2831",
-    "run_period": [
-      "Run2011A"
-    ],
     "title": "High-Level Trigger path information HLT_Photon36_IsoVL_Photon22 (Photon dataset)",
     "type": {
       "primary": "Supplementaries",
@@ -27467,9 +22475,6 @@
     "collections": [
       "CMS-Trigger-Information"
     ],
-    "collision_information": {
-      "energy": "7TeV"
-    },
     "date_created": [
       "2011"
     ],
@@ -27477,9 +22482,6 @@
     "experiment": "CMS",
     "publisher": "CERN Open Data Portal",
     "recid": "2832",
-    "run_period": [
-      "Run2011A"
-    ],
     "title": "High-Level Trigger path information HLT_Photon36_Photon22 (Photon dataset)",
     "type": {
       "primary": "Supplementaries",
@@ -27500,9 +22502,6 @@
     "collections": [
       "CMS-Trigger-Information"
     ],
-    "collision_information": {
-      "energy": "7TeV"
-    },
     "date_created": [
       "2011"
     ],
@@ -27510,9 +22509,6 @@
     "experiment": "CMS",
     "publisher": "CERN Open Data Portal",
     "recid": "2833",
-    "run_period": [
-      "Run2011A"
-    ],
     "title": "High-Level Trigger path information HLT_Photon36_R9Id_Photon22_CaloIdL_IsoVL (Photon dataset)",
     "type": {
       "primary": "Supplementaries",
@@ -27533,9 +22529,6 @@
     "collections": [
       "CMS-Trigger-Information"
     ],
-    "collision_information": {
-      "energy": "7TeV"
-    },
     "date_created": [
       "2011"
     ],
@@ -27543,9 +22536,6 @@
     "experiment": "CMS",
     "publisher": "CERN Open Data Portal",
     "recid": "2834",
-    "run_period": [
-      "Run2011A"
-    ],
     "title": "High-Level Trigger path information HLT_Photon36_R9Id_Photon22_R9Id (Photon dataset)",
     "type": {
       "primary": "Supplementaries",
@@ -27566,9 +22556,6 @@
     "collections": [
       "CMS-Trigger-Information"
     ],
-    "collision_information": {
-      "energy": "7TeV"
-    },
     "date_created": [
       "2011"
     ],
@@ -27576,9 +22563,6 @@
     "experiment": "CMS",
     "publisher": "CERN Open Data Portal",
     "recid": "2835",
-    "run_period": [
-      "Run2011A"
-    ],
     "title": "High-Level Trigger path information HLT_Photon400 (Photon dataset)",
     "type": {
       "primary": "Supplementaries",
@@ -27599,9 +22583,6 @@
     "collections": [
       "CMS-Trigger-Information"
     ],
-    "collision_information": {
-      "energy": "7TeV"
-    },
     "date_created": [
       "2011"
     ],
@@ -27609,9 +22590,6 @@
     "experiment": "CMS",
     "publisher": "CERN Open Data Portal",
     "recid": "2836",
-    "run_period": [
-      "Run2011A"
-    ],
     "title": "High-Level Trigger path information HLT_Photon40_CaloIdL_Photon28_CaloIdL (Photon dataset)",
     "type": {
       "primary": "Supplementaries",
@@ -27632,9 +22610,6 @@
     "collections": [
       "CMS-Trigger-Information"
     ],
-    "collision_information": {
-      "energy": "7TeV"
-    },
     "date_created": [
       "2011"
     ],
@@ -27642,9 +22617,6 @@
     "experiment": "CMS",
     "publisher": "CERN Open Data Portal",
     "recid": "2837",
-    "run_period": [
-      "Run2011A"
-    ],
     "title": "High-Level Trigger path information HLT_Photon40_CaloIdL_R005_MR150 (PhotonHad dataset)",
     "type": {
       "primary": "Supplementaries",
@@ -27665,9 +22637,6 @@
     "collections": [
       "CMS-Trigger-Information"
     ],
-    "collision_information": {
-      "energy": "7TeV"
-    },
     "date_created": [
       "2011"
     ],
@@ -27675,9 +22644,6 @@
     "experiment": "CMS",
     "publisher": "CERN Open Data Portal",
     "recid": "2838",
-    "run_period": [
-      "Run2011A"
-    ],
     "title": "High-Level Trigger path information HLT_Photon40_CaloIdL_R014_MR150 (PhotonHad dataset)",
     "type": {
       "primary": "Supplementaries",
@@ -27698,9 +22664,6 @@
     "collections": [
       "CMS-Trigger-Information"
     ],
-    "collision_information": {
-      "energy": "7TeV"
-    },
     "date_created": [
       "2011"
     ],
@@ -27708,9 +22671,6 @@
     "experiment": "CMS",
     "publisher": "CERN Open Data Portal",
     "recid": "2839",
-    "run_period": [
-      "Run2011A"
-    ],
     "title": "High-Level Trigger path information HLT_Photon40_CaloIdL_R014_MR500 (PhotonHad dataset)",
     "type": {
       "primary": "Supplementaries",
@@ -27731,9 +22691,6 @@
     "collections": [
       "CMS-Trigger-Information"
     ],
-    "collision_information": {
-      "energy": "7TeV"
-    },
     "date_created": [
       "2011"
     ],
@@ -27741,9 +22698,6 @@
     "experiment": "CMS",
     "publisher": "CERN Open Data Portal",
     "recid": "2840",
-    "run_period": [
-      "Run2011A"
-    ],
     "title": "High-Level Trigger path information HLT_Photon40_CaloIdL_R017_MR500 (PhotonHad dataset)",
     "type": {
       "primary": "Supplementaries",
@@ -27764,9 +22718,6 @@
     "collections": [
       "CMS-Trigger-Information"
     ],
-    "collision_information": {
-      "energy": "7TeV"
-    },
     "date_created": [
       "2011"
     ],
@@ -27774,9 +22725,6 @@
     "experiment": "CMS",
     "publisher": "CERN Open Data Portal",
     "recid": "2841",
-    "run_period": [
-      "Run2011A"
-    ],
     "title": "High-Level Trigger path information HLT_Photon40_CaloIdL_R020_MR350 (PhotonHad dataset)",
     "type": {
       "primary": "Supplementaries",
@@ -27797,9 +22745,6 @@
     "collections": [
       "CMS-Trigger-Information"
     ],
-    "collision_information": {
-      "energy": "7TeV"
-    },
     "date_created": [
       "2011"
     ],
@@ -27807,9 +22752,6 @@
     "experiment": "CMS",
     "publisher": "CERN Open Data Portal",
     "recid": "2842",
-    "run_period": [
-      "Run2011A"
-    ],
     "title": "High-Level Trigger path information HLT_Photon40_CaloIdL_R023_MR350 (PhotonHad dataset)",
     "type": {
       "primary": "Supplementaries",
@@ -27830,9 +22772,6 @@
     "collections": [
       "CMS-Trigger-Information"
     ],
-    "collision_information": {
-      "energy": "7TeV"
-    },
     "date_created": [
       "2011"
     ],
@@ -27840,9 +22779,6 @@
     "experiment": "CMS",
     "publisher": "CERN Open Data Portal",
     "recid": "2843",
-    "run_period": [
-      "Run2011A"
-    ],
     "title": "High-Level Trigger path information HLT_Photon40_CaloIdL_R025_MR250 (PhotonHad dataset)",
     "type": {
       "primary": "Supplementaries",
@@ -27863,9 +22799,6 @@
     "collections": [
       "CMS-Trigger-Information"
     ],
-    "collision_information": {
-      "energy": "7TeV"
-    },
     "date_created": [
       "2011"
     ],
@@ -27873,9 +22806,6 @@
     "experiment": "CMS",
     "publisher": "CERN Open Data Portal",
     "recid": "2844",
-    "run_period": [
-      "Run2011A"
-    ],
     "title": "High-Level Trigger path information HLT_Photon40_CaloIdL_R029_MR250 (PhotonHad dataset)",
     "type": {
       "primary": "Supplementaries",
@@ -27896,9 +22826,6 @@
     "collections": [
       "CMS-Trigger-Information"
     ],
-    "collision_information": {
-      "energy": "7TeV"
-    },
     "date_created": [
       "2011"
     ],
@@ -27906,9 +22833,6 @@
     "experiment": "CMS",
     "publisher": "CERN Open Data Portal",
     "recid": "2845",
-    "run_period": [
-      "Run2011A"
-    ],
     "title": "High-Level Trigger path information HLT_Photon40_CaloIdL_R038_MR200 (PhotonHad dataset)",
     "type": {
       "primary": "Supplementaries",
@@ -27929,9 +22853,6 @@
     "collections": [
       "CMS-Trigger-Information"
     ],
-    "collision_information": {
-      "energy": "7TeV"
-    },
     "date_created": [
       "2011"
     ],
@@ -27939,9 +22860,6 @@
     "experiment": "CMS",
     "publisher": "CERN Open Data Portal",
     "recid": "2846",
-    "run_period": [
-      "Run2011A"
-    ],
     "title": "High-Level Trigger path information HLT_Photon40_CaloIdL_R042_MR200 (PhotonHad dataset)",
     "type": {
       "primary": "Supplementaries",
@@ -27962,9 +22880,6 @@
     "collections": [
       "CMS-Trigger-Information"
     ],
-    "collision_information": {
-      "energy": "7TeV"
-    },
     "date_created": [
       "2011"
     ],
@@ -27972,9 +22887,6 @@
     "experiment": "CMS",
     "publisher": "CERN Open Data Portal",
     "recid": "2847",
-    "run_period": [
-      "Run2011A"
-    ],
     "title": "High-Level Trigger path information HLT_Photon40_R005_MR150 (PhotonHad dataset)",
     "type": {
       "primary": "Supplementaries",
@@ -27995,9 +22907,6 @@
     "collections": [
       "CMS-Trigger-Information"
     ],
-    "collision_information": {
-      "energy": "7TeV"
-    },
     "date_created": [
       "2011"
     ],
@@ -28005,9 +22914,6 @@
     "experiment": "CMS",
     "publisher": "CERN Open Data Portal",
     "recid": "2848",
-    "run_period": [
-      "Run2011A"
-    ],
     "title": "High-Level Trigger path information HLT_Photon40_R014_MR450 (PhotonHad dataset)",
     "type": {
       "primary": "Supplementaries",
@@ -28028,9 +22934,6 @@
     "collections": [
       "CMS-Trigger-Information"
     ],
-    "collision_information": {
-      "energy": "7TeV"
-    },
     "date_created": [
       "2011"
     ],
@@ -28038,9 +22941,6 @@
     "experiment": "CMS",
     "publisher": "CERN Open Data Portal",
     "recid": "2849",
-    "run_period": [
-      "Run2011A"
-    ],
     "title": "High-Level Trigger path information HLT_Photon40_R020_MR300 (PhotonHad dataset)",
     "type": {
       "primary": "Supplementaries",
@@ -28061,9 +22961,6 @@
     "collections": [
       "CMS-Trigger-Information"
     ],
-    "collision_information": {
-      "energy": "7TeV"
-    },
     "date_created": [
       "2011"
     ],
@@ -28071,9 +22968,6 @@
     "experiment": "CMS",
     "publisher": "CERN Open Data Portal",
     "recid": "2850",
-    "run_period": [
-      "Run2011A"
-    ],
     "title": "High-Level Trigger path information HLT_Photon40_R025_MR200 (PhotonHad dataset)",
     "type": {
       "primary": "Supplementaries",
@@ -28094,9 +22988,6 @@
     "collections": [
       "CMS-Trigger-Information"
     ],
-    "collision_information": {
-      "energy": "7TeV"
-    },
     "date_created": [
       "2011"
     ],
@@ -28104,9 +22995,6 @@
     "experiment": "CMS",
     "publisher": "CERN Open Data Portal",
     "recid": "2851",
-    "run_period": [
-      "Run2011A"
-    ],
     "title": "High-Level Trigger path information HLT_Photon40_R038_MR150 (PhotonHad dataset)",
     "type": {
       "primary": "Supplementaries",
@@ -28127,9 +23015,6 @@
     "collections": [
       "CMS-Trigger-Information"
     ],
-    "collision_information": {
-      "energy": "7TeV"
-    },
     "date_created": [
       "2011"
     ],
@@ -28137,9 +23022,6 @@
     "experiment": "CMS",
     "publisher": "CERN Open Data Portal",
     "recid": "2852",
-    "run_period": [
-      "Run2011A"
-    ],
     "title": "High-Level Trigger path information HLT_Photon44_CaloIdL_Photon34_CaloIdL (Photon dataset)",
     "type": {
       "primary": "Supplementaries",
@@ -28160,9 +23042,6 @@
     "collections": [
       "CMS-Trigger-Information"
     ],
-    "collision_information": {
-      "energy": "7TeV"
-    },
     "date_created": [
       "2011"
     ],
@@ -28170,9 +23049,6 @@
     "experiment": "CMS",
     "publisher": "CERN Open Data Portal",
     "recid": "2853",
-    "run_period": [
-      "Run2011A"
-    ],
     "title": "High-Level Trigger path information HLT_Photon48_CaloIdL_Photon38_CaloIdL (Photon dataset)",
     "type": {
       "primary": "Supplementaries",
@@ -28193,9 +23069,6 @@
     "collections": [
       "CMS-Trigger-Information"
     ],
-    "collision_information": {
-      "energy": "7TeV"
-    },
     "date_created": [
       "2011"
     ],
@@ -28203,9 +23076,6 @@
     "experiment": "CMS",
     "publisher": "CERN Open Data Portal",
     "recid": "2854",
-    "run_period": [
-      "Run2011A"
-    ],
     "title": "High-Level Trigger path information HLT_Photon50_CaloIdVL (Photon dataset)",
     "type": {
       "primary": "Supplementaries",
@@ -28226,9 +23096,6 @@
     "collections": [
       "CMS-Trigger-Information"
     ],
-    "collision_information": {
-      "energy": "7TeV"
-    },
     "date_created": [
       "2011"
     ],
@@ -28236,9 +23103,6 @@
     "experiment": "CMS",
     "publisher": "CERN Open Data Portal",
     "recid": "2855",
-    "run_period": [
-      "Run2011A"
-    ],
     "title": "High-Level Trigger path information HLT_Photon50_CaloIdVL_IsoL (Photon dataset)",
     "type": {
       "primary": "Supplementaries",
@@ -28259,9 +23123,6 @@
     "collections": [
       "CMS-Trigger-Information"
     ],
-    "collision_information": {
-      "energy": "7TeV"
-    },
     "date_created": [
       "2011"
     ],
@@ -28269,9 +23130,6 @@
     "experiment": "CMS",
     "publisher": "CERN Open Data Portal",
     "recid": "2856",
-    "run_period": [
-      "Run2011A"
-    ],
     "title": "High-Level Trigger path information HLT_Photon55_CaloIdL_R017_MR500 (PhotonHad dataset)",
     "type": {
       "primary": "Supplementaries",
@@ -28292,9 +23150,6 @@
     "collections": [
       "CMS-Trigger-Information"
     ],
-    "collision_information": {
-      "energy": "7TeV"
-    },
     "date_created": [
       "2011"
     ],
@@ -28302,9 +23157,6 @@
     "experiment": "CMS",
     "publisher": "CERN Open Data Portal",
     "recid": "2857",
-    "run_period": [
-      "Run2011A"
-    ],
     "title": "High-Level Trigger path information HLT_Photon55_CaloIdL_R023_MR350 (PhotonHad dataset)",
     "type": {
       "primary": "Supplementaries",
@@ -28325,9 +23177,6 @@
     "collections": [
       "CMS-Trigger-Information"
     ],
-    "collision_information": {
-      "energy": "7TeV"
-    },
     "date_created": [
       "2011"
     ],
@@ -28335,9 +23184,6 @@
     "experiment": "CMS",
     "publisher": "CERN Open Data Portal",
     "recid": "2858",
-    "run_period": [
-      "Run2011A"
-    ],
     "title": "High-Level Trigger path information HLT_Photon55_CaloIdL_R029_MR250 (PhotonHad dataset)",
     "type": {
       "primary": "Supplementaries",
@@ -28358,9 +23204,6 @@
     "collections": [
       "CMS-Trigger-Information"
     ],
-    "collision_information": {
-      "energy": "7TeV"
-    },
     "date_created": [
       "2011"
     ],
@@ -28368,9 +23211,6 @@
     "experiment": "CMS",
     "publisher": "CERN Open Data Portal",
     "recid": "2859",
-    "run_period": [
-      "Run2011A"
-    ],
     "title": "High-Level Trigger path information HLT_Photon55_CaloIdL_R042_MR200 (PhotonHad dataset)",
     "type": {
       "primary": "Supplementaries",
@@ -28391,9 +23231,6 @@
     "collections": [
       "CMS-Trigger-Information"
     ],
-    "collision_information": {
-      "energy": "7TeV"
-    },
     "date_created": [
       "2011"
     ],
@@ -28401,9 +23238,6 @@
     "experiment": "CMS",
     "publisher": "CERN Open Data Portal",
     "recid": "2860",
-    "run_period": [
-      "Run2011A"
-    ],
     "title": "High-Level Trigger path information HLT_Photon60_CaloIdL_HT200 (PhotonHad dataset)",
     "type": {
       "primary": "Supplementaries",
@@ -28424,9 +23258,6 @@
     "collections": [
       "CMS-Trigger-Information"
     ],
-    "collision_information": {
-      "energy": "7TeV"
-    },
     "date_created": [
       "2011"
     ],
@@ -28434,9 +23265,6 @@
     "experiment": "CMS",
     "publisher": "CERN Open Data Portal",
     "recid": "2861",
-    "run_period": [
-      "Run2011A"
-    ],
     "title": "High-Level Trigger path information HLT_Photon60_CaloIdL_HT300 (PhotonHad dataset)",
     "type": {
       "primary": "Supplementaries",
@@ -28457,9 +23285,6 @@
     "collections": [
       "CMS-Trigger-Information"
     ],
-    "collision_information": {
-      "energy": "7TeV"
-    },
     "date_created": [
       "2011"
     ],
@@ -28467,9 +23292,6 @@
     "experiment": "CMS",
     "publisher": "CERN Open Data Portal",
     "recid": "2862",
-    "run_period": [
-      "Run2011A"
-    ],
     "title": "High-Level Trigger path information HLT_Photon60_CaloIdL_MHT70 (PhotonHad dataset)",
     "type": {
       "primary": "Supplementaries",
@@ -28490,9 +23312,6 @@
     "collections": [
       "CMS-Trigger-Information"
     ],
-    "collision_information": {
-      "energy": "7TeV"
-    },
     "date_created": [
       "2011"
     ],
@@ -28500,9 +23319,6 @@
     "experiment": "CMS",
     "publisher": "CERN Open Data Portal",
     "recid": "2863",
-    "run_period": [
-      "Run2011A"
-    ],
     "title": "High-Level Trigger path information HLT_Photon70_CaloIdL_HT200 (PhotonHad dataset)",
     "type": {
       "primary": "Supplementaries",
@@ -28523,9 +23339,6 @@
     "collections": [
       "CMS-Trigger-Information"
     ],
-    "collision_information": {
-      "energy": "7TeV"
-    },
     "date_created": [
       "2011"
     ],
@@ -28533,9 +23346,6 @@
     "experiment": "CMS",
     "publisher": "CERN Open Data Portal",
     "recid": "2864",
-    "run_period": [
-      "Run2011A"
-    ],
     "title": "High-Level Trigger path information HLT_Photon70_CaloIdL_HT300 (PhotonHad dataset)",
     "type": {
       "primary": "Supplementaries",
@@ -28556,9 +23366,6 @@
     "collections": [
       "CMS-Trigger-Information"
     ],
-    "collision_information": {
-      "energy": "7TeV"
-    },
     "date_created": [
       "2011"
     ],
@@ -28566,9 +23373,6 @@
     "experiment": "CMS",
     "publisher": "CERN Open Data Portal",
     "recid": "2865",
-    "run_period": [
-      "Run2011A"
-    ],
     "title": "High-Level Trigger path information HLT_Photon70_CaloIdL_HT350 (PhotonHad dataset)",
     "type": {
       "primary": "Supplementaries",
@@ -28589,9 +23393,6 @@
     "collections": [
       "CMS-Trigger-Information"
     ],
-    "collision_information": {
-      "energy": "7TeV"
-    },
     "date_created": [
       "2011"
     ],
@@ -28599,9 +23400,6 @@
     "experiment": "CMS",
     "publisher": "CERN Open Data Portal",
     "recid": "2866",
-    "run_period": [
-      "Run2011A"
-    ],
     "title": "High-Level Trigger path information HLT_Photon70_CaloIdL_HT400 (PhotonHad dataset)",
     "type": {
       "primary": "Supplementaries",
@@ -28622,9 +23420,6 @@
     "collections": [
       "CMS-Trigger-Information"
     ],
-    "collision_information": {
-      "energy": "7TeV"
-    },
     "date_created": [
       "2011"
     ],
@@ -28632,9 +23427,6 @@
     "experiment": "CMS",
     "publisher": "CERN Open Data Portal",
     "recid": "2867",
-    "run_period": [
-      "Run2011A"
-    ],
     "title": "High-Level Trigger path information HLT_Photon70_CaloIdL_HT500 (PhotonHad dataset)",
     "type": {
       "primary": "Supplementaries",
@@ -28655,9 +23447,6 @@
     "collections": [
       "CMS-Trigger-Information"
     ],
-    "collision_information": {
-      "energy": "7TeV"
-    },
     "date_created": [
       "2011"
     ],
@@ -28665,9 +23454,6 @@
     "experiment": "CMS",
     "publisher": "CERN Open Data Portal",
     "recid": "2868",
-    "run_period": [
-      "Run2011A"
-    ],
     "title": "High-Level Trigger path information HLT_Photon70_CaloIdL_MHT110 (PhotonHad dataset)",
     "type": {
       "primary": "Supplementaries",
@@ -28688,9 +23474,6 @@
     "collections": [
       "CMS-Trigger-Information"
     ],
-    "collision_information": {
-      "energy": "7TeV"
-    },
     "date_created": [
       "2011"
     ],
@@ -28698,9 +23481,6 @@
     "experiment": "CMS",
     "publisher": "CERN Open Data Portal",
     "recid": "2869",
-    "run_period": [
-      "Run2011A"
-    ],
     "title": "High-Level Trigger path information HLT_Photon70_CaloIdL_MHT30 (PhotonHad dataset)",
     "type": {
       "primary": "Supplementaries",
@@ -28721,9 +23501,6 @@
     "collections": [
       "CMS-Trigger-Information"
     ],
-    "collision_information": {
-      "energy": "7TeV"
-    },
     "date_created": [
       "2011"
     ],
@@ -28731,9 +23508,6 @@
     "experiment": "CMS",
     "publisher": "CERN Open Data Portal",
     "recid": "2870",
-    "run_period": [
-      "Run2011A"
-    ],
     "title": "High-Level Trigger path information HLT_Photon70_CaloIdL_MHT50 (PhotonHad dataset)",
     "type": {
       "primary": "Supplementaries",
@@ -28754,9 +23528,6 @@
     "collections": [
       "CMS-Trigger-Information"
     ],
-    "collision_information": {
-      "energy": "7TeV"
-    },
     "date_created": [
       "2011"
     ],
@@ -28764,9 +23535,6 @@
     "experiment": "CMS",
     "publisher": "CERN Open Data Portal",
     "recid": "2871",
-    "run_period": [
-      "Run2011A"
-    ],
     "title": "High-Level Trigger path information HLT_Photon70_CaloIdL_MHT70 (PhotonHad dataset)",
     "type": {
       "primary": "Supplementaries",
@@ -28787,9 +23555,6 @@
     "collections": [
       "CMS-Trigger-Information"
     ],
-    "collision_information": {
-      "energy": "7TeV"
-    },
     "date_created": [
       "2011"
     ],
@@ -28797,9 +23562,6 @@
     "experiment": "CMS",
     "publisher": "CERN Open Data Portal",
     "recid": "2872",
-    "run_period": [
-      "Run2011A"
-    ],
     "title": "High-Level Trigger path information HLT_Photon70_CaloIdL_MHT90 (PhotonHad dataset)",
     "type": {
       "primary": "Supplementaries",
@@ -28820,9 +23582,6 @@
     "collections": [
       "CMS-Trigger-Information"
     ],
-    "collision_information": {
-      "energy": "7TeV"
-    },
     "date_created": [
       "2011"
     ],
@@ -28830,9 +23589,6 @@
     "experiment": "CMS",
     "publisher": "CERN Open Data Portal",
     "recid": "2873",
-    "run_period": [
-      "Run2011A"
-    ],
     "title": "High-Level Trigger path information HLT_Photon70_CaloIdXL_HT400 (PhotonHad dataset)",
     "type": {
       "primary": "Supplementaries",
@@ -28853,9 +23609,6 @@
     "collections": [
       "CMS-Trigger-Information"
     ],
-    "collision_information": {
-      "energy": "7TeV"
-    },
     "date_created": [
       "2011"
     ],
@@ -28863,9 +23616,6 @@
     "experiment": "CMS",
     "publisher": "CERN Open Data Portal",
     "recid": "2874",
-    "run_period": [
-      "Run2011A"
-    ],
     "title": "High-Level Trigger path information HLT_Photon70_CaloIdXL_HT500 (PhotonHad dataset)",
     "type": {
       "primary": "Supplementaries",
@@ -28886,9 +23636,6 @@
     "collections": [
       "CMS-Trigger-Information"
     ],
-    "collision_information": {
-      "energy": "7TeV"
-    },
     "date_created": [
       "2011"
     ],
@@ -28896,9 +23643,6 @@
     "experiment": "CMS",
     "publisher": "CERN Open Data Portal",
     "recid": "2875",
-    "run_period": [
-      "Run2011A"
-    ],
     "title": "High-Level Trigger path information HLT_Photon70_CaloIdXL_MHT100 (PhotonHad dataset)",
     "type": {
       "primary": "Supplementaries",
@@ -28919,9 +23663,6 @@
     "collections": [
       "CMS-Trigger-Information"
     ],
-    "collision_information": {
-      "energy": "7TeV"
-    },
     "date_created": [
       "2011"
     ],
@@ -28929,9 +23670,6 @@
     "experiment": "CMS",
     "publisher": "CERN Open Data Portal",
     "recid": "2876",
-    "run_period": [
-      "Run2011A"
-    ],
     "title": "High-Level Trigger path information HLT_Photon70_CaloIdXL_MHT90 (PhotonHad dataset)",
     "type": {
       "primary": "Supplementaries",
@@ -28952,9 +23690,6 @@
     "collections": [
       "CMS-Trigger-Information"
     ],
-    "collision_information": {
-      "energy": "7TeV"
-    },
     "date_created": [
       "2011"
     ],
@@ -28962,9 +23697,6 @@
     "experiment": "CMS",
     "publisher": "CERN Open Data Portal",
     "recid": "2877",
-    "run_period": [
-      "Run2011A"
-    ],
     "title": "High-Level Trigger path information HLT_Photon75_CaloIdVL (Photon dataset)",
     "type": {
       "primary": "Supplementaries",
@@ -28985,9 +23717,6 @@
     "collections": [
       "CMS-Trigger-Information"
     ],
-    "collision_information": {
-      "energy": "7TeV"
-    },
     "date_created": [
       "2011"
     ],
@@ -28995,9 +23724,6 @@
     "experiment": "CMS",
     "publisher": "CERN Open Data Portal",
     "recid": "2878",
-    "run_period": [
-      "Run2011A"
-    ],
     "title": "High-Level Trigger path information HLT_Photon75_CaloIdVL_IsoL (Photon dataset)",
     "type": {
       "primary": "Supplementaries",
@@ -29018,9 +23744,6 @@
     "collections": [
       "CMS-Trigger-Information"
     ],
-    "collision_information": {
-      "energy": "7TeV"
-    },
     "date_created": [
       "2011"
     ],
@@ -29028,9 +23751,6 @@
     "experiment": "CMS",
     "publisher": "CERN Open Data Portal",
     "recid": "2879",
-    "run_period": [
-      "Run2011A"
-    ],
     "title": "High-Level Trigger path information HLT_Photon90EBOnly_CaloIdVL_IsoL_TriPFJet25 (PhotonHad dataset)",
     "type": {
       "primary": "Supplementaries",
@@ -29051,9 +23771,6 @@
     "collections": [
       "CMS-Trigger-Information"
     ],
-    "collision_information": {
-      "energy": "7TeV"
-    },
     "date_created": [
       "2011"
     ],
@@ -29061,9 +23778,6 @@
     "experiment": "CMS",
     "publisher": "CERN Open Data Portal",
     "recid": "2880",
-    "run_period": [
-      "Run2011A"
-    ],
     "title": "High-Level Trigger path information HLT_Photon90EBOnly_CaloIdVL_IsoL_TriPFJet30 (PhotonHad dataset)",
     "type": {
       "primary": "Supplementaries",
@@ -29084,9 +23798,6 @@
     "collections": [
       "CMS-Trigger-Information"
     ],
-    "collision_information": {
-      "energy": "7TeV"
-    },
     "date_created": [
       "2011"
     ],
@@ -29094,9 +23805,6 @@
     "experiment": "CMS",
     "publisher": "CERN Open Data Portal",
     "recid": "2881",
-    "run_period": [
-      "Run2011A"
-    ],
     "title": "High-Level Trigger path information HLT_Photon90_CaloIdVL (Photon dataset)",
     "type": {
       "primary": "Supplementaries",
@@ -29117,9 +23825,6 @@
     "collections": [
       "CMS-Trigger-Information"
     ],
-    "collision_information": {
-      "energy": "7TeV"
-    },
     "date_created": [
       "2011"
     ],
@@ -29127,9 +23832,6 @@
     "experiment": "CMS",
     "publisher": "CERN Open Data Portal",
     "recid": "2882",
-    "run_period": [
-      "Run2011A"
-    ],
     "title": "High-Level Trigger path information HLT_Photon90_CaloIdVL_IsoL (Photon dataset)",
     "type": {
       "primary": "Supplementaries",
@@ -29150,9 +23852,6 @@
     "collections": [
       "CMS-Trigger-Information"
     ],
-    "collision_information": {
-      "energy": "7TeV"
-    },
     "date_created": [
       "2011"
     ],
@@ -29160,9 +23859,6 @@
     "experiment": "CMS",
     "publisher": "CERN Open Data Portal",
     "recid": "2883",
-    "run_period": [
-      "Run2011A"
-    ],
     "title": "High-Level Trigger path information HLT_Physics (MinimumBias dataset)",
     "type": {
       "primary": "Supplementaries",
@@ -29183,9 +23879,6 @@
     "collections": [
       "CMS-Trigger-Information"
     ],
-    "collision_information": {
-      "energy": "7TeV"
-    },
     "date_created": [
       "2011"
     ],
@@ -29193,9 +23886,6 @@
     "experiment": "CMS",
     "publisher": "CERN Open Data Portal",
     "recid": "2884",
-    "run_period": [
-      "Run2011A"
-    ],
     "title": "High-Level Trigger path information HLT_PhysicsPF",
     "type": {
       "primary": "Supplementaries",
@@ -29216,9 +23906,6 @@
     "collections": [
       "CMS-Trigger-Information"
     ],
-    "collision_information": {
-      "energy": "7TeV"
-    },
     "date_created": [
       "2011"
     ],
@@ -29226,9 +23913,6 @@
     "experiment": "CMS",
     "publisher": "CERN Open Data Portal",
     "recid": "2885",
-    "run_period": [
-      "Run2011A"
-    ],
     "title": "High-Level Trigger path information HLT_Physics_NanoDST",
     "type": {
       "primary": "Supplementaries",
@@ -29249,9 +23933,6 @@
     "collections": [
       "CMS-Trigger-Information"
     ],
-    "collision_information": {
-      "energy": "7TeV"
-    },
     "date_created": [
       "2011"
     ],
@@ -29259,9 +23940,6 @@
     "experiment": "CMS",
     "publisher": "CERN Open Data Portal",
     "recid": "2886",
-    "run_period": [
-      "Run2011A"
-    ],
     "title": "High-Level Trigger path information HLT_PixelTracks_Multiplicity100 (MinimumBias dataset)",
     "type": {
       "primary": "Supplementaries",
@@ -29282,9 +23960,6 @@
     "collections": [
       "CMS-Trigger-Information"
     ],
-    "collision_information": {
-      "energy": "7TeV"
-    },
     "date_created": [
       "2011"
     ],
@@ -29292,9 +23967,6 @@
     "experiment": "CMS",
     "publisher": "CERN Open Data Portal",
     "recid": "2887",
-    "run_period": [
-      "Run2011A"
-    ],
     "title": "High-Level Trigger path information HLT_PixelTracks_Multiplicity110 (MinimumBias dataset)",
     "type": {
       "primary": "Supplementaries",
@@ -29315,9 +23987,6 @@
     "collections": [
       "CMS-Trigger-Information"
     ],
-    "collision_information": {
-      "energy": "7TeV"
-    },
     "date_created": [
       "2011"
     ],
@@ -29325,9 +23994,6 @@
     "experiment": "CMS",
     "publisher": "CERN Open Data Portal",
     "recid": "2888",
-    "run_period": [
-      "Run2011A"
-    ],
     "title": "High-Level Trigger path information HLT_PixelTracks_Multiplicity125 (MinimumBias dataset)",
     "type": {
       "primary": "Supplementaries",
@@ -29348,9 +24014,6 @@
     "collections": [
       "CMS-Trigger-Information"
     ],
-    "collision_information": {
-      "energy": "7TeV"
-    },
     "date_created": [
       "2011"
     ],
@@ -29358,9 +24021,6 @@
     "experiment": "CMS",
     "publisher": "CERN Open Data Portal",
     "recid": "2889",
-    "run_period": [
-      "Run2011A"
-    ],
     "title": "High-Level Trigger path information HLT_PixelTracks_Multiplicity50_Loose (AllPhysics2760 dataset)",
     "type": {
       "primary": "Supplementaries",
@@ -29381,9 +24041,6 @@
     "collections": [
       "CMS-Trigger-Information"
     ],
-    "collision_information": {
-      "energy": "7TeV"
-    },
     "date_created": [
       "2011"
     ],
@@ -29391,9 +24048,6 @@
     "experiment": "CMS",
     "publisher": "CERN Open Data Portal",
     "recid": "2890",
-    "run_period": [
-      "Run2011A"
-    ],
     "title": "High-Level Trigger path information HLT_PixelTracks_Multiplicity60_Loose (AllPhysics2760 dataset)",
     "type": {
       "primary": "Supplementaries",
@@ -29414,9 +24068,6 @@
     "collections": [
       "CMS-Trigger-Information"
     ],
-    "collision_information": {
-      "energy": "7TeV"
-    },
     "date_created": [
       "2011"
     ],
@@ -29424,9 +24075,6 @@
     "experiment": "CMS",
     "publisher": "CERN Open Data Portal",
     "recid": "2891",
-    "run_period": [
-      "Run2011A"
-    ],
     "title": "High-Level Trigger path information HLT_PixelTracks_Multiplicity70_Loose (AllPhysics2760 dataset)",
     "type": {
       "primary": "Supplementaries",
@@ -29447,9 +24095,6 @@
     "collections": [
       "CMS-Trigger-Information"
     ],
-    "collision_information": {
-      "energy": "7TeV"
-    },
     "date_created": [
       "2011"
     ],
@@ -29457,9 +24102,6 @@
     "experiment": "CMS",
     "publisher": "CERN Open Data Portal",
     "recid": "2892",
-    "run_period": [
-      "Run2011A"
-    ],
     "title": "High-Level Trigger path information HLT_PixelTracks_Multiplicity80 (MinimumBias dataset)",
     "type": {
       "primary": "Supplementaries",
@@ -29480,9 +24122,6 @@
     "collections": [
       "CMS-Trigger-Information"
     ],
-    "collision_information": {
-      "energy": "7TeV"
-    },
     "date_created": [
       "2011"
     ],
@@ -29490,9 +24129,6 @@
     "experiment": "CMS",
     "publisher": "CERN Open Data Portal",
     "recid": "2893",
-    "run_period": [
-      "Run2011A"
-    ],
     "title": "High-Level Trigger path information HLT_QuadJet40 (MultiJet dataset)",
     "type": {
       "primary": "Supplementaries",
@@ -29513,9 +24149,6 @@
     "collections": [
       "CMS-Trigger-Information"
     ],
-    "collision_information": {
-      "energy": "7TeV"
-    },
     "date_created": [
       "2011"
     ],
@@ -29523,9 +24156,6 @@
     "experiment": "CMS",
     "publisher": "CERN Open Data Portal",
     "recid": "2894",
-    "run_period": [
-      "Run2011A"
-    ],
     "title": "High-Level Trigger path information HLT_QuadJet40_IsoPFTau40 (MultiJet dataset)",
     "type": {
       "primary": "Supplementaries",
@@ -29546,9 +24176,6 @@
     "collections": [
       "CMS-Trigger-Information"
     ],
-    "collision_information": {
-      "energy": "7TeV"
-    },
     "date_created": [
       "2011"
     ],
@@ -29556,9 +24183,6 @@
     "experiment": "CMS",
     "publisher": "CERN Open Data Portal",
     "recid": "2895",
-    "run_period": [
-      "Run2011A"
-    ],
     "title": "High-Level Trigger path information HLT_QuadJet45_DiJet40 (MultiJet dataset)",
     "type": {
       "primary": "Supplementaries",
@@ -29579,9 +24203,6 @@
     "collections": [
       "CMS-Trigger-Information"
     ],
-    "collision_information": {
-      "energy": "7TeV"
-    },
     "date_created": [
       "2011"
     ],
@@ -29589,9 +24210,6 @@
     "experiment": "CMS",
     "publisher": "CERN Open Data Portal",
     "recid": "2896",
-    "run_period": [
-      "Run2011A"
-    ],
     "title": "High-Level Trigger path information HLT_QuadJet45_IsoPFTau45 (MultiJet dataset)",
     "type": {
       "primary": "Supplementaries",
@@ -29612,9 +24230,6 @@
     "collections": [
       "CMS-Trigger-Information"
     ],
-    "collision_information": {
-      "energy": "7TeV"
-    },
     "date_created": [
       "2011"
     ],
@@ -29622,9 +24237,6 @@
     "experiment": "CMS",
     "publisher": "CERN Open Data Portal",
     "recid": "2897",
-    "run_period": [
-      "Run2011A"
-    ],
     "title": "High-Level Trigger path information HLT_QuadJet50_BTagIP (MultiJet dataset)",
     "type": {
       "primary": "Supplementaries",
@@ -29645,9 +24257,6 @@
     "collections": [
       "CMS-Trigger-Information"
     ],
-    "collision_information": {
-      "energy": "7TeV"
-    },
     "date_created": [
       "2011"
     ],
@@ -29655,9 +24264,6 @@
     "experiment": "CMS",
     "publisher": "CERN Open Data Portal",
     "recid": "2898",
-    "run_period": [
-      "Run2011A"
-    ],
     "title": "High-Level Trigger path information HLT_QuadJet50_DiJet40 (MultiJet dataset)",
     "type": {
       "primary": "Supplementaries",
@@ -29678,9 +24284,6 @@
     "collections": [
       "CMS-Trigger-Information"
     ],
-    "collision_information": {
-      "energy": "7TeV"
-    },
     "date_created": [
       "2011"
     ],
@@ -29688,9 +24291,6 @@
     "experiment": "CMS",
     "publisher": "CERN Open Data Portal",
     "recid": "2899",
-    "run_period": [
-      "Run2011A"
-    ],
     "title": "High-Level Trigger path information HLT_QuadJet50_DiJet40_L1FastJet (MultiJet dataset)",
     "type": {
       "primary": "Supplementaries",
@@ -29711,9 +24311,6 @@
     "collections": [
       "CMS-Trigger-Information"
     ],
-    "collision_information": {
-      "energy": "7TeV"
-    },
     "date_created": [
       "2011"
     ],
@@ -29721,9 +24318,6 @@
     "experiment": "CMS",
     "publisher": "CERN Open Data Portal",
     "recid": "2900",
-    "run_period": [
-      "Run2011A"
-    ],
     "title": "High-Level Trigger path information HLT_QuadJet50_IsoPFTau50 (MultiJet, TauPlusX datasets)",
     "type": {
       "primary": "Supplementaries",
@@ -29744,9 +24338,6 @@
     "collections": [
       "CMS-Trigger-Information"
     ],
-    "collision_information": {
-      "energy": "7TeV"
-    },
     "date_created": [
       "2011"
     ],
@@ -29754,9 +24345,6 @@
     "experiment": "CMS",
     "publisher": "CERN Open Data Portal",
     "recid": "2901",
-    "run_period": [
-      "Run2011A"
-    ],
     "title": "High-Level Trigger path information HLT_QuadJet50_Jet40 (MultiJet dataset)",
     "type": {
       "primary": "Supplementaries",
@@ -29777,9 +24365,6 @@
     "collections": [
       "CMS-Trigger-Information"
     ],
-    "collision_information": {
-      "energy": "7TeV"
-    },
     "date_created": [
       "2011"
     ],
@@ -29787,9 +24372,6 @@
     "experiment": "CMS",
     "publisher": "CERN Open Data Portal",
     "recid": "2902",
-    "run_period": [
-      "Run2011A"
-    ],
     "title": "High-Level Trigger path information HLT_QuadJet50_Jet40_Jet30 (MultiJet dataset)",
     "type": {
       "primary": "Supplementaries",
@@ -29810,9 +24392,6 @@
     "collections": [
       "CMS-Trigger-Information"
     ],
-    "collision_information": {
-      "energy": "7TeV"
-    },
     "date_created": [
       "2011"
     ],
@@ -29820,9 +24399,6 @@
     "experiment": "CMS",
     "publisher": "CERN Open Data Portal",
     "recid": "2903",
-    "run_period": [
-      "Run2011A"
-    ],
     "title": "High-Level Trigger path information HLT_QuadJet60 (MultiJet dataset)",
     "type": {
       "primary": "Supplementaries",
@@ -29843,9 +24419,6 @@
     "collections": [
       "CMS-Trigger-Information"
     ],
-    "collision_information": {
-      "energy": "7TeV"
-    },
     "date_created": [
       "2011"
     ],
@@ -29853,9 +24426,6 @@
     "experiment": "CMS",
     "publisher": "CERN Open Data Portal",
     "recid": "2904",
-    "run_period": [
-      "Run2011A"
-    ],
     "title": "High-Level Trigger path information HLT_QuadJet70 (MultiJet dataset)",
     "type": {
       "primary": "Supplementaries",
@@ -29876,9 +24446,6 @@
     "collections": [
       "CMS-Trigger-Information"
     ],
-    "collision_information": {
-      "energy": "7TeV"
-    },
     "date_created": [
       "2011"
     ],
@@ -29886,9 +24453,6 @@
     "experiment": "CMS",
     "publisher": "CERN Open Data Portal",
     "recid": "2905",
-    "run_period": [
-      "Run2011A"
-    ],
     "title": "High-Level Trigger path information HLT_QuadJet80 (MultiJet dataset)",
     "type": {
       "primary": "Supplementaries",
@@ -29909,9 +24473,6 @@
     "collections": [
       "CMS-Trigger-Information"
     ],
-    "collision_information": {
-      "energy": "7TeV"
-    },
     "date_created": [
       "2011"
     ],
@@ -29919,9 +24480,6 @@
     "experiment": "CMS",
     "publisher": "CERN Open Data Portal",
     "recid": "2906",
-    "run_period": [
-      "Run2011A"
-    ],
     "title": "High-Level Trigger path information HLT_QuadJet80_L1FastJet (MultiJet dataset)",
     "type": {
       "primary": "Supplementaries",
@@ -29942,9 +24500,6 @@
     "collections": [
       "CMS-Trigger-Information"
     ],
-    "collision_information": {
-      "energy": "7TeV"
-    },
     "date_created": [
       "2011"
     ],
@@ -29952,9 +24507,6 @@
     "experiment": "CMS",
     "publisher": "CERN Open Data Portal",
     "recid": "2907",
-    "run_period": [
-      "Run2011A"
-    ],
     "title": "High-Level Trigger path information HLT_QuadJet90 (MultiJet dataset)",
     "type": {
       "primary": "Supplementaries",
@@ -29975,9 +24527,6 @@
     "collections": [
       "CMS-Trigger-Information"
     ],
-    "collision_information": {
-      "energy": "7TeV"
-    },
     "date_created": [
       "2011"
     ],
@@ -29985,9 +24534,6 @@
     "experiment": "CMS",
     "publisher": "CERN Open Data Portal",
     "recid": "2908",
-    "run_period": [
-      "Run2011A"
-    ],
     "title": "High-Level Trigger path information HLT_R014_MR150 (HT dataset)",
     "type": {
       "primary": "Supplementaries",
@@ -30008,9 +24554,6 @@
     "collections": [
       "CMS-Trigger-Information"
     ],
-    "collision_information": {
-      "energy": "7TeV"
-    },
     "date_created": [
       "2011"
     ],
@@ -30018,9 +24561,6 @@
     "experiment": "CMS",
     "publisher": "CERN Open Data Portal",
     "recid": "2909",
-    "run_period": [
-      "Run2011A"
-    ],
     "title": "High-Level Trigger path information HLT_R014_MR150_CentralJet40_BTagIP (HT dataset)",
     "type": {
       "primary": "Supplementaries",
@@ -30041,9 +24581,6 @@
     "collections": [
       "CMS-Trigger-Information"
     ],
-    "collision_information": {
-      "energy": "7TeV"
-    },
     "date_created": [
       "2011"
     ],
@@ -30051,9 +24588,6 @@
     "experiment": "CMS",
     "publisher": "CERN Open Data Portal",
     "recid": "2910",
-    "run_period": [
-      "Run2011A"
-    ],
     "title": "High-Level Trigger path information HLT_R014_MR200_CentralJet40_BTagIP (MET dataset)",
     "type": {
       "primary": "Supplementaries",
@@ -30074,9 +24608,6 @@
     "collections": [
       "CMS-Trigger-Information"
     ],
-    "collision_information": {
-      "energy": "7TeV"
-    },
     "date_created": [
       "2011"
     ],
@@ -30084,9 +24615,6 @@
     "experiment": "CMS",
     "publisher": "CERN Open Data Portal",
     "recid": "2911",
-    "run_period": [
-      "Run2011A"
-    ],
     "title": "High-Level Trigger path information HLT_R014_MR400_CentralJet40_BTagIP (MET dataset)",
     "type": {
       "primary": "Supplementaries",
@@ -30107,9 +24635,6 @@
     "collections": [
       "CMS-Trigger-Information"
     ],
-    "collision_information": {
-      "energy": "7TeV"
-    },
     "date_created": [
       "2011"
     ],
@@ -30117,9 +24642,6 @@
     "experiment": "CMS",
     "publisher": "CERN Open Data Portal",
     "recid": "2912",
-    "run_period": [
-      "Run2011A"
-    ],
     "title": "High-Level Trigger path information HLT_R014_MR450_CentralJet40_BTagIP (HT, MET datasets)",
     "type": {
       "primary": "Supplementaries",
@@ -30140,9 +24662,6 @@
     "collections": [
       "CMS-Trigger-Information"
     ],
-    "collision_information": {
-      "energy": "7TeV"
-    },
     "date_created": [
       "2011"
     ],
@@ -30150,9 +24669,6 @@
     "experiment": "CMS",
     "publisher": "CERN Open Data Portal",
     "recid": "2913",
-    "run_period": [
-      "Run2011A"
-    ],
     "title": "High-Level Trigger path information HLT_R017_MR450_CentralJet40_BTagIP (HT dataset)",
     "type": {
       "primary": "Supplementaries",
@@ -30173,9 +24689,6 @@
     "collections": [
       "CMS-Trigger-Information"
     ],
-    "collision_information": {
-      "energy": "7TeV"
-    },
     "date_created": [
       "2011"
     ],
@@ -30183,9 +24696,6 @@
     "experiment": "CMS",
     "publisher": "CERN Open Data Portal",
     "recid": "2914",
-    "run_period": [
-      "Run2011A"
-    ],
     "title": "High-Level Trigger path information HLT_R017_MR500_CentralJet40_BTagIP (HT dataset)",
     "type": {
       "primary": "Supplementaries",
@@ -30206,9 +24716,6 @@
     "collections": [
       "CMS-Trigger-Information"
     ],
-    "collision_information": {
-      "energy": "7TeV"
-    },
     "date_created": [
       "2011"
     ],
@@ -30216,9 +24723,6 @@
     "experiment": "CMS",
     "publisher": "CERN Open Data Portal",
     "recid": "2915",
-    "run_period": [
-      "Run2011A"
-    ],
     "title": "High-Level Trigger path information HLT_R020_MR150 (HT dataset)",
     "type": {
       "primary": "Supplementaries",
@@ -30239,9 +24743,6 @@
     "collections": [
       "CMS-Trigger-Information"
     ],
-    "collision_information": {
-      "energy": "7TeV"
-    },
     "date_created": [
       "2011"
     ],
@@ -30249,9 +24750,6 @@
     "experiment": "CMS",
     "publisher": "CERN Open Data Portal",
     "recid": "2916",
-    "run_period": [
-      "Run2011A"
-    ],
     "title": "High-Level Trigger path information HLT_R020_MR300_CentralJet40_BTagIP (MET dataset)",
     "type": {
       "primary": "Supplementaries",
@@ -30272,9 +24770,6 @@
     "collections": [
       "CMS-Trigger-Information"
     ],
-    "collision_information": {
-      "energy": "7TeV"
-    },
     "date_created": [
       "2011"
     ],
@@ -30282,9 +24777,6 @@
     "experiment": "CMS",
     "publisher": "CERN Open Data Portal",
     "recid": "2917",
-    "run_period": [
-      "Run2011A"
-    ],
     "title": "High-Level Trigger path information HLT_R020_MR350_CentralJet40_BTagIP (HT, MET datasets)",
     "type": {
       "primary": "Supplementaries",
@@ -30305,9 +24797,6 @@
     "collections": [
       "CMS-Trigger-Information"
     ],
-    "collision_information": {
-      "energy": "7TeV"
-    },
     "date_created": [
       "2011"
     ],
@@ -30315,9 +24804,6 @@
     "experiment": "CMS",
     "publisher": "CERN Open Data Portal",
     "recid": "2918",
-    "run_period": [
-      "Run2011A"
-    ],
     "title": "High-Level Trigger path information HLT_R020_MR500 (HT dataset)",
     "type": {
       "primary": "Supplementaries",
@@ -30338,9 +24824,6 @@
     "collections": [
       "CMS-Trigger-Information"
     ],
-    "collision_information": {
-      "energy": "7TeV"
-    },
     "date_created": [
       "2011"
     ],
@@ -30348,9 +24831,6 @@
     "experiment": "CMS",
     "publisher": "CERN Open Data Portal",
     "recid": "2919",
-    "run_period": [
-      "Run2011A"
-    ],
     "title": "High-Level Trigger path information HLT_R020_MR550 (HT dataset)",
     "type": {
       "primary": "Supplementaries",
@@ -30371,9 +24851,6 @@
     "collections": [
       "CMS-Trigger-Information"
     ],
-    "collision_information": {
-      "energy": "7TeV"
-    },
     "date_created": [
       "2011"
     ],
@@ -30381,9 +24858,6 @@
     "experiment": "CMS",
     "publisher": "CERN Open Data Portal",
     "recid": "2920",
-    "run_period": [
-      "Run2011A"
-    ],
     "title": "High-Level Trigger path information HLT_R023_MR350_CentralJet40_BTagIP (HT dataset)",
     "type": {
       "primary": "Supplementaries",
@@ -30404,9 +24878,6 @@
     "collections": [
       "CMS-Trigger-Information"
     ],
-    "collision_information": {
-      "energy": "7TeV"
-    },
     "date_created": [
       "2011"
     ],
@@ -30414,9 +24885,6 @@
     "experiment": "CMS",
     "publisher": "CERN Open Data Portal",
     "recid": "2921",
-    "run_period": [
-      "Run2011A"
-    ],
     "title": "High-Level Trigger path information HLT_R023_MR400_CentralJet40_BTagIP (HT dataset)",
     "type": {
       "primary": "Supplementaries",
@@ -30437,9 +24905,6 @@
     "collections": [
       "CMS-Trigger-Information"
     ],
-    "collision_information": {
-      "energy": "7TeV"
-    },
     "date_created": [
       "2011"
     ],
@@ -30447,9 +24912,6 @@
     "experiment": "CMS",
     "publisher": "CERN Open Data Portal",
     "recid": "2922",
-    "run_period": [
-      "Run2011A"
-    ],
     "title": "High-Level Trigger path information HLT_R023_MR550 (HT dataset)",
     "type": {
       "primary": "Supplementaries",
@@ -30470,9 +24932,6 @@
     "collections": [
       "CMS-Trigger-Information"
     ],
-    "collision_information": {
-      "energy": "7TeV"
-    },
     "date_created": [
       "2011"
     ],
@@ -30480,9 +24939,6 @@
     "experiment": "CMS",
     "publisher": "CERN Open Data Portal",
     "recid": "2923",
-    "run_period": [
-      "Run2011A"
-    ],
     "title": "High-Level Trigger path information HLT_R025_MR150 (HT dataset)",
     "type": {
       "primary": "Supplementaries",
@@ -30503,9 +24959,6 @@
     "collections": [
       "CMS-Trigger-Information"
     ],
-    "collision_information": {
-      "energy": "7TeV"
-    },
     "date_created": [
       "2011"
     ],
@@ -30513,9 +24966,6 @@
     "experiment": "CMS",
     "publisher": "CERN Open Data Portal",
     "recid": "2924",
-    "run_period": [
-      "Run2011A"
-    ],
     "title": "High-Level Trigger path information HLT_R025_MR250_CentralJet40_BTagIP (HT dataset)",
     "type": {
       "primary": "Supplementaries",
@@ -30536,9 +24986,6 @@
     "collections": [
       "CMS-Trigger-Information"
     ],
-    "collision_information": {
-      "energy": "7TeV"
-    },
     "date_created": [
       "2011"
     ],
@@ -30546,9 +24993,6 @@
     "experiment": "CMS",
     "publisher": "CERN Open Data Portal",
     "recid": "2925",
-    "run_period": [
-      "Run2011A"
-    ],
     "title": "High-Level Trigger path information HLT_R025_MR400 (HT dataset)",
     "type": {
       "primary": "Supplementaries",
@@ -30569,9 +25013,6 @@
     "collections": [
       "CMS-Trigger-Information"
     ],
-    "collision_information": {
-      "energy": "7TeV"
-    },
     "date_created": [
       "2011"
     ],
@@ -30579,9 +25020,6 @@
     "experiment": "CMS",
     "publisher": "CERN Open Data Portal",
     "recid": "2926",
-    "run_period": [
-      "Run2011A"
-    ],
     "title": "High-Level Trigger path information HLT_R025_MR450 (HT dataset)",
     "type": {
       "primary": "Supplementaries",
@@ -30602,9 +25040,6 @@
     "collections": [
       "CMS-Trigger-Information"
     ],
-    "collision_information": {
-      "energy": "7TeV"
-    },
     "date_created": [
       "2011"
     ],
@@ -30612,9 +25047,6 @@
     "experiment": "CMS",
     "publisher": "CERN Open Data Portal",
     "recid": "2927",
-    "run_period": [
-      "Run2011A"
-    ],
     "title": "High-Level Trigger path information HLT_R029_MR250_CentralJet40_BTagIP (HT dataset)",
     "type": {
       "primary": "Supplementaries",
@@ -30635,9 +25067,6 @@
     "collections": [
       "CMS-Trigger-Information"
     ],
-    "collision_information": {
-      "energy": "7TeV"
-    },
     "date_created": [
       "2011"
     ],
@@ -30645,9 +25074,6 @@
     "experiment": "CMS",
     "publisher": "CERN Open Data Portal",
     "recid": "2928",
-    "run_period": [
-      "Run2011A"
-    ],
     "title": "High-Level Trigger path information HLT_R029_MR300_CentralJet40_BTagIP (HT dataset)",
     "type": {
       "primary": "Supplementaries",
@@ -30668,9 +25094,6 @@
     "collections": [
       "CMS-Trigger-Information"
     ],
-    "collision_information": {
-      "energy": "7TeV"
-    },
     "date_created": [
       "2011"
     ],
@@ -30678,9 +25101,6 @@
     "experiment": "CMS",
     "publisher": "CERN Open Data Portal",
     "recid": "2929",
-    "run_period": [
-      "Run2011A"
-    ],
     "title": "High-Level Trigger path information HLT_R029_MR450 (HT dataset)",
     "type": {
       "primary": "Supplementaries",
@@ -30701,9 +25121,6 @@
     "collections": [
       "CMS-Trigger-Information"
     ],
-    "collision_information": {
-      "energy": "7TeV"
-    },
     "date_created": [
       "2011"
     ],
@@ -30711,9 +25128,6 @@
     "experiment": "CMS",
     "publisher": "CERN Open Data Portal",
     "recid": "2930",
-    "run_period": [
-      "Run2011A"
-    ],
     "title": "High-Level Trigger path information HLT_R030_MR200_CentralJet40_BTagIP (MET dataset)",
     "type": {
       "primary": "Supplementaries",
@@ -30734,9 +25148,6 @@
     "collections": [
       "CMS-Trigger-Information"
     ],
-    "collision_information": {
-      "energy": "7TeV"
-    },
     "date_created": [
       "2011"
     ],
@@ -30744,9 +25155,6 @@
     "experiment": "CMS",
     "publisher": "CERN Open Data Portal",
     "recid": "2931",
-    "run_period": [
-      "Run2011A"
-    ],
     "title": "High-Level Trigger path information HLT_R030_MR250_CentralJet40_BTagIP (MET dataset)",
     "type": {
       "primary": "Supplementaries",
@@ -30767,9 +25175,6 @@
     "collections": [
       "CMS-Trigger-Information"
     ],
-    "collision_information": {
-      "energy": "7TeV"
-    },
     "date_created": [
       "2011"
     ],
@@ -30777,9 +25182,6 @@
     "experiment": "CMS",
     "publisher": "CERN Open Data Portal",
     "recid": "2932",
-    "run_period": [
-      "Run2011A"
-    ],
     "title": "High-Level Trigger path information HLT_R032 (HT dataset)",
     "type": {
       "primary": "Supplementaries",
@@ -30800,9 +25202,6 @@
     "collections": [
       "CMS-Trigger-Information"
     ],
-    "collision_information": {
-      "energy": "7TeV"
-    },
     "date_created": [
       "2011"
     ],
@@ -30810,9 +25209,6 @@
     "experiment": "CMS",
     "publisher": "CERN Open Data Portal",
     "recid": "2933",
-    "run_period": [
-      "Run2011A"
-    ],
     "title": "High-Level Trigger path information HLT_R032_MR100 (HT dataset)",
     "type": {
       "primary": "Supplementaries",
@@ -30833,9 +25229,6 @@
     "collections": [
       "CMS-Trigger-Information"
     ],
-    "collision_information": {
-      "energy": "7TeV"
-    },
     "date_created": [
       "2011"
     ],
@@ -30843,9 +25236,6 @@
     "experiment": "CMS",
     "publisher": "CERN Open Data Portal",
     "recid": "2934",
-    "run_period": [
-      "Run2011A"
-    ],
     "title": "High-Level Trigger path information HLT_R033_MR200_CentralJet40_BTagIP (HT dataset)",
     "type": {
       "primary": "Supplementaries",
@@ -30866,9 +25256,6 @@
     "collections": [
       "CMS-Trigger-Information"
     ],
-    "collision_information": {
-      "energy": "7TeV"
-    },
     "date_created": [
       "2011"
     ],
@@ -30876,9 +25263,6 @@
     "experiment": "CMS",
     "publisher": "CERN Open Data Portal",
     "recid": "2935",
-    "run_period": [
-      "Run2011A"
-    ],
     "title": "High-Level Trigger path information HLT_R033_MR300 (HT dataset)",
     "type": {
       "primary": "Supplementaries",
@@ -30899,9 +25283,6 @@
     "collections": [
       "CMS-Trigger-Information"
     ],
-    "collision_information": {
-      "energy": "7TeV"
-    },
     "date_created": [
       "2011"
     ],
@@ -30909,9 +25290,6 @@
     "experiment": "CMS",
     "publisher": "CERN Open Data Portal",
     "recid": "2936",
-    "run_period": [
-      "Run2011A"
-    ],
     "title": "High-Level Trigger path information HLT_R033_MR350 (HT dataset)",
     "type": {
       "primary": "Supplementaries",
@@ -30932,9 +25310,6 @@
     "collections": [
       "CMS-Trigger-Information"
     ],
-    "collision_information": {
-      "energy": "7TeV"
-    },
     "date_created": [
       "2011"
     ],
@@ -30942,9 +25317,6 @@
     "experiment": "CMS",
     "publisher": "CERN Open Data Portal",
     "recid": "2937",
-    "run_period": [
-      "Run2011A"
-    ],
     "title": "High-Level Trigger path information HLT_R035_MR100 (HT dataset)",
     "type": {
       "primary": "Supplementaries",
@@ -30965,9 +25337,6 @@
     "collections": [
       "CMS-Trigger-Information"
     ],
-    "collision_information": {
-      "energy": "7TeV"
-    },
     "date_created": [
       "2011"
     ],
@@ -30975,9 +25344,6 @@
     "experiment": "CMS",
     "publisher": "CERN Open Data Portal",
     "recid": "2938",
-    "run_period": [
-      "Run2011A"
-    ],
     "title": "High-Level Trigger path information HLT_R036_MR200_CentralJet40_BTagIP (HT dataset)",
     "type": {
       "primary": "Supplementaries",
@@ -30998,9 +25364,6 @@
     "collections": [
       "CMS-Trigger-Information"
     ],
-    "collision_information": {
-      "energy": "7TeV"
-    },
     "date_created": [
       "2011"
     ],
@@ -31008,9 +25371,6 @@
     "experiment": "CMS",
     "publisher": "CERN Open Data Portal",
     "recid": "2939",
-    "run_period": [
-      "Run2011A"
-    ],
     "title": "High-Level Trigger path information HLT_R036_MR350 (HT dataset)",
     "type": {
       "primary": "Supplementaries",
@@ -31031,9 +25391,6 @@
     "collections": [
       "CMS-Trigger-Information"
     ],
-    "collision_information": {
-      "energy": "7TeV"
-    },
     "date_created": [
       "2011"
     ],
@@ -31041,9 +25398,6 @@
     "experiment": "CMS",
     "publisher": "CERN Open Data Portal",
     "recid": "2940",
-    "run_period": [
-      "Run2011A"
-    ],
     "title": "High-Level Trigger path information HLT_R038_MR200 (HT dataset)",
     "type": {
       "primary": "Supplementaries",
@@ -31064,9 +25418,6 @@
     "collections": [
       "CMS-Trigger-Information"
     ],
-    "collision_information": {
-      "energy": "7TeV"
-    },
     "date_created": [
       "2011"
     ],
@@ -31074,9 +25425,6 @@
     "experiment": "CMS",
     "publisher": "CERN Open Data Portal",
     "recid": "2941",
-    "run_period": [
-      "Run2011A"
-    ],
     "title": "High-Level Trigger path information HLT_R038_MR250 (HT dataset)",
     "type": {
       "primary": "Supplementaries",
@@ -31097,9 +25445,6 @@
     "collections": [
       "CMS-Trigger-Information"
     ],
-    "collision_information": {
-      "energy": "7TeV"
-    },
     "date_created": [
       "2011"
     ],
@@ -31107,9 +25452,6 @@
     "experiment": "CMS",
     "publisher": "CERN Open Data Portal",
     "recid": "2942",
-    "run_period": [
-      "Run2011A"
-    ],
     "title": "High-Level Trigger path information HLT_R038_MR300 (HT dataset)",
     "type": {
       "primary": "Supplementaries",
@@ -31130,9 +25472,6 @@
     "collections": [
       "CMS-Trigger-Information"
     ],
-    "collision_information": {
-      "energy": "7TeV"
-    },
     "date_created": [
       "2011"
     ],
@@ -31140,9 +25479,6 @@
     "experiment": "CMS",
     "publisher": "CERN Open Data Portal",
     "recid": "2943",
-    "run_period": [
-      "Run2011A"
-    ],
     "title": "High-Level Trigger path information HLT_R042_MR250 (HT dataset)",
     "type": {
       "primary": "Supplementaries",
@@ -31163,9 +25499,6 @@
     "collections": [
       "CMS-Trigger-Information"
     ],
-    "collision_information": {
-      "energy": "7TeV"
-    },
     "date_created": [
       "2011"
     ],
@@ -31173,9 +25506,6 @@
     "experiment": "CMS",
     "publisher": "CERN Open Data Portal",
     "recid": "2944",
-    "run_period": [
-      "Run2011A"
-    ],
     "title": "High-Level Trigger path information HLT_RMR65 (HT dataset)",
     "type": {
       "primary": "Supplementaries",
@@ -31196,9 +25526,6 @@
     "collections": [
       "CMS-Trigger-Information"
     ],
-    "collision_information": {
-      "energy": "7TeV"
-    },
     "date_created": [
       "2011"
     ],
@@ -31206,9 +25533,6 @@
     "experiment": "CMS",
     "publisher": "CERN Open Data Portal",
     "recid": "2945",
-    "run_period": [
-      "Run2011A"
-    ],
     "title": "High-Level Trigger path information HLT_Random (MinimumBias dataset)",
     "type": {
       "primary": "Supplementaries",
@@ -31229,9 +25553,6 @@
     "collections": [
       "CMS-Trigger-Information"
     ],
-    "collision_information": {
-      "energy": "7TeV"
-    },
     "date_created": [
       "2011"
     ],
@@ -31239,9 +25560,6 @@
     "experiment": "CMS",
     "publisher": "CERN Open Data Portal",
     "recid": "2946",
-    "run_period": [
-      "Run2011A"
-    ],
     "title": "High-Level Trigger path information HLT_RegionalCosmicTracking (Cosmics dataset)",
     "type": {
       "primary": "Supplementaries",
@@ -31262,9 +25580,6 @@
     "collections": [
       "CMS-Trigger-Information"
     ],
-    "collision_information": {
-      "energy": "7TeV"
-    },
     "date_created": [
       "2011"
     ],
@@ -31272,9 +25587,6 @@
     "experiment": "CMS",
     "publisher": "CERN Open Data Portal",
     "recid": "2947",
-    "run_period": [
-      "Run2011A"
-    ],
     "title": "High-Level Trigger path information HLT_SixJet45 (MultiJet dataset)",
     "type": {
       "primary": "Supplementaries",
@@ -31295,9 +25607,6 @@
     "collections": [
       "CMS-Trigger-Information"
     ],
-    "collision_information": {
-      "energy": "7TeV"
-    },
     "date_created": [
       "2011"
     ],
@@ -31305,9 +25614,6 @@
     "experiment": "CMS",
     "publisher": "CERN Open Data Portal",
     "recid": "2948",
-    "run_period": [
-      "Run2011A"
-    ],
     "title": "High-Level Trigger path information HLT_SixJet45_L1FastJet (MultiJet dataset)",
     "type": {
       "primary": "Supplementaries",
@@ -31328,9 +25634,6 @@
     "collections": [
       "CMS-Trigger-Information"
     ],
-    "collision_information": {
-      "energy": "7TeV"
-    },
     "date_created": [
       "2011"
     ],
@@ -31338,9 +25641,6 @@
     "experiment": "CMS",
     "publisher": "CERN Open Data Portal",
     "recid": "2949",
-    "run_period": [
-      "Run2011A"
-    ],
     "title": "High-Level Trigger path information HLT_Spike20 (Commissioning dataset)",
     "type": {
       "primary": "Supplementaries",
@@ -31361,9 +25661,6 @@
     "collections": [
       "CMS-Trigger-Information"
     ],
-    "collision_information": {
-      "energy": "7TeV"
-    },
     "date_created": [
       "2011"
     ],
@@ -31371,9 +25668,6 @@
     "experiment": "CMS",
     "publisher": "CERN Open Data Portal",
     "recid": "2950",
-    "run_period": [
-      "Run2011A"
-    ],
     "title": "High-Level Trigger path information HLT_TkIso10Mu5_Ele8_CaloIdT_CaloIsoVVL_TrkIdVL_Mass8_HT150 (MuHad dataset)",
     "type": {
       "primary": "Supplementaries",
@@ -31394,9 +25688,6 @@
     "collections": [
       "CMS-Trigger-Information"
     ],
-    "collision_information": {
-      "energy": "7TeV"
-    },
     "date_created": [
       "2011"
     ],
@@ -31404,9 +25695,6 @@
     "experiment": "CMS",
     "publisher": "CERN Open Data Portal",
     "recid": "2951",
-    "run_period": [
-      "Run2011A"
-    ],
     "title": "High-Level Trigger path information HLT_TkIso10Mu5_Ele8_CaloIdT_CaloIsoVVL_TrkIdVL_Mass8_HT200 (MuHad dataset)",
     "type": {
       "primary": "Supplementaries",
@@ -31427,9 +25715,6 @@
     "collections": [
       "CMS-Trigger-Information"
     ],
-    "collision_information": {
-      "energy": "7TeV"
-    },
     "date_created": [
       "2011"
     ],
@@ -31437,9 +25722,6 @@
     "experiment": "CMS",
     "publisher": "CERN Open Data Portal",
     "recid": "2952",
-    "run_period": [
-      "Run2011A"
-    ],
     "title": "High-Level Trigger path information HLT_TrackerCalibration",
     "type": {
       "primary": "Supplementaries",
@@ -31460,9 +25742,6 @@
     "collections": [
       "CMS-Trigger-Information"
     ],
-    "collision_information": {
-      "energy": "7TeV"
-    },
     "date_created": [
       "2011"
     ],
@@ -31470,9 +25749,6 @@
     "experiment": "CMS",
     "publisher": "CERN Open Data Portal",
     "recid": "2953",
-    "run_period": [
-      "Run2011A"
-    ],
     "title": "High-Level Trigger path information HLT_TripleEle10_CaloIdL_TrkIdVL (DoubleElectron dataset)",
     "type": {
       "primary": "Supplementaries",
@@ -31493,9 +25769,6 @@
     "collections": [
       "CMS-Trigger-Information"
     ],
-    "collision_information": {
-      "energy": "7TeV"
-    },
     "date_created": [
       "2011"
     ],
@@ -31503,9 +25776,6 @@
     "experiment": "CMS",
     "publisher": "CERN Open Data Portal",
     "recid": "2954",
-    "run_period": [
-      "Run2011A"
-    ],
     "title": "High-Level Trigger path information HLT_TripleMu0_TauTo3Mu (MuOnia dataset)",
     "type": {
       "primary": "Supplementaries",
@@ -31526,9 +25796,6 @@
     "collections": [
       "CMS-Trigger-Information"
     ],
-    "collision_information": {
-      "energy": "7TeV"
-    },
     "date_created": [
       "2011"
     ],
@@ -31536,9 +25803,6 @@
     "experiment": "CMS",
     "publisher": "CERN Open Data Portal",
     "recid": "2955",
-    "run_period": [
-      "Run2011A"
-    ],
     "title": "High-Level Trigger path information HLT_TripleMu5 (DoubleMu dataset)",
     "type": {
       "primary": "Supplementaries",
@@ -31559,9 +25823,6 @@
     "collections": [
       "CMS-Trigger-Information"
     ],
-    "collision_information": {
-      "energy": "7TeV"
-    },
     "date_created": [
       "2011"
     ],
@@ -31569,9 +25830,6 @@
     "experiment": "CMS",
     "publisher": "CERN Open Data Portal",
     "recid": "2956",
-    "run_period": [
-      "Run2011A"
-    ],
     "title": "High-Level Trigger path information HLT_ZeroBias (MinimumBias dataset)",
     "type": {
       "primary": "Supplementaries",
@@ -31592,9 +25850,6 @@
     "collections": [
       "CMS-Trigger-Information"
     ],
-    "collision_information": {
-      "energy": "7TeV"
-    },
     "date_created": [
       "2011"
     ],
@@ -31602,9 +25857,6 @@
     "experiment": "CMS",
     "publisher": "CERN Open Data Portal",
     "recid": "2957",
-    "run_period": [
-      "Run2011A"
-    ],
     "title": "High-Level Trigger path information HLT_ZeroBiasPixel_SingleTrack (AllPhysics2760 dataset)",
     "type": {
       "primary": "Supplementaries",
@@ -31625,9 +25877,6 @@
     "collections": [
       "CMS-Trigger-Information"
     ],
-    "collision_information": {
-      "energy": "7TeV"
-    },
     "date_created": [
       "2011"
     ],
@@ -31635,9 +25884,6 @@
     "experiment": "CMS",
     "publisher": "CERN Open Data Portal",
     "recid": "2958",
-    "run_period": [
-      "Run2011A"
-    ],
     "title": "High-Level Trigger path information HLT_ZeroBias_part0 (MinBias0Tesla0 dataset)",
     "type": {
       "primary": "Supplementaries",
@@ -31658,9 +25904,6 @@
     "collections": [
       "CMS-Trigger-Information"
     ],
-    "collision_information": {
-      "energy": "7TeV"
-    },
     "date_created": [
       "2011"
     ],
@@ -31668,9 +25911,6 @@
     "experiment": "CMS",
     "publisher": "CERN Open Data Portal",
     "recid": "2959",
-    "run_period": [
-      "Run2011A"
-    ],
     "title": "High-Level Trigger path information HLT_ZeroBias_part1 (MinBias0Tesla1 dataset)",
     "type": {
       "primary": "Supplementaries",
@@ -31691,9 +25931,6 @@
     "collections": [
       "CMS-Trigger-Information"
     ],
-    "collision_information": {
-      "energy": "7TeV"
-    },
     "date_created": [
       "2011"
     ],
@@ -31701,9 +25938,6 @@
     "experiment": "CMS",
     "publisher": "CERN Open Data Portal",
     "recid": "2960",
-    "run_period": [
-      "Run2011A"
-    ],
     "title": "High-Level Trigger path information HLT_ZeroBias_part2 (MinBias0Tesla2 dataset)",
     "type": {
       "primary": "Supplementaries",
@@ -31724,9 +25958,6 @@
     "collections": [
       "CMS-Trigger-Information"
     ],
-    "collision_information": {
-      "energy": "7TeV"
-    },
     "date_created": [
       "2011"
     ],
@@ -31734,9 +25965,6 @@
     "experiment": "CMS",
     "publisher": "CERN Open Data Portal",
     "recid": "2961",
-    "run_period": [
-      "Run2011A"
-    ],
     "title": "High-Level Trigger path information HLT_ZeroBias_part3 (ZeroBiasHPF3 dataset)",
     "type": {
       "primary": "Supplementaries",
@@ -31757,9 +25985,6 @@
     "collections": [
       "CMS-Trigger-Information"
     ],
-    "collision_information": {
-      "energy": "7TeV"
-    },
     "date_created": [
       "2011"
     ],
@@ -31767,9 +25992,6 @@
     "experiment": "CMS",
     "publisher": "CERN Open Data Portal",
     "recid": "2962",
-    "run_period": [
-      "Run2011A"
-    ],
     "title": "High-Level Trigger path information HLTriggerFinalPath",
     "type": {
       "primary": "Supplementaries",
@@ -31790,9 +26012,6 @@
     "collections": [
       "CMS-Trigger-Information"
     ],
-    "collision_information": {
-      "energy": "7TeV"
-    },
     "date_created": [
       "2011"
     ],
@@ -31800,9 +26019,6 @@
     "experiment": "CMS",
     "publisher": "CERN Open Data Portal",
     "recid": "2963",
-    "run_period": [
-      "Run2011A"
-    ],
     "title": "High-Level Trigger path information NanoDSTOutput",
     "type": {
       "primary": "Supplementaries",
@@ -31823,9 +26039,6 @@
     "collections": [
       "CMS-Trigger-Information"
     ],
-    "collision_information": {
-      "energy": "7TeV"
-    },
     "date_created": [
       "2011"
     ],
@@ -31833,9 +26046,6 @@
     "experiment": "CMS",
     "publisher": "CERN Open Data Portal",
     "recid": "2964",
-    "run_period": [
-      "Run2011A"
-    ],
     "title": "High-Level Trigger path information OnlineErrorsOutput",
     "type": {
       "primary": "Supplementaries",
@@ -31856,9 +26066,6 @@
     "collections": [
       "CMS-Trigger-Information"
     ],
-    "collision_information": {
-      "energy": "7TeV"
-    },
     "date_created": [
       "2011"
     ],
@@ -31866,9 +26073,6 @@
     "experiment": "CMS",
     "publisher": "CERN Open Data Portal",
     "recid": "2965",
-    "run_period": [
-      "Run2011A"
-    ],
     "title": "High-Level Trigger path information PhysicsDSTOutput",
     "type": {
       "primary": "Supplementaries",
@@ -31889,9 +26093,6 @@
     "collections": [
       "CMS-Trigger-Information"
     ],
-    "collision_information": {
-      "energy": "7TeV"
-    },
     "date_created": [
       "2011"
     ],
@@ -31899,9 +26100,6 @@
     "experiment": "CMS",
     "publisher": "CERN Open Data Portal",
     "recid": "2966",
-    "run_period": [
-      "Run2011A"
-    ],
     "title": "High-Level Trigger path information RPCMONOutput",
     "type": {
       "primary": "Supplementaries",


### PR DESCRIPTION
Removes collision information and run period information from CMS 2011 2012 HLT trigger path records. Closes cernopendata/opendata.cern.ch#3425.