### PR TITLE
templates: fix display of collision info badges

### DIFF
--- a/cernopendata/templates/cernopendata_records_ui/records/record_detail.html
+++ b/cernopendata/templates/cernopendata_records_ui/records/record_detail.html
@@ -76,17 +76,15 @@
            {% endfor %}
         {% endif %}
         {% if record.experiment %} <a class="ui tiny label navy" href="/search?f=experiment:{{ record.experiment }}">{{ record.experiment }}</a> {% endif %}
-        {% if record.collision_information %} <a class="ui tiny label grey" href="/search?q={{ record.collision_information.energy }}"> {{ record.collision_information.energy }}</a> {% endif %}
         {% if record.collision_information %}
            {% if record.collision_information.energy %}
-             <a class="badge badge-tag" href="/search?collision_energy={{ record.collision_information.energy }}"> {{ record.collision_information.energy }}</a>
+             <a class="ui tiny label grey" href="/search?f=collision_energy:{{ record.collision_information.energy }}">{{ record.collision_information.energy }}</a>
            {% endif %}
            {% if record.collision_information.type %}
-             <a class="badge badge-tag" href="/search?collision_type={{ record.collision_information.type }}"> {{ record.collision_information.type }}</a>
+             <a class="ui tiny label grey" href="/search?f=collision_type:{{ record.collision_information.type }}">{{ record.collision_information.type }}</a>
            {% endif %}
         {% endif %}
         {% if record.accelerator %} <a class="ui tiny label grey"  href="/search?q={{ record.accelerator }}"> {{ record.accelerator }}</a> {% endif %}
-        {% if record.experiment %} <a class="badge badge-experiment" href="/search?experiment={{ record.experiment }}">{{ record.experiment }}</a> {% endif %}
         {% if record.relations %}
         {% for relation in record.relations %}
             {% if relation.type == 'isChildOf' and relation.recid %} <a  class="ui tiny label grey" href="/record/{{ relation.recid or relation.title }}"> Parent Dataset: {{relation.title}}</a> {% endif %}


### PR DESCRIPTION
Fixes the display of the collision energy badge and the collision type badge in detailed record pages that broke during the recent "qa" to "master" merge.