### PR TITLE
records: CMS 2013 HI fix DOI prefix

### DIFF
--- a/cernopendata/modules/fixtures/data/records/cms-primary-datasets-HIRun2013A.json
+++ b/cernopendata/modules/fixtures/data/records/cms-primary-datasets-HIRun2013A.json
@@ -39,7 +39,7 @@
       "number_files": 15175,
       "size": 103541400930704
     },
-    "doi": "10.5072/OPENDATA.CMS.8EWL.W02X",
+    "doi": "10.7483/OPENDATA.CMS.8EWL.W02X",
     "experiment": "CMS",
     "files": [
       {
@@ -601,7 +601,7 @@
       "number_files": 470,
       "size": 1713483346183
     },
-    "doi": "10.5072/OPENDATA.CMS.EKLF.9PZJ",
+    "doi": "10.7483/OPENDATA.CMS.EKLF.9PZJ",
     "experiment": "CMS",
     "files": [
       {
@@ -868,7 +868,7 @@
       "number_files": 630,
       "size": 2044834897566
     },
-    "doi": "10.5072/OPENDATA.CMS.TIQ0.V8KE",
+    "doi": "10.7483/OPENDATA.CMS.TIQ0.V8KE",
     "experiment": "CMS",
     "files": [
       {
@@ -1130,7 +1130,7 @@
       "number_files": 8345,
       "size": 44416192413170
     },
-    "doi": "10.5072/OPENDATA.CMS.33AQ.83WZ",
+    "doi": "10.7483/OPENDATA.CMS.33AQ.83WZ",
     "experiment": "CMS",
     "files": [
       {
@@ -1684,7 +1684,7 @@
       "number_files": 5137,
       "size": 36796217501039
     },
-    "doi": "10.5072/OPENDATA.CMS.A9Z5.UQIN",
+    "doi": "10.7483/OPENDATA.CMS.A9Z5.UQIN",
     "experiment": "CMS",
     "files": [
       {
@@ -2248,7 +2248,7 @@
       "number_files": 4844,
       "size": 17698528573500
     },
-    "doi": "10.5072/OPENDATA.CMS.OAKC.0YCP",
+    "doi": "10.7483/OPENDATA.CMS.OAKC.0YCP",
     "experiment": "CMS",
     "files": [
       {
@@ -2469,7 +2469,7 @@
       "number_files": 155,
       "size": 536124445413
     },
-    "doi": "10.5072/OPENDATA.CMS.QDFC.VGTU",
+    "doi": "10.7483/OPENDATA.CMS.QDFC.VGTU",
     "experiment": "CMS",
     "files": [
       {
@@ -2601,7 +2601,7 @@
       "number_files": 2031,
       "size": 7078881027006
     },
-    "doi": "10.5072/OPENDATA.CMS.I2YK.2QAX",
+    "doi": "10.7483/OPENDATA.CMS.I2YK.2QAX",
     "experiment": "CMS",
     "files": [
       {
@@ -2794,7 +2794,7 @@
       "number_files": 1636,
       "size": 5515355571479
     },
-    "doi": "10.5072/OPENDATA.CMS.B1W4.HP9Z",
+    "doi": "10.7483/OPENDATA.CMS.B1W4.HP9Z",
     "experiment": "CMS",
     "files": [
       {


### PR DESCRIPTION
Use "real" DOI prefix instead of the "test" one.