### PR TITLE
records: add cms 2016 validated runs record

### DIFF
--- a/cernopendata/modules/fixtures/data/records/cms-validated-runs-ppRun2.json
+++ b/cernopendata/modules/fixtures/data/records/cms-validated-runs-ppRun2.json
@@ -133,7 +133,19 @@
       "2016"
     ],
     "date_published": "2023",
+    "distribution": {
+      "formats": [
+        "txt"
+      ]
+    },
     "experiment": "CMS",
+    "files": [
+      {
+        "checksum": "adler32:8690115c",
+        "size": 11686,
+        "uri": "root://eospublic.cern.ch//eos/opendata/cms/validated-runs/2016/Cert_271036-284044_13TeV_Legacy2016_Collisions16_JSON.txt"
+      }
+    ],
     "license": {
       "attribution": "CC0"
     },
@@ -189,7 +201,19 @@
       "2016"
     ],
     "date_published": "2023",
+    "distribution": {
+      "formats": [
+        "txt"
+      ]
+    },
     "experiment": "CMS",
+    "files": [
+      {
+        "checksum": "adler32:a562515d",
+        "size": 10535,
+        "uri": "root://eospublic.cern.ch//eos/opendata/cms/validated-runs/2016/Cert_271036-284044_13TeV_Legacy2016_Collisions16_JSON_MuonPhys.txt"
+      }
+    ],
     "license": {
       "attribution": "CC0"
     },

--- a/cernopendata/modules/fixtures/data/records/cms-validated-runs-ppRun2.json
+++ b/cernopendata/modules/fixtures/data/records/cms-validated-runs-ppRun2.json
@@ -112,5 +112,117 @@
         }
       ]
     }
+  },
+  {
+    "abstract": {
+      "description": "<p>This file describes which luminosity sections in which runs are considered good and should be processed.</p><p>This list covers 13TeV proton-proton collision data taken in 2016. Run2016G is between run numbers 278820 and 280385. Run2016H is between run numbers 280919 and 284044.</p>"
+    },
+    "accelerator": "CERN-LHC",
+    "collaboration": {
+      "name": "CMS collaboration"
+    },
+    "collections": [
+      "CMS-Validated-Runs",
+      "CMS-Validation-Utilities"
+    ],
+    "collision_information": {
+      "energy": "13TeV",
+      "type": "pp"
+    },
+    "date_created": [
+      "2016"
+    ],
+    "date_published": "2023",
+    "experiment": "CMS",
+    "license": {
+      "attribution": "CC0"
+    },
+    "publisher": "CERN Open Data Portal",
+    "recid": "14220",
+    "run_period": [
+      "Run2016B",
+      "Run2016C",
+      "Run2016D",
+      "Run2016E",
+      "Run2016F",
+      "Run2016G",
+      "Run2016H"
+    ],
+    "title": "CMS list of validated runs Cert_271036-284044_13TeV_Legacy2016_Collisions16_JSON.txt",
+    "title_additional": "CMS list of validated runs for 13TeV proton-proton collision data taken in 2016",
+    "type": {
+      "primary": "Environment",
+      "secondary": [
+        "Validation"
+      ]
+    },
+    "usage": {
+      "description": "<p>Add the following lines in the configuration file for a cmsRun job: <br /> <pre>   import FWCore.ParameterSet.Config as cms</pre><pre>   import FWCore.PythonUtilities.LumiList as LumiList</pre><pre>   goodJSON = 'Cert_271036-284044_13TeV_Legacy2016_Collisions16_JSON.txt'</pre><pre>   myLumis = LumiList.LumiList(filename = goodJSON).getCMSSWString().split(',') </pre></p><p> Add the file path if needed in the file name.</p><p> Add the following statements after the <code>process.source</code> input file definition: <br /><pre>   process.source.lumisToProcess = cms.untracked.VLuminosityBlockRange()</pre><pre>   process.source.lumisToProcess.extend(myLumis)</pre></p><p>Note that the two last statements must be placed after the <code>process.source</code> statement defining the input files.</p>"
+    },
+    "validation": {
+      "description": "During data taking all the runs recorded by CMS are certified as good for physics analysis if all subdetectors, trigger, lumi and physics objects (tracking, electron, muon, photon, jet and MET) show the expected performance. Certification is based first on the offline shifters evaluation and later on the feedback provided by detector and Physics Object Group experts. Based on the above information, which is stored in a specific database called Run Registry, the Data Quality Monitoring group verifies the consistency of the certification and prepares a json file of certified runs to be used for physics analysis. For each reprocessing of the raw data, the above mentioned steps are repeated. For more information see:",
+      "links": [
+        {
+          "description": "The Data Quality Monitoring Software for the CMS experiment at the LHC: past, present and future",
+          "url": "https://www.epj-conferences.org/articles/epjconf/pdf/2019/19/epjconf_chep2018_02003.pdf"
+        }
+      ]
+    }
+  },
+  {
+    "abstract": {
+      "description": "<p>This file describes which luminosity sections in which runs are considered good and should be processed, for analyses requiring only valid muons.</p><p>This list covers 13TeV proton-proton collision data taken in 2016. Run2016G is between run numbers 278820 and 280385. Run2016H is between run numbers 280919 and 284044.</p>"
+    },
+    "accelerator": "CERN-LHC",
+    "collaboration": {
+      "name": "CMS collaboration"
+    },
+    "collections": [
+      "CMS-Validated-Runs",
+      "CMS-Validation-Utilities"
+    ],
+    "collision_information": {
+      "energy": "13TeV",
+      "type": "pp"
+    },
+    "date_created": [
+      "2016"
+    ],
+    "date_published": "2023",
+    "experiment": "CMS",
+    "license": {
+      "attribution": "CC0"
+    },
+    "publisher": "CERN Open Data Portal",
+    "recid": "14221",
+    "run_period": [
+      "Run2016B",
+      "Run2016C",
+      "Run2016D",
+      "Run2016E",
+      "Run2016F",
+      "Run2016G",
+      "Run2016H"
+    ],
+    "title": "CMS list of validated runs Cert_271036-284044_13TeV_Legacy2016_Collisions16_JSON_MuonPhys.txt",
+    "title_additional": "CMS list of validated runs for 13TeV proton-proton collision data taken in 2016, only valid muons",
+    "type": {
+      "primary": "Environment",
+      "secondary": [
+        "Validation"
+      ]
+    },
+    "usage": {
+      "description": "<p>Add the following lines in the configuration file for a cmsRun job: <br /> <pre>   import FWCore.ParameterSet.Config as cms</pre><pre>   import FWCore.PythonUtilities.LumiList as LumiList</pre><pre>   goodJSON = 'Cert_271036-284044_13TeV_Legacy2016_Collisions16_JSON_MuonPhys.txt'</pre><pre>   myLumis = LumiList.LumiList(filename = goodJSON).getCMSSWString().split(',') </pre></p><p> Add the file path if needed in the file name.</p><p> Add the following statements after the <code>process.source</code> input file definition: <br /><pre>   process.source.lumisToProcess = cms.untracked.VLuminosityBlockRange()</pre><pre>   process.source.lumisToProcess.extend(myLumis)</pre></p><p>Note that the two last statements must be placed after the <code>process.source</code> statement defining the input files.</p>"
+    },
+    "validation": {
+      "description": "During data taking all the runs recorded by CMS are certified as good for physics analysis if all subdetectors, trigger, lumi and physics objects (tracking, electron, muon, photon, jet and MET) show the expected performance. Certification is based first on the offline shifters evaluation and later on the feedback provided by detector and Physics Object Group experts. Based on the above information, which is stored in a specific database called Run Registry, the Data Quality Monitoring group verifies the consistency of the certification and prepares a json file of certified runs to be used for physics analysis. For each reprocessing of the raw data, the above mentioned steps are repeated. For more information see:",
+      "links": [
+        {
+          "description": "The Data Quality Monitoring Software for the CMS experiment at the LHC: past, present and future",
+          "url": "https://www.epj-conferences.org/articles/epjconf/pdf/2019/19/epjconf_chep2018_02003.pdf"
+        }
+      ]
+    }
   }
 ]


### PR DESCRIPTION
(closes #3446)

Add 2016 validated run records, reicd 14220 and 14221

To-do:

copy the actual json files from
14220: https://cms-service-dqmdc.web.cern.ch/CAF/certification/Collisions16/13TeV/Legacy_2016/Cert_271036-284044_13TeV_Legacy2016_Collisions16_JSON.txt
14221: https://cms-service-dqmdc.web.cern.ch/CAF/certification/Collisions16/13TeV/Legacy_2016/Cert_271036-284044_13TeV_Legacy2016_Collisions16_JSON_MuonPhys.txt

