### PR TITLE
records: cms 2016 conddb records and updates to old record titles

### DIFF
--- a/cernopendata/modules/fixtures/data/records/cms-condition-data-2012.json
+++ b/cernopendata/modules/fixtures/data/records/cms-condition-data-2012.json
@@ -69,7 +69,7 @@
       "Run2012C",
       "Run2012D"
     ],
-    "title": "Condition data for 2012 CMS collision data",
+    "title": "Condition data for 2012 CMS proton-proton collision data at 8 TeV",
     "type": {
       "primary": "Environment",
       "secondary": [
@@ -130,7 +130,7 @@
       "Run2012C",
       "Run2012D"
     ],
-    "title": "Condition data for 2012 CMS simulated datasets",
+    "title": "Condition data for 2012 CMS proton-proton simulated datasets at 8 TeV",
     "type": {
       "primary": "Environment",
       "secondary": [
@@ -191,7 +191,7 @@
       "Run2012C",
       "Run2012D"
     ],
-    "title": "Condition data for 2012 run-dependent simulated data production",
+    "title": "Condition data for 2012 run-dependent proton-proton simulated data production at 8 TeV",
     "type": {
       "primary": "Environment",
       "secondary": [

--- a/cernopendata/modules/fixtures/data/records/cms-condition-data-2015.json
+++ b/cernopendata/modules/fixtures/data/records/cms-condition-data-2015.json
@@ -41,7 +41,7 @@
       "Run2015C",
       "Run2015D"
     ],
-    "title": "Condition data for 2015 CMS collision data",
+    "title": "Condition data for 2015 CMS proton-proton collision data at 13 TeV",
     "type": {
       "primary": "Environment",
       "secondary": [
@@ -94,7 +94,7 @@
       "Run2015C",
       "Run2015D"
     ],
-    "title": "Condition data for 2015 CMS simulated datasets",
+    "title": "Condition data for 2015 CMS proton-proton simulated data at 13 TeV",
     "type": {
       "primary": "Environment",
       "secondary": [

--- a/cernopendata/modules/fixtures/data/records/cms-condition-data-2016.json
+++ b/cernopendata/modules/fixtures/data/records/cms-condition-data-2016.json
@@ -19,7 +19,21 @@
       "2016"
     ],
     "date_published": "2024",
+    "distribution": {
+      "formats": [
+        "db"
+      ],
+      "number_files": 1,
+      "size": 1727193088
+    },
     "experiment": "CMS",
+    "files": [
+      {
+        "checksum": "adler32:d0225bd3",
+        "size": 1727193088,
+        "uri": "root://eospublic.cern.ch//eos/opendata/cms/conddb/106X_dataRun2_v37.db"
+      }
+    ],
     "publisher": "CERN Open Data Portal",
     "recid": "1818",
     "run_period": [
@@ -57,7 +71,21 @@
       "2016"
     ],
     "date_published": "2024",
+    "distribution": {
+      "formats": [
+        "db"
+      ],
+      "number_files": 1,
+      "size": 664346624
+    },
     "experiment": "CMS",
+    "files": [
+      {
+        "checksum": "adler32:c1e9b4f0",
+        "size": 664346624,
+        "uri": "root://eospublic.cern.ch//eos/opendata/cms/conddb/106X_mcRun2_asymptotic_v17.db"
+      }
+    ],
     "publisher": "CERN Open Data Portal",
     "recid": "1819",
     "title": "Condition data for 2016 CMS proton-proton simulated data at 13 TeV",

--- a/cernopendata/modules/fixtures/data/records/cms-condition-data-2016.json
+++ b/cernopendata/modules/fixtures/data/records/cms-condition-data-2016.json
@@ -1,0 +1,74 @@
+[
+  {
+    "abstract": {
+      "description": "<p>Condition database includes non-event-related information (Alignment, Calibration, Temperature, etc.) and parameters for simulation/reconstruction/analysis software.</p>\n    <p> These files are needed when running a CMSSW job on the open data environment (VM or container), and they are available in the /cvmfs/cms-opendata-conddb.cern.ch file system. They are automatically read from /cvmfs/cms-opendata-conddb.cern.ch/106X_dataRun2_v37.db runtime.</p>\n       <p>106X_dataRun2_v37.db is to be used with the proton-proton collision data at 13 TeV from 2016.</p>\n      <p>See further information in <a href=\"/docs/cms-guide-for-condition-database\">the guide to CMS condition database</a>.</p></p>\n       <p>For condition data to be used with 2016 CMS simulated datasets see:</p>",
+      "links": [
+        {
+          "recid": "1819"
+        }
+      ]
+    },
+    "accelerator": "CERN-LHC",
+    "collaboration": {
+      "name": "CMS collaboration"
+    },
+    "collections": [
+      "CMS-Condition-Data"
+    ],
+    "date_created": [
+      "2016"
+    ],
+    "date_published": "2024",
+    "experiment": "CMS",
+    "publisher": "CERN Open Data Portal",
+    "recid": "1818",
+    "run_period": [
+      "Run2016G",
+      "Run2016H"
+    ],
+    "title": "Condition data for 2016 CMS proton-proton collision data at 13 TeV",
+    "type": {
+      "primary": "Environment",
+      "secondary": [
+        "Condition"
+      ]
+    },
+    "usage": {
+      "description": "If you are using the <a href=\"/record/258\">CMS Virtual Machine</a> image or the <a href=\"/docs/cms-guide-docker\">CMS container</a> image environments, then the condition data files will be served automatically from <code>/cvmfs/cms-opendata-conddb.cern.ch/</code> or from a file server at runtime, and therefore you do not need to download these files. If you need to have them locally, you can download them from here."
+    }
+  },
+  {
+    "abstract": {
+      "description": "<p>Condition database includes non-event-related information (Alignment, Calibration, Temperature, etc.) and parameters for simulation/reconstruction/analysis software.</p>\n    <p> These files are needed when running a CMSSW job on the open data environment (VM or container), and they are available in the /cvmfs/cms-opendata-conddb.cern.ch file system. They are automatically read from /cvmfs/cms-opendata-conddb.cern.ch/106X_mcRun2_asymptotic_v17.db runtime.</p>\n       <p>106X_mcRun2_asymptotic_v17.db is to be used with the proton-proton simulated data at 13 TeV from 2016.</p>\n      <p>See further information in <a href=\"/docs/cms-guide-for-condition-database\">the guide to CMS condition database</a>.</p></p>\n       <p>For condition data to be used with 2016 CMS simulated datasets see:</p>",
+      "links": [
+        {
+          "recid": "1818"
+        }
+      ]
+    },
+    "accelerator": "CERN-LHC",
+    "collaboration": {
+      "name": "CMS collaboration"
+    },
+    "collections": [
+      "CMS-Condition-Data"
+    ],
+    "date_created": [
+      "2016"
+    ],
+    "date_published": "2024",
+    "experiment": "CMS",
+    "publisher": "CERN Open Data Portal",
+    "recid": "1819",
+    "title": "Condition data for 2016 CMS proton-proton simulated data at 13 TeV",
+    "type": {
+      "primary": "Environment",
+      "secondary": [
+        "Condition"
+      ]
+    },
+    "usage": {
+      "description": "If you are using the <a href=\"/record/258\">CMS Virtual Machine</a> image or the <a href=\"/docs/cms-guide-docker\">CMS container</a> image environments, then the condition data files will be served automatically from <code>/cvmfs/cms-opendata-conddb.cern.ch/</code> or from a file server at runtime, and therefore you do not need to download these files. If you need to have them locally, you can download them from here."
+    }
+  }
+]

--- a/cernopendata/modules/fixtures/data/records/cms-condition-data-HIRun1.json
+++ b/cernopendata/modules/fixtures/data/records/cms-condition-data-HIRun1.json
@@ -44,7 +44,7 @@
     "run_period": [
       "HIRun2010"
     ],
-    "title": "Condition data for 2010 CMS heavy-ion collision data",
+    "title": "Condition data for 2010 CMS heavy-ion collision data at 2.76 TeV",
     "type": {
       "primary": "Environment",
       "secondary": [
@@ -101,7 +101,7 @@
       "HIRun2011",
       "Run2011A"
     ],
-    "title": "Condition data for 2011 CMS heavy-ion collision data and proton-proton reference data",
+    "title": "Condition data for 2011 CMS heavy-ion collision data at 2.76 TeV and proton-proton reference data at 2.76 TeV and 7 TeV",
     "type": {
       "primary": "Environment",
       "secondary": [

--- a/cernopendata/modules/fixtures/data/records/cms-condition-data-Run2010B.json
+++ b/cernopendata/modules/fixtures/data/records/cms-condition-data-Run2010B.json
@@ -47,7 +47,7 @@
       "Run2010A",
       "Run2010B"
     ],
-    "title": "Condition data for 2010 CMS collision data",
+    "title": "Condition data for 2010 CMS proton-proton collision data at 7 TeV",
     "type": {
       "primary": "Environment",
       "secondary": [
@@ -106,7 +106,7 @@
       "Run2010A",
       "Run2010B"
     ],
-    "title": "Condition data for 2010 CMS simulated datasets",
+    "title": "Condition data for 2010 CMS proton-proton simulated data at 7 TeV",
     "type": {
       "primary": "Environment",
       "secondary": [

--- a/cernopendata/modules/fixtures/data/records/cms-condition-data-Run2011A.json
+++ b/cernopendata/modules/fixtures/data/records/cms-condition-data-Run2011A.json
@@ -56,7 +56,7 @@
     "run_period": [
       "Run2011A"
     ],
-    "title": "Condition data for 2011 CMS collision data",
+    "title": "Condition data for 2011 CMS proton-proton collision data at 7 TeV",
     "type": {
       "primary": "Environment",
       "secondary": [
@@ -114,7 +114,7 @@
     "run_period": [
       "Run2011A"
     ],
-    "title": "Condition data for 2011 CMS simulated datasets",
+    "title": "Condition data for 2011 CMS proton-proton simulated data at 7 TeV",
     "type": {
       "primary": "Environment",
       "secondary": [


### PR DESCRIPTION
(Closes #3538)

Adds the two 2016 condition data records

Updates the titles with old condition data records with collision type and energy

To do for 2016:
- add the db files from /eos/opendata/cms/conddb/106X_dataRun2_v37.db and /eos/opendata/cms/conddb/106X_mcRun2_asymptotic_v17.db