### PR TITLE
facets: display the facets on the mobile application

### DIFF
--- a/cernopendata/modules/theme/assets/semantic-ui/scss/search.scss
+++ b/cernopendata/modules/theme/assets/semantic-ui/scss/search.scss
@@ -36,10 +36,6 @@
   min-height: 75px;
 }
 
-.ui.grid.relaxed > .row:not(.result-options) > .four.wide.column {
-  margin-top: -70px;
-}
-
 .footer {
   margin-top: 1em;
 }


### PR DESCRIPTION
Right now, the button to display the facets on a mobile display cannot be clicked. There is a ` div` overlapping. This PR ensures that there is no overlap between the different elements