### PR TITLE
docker: XRootD 5.6.4

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -25,8 +25,8 @@
 # Use Invenio's alma image with Python-3.9
 FROM registry.cern.ch/inveniosoftware/almalinux:1
 
-# Use XRootD 5.6.3
-ENV XROOTD_VERSION=5.6.3
+# Use XRootD 5.6.4
+ENV XROOTD_VERSION=5.6.4
 
 # Install CERN Open Data Portal web node pre-requisites
 # hadolint ignore=DL3033


### PR DESCRIPTION
Upgrades XRootD version, fixing build troubles related to recent update of the XRootD package in the Alma Linux 9 ecosystem.

Closes #3509.