### PR TITLE
records: cms 2016 vm

### DIFF
--- a/cernopendata/modules/fixtures/data/records/cms-tools-vm-image-2016-2018.json
+++ b/cernopendata/modules/fixtures/data/records/cms-tools-vm-image-2016-2018.json
@@ -20,7 +20,23 @@
       "2016"
     ],
     "date_published": "2024",
-    "experiment": "CMS",
+    "distribution": {
+      "formats": [
+        "ova"
+      ],
+      "number_files": 1,
+      "size": 20500480
+    },
+    "experiment": [
+      "CMS"
+    ],
+    "files": [
+      {
+        "checksum": "adler32:24f015c5",
+        "size": 20500480,
+        "uri": "root://eospublic.cern.ch//eos/opendata/cms/environment/1.6.0/CMS-OpenData-1.6.0.ova"
+      }
+    ],
     "methodology": {
       "description": "The contextualisation scripts used for setting up the CMS VM images are available at",
       "links": [
@@ -64,7 +80,46 @@
       "2016"
     ],
     "date_published": "2024",
-    "experiment": "CMS",
+    "distribution": {
+      "formats": [
+        "hdd",
+        "iso",
+        "sh",
+        "txt"
+      ],
+      "number_files": 5,
+      "size": 25604650
+    },
+    "experiment": [
+      "CMS"
+    ],
+    "files": [
+      {
+        "checksum": "adler32:f13714c4",
+        "size": 368640,
+        "uri": "root://eospublic.cern.ch//eos/opendata/cms/environment/1.6.0/CMS-OpenData-1.6.0.context.iso"
+      },
+      {
+        "checksum": "adler32:180f3ca3",
+        "size": 196,
+        "uri": "root://eospublic.cern.ch//eos/opendata/cms/environment/1.6.0/cernvm-script"
+      },
+      {
+        "checksum": "adler32:175a7154",
+        "size": 4302,
+        "uri": "root://eospublic.cern.ch//eos/opendata/cms/environment/1.6.0/cms-user-data.txt"
+      },
+      {
+        "checksum": "adler32:786f33c7",
+        "size": 152,
+        "uri": "root://eospublic.cern.ch//eos/opendata/cms/environment/1.6.0/opendata-desktop-settings"
+      },
+      {
+        "checksum": "adler32:9c7c8157",
+        "size": 25231360,
+        "uri": "root://eospublic.cern.ch//eos/opendata/cms/environment/1.6.0/ucernvm-v4prod.2020.07-1.cernvm.x86_64.hdd"
+      }
+    ],
     "publisher": "CERN Open Data Portal",
     "recid": "259",
     "relations": [

--- a/cernopendata/modules/fixtures/data/records/cms-tools-vm-image-2016-2018.json
+++ b/cernopendata/modules/fixtures/data/records/cms-tools-vm-image-2016-2018.json
@@ -1,0 +1,92 @@
+[
+  {
+    "abstract": {
+      "description": " <p>This virtual machine image provides CMS computing environment to be used with the CMS MiniAOD open data from 2016 - 2018. The virtual machine is based on <a href=\"https://cernvm.cern.ch/appliance/\">CernVM</a>. The image gets the CMS software (CMSSW) from <code>/cvmfs/cms.cern.ch</code> and the jobs running on the VM read the condition data from <code>/cvmfs/cms-opendata-conddb.cern.ch</code>. Access to the data is through XRootD.</p> <p>It has a 40G virtual hard disk and a 20G cvmfs cache, which is large enough for condition data for full event range for 2016 data (see <a href=\"/docs/cms-guide-for-condition-database\">the CMS guide to the condition database</a> for further details). It has an embedded CERN CentOS (cc7) shell with the architecture compatible with the CMS software version, in which all CMS software specific commands should be executed. Additionally, it has another CERN CentOS 7 (cc7) shell, which can be used in the same session.</p>   <p>For known issues and limitations see</p>",
+      "links": [
+        {
+          "title": "CMS CC7 Virtual Machines - Known Issues and Limitations",
+          "url": "/docs/cms-virtual-machine-cc7#issue"
+        }
+      ]
+    },
+    "accelerator": "CERN-LHC",
+    "collaboration": {
+      "name": "CMS Collaboration"
+    },
+    "collections": [
+      "CMS-Tools"
+    ],
+    "date_created": [
+      "2016"
+    ],
+    "date_published": "2024",
+    "experiment": "CMS",
+    "methodology": {
+      "description": "The contextualisation scripts used for setting up the CMS VM images are available at",
+      "links": [
+        {
+          "recid": "259"
+        }
+      ]
+    },
+    "publisher": "CERN Open Data Portal",
+    "recid": "258",
+    "run_period": [
+      "Run2016G",
+      "Run2016H"
+    ],
+    "title": "CMS CC7 VM Image, for CMS MiniAOD open data from 2016 - 2018",
+    "type": {
+      "primary": "Environment",
+      "secondary": [
+        "VM"
+      ]
+    },
+    "usage": {
+      "description": "Please follow the instructions on how to use the CMS Virtual Machine",
+      "links": [
+        {
+          "description": "CMS CC7 Virtual Machines: How to install",
+          "url": "/docs/cms-virtual-machine-cc7"
+        }
+      ]
+    }
+  },
+  {
+    "abstract": {
+      "description": " <p>The scripts provided create the CMS virtual machine image based on <a href=\"https://cernvm.cern.ch/appliance/\">CernVM</a>, with CERN CentOS 7 (cc7).</p> "
+    },
+    "accelerator": "CERN-LHC",
+    "collections": [
+      "CMS-Tools"
+    ],
+    "date_created": [
+      "2016"
+    ],
+    "date_published": "2024",
+    "experiment": "CMS",
+    "publisher": "CERN Open Data Portal",
+    "recid": "259",
+    "relations": [
+      {
+        "description": "The CERN VM image produced by these scripts can be found here:",
+        "recid": "258",
+        "type": "isRelatedTo"
+      }
+    ],
+    "run_period": [
+      "Run2016G",
+      "Run2016H"
+    ],
+    "title": "Contextualisation scripts to create the CMS VM Image version 1.6.0",
+    "type": {
+      "primary": "Environment",
+      "secondary": [
+        "VM"
+      ]
+    },
+    "usage": {
+      "description": " <p> First, you need to run a normal Micro-CernVM, using your own context so you can login. Copy the attached files to the running VM and then login.</p><p>Inside the VM, you need a copy of the latest Micro-CernVM release as a template for the Open Data image. Download the template <code>ucernvm-v4prod.2020.07-1.cernvm.x86_64.hdd</code> from this record, inside the running VM placing it in the same directory as the other files.</p><p>Run the script:<br/><code>./cernvm-script</code><br/>which will produce some output on the terminal, and then finish.</p><p>The result should be a file with the title coming from the -n field in the script, in this case:<br/><code>CMS-OpenData-1.6.0.ova</code><br/>which can be copied from the running VM to elsewhere.</p> "
+    }
+  }
+]

--- a/cernopendata/modules/fixtures/data/records/cms-tools-vm-image-Run2011A.json
+++ b/cernopendata/modules/fixtures/data/records/cms-tools-vm-image-Run2011A.json
@@ -5,7 +5,7 @@
       "links": [
         {
           "title": "CMS Virtual Machines - Known Issues and Limitations",
-          "url": "/VM/CMS/2011#issue"
+          "url": "/docs/cms-virtual-machine-2015#issue"
         }
       ]
     },

--- a/cernopendata/modules/fixtures/data/records/cms-tools-vm-image.json
+++ b/cernopendata/modules/fixtures/data/records/cms-tools-vm-image.json
@@ -5,7 +5,7 @@
       "links": [
         {
           "title": "CMS Virtual Machines - Known Issues and Limitations",
-          "url": "/VM/CMS/2010#issues2010"
+          "url": "/docs/cms-virtual-machine-2010#issues2010"
         }
       ]
     },
@@ -76,7 +76,7 @@
       "links": [
         {
           "description": "CMS Virtual Machines: How to install",
-          "url": "/VM/CMS/2010"
+          "url": "/docs/cms-virtual-machine-2010"
         }
       ]
     },


### PR DESCRIPTION
(Closes #3537 )

Add records for
- the new VM image
- the contextualization scripts to build it

To do:

Copy from `/eos/opendata/cms/upload/vm160:`

For the VM record 258

```
CMS-OpenData-1.6.0.ova
```

For the contextualization scripts

```
ucernvm-v4prod.2020.07-1.cernvm.x86_64.hdd
cernvm-script
cms-user-data.txt
opendata-desktop-settings
```