### PR TITLE
style: Add margins on the search page

### DIFF
--- a/cernopendata/templates/cernopendata_search_ui/search.html
+++ b/cernopendata/templates/cernopendata_search_ui/search.html
@@ -33,3 +33,15 @@
     {{ super() }}
     {{ webpack['cernopendata_search_app.js'] }}
 {%- endblock %}
+
+{%- block page_body %}
+<div class="ui container">
+<div data-invenio-search-config='{{
+  search_app_helpers.invenio_records_rest.generate(
+    dict(
+      endpoint_id="recid",
+      app_id="search"
+    )
+  ) | tojson(indent=2) }}'></div>
+</div>
+{%- endblock page_body -%}


### PR DESCRIPTION
The results page does not leave any border on the sides. See the first screenshot.

![Screenshot 2023-12-11 at 15 48 23](https://github.com/cernopendata/opendata.cern.ch/assets/12909623/2ed5013b-9ce7-4344-98ff-3d35a9905614)


This merge request gives some border on both sides. See the results:
![Screenshot 2023-12-11 at 15 49 21](https://github.com/cernopendata/opendata.cern.ch/assets/12909623/0b1cd8c1-ece4-4c0c-9e64-9c927198e319)
