### PR TITLE
records: add 2016 pileup record

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -25,8 +25,8 @@
 # Use Invenio's alma image with Python-3.9
 FROM registry.cern.ch/inveniosoftware/almalinux:1
 
-# Use XRootD 5.6.7
-ENV XROOTD_VERSION=5.6.7
+# Use XRootD 5.6.8
+ENV XROOTD_VERSION=5.6.8
 
 # Install CERN Open Data Portal web node pre-requisites
 # hadolint ignore=DL3033

--- a/cernopendata/modules/fixtures/data/records/cms-simulated-datasets-2016-pileup.json
+++ b/cernopendata/modules/fixtures/data/records/cms-simulated-datasets-2016-pileup.json
@@ -22,7 +22,7 @@
     "date_created": [
       "2016"
     ],
-    "date_published": "2023",
+    "date_published": "2024",
     "date_reprocessed": "2020",
     "distribution": {
       "formats": [
@@ -31,10 +31,2337 @@
       ],
       "number_events": 27646400,
       "number_files": 17279,
-      "size": 0
+      "size": 55600743325296
     },
+    "doi": "10.7483/OPENDATA.CMS.VWUA.G7SB",
     "experiment": [
       "CMS"
+    ],
+    "files": [
+      {
+        "checksum": "adler32:c43db880",
+        "description": "Neutrino_E-10_gunPREMIX dataset file index (1 of 166) for access to data via CMS virtual machine",
+        "size": 61373,
+        "type": "index.json",
+        "uri": "root://eospublic.cern.ch//eos/opendata/cms/mc/RunIISummer20ULPrePremix/Neutrino_E-10_gun/PREMIX/UL16_106X_mcRun2_asymptotic_v13-v1/file-indexes/CMS_mc_RunIISummer20ULPrePremix_Neutrino_E-10_gun_PREMIX_UL16_106X_mcRun2_asymptotic_v13-v1_120000_file_index.json"
+      },
+      {
+        "checksum": "adler32:2e2fcae2",
+        "description": "Neutrino_E-10_gunPREMIX dataset file index (2 of 166) for access to data via CMS virtual machine",
+        "size": 75908,
+        "type": "index.json",
+        "uri": "root://eospublic.cern.ch//eos/opendata/cms/mc/RunIISummer20ULPrePremix/Neutrino_E-10_gun/PREMIX/UL16_106X_mcRun2_asymptotic_v13-v1/file-indexes/CMS_mc_RunIISummer20ULPrePremix_Neutrino_E-10_gun_PREMIX_UL16_106X_mcRun2_asymptotic_v13-v1_120001_file_index.json"
+      },
+      {
+        "checksum": "adler32:d5107570",
+        "description": "Neutrino_E-10_gunPREMIX dataset file index (3 of 166) for access to data via CMS virtual machine",
+        "size": 20352,
+        "type": "index.json",
+        "uri": "root://eospublic.cern.ch//eos/opendata/cms/mc/RunIISummer20ULPrePremix/Neutrino_E-10_gun/PREMIX/UL16_106X_mcRun2_asymptotic_v13-v1/file-indexes/CMS_mc_RunIISummer20ULPrePremix_Neutrino_E-10_gun_PREMIX_UL16_106X_mcRun2_asymptotic_v13-v1_120002_file_index.json"
+      },
+      {
+        "checksum": "adler32:57d6da4d",
+        "description": "Neutrino_E-10_gunPREMIX dataset file index (4 of 166) for access to data via CMS virtual machine",
+        "size": 7109,
+        "type": "index.json",
+        "uri": "root://eospublic.cern.ch//eos/opendata/cms/mc/RunIISummer20ULPrePremix/Neutrino_E-10_gun/PREMIX/UL16_106X_mcRun2_asymptotic_v13-v1/file-indexes/CMS_mc_RunIISummer20ULPrePremix_Neutrino_E-10_gun_PREMIX_UL16_106X_mcRun2_asymptotic_v13-v1_120003_file_index.json"
+      },
+      {
+        "checksum": "adler32:03474dce",
+        "description": "Neutrino_E-10_gunPREMIX dataset file index (5 of 166) for access to data via CMS virtual machine",
+        "size": 18414,
+        "type": "index.json",
+        "uri": "root://eospublic.cern.ch//eos/opendata/cms/mc/RunIISummer20ULPrePremix/Neutrino_E-10_gun/PREMIX/UL16_106X_mcRun2_asymptotic_v13-v1/file-indexes/CMS_mc_RunIISummer20ULPrePremix_Neutrino_E-10_gun_PREMIX_UL16_106X_mcRun2_asymptotic_v13-v1_120004_file_index.json"
+      },
+      {
+        "checksum": "adler32:91fad4eb",
+        "description": "Neutrino_E-10_gunPREMIX dataset file index (6 of 166) for access to data via CMS virtual machine",
+        "size": 16153,
+        "type": "index.json",
+        "uri": "root://eospublic.cern.ch//eos/opendata/cms/mc/RunIISummer20ULPrePremix/Neutrino_E-10_gun/PREMIX/UL16_106X_mcRun2_asymptotic_v13-v1/file-indexes/CMS_mc_RunIISummer20ULPrePremix_Neutrino_E-10_gun_PREMIX_UL16_106X_mcRun2_asymptotic_v13-v1_120005_file_index.json"
+      },
+      {
+        "checksum": "adler32:bc18f80b",
+        "description": "Neutrino_E-10_gunPREMIX dataset file index (7 of 166) for access to data via CMS virtual machine",
+        "size": 13569,
+        "type": "index.json",
+        "uri": "root://eospublic.cern.ch//eos/opendata/cms/mc/RunIISummer20ULPrePremix/Neutrino_E-10_gun/PREMIX/UL16_106X_mcRun2_asymptotic_v13-v1/file-indexes/CMS_mc_RunIISummer20ULPrePremix_Neutrino_E-10_gun_PREMIX_UL16_106X_mcRun2_asymptotic_v13-v1_120006_file_index.json"
+      },
+      {
+        "checksum": "adler32:1de7cb0f",
+        "description": "Neutrino_E-10_gunPREMIX dataset file index (8 of 166) for access to data via CMS virtual machine",
+        "size": 29719,
+        "type": "index.json",
+        "uri": "root://eospublic.cern.ch//eos/opendata/cms/mc/RunIISummer20ULPrePremix/Neutrino_E-10_gun/PREMIX/UL16_106X_mcRun2_asymptotic_v13-v1/file-indexes/CMS_mc_RunIISummer20ULPrePremix_Neutrino_E-10_gun_PREMIX_UL16_106X_mcRun2_asymptotic_v13-v1_120007_file_index.json"
+      },
+      {
+        "checksum": "adler32:1a066813",
+        "description": "Neutrino_E-10_gunPREMIX dataset file index (9 of 166) for access to data via CMS virtual machine",
+        "size": 23905,
+        "type": "index.json",
+        "uri": "root://eospublic.cern.ch//eos/opendata/cms/mc/RunIISummer20ULPrePremix/Neutrino_E-10_gun/PREMIX/UL16_106X_mcRun2_asymptotic_v13-v1/file-indexes/CMS_mc_RunIISummer20ULPrePremix_Neutrino_E-10_gun_PREMIX_UL16_106X_mcRun2_asymptotic_v13-v1_120008_file_index.json"
+      },
+      {
+        "checksum": "adler32:9f5f30be",
+        "description": "Neutrino_E-10_gunPREMIX dataset file index (10 of 166) for access to data via CMS virtual machine",
+        "size": 49099,
+        "type": "index.json",
+        "uri": "root://eospublic.cern.ch//eos/opendata/cms/mc/RunIISummer20ULPrePremix/Neutrino_E-10_gun/PREMIX/UL16_106X_mcRun2_asymptotic_v13-v1/file-indexes/CMS_mc_RunIISummer20ULPrePremix_Neutrino_E-10_gun_PREMIX_UL16_106X_mcRun2_asymptotic_v13-v1_120009_file_index.json"
+      },
+      {
+        "checksum": "adler32:28e0aba1",
+        "description": "Neutrino_E-10_gunPREMIX dataset file index (11 of 166) for access to data via CMS virtual machine",
+        "size": 18737,
+        "type": "index.json",
+        "uri": "root://eospublic.cern.ch//eos/opendata/cms/mc/RunIISummer20ULPrePremix/Neutrino_E-10_gun/PREMIX/UL16_106X_mcRun2_asymptotic_v13-v1/file-indexes/CMS_mc_RunIISummer20ULPrePremix_Neutrino_E-10_gun_PREMIX_UL16_106X_mcRun2_asymptotic_v13-v1_120010_file_index.json"
+      },
+      {
+        "checksum": "adler32:5fdd8e92",
+        "description": "Neutrino_E-10_gunPREMIX dataset file index (12 of 166) for access to data via CMS virtual machine",
+        "size": 12277,
+        "type": "index.json",
+        "uri": "root://eospublic.cern.ch//eos/opendata/cms/mc/RunIISummer20ULPrePremix/Neutrino_E-10_gun/PREMIX/UL16_106X_mcRun2_asymptotic_v13-v1/file-indexes/CMS_mc_RunIISummer20ULPrePremix_Neutrino_E-10_gun_PREMIX_UL16_106X_mcRun2_asymptotic_v13-v1_120011_file_index.json"
+      },
+      {
+        "checksum": "adler32:4756771e",
+        "description": "Neutrino_E-10_gunPREMIX dataset file index (13 of 166) for access to data via CMS virtual machine",
+        "size": 15830,
+        "type": "index.json",
+        "uri": "root://eospublic.cern.ch//eos/opendata/cms/mc/RunIISummer20ULPrePremix/Neutrino_E-10_gun/PREMIX/UL16_106X_mcRun2_asymptotic_v13-v1/file-indexes/CMS_mc_RunIISummer20ULPrePremix_Neutrino_E-10_gun_PREMIX_UL16_106X_mcRun2_asymptotic_v13-v1_120012_file_index.json"
+      },
+      {
+        "checksum": "adler32:dedba8c1",
+        "description": "Neutrino_E-10_gunPREMIX dataset file index (14 of 166) for access to data via CMS virtual machine",
+        "size": 32303,
+        "type": "index.json",
+        "uri": "root://eospublic.cern.ch//eos/opendata/cms/mc/RunIISummer20ULPrePremix/Neutrino_E-10_gun/PREMIX/UL16_106X_mcRun2_asymptotic_v13-v1/file-indexes/CMS_mc_RunIISummer20ULPrePremix_Neutrino_E-10_gun_PREMIX_UL16_106X_mcRun2_asymptotic_v13-v1_120013_file_index.json"
+      },
+      {
+        "checksum": "adler32:ff54ee3a",
+        "description": "Neutrino_E-10_gunPREMIX dataset file index (15 of 166) for access to data via CMS virtual machine",
+        "size": 31657,
+        "type": "index.json",
+        "uri": "root://eospublic.cern.ch//eos/opendata/cms/mc/RunIISummer20ULPrePremix/Neutrino_E-10_gun/PREMIX/UL16_106X_mcRun2_asymptotic_v13-v1/file-indexes/CMS_mc_RunIISummer20ULPrePremix_Neutrino_E-10_gun_PREMIX_UL16_106X_mcRun2_asymptotic_v13-v1_120014_file_index.json"
+      },
+      {
+        "checksum": "adler32:14b853ef",
+        "description": "Neutrino_E-10_gunPREMIX dataset file index (16 of 166) for access to data via CMS virtual machine",
+        "size": 27458,
+        "type": "index.json",
+        "uri": "root://eospublic.cern.ch//eos/opendata/cms/mc/RunIISummer20ULPrePremix/Neutrino_E-10_gun/PREMIX/UL16_106X_mcRun2_asymptotic_v13-v1/file-indexes/CMS_mc_RunIISummer20ULPrePremix_Neutrino_E-10_gun_PREMIX_UL16_106X_mcRun2_asymptotic_v13-v1_120015_file_index.json"
+      },
+      {
+        "checksum": "adler32:7c53b534",
+        "description": "Neutrino_E-10_gunPREMIX dataset file index (17 of 166) for access to data via CMS virtual machine",
+        "size": 37794,
+        "type": "index.json",
+        "uri": "root://eospublic.cern.ch//eos/opendata/cms/mc/RunIISummer20ULPrePremix/Neutrino_E-10_gun/PREMIX/UL16_106X_mcRun2_asymptotic_v13-v1/file-indexes/CMS_mc_RunIISummer20ULPrePremix_Neutrino_E-10_gun_PREMIX_UL16_106X_mcRun2_asymptotic_v13-v1_120016_file_index.json"
+      },
+      {
+        "checksum": "adler32:e1d62da4",
+        "description": "Neutrino_E-10_gunPREMIX dataset file index (18 of 166) for access to data via CMS virtual machine",
+        "size": 16476,
+        "type": "index.json",
+        "uri": "root://eospublic.cern.ch//eos/opendata/cms/mc/RunIISummer20ULPrePremix/Neutrino_E-10_gun/PREMIX/UL16_106X_mcRun2_asymptotic_v13-v1/file-indexes/CMS_mc_RunIISummer20ULPrePremix_Neutrino_E-10_gun_PREMIX_UL16_106X_mcRun2_asymptotic_v13-v1_120017_file_index.json"
+      },
+      {
+        "checksum": "adler32:7903c9d8",
+        "description": "Neutrino_E-10_gunPREMIX dataset file index (19 of 166) for access to data via CMS virtual machine",
+        "size": 34241,
+        "type": "index.json",
+        "uri": "root://eospublic.cern.ch//eos/opendata/cms/mc/RunIISummer20ULPrePremix/Neutrino_E-10_gun/PREMIX/UL16_106X_mcRun2_asymptotic_v13-v1/file-indexes/CMS_mc_RunIISummer20ULPrePremix_Neutrino_E-10_gun_PREMIX_UL16_106X_mcRun2_asymptotic_v13-v1_120018_file_index.json"
+      },
+      {
+        "checksum": "adler32:c783fc8b",
+        "description": "Neutrino_E-10_gunPREMIX dataset file index (20 of 166) for access to data via CMS virtual machine",
+        "size": 13569,
+        "type": "index.json",
+        "uri": "root://eospublic.cern.ch//eos/opendata/cms/mc/RunIISummer20ULPrePremix/Neutrino_E-10_gun/PREMIX/UL16_106X_mcRun2_asymptotic_v13-v1/file-indexes/CMS_mc_RunIISummer20ULPrePremix_Neutrino_E-10_gun_PREMIX_UL16_106X_mcRun2_asymptotic_v13-v1_120019_file_index.json"
+      },
+      {
+        "checksum": "adler32:c807ab78",
+        "description": "Neutrino_E-10_gunPREMIX dataset file index (21 of 166) for access to data via CMS virtual machine",
+        "size": 27781,
+        "type": "index.json",
+        "uri": "root://eospublic.cern.ch//eos/opendata/cms/mc/RunIISummer20ULPrePremix/Neutrino_E-10_gun/PREMIX/UL16_106X_mcRun2_asymptotic_v13-v1/file-indexes/CMS_mc_RunIISummer20ULPrePremix_Neutrino_E-10_gun_PREMIX_UL16_106X_mcRun2_asymptotic_v13-v1_120020_file_index.json"
+      },
+      {
+        "checksum": "adler32:326ab55f",
+        "description": "Neutrino_E-10_gunPREMIX dataset file index (22 of 166) for access to data via CMS virtual machine",
+        "size": 5171,
+        "type": "index.json",
+        "uri": "root://eospublic.cern.ch//eos/opendata/cms/mc/RunIISummer20ULPrePremix/Neutrino_E-10_gun/PREMIX/UL16_106X_mcRun2_asymptotic_v13-v1/file-indexes/CMS_mc_RunIISummer20ULPrePremix_Neutrino_E-10_gun_PREMIX_UL16_106X_mcRun2_asymptotic_v13-v1_120021_file_index.json"
+      },
+      {
+        "checksum": "adler32:0f9fede9",
+        "description": "Neutrino_E-10_gunPREMIX dataset file index (23 of 166) for access to data via CMS virtual machine",
+        "size": 3556,
+        "type": "index.json",
+        "uri": "root://eospublic.cern.ch//eos/opendata/cms/mc/RunIISummer20ULPrePremix/Neutrino_E-10_gun/PREMIX/UL16_106X_mcRun2_asymptotic_v13-v1/file-indexes/CMS_mc_RunIISummer20ULPrePremix_Neutrino_E-10_gun_PREMIX_UL16_106X_mcRun2_asymptotic_v13-v1_120022_file_index.json"
+      },
+      {
+        "checksum": "adler32:c89d679d",
+        "description": "Neutrino_E-10_gunPREMIX dataset file index (24 of 166) for access to data via CMS virtual machine",
+        "size": 14861,
+        "type": "index.json",
+        "uri": "root://eospublic.cern.ch//eos/opendata/cms/mc/RunIISummer20ULPrePremix/Neutrino_E-10_gun/PREMIX/UL16_106X_mcRun2_asymptotic_v13-v1/file-indexes/CMS_mc_RunIISummer20ULPrePremix_Neutrino_E-10_gun_PREMIX_UL16_106X_mcRun2_asymptotic_v13-v1_120023_file_index.json"
+      },
+      {
+        "checksum": "adler32:0340494b",
+        "description": "Neutrino_E-10_gunPREMIX dataset file index (25 of 166) for access to data via CMS virtual machine",
+        "size": 36502,
+        "type": "index.json",
+        "uri": "root://eospublic.cern.ch//eos/opendata/cms/mc/RunIISummer20ULPrePremix/Neutrino_E-10_gun/PREMIX/UL16_106X_mcRun2_asymptotic_v13-v1/file-indexes/CMS_mc_RunIISummer20ULPrePremix_Neutrino_E-10_gun_PREMIX_UL16_106X_mcRun2_asymptotic_v13-v1_120024_file_index.json"
+      },
+      {
+        "checksum": "adler32:40209cde",
+        "description": "Neutrino_E-10_gunPREMIX dataset file index (26 of 166) for access to data via CMS virtual machine",
+        "size": 22290,
+        "type": "index.json",
+        "uri": "root://eospublic.cern.ch//eos/opendata/cms/mc/RunIISummer20ULPrePremix/Neutrino_E-10_gun/PREMIX/UL16_106X_mcRun2_asymptotic_v13-v1/file-indexes/CMS_mc_RunIISummer20ULPrePremix_Neutrino_E-10_gun_PREMIX_UL16_106X_mcRun2_asymptotic_v13-v1_120025_file_index.json"
+      },
+      {
+        "checksum": "adler32:1976fbb3",
+        "description": "Neutrino_E-10_gunPREMIX dataset file index (27 of 166) for access to data via CMS virtual machine",
+        "size": 18091,
+        "type": "index.json",
+        "uri": "root://eospublic.cern.ch//eos/opendata/cms/mc/RunIISummer20ULPrePremix/Neutrino_E-10_gun/PREMIX/UL16_106X_mcRun2_asymptotic_v13-v1/file-indexes/CMS_mc_RunIISummer20ULPrePremix_Neutrino_E-10_gun_PREMIX_UL16_106X_mcRun2_asymptotic_v13-v1_120026_file_index.json"
+      },
+      {
+        "checksum": "adler32:9efeb006",
+        "description": "Neutrino_E-10_gunPREMIX dataset file index (28 of 166) for access to data via CMS virtual machine",
+        "size": 23259,
+        "type": "index.json",
+        "uri": "root://eospublic.cern.ch//eos/opendata/cms/mc/RunIISummer20ULPrePremix/Neutrino_E-10_gun/PREMIX/UL16_106X_mcRun2_asymptotic_v13-v1/file-indexes/CMS_mc_RunIISummer20ULPrePremix_Neutrino_E-10_gun_PREMIX_UL16_106X_mcRun2_asymptotic_v13-v1_120027_file_index.json"
+      },
+      {
+        "checksum": "adler32:49987091",
+        "description": "Neutrino_E-10_gunPREMIX dataset file index (29 of 166) for access to data via CMS virtual machine",
+        "size": 33918,
+        "type": "index.json",
+        "uri": "root://eospublic.cern.ch//eos/opendata/cms/mc/RunIISummer20ULPrePremix/Neutrino_E-10_gun/PREMIX/UL16_106X_mcRun2_asymptotic_v13-v1/file-indexes/CMS_mc_RunIISummer20ULPrePremix_Neutrino_E-10_gun_PREMIX_UL16_106X_mcRun2_asymptotic_v13-v1_120028_file_index.json"
+      },
+      {
+        "checksum": "adler32:8cff40cc",
+        "description": "Neutrino_E-10_gunPREMIX dataset file index (30 of 166) for access to data via CMS virtual machine",
+        "size": 45546,
+        "type": "index.json",
+        "uri": "root://eospublic.cern.ch//eos/opendata/cms/mc/RunIISummer20ULPrePremix/Neutrino_E-10_gun/PREMIX/UL16_106X_mcRun2_asymptotic_v13-v1/file-indexes/CMS_mc_RunIISummer20ULPrePremix_Neutrino_E-10_gun_PREMIX_UL16_106X_mcRun2_asymptotic_v13-v1_120029_file_index.json"
+      },
+      {
+        "checksum": "adler32:da55ca5d",
+        "description": "Neutrino_E-10_gunPREMIX dataset file index (31 of 166) for access to data via CMS virtual machine",
+        "size": 34241,
+        "type": "index.json",
+        "uri": "root://eospublic.cern.ch//eos/opendata/cms/mc/RunIISummer20ULPrePremix/Neutrino_E-10_gun/PREMIX/UL16_106X_mcRun2_asymptotic_v13-v1/file-indexes/CMS_mc_RunIISummer20ULPrePremix_Neutrino_E-10_gun_PREMIX_UL16_106X_mcRun2_asymptotic_v13-v1_120030_file_index.json"
+      },
+      {
+        "checksum": "adler32:1e777f95",
+        "description": "Neutrino_E-10_gunPREMIX dataset file index (32 of 166) for access to data via CMS virtual machine",
+        "size": 2264,
+        "type": "index.json",
+        "uri": "root://eospublic.cern.ch//eos/opendata/cms/mc/RunIISummer20ULPrePremix/Neutrino_E-10_gun/PREMIX/UL16_106X_mcRun2_asymptotic_v13-v1/file-indexes/CMS_mc_RunIISummer20ULPrePremix_Neutrino_E-10_gun_PREMIX_UL16_106X_mcRun2_asymptotic_v13-v1_130000_file_index.json"
+      },
+      {
+        "checksum": "adler32:20900fb2",
+        "description": "Neutrino_E-10_gunPREMIX dataset file index (33 of 166) for access to data via CMS virtual machine",
+        "size": 5494,
+        "type": "index.json",
+        "uri": "root://eospublic.cern.ch//eos/opendata/cms/mc/RunIISummer20ULPrePremix/Neutrino_E-10_gun/PREMIX/UL16_106X_mcRun2_asymptotic_v13-v1/file-indexes/CMS_mc_RunIISummer20ULPrePremix_Neutrino_E-10_gun_PREMIX_UL16_106X_mcRun2_asymptotic_v13-v1_130001_file_index.json"
+      },
+      {
+        "checksum": "adler32:cffda2f5",
+        "description": "Neutrino_E-10_gunPREMIX dataset file index (34 of 166) for access to data via CMS virtual machine",
+        "size": 4202,
+        "type": "index.json",
+        "uri": "root://eospublic.cern.ch//eos/opendata/cms/mc/RunIISummer20ULPrePremix/Neutrino_E-10_gun/PREMIX/UL16_106X_mcRun2_asymptotic_v13-v1/file-indexes/CMS_mc_RunIISummer20ULPrePremix_Neutrino_E-10_gun_PREMIX_UL16_106X_mcRun2_asymptotic_v13-v1_130002_file_index.json"
+      },
+      {
+        "checksum": "adler32:cf92205e",
+        "description": "Neutrino_E-10_gunPREMIX dataset file index (35 of 166) for access to data via CMS virtual machine",
+        "size": 6463,
+        "type": "index.json",
+        "uri": "root://eospublic.cern.ch//eos/opendata/cms/mc/RunIISummer20ULPrePremix/Neutrino_E-10_gun/PREMIX/UL16_106X_mcRun2_asymptotic_v13-v1/file-indexes/CMS_mc_RunIISummer20ULPrePremix_Neutrino_E-10_gun_PREMIX_UL16_106X_mcRun2_asymptotic_v13-v1_130003_file_index.json"
+      },
+      {
+        "checksum": "adler32:c6905b02",
+        "description": "Neutrino_E-10_gunPREMIX dataset file index (36 of 166) for access to data via CMS virtual machine",
+        "size": 326,
+        "type": "index.json",
+        "uri": "root://eospublic.cern.ch//eos/opendata/cms/mc/RunIISummer20ULPrePremix/Neutrino_E-10_gun/PREMIX/UL16_106X_mcRun2_asymptotic_v13-v1/file-indexes/CMS_mc_RunIISummer20ULPrePremix_Neutrino_E-10_gun_PREMIX_UL16_106X_mcRun2_asymptotic_v13-v1_130004_file_index.json"
+      },
+      {
+        "checksum": "adler32:2878b6aa",
+        "description": "Neutrino_E-10_gunPREMIX dataset file index (37 of 166) for access to data via CMS virtual machine",
+        "size": 5171,
+        "type": "index.json",
+        "uri": "root://eospublic.cern.ch//eos/opendata/cms/mc/RunIISummer20ULPrePremix/Neutrino_E-10_gun/PREMIX/UL16_106X_mcRun2_asymptotic_v13-v1/file-indexes/CMS_mc_RunIISummer20ULPrePremix_Neutrino_E-10_gun_PREMIX_UL16_106X_mcRun2_asymptotic_v13-v1_130005_file_index.json"
+      },
+      {
+        "checksum": "adler32:562f57b5",
+        "description": "Neutrino_E-10_gunPREMIX dataset file index (38 of 166) for access to data via CMS virtual machine",
+        "size": 4848,
+        "type": "index.json",
+        "uri": "root://eospublic.cern.ch//eos/opendata/cms/mc/RunIISummer20ULPrePremix/Neutrino_E-10_gun/PREMIX/UL16_106X_mcRun2_asymptotic_v13-v1/file-indexes/CMS_mc_RunIISummer20ULPrePremix_Neutrino_E-10_gun_PREMIX_UL16_106X_mcRun2_asymptotic_v13-v1_130006_file_index.json"
+      },
+      {
+        "checksum": "adler32:7906c4f5",
+        "description": "Neutrino_E-10_gunPREMIX dataset file index (39 of 166) for access to data via CMS virtual machine",
+        "size": 10662,
+        "type": "index.json",
+        "uri": "root://eospublic.cern.ch//eos/opendata/cms/mc/RunIISummer20ULPrePremix/Neutrino_E-10_gun/PREMIX/UL16_106X_mcRun2_asymptotic_v13-v1/file-indexes/CMS_mc_RunIISummer20ULPrePremix_Neutrino_E-10_gun_PREMIX_UL16_106X_mcRun2_asymptotic_v13-v1_130007_file_index.json"
+      },
+      {
+        "checksum": "adler32:93b971b1",
+        "description": "Neutrino_E-10_gunPREMIX dataset file index (40 of 166) for access to data via CMS virtual machine",
+        "size": 33918,
+        "type": "index.json",
+        "uri": "root://eospublic.cern.ch//eos/opendata/cms/mc/RunIISummer20ULPrePremix/Neutrino_E-10_gun/PREMIX/UL16_106X_mcRun2_asymptotic_v13-v1/file-indexes/CMS_mc_RunIISummer20ULPrePremix_Neutrino_E-10_gun_PREMIX_UL16_106X_mcRun2_asymptotic_v13-v1_130008_file_index.json"
+      },
+      {
+        "checksum": "adler32:e901b3cb",
+        "description": "Neutrino_E-10_gunPREMIX dataset file index (41 of 166) for access to data via CMS virtual machine",
+        "size": 5171,
+        "type": "index.json",
+        "uri": "root://eospublic.cern.ch//eos/opendata/cms/mc/RunIISummer20ULPrePremix/Neutrino_E-10_gun/PREMIX/UL16_106X_mcRun2_asymptotic_v13-v1/file-indexes/CMS_mc_RunIISummer20ULPrePremix_Neutrino_E-10_gun_PREMIX_UL16_106X_mcRun2_asymptotic_v13-v1_130009_file_index.json"
+      },
+      {
+        "checksum": "adler32:9ec26860",
+        "description": "Neutrino_E-10_gunPREMIX dataset file index (42 of 166) for access to data via CMS virtual machine",
+        "size": 10339,
+        "type": "index.json",
+        "uri": "root://eospublic.cern.ch//eos/opendata/cms/mc/RunIISummer20ULPrePremix/Neutrino_E-10_gun/PREMIX/UL16_106X_mcRun2_asymptotic_v13-v1/file-indexes/CMS_mc_RunIISummer20ULPrePremix_Neutrino_E-10_gun_PREMIX_UL16_106X_mcRun2_asymptotic_v13-v1_130010_file_index.json"
+      },
+      {
+        "checksum": "adler32:52d39379",
+        "description": "Neutrino_E-10_gunPREMIX dataset file index (43 of 166) for access to data via CMS virtual machine",
+        "size": 7755,
+        "type": "index.json",
+        "uri": "root://eospublic.cern.ch//eos/opendata/cms/mc/RunIISummer20ULPrePremix/Neutrino_E-10_gun/PREMIX/UL16_106X_mcRun2_asymptotic_v13-v1/file-indexes/CMS_mc_RunIISummer20ULPrePremix_Neutrino_E-10_gun_PREMIX_UL16_106X_mcRun2_asymptotic_v13-v1_130011_file_index.json"
+      },
+      {
+        "checksum": "adler32:22b1312b",
+        "description": "Neutrino_E-10_gunPREMIX dataset file index (44 of 166) for access to data via CMS virtual machine",
+        "size": 7432,
+        "type": "index.json",
+        "uri": "root://eospublic.cern.ch//eos/opendata/cms/mc/RunIISummer20ULPrePremix/Neutrino_E-10_gun/PREMIX/UL16_106X_mcRun2_asymptotic_v13-v1/file-indexes/CMS_mc_RunIISummer20ULPrePremix_Neutrino_E-10_gun_PREMIX_UL16_106X_mcRun2_asymptotic_v13-v1_130012_file_index.json"
+      },
+      {
+        "checksum": "adler32:ba86ed98",
+        "description": "Neutrino_E-10_gunPREMIX dataset file index (45 of 166) for access to data via CMS virtual machine",
+        "size": 8078,
+        "type": "index.json",
+        "uri": "root://eospublic.cern.ch//eos/opendata/cms/mc/RunIISummer20ULPrePremix/Neutrino_E-10_gun/PREMIX/UL16_106X_mcRun2_asymptotic_v13-v1/file-indexes/CMS_mc_RunIISummer20ULPrePremix_Neutrino_E-10_gun_PREMIX_UL16_106X_mcRun2_asymptotic_v13-v1_130013_file_index.json"
+      },
+      {
+        "checksum": "adler32:b1bf13f8",
+        "description": "Neutrino_E-10_gunPREMIX dataset file index (46 of 166) for access to data via CMS virtual machine",
+        "size": 75262,
+        "type": "index.json",
+        "uri": "root://eospublic.cern.ch//eos/opendata/cms/mc/RunIISummer20ULPrePremix/Neutrino_E-10_gun/PREMIX/UL16_106X_mcRun2_asymptotic_v13-v1/file-indexes/CMS_mc_RunIISummer20ULPrePremix_Neutrino_E-10_gun_PREMIX_UL16_106X_mcRun2_asymptotic_v13-v1_130014_file_index.json"
+      },
+      {
+        "checksum": "adler32:adfd7d69",
+        "description": "Neutrino_E-10_gunPREMIX dataset file index (47 of 166) for access to data via CMS virtual machine",
+        "size": 34887,
+        "type": "index.json",
+        "uri": "root://eospublic.cern.ch//eos/opendata/cms/mc/RunIISummer20ULPrePremix/Neutrino_E-10_gun/PREMIX/UL16_106X_mcRun2_asymptotic_v13-v1/file-indexes/CMS_mc_RunIISummer20ULPrePremix_Neutrino_E-10_gun_PREMIX_UL16_106X_mcRun2_asymptotic_v13-v1_130015_file_index.json"
+      },
+      {
+        "checksum": "adler32:0fef4747",
+        "description": "Neutrino_E-10_gunPREMIX dataset file index (48 of 166) for access to data via CMS virtual machine",
+        "size": 8401,
+        "type": "index.json",
+        "uri": "root://eospublic.cern.ch//eos/opendata/cms/mc/RunIISummer20ULPrePremix/Neutrino_E-10_gun/PREMIX/UL16_106X_mcRun2_asymptotic_v13-v1/file-indexes/CMS_mc_RunIISummer20ULPrePremix_Neutrino_E-10_gun_PREMIX_UL16_106X_mcRun2_asymptotic_v13-v1_130016_file_index.json"
+      },
+      {
+        "checksum": "adler32:99b10d48",
+        "description": "Neutrino_E-10_gunPREMIX dataset file index (49 of 166) for access to data via CMS virtual machine",
+        "size": 10016,
+        "type": "index.json",
+        "uri": "root://eospublic.cern.ch//eos/opendata/cms/mc/RunIISummer20ULPrePremix/Neutrino_E-10_gun/PREMIX/UL16_106X_mcRun2_asymptotic_v13-v1/file-indexes/CMS_mc_RunIISummer20ULPrePremix_Neutrino_E-10_gun_PREMIX_UL16_106X_mcRun2_asymptotic_v13-v1_130017_file_index.json"
+      },
+      {
+        "checksum": "adler32:085007c4",
+        "description": "Neutrino_E-10_gunPREMIX dataset file index (50 of 166) for access to data via CMS virtual machine",
+        "size": 23582,
+        "type": "index.json",
+        "uri": "root://eospublic.cern.ch//eos/opendata/cms/mc/RunIISummer20ULPrePremix/Neutrino_E-10_gun/PREMIX/UL16_106X_mcRun2_asymptotic_v13-v1/file-indexes/CMS_mc_RunIISummer20ULPrePremix_Neutrino_E-10_gun_PREMIX_UL16_106X_mcRun2_asymptotic_v13-v1_130018_file_index.json"
+      },
+      {
+        "checksum": "adler32:cebf5a98",
+        "description": "Neutrino_E-10_gunPREMIX dataset file index (51 of 166) for access to data via CMS virtual machine",
+        "size": 4848,
+        "type": "index.json",
+        "uri": "root://eospublic.cern.ch//eos/opendata/cms/mc/RunIISummer20ULPrePremix/Neutrino_E-10_gun/PREMIX/UL16_106X_mcRun2_asymptotic_v13-v1/file-indexes/CMS_mc_RunIISummer20ULPrePremix_Neutrino_E-10_gun_PREMIX_UL16_106X_mcRun2_asymptotic_v13-v1_130019_file_index.json"
+      },
+      {
+        "checksum": "adler32:d076c5a0",
+        "description": "Neutrino_E-10_gunPREMIX dataset file index (52 of 166) for access to data via CMS virtual machine",
+        "size": 10662,
+        "type": "index.json",
+        "uri": "root://eospublic.cern.ch//eos/opendata/cms/mc/RunIISummer20ULPrePremix/Neutrino_E-10_gun/PREMIX/UL16_106X_mcRun2_asymptotic_v13-v1/file-indexes/CMS_mc_RunIISummer20ULPrePremix_Neutrino_E-10_gun_PREMIX_UL16_106X_mcRun2_asymptotic_v13-v1_130020_file_index.json"
+      },
+      {
+        "checksum": "adler32:61a8447b",
+        "description": "Neutrino_E-10_gunPREMIX dataset file index (53 of 166) for access to data via CMS virtual machine",
+        "size": 8401,
+        "type": "index.json",
+        "uri": "root://eospublic.cern.ch//eos/opendata/cms/mc/RunIISummer20ULPrePremix/Neutrino_E-10_gun/PREMIX/UL16_106X_mcRun2_asymptotic_v13-v1/file-indexes/CMS_mc_RunIISummer20ULPrePremix_Neutrino_E-10_gun_PREMIX_UL16_106X_mcRun2_asymptotic_v13-v1_130021_file_index.json"
+      },
+      {
+        "checksum": "adler32:b3aba208",
+        "description": "Neutrino_E-10_gunPREMIX dataset file index (54 of 166) for access to data via CMS virtual machine",
+        "size": 17768,
+        "type": "index.json",
+        "uri": "root://eospublic.cern.ch//eos/opendata/cms/mc/RunIISummer20ULPrePremix/Neutrino_E-10_gun/PREMIX/UL16_106X_mcRun2_asymptotic_v13-v1/file-indexes/CMS_mc_RunIISummer20ULPrePremix_Neutrino_E-10_gun_PREMIX_UL16_106X_mcRun2_asymptotic_v13-v1_130022_file_index.json"
+      },
+      {
+        "checksum": "adler32:5327888f",
+        "description": "Neutrino_E-10_gunPREMIX dataset file index (55 of 166) for access to data via CMS virtual machine",
+        "size": 34887,
+        "type": "index.json",
+        "uri": "root://eospublic.cern.ch//eos/opendata/cms/mc/RunIISummer20ULPrePremix/Neutrino_E-10_gun/PREMIX/UL16_106X_mcRun2_asymptotic_v13-v1/file-indexes/CMS_mc_RunIISummer20ULPrePremix_Neutrino_E-10_gun_PREMIX_UL16_106X_mcRun2_asymptotic_v13-v1_130023_file_index.json"
+      },
+      {
+        "checksum": "adler32:b3672dce",
+        "description": "Neutrino_E-10_gunPREMIX dataset file index (56 of 166) for access to data via CMS virtual machine",
+        "size": 20998,
+        "type": "index.json",
+        "uri": "root://eospublic.cern.ch//eos/opendata/cms/mc/RunIISummer20ULPrePremix/Neutrino_E-10_gun/PREMIX/UL16_106X_mcRun2_asymptotic_v13-v1/file-indexes/CMS_mc_RunIISummer20ULPrePremix_Neutrino_E-10_gun_PREMIX_UL16_106X_mcRun2_asymptotic_v13-v1_130024_file_index.json"
+      },
+      {
+        "checksum": "adler32:54ef0a3f",
+        "description": "Neutrino_E-10_gunPREMIX dataset file index (57 of 166) for access to data via CMS virtual machine",
+        "size": 28104,
+        "type": "index.json",
+        "uri": "root://eospublic.cern.ch//eos/opendata/cms/mc/RunIISummer20ULPrePremix/Neutrino_E-10_gun/PREMIX/UL16_106X_mcRun2_asymptotic_v13-v1/file-indexes/CMS_mc_RunIISummer20ULPrePremix_Neutrino_E-10_gun_PREMIX_UL16_106X_mcRun2_asymptotic_v13-v1_130025_file_index.json"
+      },
+      {
+        "checksum": "adler32:c94a8bbc",
+        "description": "Neutrino_E-10_gunPREMIX dataset file index (58 of 166) for access to data via CMS virtual machine",
+        "size": 21321,
+        "type": "index.json",
+        "uri": "root://eospublic.cern.ch//eos/opendata/cms/mc/RunIISummer20ULPrePremix/Neutrino_E-10_gun/PREMIX/UL16_106X_mcRun2_asymptotic_v13-v1/file-indexes/CMS_mc_RunIISummer20ULPrePremix_Neutrino_E-10_gun_PREMIX_UL16_106X_mcRun2_asymptotic_v13-v1_130026_file_index.json"
+      },
+      {
+        "checksum": "adler32:bac51dc0",
+        "description": "Neutrino_E-10_gunPREMIX dataset file index (59 of 166) for access to data via CMS virtual machine",
+        "size": 10985,
+        "type": "index.json",
+        "uri": "root://eospublic.cern.ch//eos/opendata/cms/mc/RunIISummer20ULPrePremix/Neutrino_E-10_gun/PREMIX/UL16_106X_mcRun2_asymptotic_v13-v1/file-indexes/CMS_mc_RunIISummer20ULPrePremix_Neutrino_E-10_gun_PREMIX_UL16_106X_mcRun2_asymptotic_v13-v1_130027_file_index.json"
+      },
+      {
+        "checksum": "adler32:4484dd52",
+        "description": "Neutrino_E-10_gunPREMIX dataset file index (60 of 166) for access to data via CMS virtual machine",
+        "size": 2587,
+        "type": "index.json",
+        "uri": "root://eospublic.cern.ch//eos/opendata/cms/mc/RunIISummer20ULPrePremix/Neutrino_E-10_gun/PREMIX/UL16_106X_mcRun2_asymptotic_v13-v1/file-indexes/CMS_mc_RunIISummer20ULPrePremix_Neutrino_E-10_gun_PREMIX_UL16_106X_mcRun2_asymptotic_v13-v1_130028_file_index.json"
+      },
+      {
+        "checksum": "adler32:46132332",
+        "description": "Neutrino_E-10_gunPREMIX dataset file index (61 of 166) for access to data via CMS virtual machine",
+        "size": 6463,
+        "type": "index.json",
+        "uri": "root://eospublic.cern.ch//eos/opendata/cms/mc/RunIISummer20ULPrePremix/Neutrino_E-10_gun/PREMIX/UL16_106X_mcRun2_asymptotic_v13-v1/file-indexes/CMS_mc_RunIISummer20ULPrePremix_Neutrino_E-10_gun_PREMIX_UL16_106X_mcRun2_asymptotic_v13-v1_130029_file_index.json"
+      },
+      {
+        "checksum": "adler32:d57ebc93",
+        "description": "Neutrino_E-10_gunPREMIX dataset file index (62 of 166) for access to data via CMS virtual machine",
+        "size": 28750,
+        "type": "index.json",
+        "uri": "root://eospublic.cern.ch//eos/opendata/cms/mc/RunIISummer20ULPrePremix/Neutrino_E-10_gun/PREMIX/UL16_106X_mcRun2_asymptotic_v13-v1/file-indexes/CMS_mc_RunIISummer20ULPrePremix_Neutrino_E-10_gun_PREMIX_UL16_106X_mcRun2_asymptotic_v13-v1_130030_file_index.json"
+      },
+      {
+        "checksum": "adler32:1f4cb86c",
+        "description": "Neutrino_E-10_gunPREMIX dataset file index (63 of 166) for access to data via CMS virtual machine",
+        "size": 651,
+        "type": "index.json",
+        "uri": "root://eospublic.cern.ch//eos/opendata/cms/mc/RunIISummer20ULPrePremix/Neutrino_E-10_gun/PREMIX/UL16_106X_mcRun2_asymptotic_v13-v1/file-indexes/CMS_mc_RunIISummer20ULPrePremix_Neutrino_E-10_gun_PREMIX_UL16_106X_mcRun2_asymptotic_v13-v1_1320000_file_index.json"
+      },
+      {
+        "checksum": "adler32:84e69237",
+        "description": "Neutrino_E-10_gunPREMIX dataset file index (64 of 166) for access to data via CMS virtual machine",
+        "size": 3243,
+        "type": "index.json",
+        "uri": "root://eospublic.cern.ch//eos/opendata/cms/mc/RunIISummer20ULPrePremix/Neutrino_E-10_gun/PREMIX/UL16_106X_mcRun2_asymptotic_v13-v1/file-indexes/CMS_mc_RunIISummer20ULPrePremix_Neutrino_E-10_gun_PREMIX_UL16_106X_mcRun2_asymptotic_v13-v1_1320001_file_index.json"
+      },
+      {
+        "checksum": "adler32:e6e0c925",
+        "description": "Neutrino_E-10_gunPREMIX dataset file index (65 of 166) for access to data via CMS virtual machine",
+        "size": 1623,
+        "type": "index.json",
+        "uri": "root://eospublic.cern.ch//eos/opendata/cms/mc/RunIISummer20ULPrePremix/Neutrino_E-10_gun/PREMIX/UL16_106X_mcRun2_asymptotic_v13-v1/file-indexes/CMS_mc_RunIISummer20ULPrePremix_Neutrino_E-10_gun_PREMIX_UL16_106X_mcRun2_asymptotic_v13-v1_1320002_file_index.json"
+      },
+      {
+        "checksum": "adler32:bee09c78",
+        "description": "Neutrino_E-10_gunPREMIX dataset file index (66 of 166) for access to data via CMS virtual machine",
+        "size": 21387,
+        "type": "index.json",
+        "uri": "root://eospublic.cern.ch//eos/opendata/cms/mc/RunIISummer20ULPrePremix/Neutrino_E-10_gun/PREMIX/UL16_106X_mcRun2_asymptotic_v13-v1/file-indexes/CMS_mc_RunIISummer20ULPrePremix_Neutrino_E-10_gun_PREMIX_UL16_106X_mcRun2_asymptotic_v13-v1_1320003_file_index.json"
+      },
+      {
+        "checksum": "adler32:0c5d47f1",
+        "description": "Neutrino_E-10_gunPREMIX dataset file index (67 of 166) for access to data via CMS virtual machine",
+        "size": 8427,
+        "type": "index.json",
+        "uri": "root://eospublic.cern.ch//eos/opendata/cms/mc/RunIISummer20ULPrePremix/Neutrino_E-10_gun/PREMIX/UL16_106X_mcRun2_asymptotic_v13-v1/file-indexes/CMS_mc_RunIISummer20ULPrePremix_Neutrino_E-10_gun_PREMIX_UL16_106X_mcRun2_asymptotic_v13-v1_1320004_file_index.json"
+      },
+      {
+        "checksum": "adler32:b84f15aa",
+        "description": "Neutrino_E-10_gunPREMIX dataset file index (68 of 166) for access to data via CMS virtual machine",
+        "size": 23655,
+        "type": "index.json",
+        "uri": "root://eospublic.cern.ch//eos/opendata/cms/mc/RunIISummer20ULPrePremix/Neutrino_E-10_gun/PREMIX/UL16_106X_mcRun2_asymptotic_v13-v1/file-indexes/CMS_mc_RunIISummer20ULPrePremix_Neutrino_E-10_gun_PREMIX_UL16_106X_mcRun2_asymptotic_v13-v1_1320005_file_index.json"
+      },
+      {
+        "checksum": "adler32:5ae548e9",
+        "description": "Neutrino_E-10_gunPREMIX dataset file index (69 of 166) for access to data via CMS virtual machine",
+        "size": 40179,
+        "type": "index.json",
+        "uri": "root://eospublic.cern.ch//eos/opendata/cms/mc/RunIISummer20ULPrePremix/Neutrino_E-10_gun/PREMIX/UL16_106X_mcRun2_asymptotic_v13-v1/file-indexes/CMS_mc_RunIISummer20ULPrePremix_Neutrino_E-10_gun_PREMIX_UL16_106X_mcRun2_asymptotic_v13-v1_1320006_file_index.json"
+      },
+      {
+        "checksum": "adler32:63b1dd52",
+        "description": "Neutrino_E-10_gunPREMIX dataset file index (70 of 166) for access to data via CMS virtual machine",
+        "size": 52491,
+        "type": "index.json",
+        "uri": "root://eospublic.cern.ch//eos/opendata/cms/mc/RunIISummer20ULPrePremix/Neutrino_E-10_gun/PREMIX/UL16_106X_mcRun2_asymptotic_v13-v1/file-indexes/CMS_mc_RunIISummer20ULPrePremix_Neutrino_E-10_gun_PREMIX_UL16_106X_mcRun2_asymptotic_v13-v1_1320007_file_index.json"
+      },
+      {
+        "checksum": "adler32:a2e35ce5",
+        "description": "Neutrino_E-10_gunPREMIX dataset file index (71 of 166) for access to data via CMS virtual machine",
+        "size": 9399,
+        "type": "index.json",
+        "uri": "root://eospublic.cern.ch//eos/opendata/cms/mc/RunIISummer20ULPrePremix/Neutrino_E-10_gun/PREMIX/UL16_106X_mcRun2_asymptotic_v13-v1/file-indexes/CMS_mc_RunIISummer20ULPrePremix_Neutrino_E-10_gun_PREMIX_UL16_106X_mcRun2_asymptotic_v13-v1_1320008_file_index.json"
+      },
+      {
+        "checksum": "adler32:b5c112f3",
+        "description": "Neutrino_E-10_gunPREMIX dataset file index (72 of 166) for access to data via CMS virtual machine",
+        "size": 975,
+        "type": "index.json",
+        "uri": "root://eospublic.cern.ch//eos/opendata/cms/mc/RunIISummer20ULPrePremix/Neutrino_E-10_gun/PREMIX/UL16_106X_mcRun2_asymptotic_v13-v1/file-indexes/CMS_mc_RunIISummer20ULPrePremix_Neutrino_E-10_gun_PREMIX_UL16_106X_mcRun2_asymptotic_v13-v1_1320009_file_index.json"
+      },
+      {
+        "checksum": "adler32:66785bef",
+        "description": "Neutrino_E-10_gunPREMIX dataset file index (73 of 166) for access to data via CMS virtual machine",
+        "size": 326,
+        "type": "index.json",
+        "uri": "root://eospublic.cern.ch//eos/opendata/cms/mc/RunIISummer20ULPrePremix/Neutrino_E-10_gun/PREMIX/UL16_106X_mcRun2_asymptotic_v13-v1/file-indexes/CMS_mc_RunIISummer20ULPrePremix_Neutrino_E-10_gun_PREMIX_UL16_106X_mcRun2_asymptotic_v13-v1_250000_file_index.json"
+      },
+      {
+        "checksum": "adler32:72f7e214",
+        "description": "Neutrino_E-10_gunPREMIX dataset file index (74 of 166) for access to data via CMS virtual machine",
+        "size": 86890,
+        "type": "index.json",
+        "uri": "root://eospublic.cern.ch//eos/opendata/cms/mc/RunIISummer20ULPrePremix/Neutrino_E-10_gun/PREMIX/UL16_106X_mcRun2_asymptotic_v13-v1/file-indexes/CMS_mc_RunIISummer20ULPrePremix_Neutrino_E-10_gun_PREMIX_UL16_106X_mcRun2_asymptotic_v13-v1_260000_file_index.json"
+      },
+      {
+        "checksum": "adler32:0c5dad0a",
+        "description": "Neutrino_E-10_gunPREMIX dataset file index (75 of 166) for access to data via CMS virtual machine",
+        "size": 64926,
+        "type": "index.json",
+        "uri": "root://eospublic.cern.ch//eos/opendata/cms/mc/RunIISummer20ULPrePremix/Neutrino_E-10_gun/PREMIX/UL16_106X_mcRun2_asymptotic_v13-v1/file-indexes/CMS_mc_RunIISummer20ULPrePremix_Neutrino_E-10_gun_PREMIX_UL16_106X_mcRun2_asymptotic_v13-v1_260001_file_index.json"
+      },
+      {
+        "checksum": "adler32:2f78d241",
+        "description": "Neutrino_E-10_gunPREMIX dataset file index (76 of 166) for access to data via CMS virtual machine",
+        "size": 61373,
+        "type": "index.json",
+        "uri": "root://eospublic.cern.ch//eos/opendata/cms/mc/RunIISummer20ULPrePremix/Neutrino_E-10_gun/PREMIX/UL16_106X_mcRun2_asymptotic_v13-v1/file-indexes/CMS_mc_RunIISummer20ULPrePremix_Neutrino_E-10_gun_PREMIX_UL16_106X_mcRun2_asymptotic_v13-v1_260002_file_index.json"
+      },
+      {
+        "checksum": "adler32:c64e763b",
+        "description": "Neutrino_E-10_gunPREMIX dataset file index (77 of 166) for access to data via CMS virtual machine",
+        "size": 24874,
+        "type": "index.json",
+        "uri": "root://eospublic.cern.ch//eos/opendata/cms/mc/RunIISummer20ULPrePremix/Neutrino_E-10_gun/PREMIX/UL16_106X_mcRun2_asymptotic_v13-v1/file-indexes/CMS_mc_RunIISummer20ULPrePremix_Neutrino_E-10_gun_PREMIX_UL16_106X_mcRun2_asymptotic_v13-v1_260003_file_index.json"
+      },
+      {
+        "checksum": "adler32:e14b091f",
+        "description": "Neutrino_E-10_gunPREMIX dataset file index (78 of 166) for access to data via CMS virtual machine",
+        "size": 88828,
+        "type": "index.json",
+        "uri": "root://eospublic.cern.ch//eos/opendata/cms/mc/RunIISummer20ULPrePremix/Neutrino_E-10_gun/PREMIX/UL16_106X_mcRun2_asymptotic_v13-v1/file-indexes/CMS_mc_RunIISummer20ULPrePremix_Neutrino_E-10_gun_PREMIX_UL16_106X_mcRun2_asymptotic_v13-v1_260004_file_index.json"
+      },
+      {
+        "checksum": "adler32:0f86de67",
+        "description": "Neutrino_E-10_gunPREMIX dataset file index (79 of 166) for access to data via CMS virtual machine",
+        "size": 44254,
+        "type": "index.json",
+        "uri": "root://eospublic.cern.ch//eos/opendata/cms/mc/RunIISummer20ULPrePremix/Neutrino_E-10_gun/PREMIX/UL16_106X_mcRun2_asymptotic_v13-v1/file-indexes/CMS_mc_RunIISummer20ULPrePremix_Neutrino_E-10_gun_PREMIX_UL16_106X_mcRun2_asymptotic_v13-v1_260005_file_index.json"
+      },
+      {
+        "checksum": "adler32:1569e139",
+        "description": "Neutrino_E-10_gunPREMIX dataset file index (80 of 166) for access to data via CMS virtual machine",
+        "size": 26166,
+        "type": "index.json",
+        "uri": "root://eospublic.cern.ch//eos/opendata/cms/mc/RunIISummer20ULPrePremix/Neutrino_E-10_gun/PREMIX/UL16_106X_mcRun2_asymptotic_v13-v1/file-indexes/CMS_mc_RunIISummer20ULPrePremix_Neutrino_E-10_gun_PREMIX_UL16_106X_mcRun2_asymptotic_v13-v1_260006_file_index.json"
+      },
+      {
+        "checksum": "adler32:f48f1b38",
+        "description": "Neutrino_E-10_gunPREMIX dataset file index (81 of 166) for access to data via CMS virtual machine",
+        "size": 38117,
+        "type": "index.json",
+        "uri": "root://eospublic.cern.ch//eos/opendata/cms/mc/RunIISummer20ULPrePremix/Neutrino_E-10_gun/PREMIX/UL16_106X_mcRun2_asymptotic_v13-v1/file-indexes/CMS_mc_RunIISummer20ULPrePremix_Neutrino_E-10_gun_PREMIX_UL16_106X_mcRun2_asymptotic_v13-v1_260007_file_index.json"
+      },
+      {
+        "checksum": "adler32:07e08a68",
+        "description": "Neutrino_E-10_gunPREMIX dataset file index (82 of 166) for access to data via CMS virtual machine",
+        "size": 16799,
+        "type": "index.json",
+        "uri": "root://eospublic.cern.ch//eos/opendata/cms/mc/RunIISummer20ULPrePremix/Neutrino_E-10_gun/PREMIX/UL16_106X_mcRun2_asymptotic_v13-v1/file-indexes/CMS_mc_RunIISummer20ULPrePremix_Neutrino_E-10_gun_PREMIX_UL16_106X_mcRun2_asymptotic_v13-v1_260008_file_index.json"
+      },
+      {
+        "checksum": "adler32:148a075f",
+        "description": "Neutrino_E-10_gunPREMIX dataset file index (83 of 166) for access to data via CMS virtual machine",
+        "size": 37148,
+        "type": "index.json",
+        "uri": "root://eospublic.cern.ch//eos/opendata/cms/mc/RunIISummer20ULPrePremix/Neutrino_E-10_gun/PREMIX/UL16_106X_mcRun2_asymptotic_v13-v1/file-indexes/CMS_mc_RunIISummer20ULPrePremix_Neutrino_E-10_gun_PREMIX_UL16_106X_mcRun2_asymptotic_v13-v1_260009_file_index.json"
+      },
+      {
+        "checksum": "adler32:5d78f070",
+        "description": "Neutrino_E-10_gunPREMIX dataset file index (84 of 166) for access to data via CMS virtual machine",
+        "size": 27135,
+        "type": "index.json",
+        "uri": "root://eospublic.cern.ch//eos/opendata/cms/mc/RunIISummer20ULPrePremix/Neutrino_E-10_gun/PREMIX/UL16_106X_mcRun2_asymptotic_v13-v1/file-indexes/CMS_mc_RunIISummer20ULPrePremix_Neutrino_E-10_gun_PREMIX_UL16_106X_mcRun2_asymptotic_v13-v1_260010_file_index.json"
+      },
+      {
+        "checksum": "adler32:4c4e0985",
+        "description": "Neutrino_E-10_gunPREMIX dataset file index (85 of 166) for access to data via CMS virtual machine",
+        "size": 32626,
+        "type": "index.json",
+        "uri": "root://eospublic.cern.ch//eos/opendata/cms/mc/RunIISummer20ULPrePremix/Neutrino_E-10_gun/PREMIX/UL16_106X_mcRun2_asymptotic_v13-v1/file-indexes/CMS_mc_RunIISummer20ULPrePremix_Neutrino_E-10_gun_PREMIX_UL16_106X_mcRun2_asymptotic_v13-v1_260011_file_index.json"
+      },
+      {
+        "checksum": "adler32:099d4631",
+        "description": "Neutrino_E-10_gunPREMIX dataset file index (86 of 166) for access to data via CMS virtual machine",
+        "size": 40055,
+        "type": "index.json",
+        "uri": "root://eospublic.cern.ch//eos/opendata/cms/mc/RunIISummer20ULPrePremix/Neutrino_E-10_gun/PREMIX/UL16_106X_mcRun2_asymptotic_v13-v1/file-indexes/CMS_mc_RunIISummer20ULPrePremix_Neutrino_E-10_gun_PREMIX_UL16_106X_mcRun2_asymptotic_v13-v1_260012_file_index.json"
+      },
+      {
+        "checksum": "adler32:a072332b",
+        "description": "Neutrino_E-10_gunPREMIX dataset file index (87 of 166) for access to data via CMS virtual machine",
+        "size": 44577,
+        "type": "index.json",
+        "uri": "root://eospublic.cern.ch//eos/opendata/cms/mc/RunIISummer20ULPrePremix/Neutrino_E-10_gun/PREMIX/UL16_106X_mcRun2_asymptotic_v13-v1/file-indexes/CMS_mc_RunIISummer20ULPrePremix_Neutrino_E-10_gun_PREMIX_UL16_106X_mcRun2_asymptotic_v13-v1_260013_file_index.json"
+      },
+      {
+        "checksum": "adler32:8657d498",
+        "description": "Neutrino_E-10_gunPREMIX dataset file index (88 of 166) for access to data via CMS virtual machine",
+        "size": 39732,
+        "type": "index.json",
+        "uri": "root://eospublic.cern.ch//eos/opendata/cms/mc/RunIISummer20ULPrePremix/Neutrino_E-10_gun/PREMIX/UL16_106X_mcRun2_asymptotic_v13-v1/file-indexes/CMS_mc_RunIISummer20ULPrePremix_Neutrino_E-10_gun_PREMIX_UL16_106X_mcRun2_asymptotic_v13-v1_260014_file_index.json"
+      },
+      {
+        "checksum": "adler32:c0df7346",
+        "description": "Neutrino_E-10_gunPREMIX dataset file index (89 of 166) for access to data via CMS virtual machine",
+        "size": 38440,
+        "type": "index.json",
+        "uri": "root://eospublic.cern.ch//eos/opendata/cms/mc/RunIISummer20ULPrePremix/Neutrino_E-10_gun/PREMIX/UL16_106X_mcRun2_asymptotic_v13-v1/file-indexes/CMS_mc_RunIISummer20ULPrePremix_Neutrino_E-10_gun_PREMIX_UL16_106X_mcRun2_asymptotic_v13-v1_260015_file_index.json"
+      },
+      {
+        "checksum": "adler32:f8124307",
+        "description": "Neutrino_E-10_gunPREMIX dataset file index (90 of 166) for access to data via CMS virtual machine",
+        "size": 12923,
+        "type": "index.json",
+        "uri": "root://eospublic.cern.ch//eos/opendata/cms/mc/RunIISummer20ULPrePremix/Neutrino_E-10_gun/PREMIX/UL16_106X_mcRun2_asymptotic_v13-v1/file-indexes/CMS_mc_RunIISummer20ULPrePremix_Neutrino_E-10_gun_PREMIX_UL16_106X_mcRun2_asymptotic_v13-v1_260016_file_index.json"
+      },
+      {
+        "checksum": "adler32:dfbaf7f8",
+        "description": "Neutrino_E-10_gunPREMIX dataset file index (91 of 166) for access to data via CMS virtual machine",
+        "size": 36179,
+        "type": "index.json",
+        "uri": "root://eospublic.cern.ch//eos/opendata/cms/mc/RunIISummer20ULPrePremix/Neutrino_E-10_gun/PREMIX/UL16_106X_mcRun2_asymptotic_v13-v1/file-indexes/CMS_mc_RunIISummer20ULPrePremix_Neutrino_E-10_gun_PREMIX_UL16_106X_mcRun2_asymptotic_v13-v1_260017_file_index.json"
+      },
+      {
+        "checksum": "adler32:9b4d894a",
+        "description": "Neutrino_E-10_gunPREMIX dataset file index (92 of 166) for access to data via CMS virtual machine",
+        "size": 21321,
+        "type": "index.json",
+        "uri": "root://eospublic.cern.ch//eos/opendata/cms/mc/RunIISummer20ULPrePremix/Neutrino_E-10_gun/PREMIX/UL16_106X_mcRun2_asymptotic_v13-v1/file-indexes/CMS_mc_RunIISummer20ULPrePremix_Neutrino_E-10_gun_PREMIX_UL16_106X_mcRun2_asymptotic_v13-v1_260018_file_index.json"
+      },
+      {
+        "checksum": "adler32:c2e0e21c",
+        "description": "Neutrino_E-10_gunPREMIX dataset file index (93 of 166) for access to data via CMS virtual machine",
+        "size": 26166,
+        "type": "index.json",
+        "uri": "root://eospublic.cern.ch//eos/opendata/cms/mc/RunIISummer20ULPrePremix/Neutrino_E-10_gun/PREMIX/UL16_106X_mcRun2_asymptotic_v13-v1/file-indexes/CMS_mc_RunIISummer20ULPrePremix_Neutrino_E-10_gun_PREMIX_UL16_106X_mcRun2_asymptotic_v13-v1_260019_file_index.json"
+      },
+      {
+        "checksum": "adler32:7a872e31",
+        "description": "Neutrino_E-10_gunPREMIX dataset file index (94 of 166) for access to data via CMS virtual machine",
+        "size": 25520,
+        "type": "index.json",
+        "uri": "root://eospublic.cern.ch//eos/opendata/cms/mc/RunIISummer20ULPrePremix/Neutrino_E-10_gun/PREMIX/UL16_106X_mcRun2_asymptotic_v13-v1/file-indexes/CMS_mc_RunIISummer20ULPrePremix_Neutrino_E-10_gun_PREMIX_UL16_106X_mcRun2_asymptotic_v13-v1_260020_file_index.json"
+      },
+      {
+        "checksum": "adler32:85fc9970",
+        "description": "Neutrino_E-10_gunPREMIX dataset file index (95 of 166) for access to data via CMS virtual machine",
+        "size": 26812,
+        "type": "index.json",
+        "uri": "root://eospublic.cern.ch//eos/opendata/cms/mc/RunIISummer20ULPrePremix/Neutrino_E-10_gun/PREMIX/UL16_106X_mcRun2_asymptotic_v13-v1/file-indexes/CMS_mc_RunIISummer20ULPrePremix_Neutrino_E-10_gun_PREMIX_UL16_106X_mcRun2_asymptotic_v13-v1_260021_file_index.json"
+      },
+      {
+        "checksum": "adler32:04ae53f7",
+        "description": "Neutrino_E-10_gunPREMIX dataset file index (96 of 166) for access to data via CMS virtual machine",
+        "size": 22936,
+        "type": "index.json",
+        "uri": "root://eospublic.cern.ch//eos/opendata/cms/mc/RunIISummer20ULPrePremix/Neutrino_E-10_gun/PREMIX/UL16_106X_mcRun2_asymptotic_v13-v1/file-indexes/CMS_mc_RunIISummer20ULPrePremix_Neutrino_E-10_gun_PREMIX_UL16_106X_mcRun2_asymptotic_v13-v1_260022_file_index.json"
+      },
+      {
+        "checksum": "adler32:342903f7",
+        "description": "Neutrino_E-10_gunPREMIX dataset file index (97 of 166) for access to data via CMS virtual machine",
+        "size": 28104,
+        "type": "index.json",
+        "uri": "root://eospublic.cern.ch//eos/opendata/cms/mc/RunIISummer20ULPrePremix/Neutrino_E-10_gun/PREMIX/UL16_106X_mcRun2_asymptotic_v13-v1/file-indexes/CMS_mc_RunIISummer20ULPrePremix_Neutrino_E-10_gun_PREMIX_UL16_106X_mcRun2_asymptotic_v13-v1_260023_file_index.json"
+      },
+      {
+        "checksum": "adler32:182abecb",
+        "description": "Neutrino_E-10_gunPREMIX dataset file index (98 of 166) for access to data via CMS virtual machine",
+        "size": 28750,
+        "type": "index.json",
+        "uri": "root://eospublic.cern.ch//eos/opendata/cms/mc/RunIISummer20ULPrePremix/Neutrino_E-10_gun/PREMIX/UL16_106X_mcRun2_asymptotic_v13-v1/file-indexes/CMS_mc_RunIISummer20ULPrePremix_Neutrino_E-10_gun_PREMIX_UL16_106X_mcRun2_asymptotic_v13-v1_260024_file_index.json"
+      },
+      {
+        "checksum": "adler32:48accabe",
+        "description": "Neutrino_E-10_gunPREMIX dataset file index (99 of 166) for access to data via CMS virtual machine",
+        "size": 43285,
+        "type": "index.json",
+        "uri": "root://eospublic.cern.ch//eos/opendata/cms/mc/RunIISummer20ULPrePremix/Neutrino_E-10_gun/PREMIX/UL16_106X_mcRun2_asymptotic_v13-v1/file-indexes/CMS_mc_RunIISummer20ULPrePremix_Neutrino_E-10_gun_PREMIX_UL16_106X_mcRun2_asymptotic_v13-v1_260025_file_index.json"
+      },
+      {
+        "checksum": "adler32:2c082b9b",
+        "description": "Neutrino_E-10_gunPREMIX dataset file index (100 of 166) for access to data via CMS virtual machine",
+        "size": 39086,
+        "type": "index.json",
+        "uri": "root://eospublic.cern.ch//eos/opendata/cms/mc/RunIISummer20ULPrePremix/Neutrino_E-10_gun/PREMIX/UL16_106X_mcRun2_asymptotic_v13-v1/file-indexes/CMS_mc_RunIISummer20ULPrePremix_Neutrino_E-10_gun_PREMIX_UL16_106X_mcRun2_asymptotic_v13-v1_260026_file_index.json"
+      },
+      {
+        "checksum": "adler32:a408a299",
+        "description": "Neutrino_E-10_gunPREMIX dataset file index (101 of 166) for access to data via CMS virtual machine",
+        "size": 36825,
+        "type": "index.json",
+        "uri": "root://eospublic.cern.ch//eos/opendata/cms/mc/RunIISummer20ULPrePremix/Neutrino_E-10_gun/PREMIX/UL16_106X_mcRun2_asymptotic_v13-v1/file-indexes/CMS_mc_RunIISummer20ULPrePremix_Neutrino_E-10_gun_PREMIX_UL16_106X_mcRun2_asymptotic_v13-v1_260027_file_index.json"
+      },
+      {
+        "checksum": "adler32:c80f63a6",
+        "description": "Neutrino_E-10_gunPREMIX dataset file index (102 of 166) for access to data via CMS virtual machine",
+        "size": 28427,
+        "type": "index.json",
+        "uri": "root://eospublic.cern.ch//eos/opendata/cms/mc/RunIISummer20ULPrePremix/Neutrino_E-10_gun/PREMIX/UL16_106X_mcRun2_asymptotic_v13-v1/file-indexes/CMS_mc_RunIISummer20ULPrePremix_Neutrino_E-10_gun_PREMIX_UL16_106X_mcRun2_asymptotic_v13-v1_260028_file_index.json"
+      },
+      {
+        "checksum": "adler32:741a6488",
+        "description": "Neutrino_E-10_gunPREMIX dataset file index (103 of 166) for access to data via CMS virtual machine",
+        "size": 23905,
+        "type": "index.json",
+        "uri": "root://eospublic.cern.ch//eos/opendata/cms/mc/RunIISummer20ULPrePremix/Neutrino_E-10_gun/PREMIX/UL16_106X_mcRun2_asymptotic_v13-v1/file-indexes/CMS_mc_RunIISummer20ULPrePremix_Neutrino_E-10_gun_PREMIX_UL16_106X_mcRun2_asymptotic_v13-v1_260029_file_index.json"
+      },
+      {
+        "checksum": "adler32:e299b0da",
+        "description": "Neutrino_E-10_gunPREMIX dataset file index (104 of 166) for access to data via CMS virtual machine",
+        "size": 18737,
+        "type": "index.json",
+        "uri": "root://eospublic.cern.ch//eos/opendata/cms/mc/RunIISummer20ULPrePremix/Neutrino_E-10_gun/PREMIX/UL16_106X_mcRun2_asymptotic_v13-v1/file-indexes/CMS_mc_RunIISummer20ULPrePremix_Neutrino_E-10_gun_PREMIX_UL16_106X_mcRun2_asymptotic_v13-v1_260030_file_index.json"
+      },
+      {
+        "checksum": "adler32:ca3a0c98",
+        "description": "Neutrino_E-10_gunPREMIX dataset file index (105 of 166) for access to data via CMS virtual machine",
+        "size": 47161,
+        "type": "index.json",
+        "uri": "root://eospublic.cern.ch//eos/opendata/cms/mc/RunIISummer20ULPrePremix/Neutrino_E-10_gun/PREMIX/UL16_106X_mcRun2_asymptotic_v13-v1/file-indexes/CMS_mc_RunIISummer20ULPrePremix_Neutrino_E-10_gun_PREMIX_UL16_106X_mcRun2_asymptotic_v13-v1_270000_file_index.json"
+      },
+      {
+        "checksum": "adler32:29c38b09",
+        "description": "Neutrino_E-10_gunPREMIX dataset file index (106 of 166) for access to data via CMS virtual machine",
+        "size": 53944,
+        "type": "index.json",
+        "uri": "root://eospublic.cern.ch//eos/opendata/cms/mc/RunIISummer20ULPrePremix/Neutrino_E-10_gun/PREMIX/UL16_106X_mcRun2_asymptotic_v13-v1/file-indexes/CMS_mc_RunIISummer20ULPrePremix_Neutrino_E-10_gun_PREMIX_UL16_106X_mcRun2_asymptotic_v13-v1_270001_file_index.json"
+      },
+      {
+        "checksum": "adler32:0a2ba2fc",
+        "description": "Neutrino_E-10_gunPREMIX dataset file index (107 of 166) for access to data via CMS virtual machine",
+        "size": 54913,
+        "type": "index.json",
+        "uri": "root://eospublic.cern.ch//eos/opendata/cms/mc/RunIISummer20ULPrePremix/Neutrino_E-10_gun/PREMIX/UL16_106X_mcRun2_asymptotic_v13-v1/file-indexes/CMS_mc_RunIISummer20ULPrePremix_Neutrino_E-10_gun_PREMIX_UL16_106X_mcRun2_asymptotic_v13-v1_270002_file_index.json"
+      },
+      {
+        "checksum": "adler32:c8a19468",
+        "description": "Neutrino_E-10_gunPREMIX dataset file index (108 of 166) for access to data via CMS virtual machine",
+        "size": 68479,
+        "type": "index.json",
+        "uri": "root://eospublic.cern.ch//eos/opendata/cms/mc/RunIISummer20ULPrePremix/Neutrino_E-10_gun/PREMIX/UL16_106X_mcRun2_asymptotic_v13-v1/file-indexes/CMS_mc_RunIISummer20ULPrePremix_Neutrino_E-10_gun_PREMIX_UL16_106X_mcRun2_asymptotic_v13-v1_270003_file_index.json"
+      },
+      {
+        "checksum": "adler32:077a89a4",
+        "description": "Neutrino_E-10_gunPREMIX dataset file index (109 of 166) for access to data via CMS virtual machine",
+        "size": 73001,
+        "type": "index.json",
+        "uri": "root://eospublic.cern.ch//eos/opendata/cms/mc/RunIISummer20ULPrePremix/Neutrino_E-10_gun/PREMIX/UL16_106X_mcRun2_asymptotic_v13-v1/file-indexes/CMS_mc_RunIISummer20ULPrePremix_Neutrino_E-10_gun_PREMIX_UL16_106X_mcRun2_asymptotic_v13-v1_270004_file_index.json"
+      },
+      {
+        "checksum": "adler32:3f5057e5",
+        "description": "Neutrino_E-10_gunPREMIX dataset file index (110 of 166) for access to data via CMS virtual machine",
+        "size": 55559,
+        "type": "index.json",
+        "uri": "root://eospublic.cern.ch//eos/opendata/cms/mc/RunIISummer20ULPrePremix/Neutrino_E-10_gun/PREMIX/UL16_106X_mcRun2_asymptotic_v13-v1/file-indexes/CMS_mc_RunIISummer20ULPrePremix_Neutrino_E-10_gun_PREMIX_UL16_106X_mcRun2_asymptotic_v13-v1_270005_file_index.json"
+      },
+      {
+        "checksum": "adler32:7e507b2e",
+        "description": "Neutrino_E-10_gunPREMIX dataset file index (111 of 166) for access to data via CMS virtual machine",
+        "size": 52975,
+        "type": "index.json",
+        "uri": "root://eospublic.cern.ch//eos/opendata/cms/mc/RunIISummer20ULPrePremix/Neutrino_E-10_gun/PREMIX/UL16_106X_mcRun2_asymptotic_v13-v1/file-indexes/CMS_mc_RunIISummer20ULPrePremix_Neutrino_E-10_gun_PREMIX_UL16_106X_mcRun2_asymptotic_v13-v1_270006_file_index.json"
+      },
+      {
+        "checksum": "adler32:34d9f440",
+        "description": "Neutrino_E-10_gunPREMIX dataset file index (112 of 166) for access to data via CMS virtual machine",
+        "size": 31657,
+        "type": "index.json",
+        "uri": "root://eospublic.cern.ch//eos/opendata/cms/mc/RunIISummer20ULPrePremix/Neutrino_E-10_gun/PREMIX/UL16_106X_mcRun2_asymptotic_v13-v1/file-indexes/CMS_mc_RunIISummer20ULPrePremix_Neutrino_E-10_gun_PREMIX_UL16_106X_mcRun2_asymptotic_v13-v1_270007_file_index.json"
+      },
+      {
+        "checksum": "adler32:921df144",
+        "description": "Neutrino_E-10_gunPREMIX dataset file index (113 of 166) for access to data via CMS virtual machine",
+        "size": 36179,
+        "type": "index.json",
+        "uri": "root://eospublic.cern.ch//eos/opendata/cms/mc/RunIISummer20ULPrePremix/Neutrino_E-10_gun/PREMIX/UL16_106X_mcRun2_asymptotic_v13-v1/file-indexes/CMS_mc_RunIISummer20ULPrePremix_Neutrino_E-10_gun_PREMIX_UL16_106X_mcRun2_asymptotic_v13-v1_270008_file_index.json"
+      },
+      {
+        "checksum": "adler32:8bcfd2bc",
+        "description": "Neutrino_E-10_gunPREMIX dataset file index (114 of 166) for access to data via CMS virtual machine",
+        "size": 29719,
+        "type": "index.json",
+        "uri": "root://eospublic.cern.ch//eos/opendata/cms/mc/RunIISummer20ULPrePremix/Neutrino_E-10_gun/PREMIX/UL16_106X_mcRun2_asymptotic_v13-v1/file-indexes/CMS_mc_RunIISummer20ULPrePremix_Neutrino_E-10_gun_PREMIX_UL16_106X_mcRun2_asymptotic_v13-v1_270009_file_index.json"
+      },
+      {
+        "checksum": "adler32:6a5df267",
+        "description": "Neutrino_E-10_gunPREMIX dataset file index (115 of 166) for access to data via CMS virtual machine",
+        "size": 27135,
+        "type": "index.json",
+        "uri": "root://eospublic.cern.ch//eos/opendata/cms/mc/RunIISummer20ULPrePremix/Neutrino_E-10_gun/PREMIX/UL16_106X_mcRun2_asymptotic_v13-v1/file-indexes/CMS_mc_RunIISummer20ULPrePremix_Neutrino_E-10_gun_PREMIX_UL16_106X_mcRun2_asymptotic_v13-v1_270010_file_index.json"
+      },
+      {
+        "checksum": "adler32:f56bf564",
+        "description": "Neutrino_E-10_gunPREMIX dataset file index (116 of 166) for access to data via CMS virtual machine",
+        "size": 46192,
+        "type": "index.json",
+        "uri": "root://eospublic.cern.ch//eos/opendata/cms/mc/RunIISummer20ULPrePremix/Neutrino_E-10_gun/PREMIX/UL16_106X_mcRun2_asymptotic_v13-v1/file-indexes/CMS_mc_RunIISummer20ULPrePremix_Neutrino_E-10_gun_PREMIX_UL16_106X_mcRun2_asymptotic_v13-v1_270011_file_index.json"
+      },
+      {
+        "checksum": "adler32:b84dfd0b",
+        "description": "Neutrino_E-10_gunPREMIX dataset file index (117 of 166) for access to data via CMS virtual machine",
+        "size": 46192,
+        "type": "index.json",
+        "uri": "root://eospublic.cern.ch//eos/opendata/cms/mc/RunIISummer20ULPrePremix/Neutrino_E-10_gun/PREMIX/UL16_106X_mcRun2_asymptotic_v13-v1/file-indexes/CMS_mc_RunIISummer20ULPrePremix_Neutrino_E-10_gun_PREMIX_UL16_106X_mcRun2_asymptotic_v13-v1_270012_file_index.json"
+      },
+      {
+        "checksum": "adler32:65fca925",
+        "description": "Neutrino_E-10_gunPREMIX dataset file index (118 of 166) for access to data via CMS virtual machine",
+        "size": 32303,
+        "type": "index.json",
+        "uri": "root://eospublic.cern.ch//eos/opendata/cms/mc/RunIISummer20ULPrePremix/Neutrino_E-10_gun/PREMIX/UL16_106X_mcRun2_asymptotic_v13-v1/file-indexes/CMS_mc_RunIISummer20ULPrePremix_Neutrino_E-10_gun_PREMIX_UL16_106X_mcRun2_asymptotic_v13-v1_270013_file_index.json"
+      },
+      {
+        "checksum": "adler32:680976ae",
+        "description": "Neutrino_E-10_gunPREMIX dataset file index (119 of 166) for access to data via CMS virtual machine",
+        "size": 33918,
+        "type": "index.json",
+        "uri": "root://eospublic.cern.ch//eos/opendata/cms/mc/RunIISummer20ULPrePremix/Neutrino_E-10_gun/PREMIX/UL16_106X_mcRun2_asymptotic_v13-v1/file-indexes/CMS_mc_RunIISummer20ULPrePremix_Neutrino_E-10_gun_PREMIX_UL16_106X_mcRun2_asymptotic_v13-v1_270014_file_index.json"
+      },
+      {
+        "checksum": "adler32:012a6235",
+        "description": "Neutrino_E-10_gunPREMIX dataset file index (120 of 166) for access to data via CMS virtual machine",
+        "size": 32949,
+        "type": "index.json",
+        "uri": "root://eospublic.cern.ch//eos/opendata/cms/mc/RunIISummer20ULPrePremix/Neutrino_E-10_gun/PREMIX/UL16_106X_mcRun2_asymptotic_v13-v1/file-indexes/CMS_mc_RunIISummer20ULPrePremix_Neutrino_E-10_gun_PREMIX_UL16_106X_mcRun2_asymptotic_v13-v1_270015_file_index.json"
+      },
+      {
+        "checksum": "adler32:0716d271",
+        "description": "Neutrino_E-10_gunPREMIX dataset file index (121 of 166) for access to data via CMS virtual machine",
+        "size": 29719,
+        "type": "index.json",
+        "uri": "root://eospublic.cern.ch//eos/opendata/cms/mc/RunIISummer20ULPrePremix/Neutrino_E-10_gun/PREMIX/UL16_106X_mcRun2_asymptotic_v13-v1/file-indexes/CMS_mc_RunIISummer20ULPrePremix_Neutrino_E-10_gun_PREMIX_UL16_106X_mcRun2_asymptotic_v13-v1_270016_file_index.json"
+      },
+      {
+        "checksum": "adler32:38eb590b",
+        "description": "Neutrino_E-10_gunPREMIX dataset file index (122 of 166) for access to data via CMS virtual machine",
+        "size": 22936,
+        "type": "index.json",
+        "uri": "root://eospublic.cern.ch//eos/opendata/cms/mc/RunIISummer20ULPrePremix/Neutrino_E-10_gun/PREMIX/UL16_106X_mcRun2_asymptotic_v13-v1/file-indexes/CMS_mc_RunIISummer20ULPrePremix_Neutrino_E-10_gun_PREMIX_UL16_106X_mcRun2_asymptotic_v13-v1_270017_file_index.json"
+      },
+      {
+        "checksum": "adler32:7cd3927a",
+        "description": "Neutrino_E-10_gunPREMIX dataset file index (123 of 166) for access to data via CMS virtual machine",
+        "size": 16799,
+        "type": "index.json",
+        "uri": "root://eospublic.cern.ch//eos/opendata/cms/mc/RunIISummer20ULPrePremix/Neutrino_E-10_gun/PREMIX/UL16_106X_mcRun2_asymptotic_v13-v1/file-indexes/CMS_mc_RunIISummer20ULPrePremix_Neutrino_E-10_gun_PREMIX_UL16_106X_mcRun2_asymptotic_v13-v1_270018_file_index.json"
+      },
+      {
+        "checksum": "adler32:aeb81f67",
+        "description": "Neutrino_E-10_gunPREMIX dataset file index (124 of 166) for access to data via CMS virtual machine",
+        "size": 20029,
+        "type": "index.json",
+        "uri": "root://eospublic.cern.ch//eos/opendata/cms/mc/RunIISummer20ULPrePremix/Neutrino_E-10_gun/PREMIX/UL16_106X_mcRun2_asymptotic_v13-v1/file-indexes/CMS_mc_RunIISummer20ULPrePremix_Neutrino_E-10_gun_PREMIX_UL16_106X_mcRun2_asymptotic_v13-v1_270019_file_index.json"
+      },
+      {
+        "checksum": "adler32:1fa1f4ab",
+        "description": "Neutrino_E-10_gunPREMIX dataset file index (125 of 166) for access to data via CMS virtual machine",
+        "size": 18091,
+        "type": "index.json",
+        "uri": "root://eospublic.cern.ch//eos/opendata/cms/mc/RunIISummer20ULPrePremix/Neutrino_E-10_gun/PREMIX/UL16_106X_mcRun2_asymptotic_v13-v1/file-indexes/CMS_mc_RunIISummer20ULPrePremix_Neutrino_E-10_gun_PREMIX_UL16_106X_mcRun2_asymptotic_v13-v1_270020_file_index.json"
+      },
+      {
+        "checksum": "adler32:dc661cca",
+        "description": "Neutrino_E-10_gunPREMIX dataset file index (126 of 166) for access to data via CMS virtual machine",
+        "size": 20029,
+        "type": "index.json",
+        "uri": "root://eospublic.cern.ch//eos/opendata/cms/mc/RunIISummer20ULPrePremix/Neutrino_E-10_gun/PREMIX/UL16_106X_mcRun2_asymptotic_v13-v1/file-indexes/CMS_mc_RunIISummer20ULPrePremix_Neutrino_E-10_gun_PREMIX_UL16_106X_mcRun2_asymptotic_v13-v1_270021_file_index.json"
+      },
+      {
+        "checksum": "adler32:f8b9ab5e",
+        "description": "Neutrino_E-10_gunPREMIX dataset file index (127 of 166) for access to data via CMS virtual machine",
+        "size": 14215,
+        "type": "index.json",
+        "uri": "root://eospublic.cern.ch//eos/opendata/cms/mc/RunIISummer20ULPrePremix/Neutrino_E-10_gun/PREMIX/UL16_106X_mcRun2_asymptotic_v13-v1/file-indexes/CMS_mc_RunIISummer20ULPrePremix_Neutrino_E-10_gun_PREMIX_UL16_106X_mcRun2_asymptotic_v13-v1_270022_file_index.json"
+      },
+      {
+        "checksum": "adler32:80c15c77",
+        "description": "Neutrino_E-10_gunPREMIX dataset file index (128 of 166) for access to data via CMS virtual machine",
+        "size": 28427,
+        "type": "index.json",
+        "uri": "root://eospublic.cern.ch//eos/opendata/cms/mc/RunIISummer20ULPrePremix/Neutrino_E-10_gun/PREMIX/UL16_106X_mcRun2_asymptotic_v13-v1/file-indexes/CMS_mc_RunIISummer20ULPrePremix_Neutrino_E-10_gun_PREMIX_UL16_106X_mcRun2_asymptotic_v13-v1_270023_file_index.json"
+      },
+      {
+        "checksum": "adler32:c71c3e2d",
+        "description": "Neutrino_E-10_gunPREMIX dataset file index (129 of 166) for access to data via CMS virtual machine",
+        "size": 26489,
+        "type": "index.json",
+        "uri": "root://eospublic.cern.ch//eos/opendata/cms/mc/RunIISummer20ULPrePremix/Neutrino_E-10_gun/PREMIX/UL16_106X_mcRun2_asymptotic_v13-v1/file-indexes/CMS_mc_RunIISummer20ULPrePremix_Neutrino_E-10_gun_PREMIX_UL16_106X_mcRun2_asymptotic_v13-v1_270024_file_index.json"
+      },
+      {
+        "checksum": "adler32:ee8a7b62",
+        "description": "Neutrino_E-10_gunPREMIX dataset file index (130 of 166) for access to data via CMS virtual machine",
+        "size": 15830,
+        "type": "index.json",
+        "uri": "root://eospublic.cern.ch//eos/opendata/cms/mc/RunIISummer20ULPrePremix/Neutrino_E-10_gun/PREMIX/UL16_106X_mcRun2_asymptotic_v13-v1/file-indexes/CMS_mc_RunIISummer20ULPrePremix_Neutrino_E-10_gun_PREMIX_UL16_106X_mcRun2_asymptotic_v13-v1_270025_file_index.json"
+      },
+      {
+        "checksum": "adler32:0bee508f",
+        "description": "Neutrino_E-10_gunPREMIX dataset file index (131 of 166) for access to data via CMS virtual machine",
+        "size": 31980,
+        "type": "index.json",
+        "uri": "root://eospublic.cern.ch//eos/opendata/cms/mc/RunIISummer20ULPrePremix/Neutrino_E-10_gun/PREMIX/UL16_106X_mcRun2_asymptotic_v13-v1/file-indexes/CMS_mc_RunIISummer20ULPrePremix_Neutrino_E-10_gun_PREMIX_UL16_106X_mcRun2_asymptotic_v13-v1_270026_file_index.json"
+      },
+      {
+        "checksum": "adler32:272a4074",
+        "description": "Neutrino_E-10_gunPREMIX dataset file index (132 of 166) for access to data via CMS virtual machine",
+        "size": 35533,
+        "type": "index.json",
+        "uri": "root://eospublic.cern.ch//eos/opendata/cms/mc/RunIISummer20ULPrePremix/Neutrino_E-10_gun/PREMIX/UL16_106X_mcRun2_asymptotic_v13-v1/file-indexes/CMS_mc_RunIISummer20ULPrePremix_Neutrino_E-10_gun_PREMIX_UL16_106X_mcRun2_asymptotic_v13-v1_270027_file_index.json"
+      },
+      {
+        "checksum": "adler32:9f8c86d3",
+        "description": "Neutrino_E-10_gunPREMIX dataset file index (133 of 166) for access to data via CMS virtual machine",
+        "size": 39409,
+        "type": "index.json",
+        "uri": "root://eospublic.cern.ch//eos/opendata/cms/mc/RunIISummer20ULPrePremix/Neutrino_E-10_gun/PREMIX/UL16_106X_mcRun2_asymptotic_v13-v1/file-indexes/CMS_mc_RunIISummer20ULPrePremix_Neutrino_E-10_gun_PREMIX_UL16_106X_mcRun2_asymptotic_v13-v1_270028_file_index.json"
+      },
+      {
+        "checksum": "adler32:421d1c1c",
+        "description": "Neutrino_E-10_gunPREMIX dataset file index (134 of 166) for access to data via CMS virtual machine",
+        "size": 20029,
+        "type": "index.json",
+        "uri": "root://eospublic.cern.ch//eos/opendata/cms/mc/RunIISummer20ULPrePremix/Neutrino_E-10_gun/PREMIX/UL16_106X_mcRun2_asymptotic_v13-v1/file-indexes/CMS_mc_RunIISummer20ULPrePremix_Neutrino_E-10_gun_PREMIX_UL16_106X_mcRun2_asymptotic_v13-v1_270029_file_index.json"
+      },
+      {
+        "checksum": "adler32:c7767f8c",
+        "description": "Neutrino_E-10_gunPREMIX dataset file index (135 of 166) for access to data via CMS virtual machine",
+        "size": 25843,
+        "type": "index.json",
+        "uri": "root://eospublic.cern.ch//eos/opendata/cms/mc/RunIISummer20ULPrePremix/Neutrino_E-10_gun/PREMIX/UL16_106X_mcRun2_asymptotic_v13-v1/file-indexes/CMS_mc_RunIISummer20ULPrePremix_Neutrino_E-10_gun_PREMIX_UL16_106X_mcRun2_asymptotic_v13-v1_270030_file_index.json"
+      },
+      {
+        "checksum": "adler32:c8ef7224",
+        "description": "Neutrino_E-10_gunPREMIX dataset file index (136 of 166) for access to data via CMS virtual machine",
+        "size": 29396,
+        "type": "index.json",
+        "uri": "root://eospublic.cern.ch//eos/opendata/cms/mc/RunIISummer20ULPrePremix/Neutrino_E-10_gun/PREMIX/UL16_106X_mcRun2_asymptotic_v13-v1/file-indexes/CMS_mc_RunIISummer20ULPrePremix_Neutrino_E-10_gun_PREMIX_UL16_106X_mcRun2_asymptotic_v13-v1_280000_file_index.json"
+      },
+      {
+        "checksum": "adler32:6da8b5b4",
+        "description": "Neutrino_E-10_gunPREMIX dataset file index (137 of 166) for access to data via CMS virtual machine",
+        "size": 46838,
+        "type": "index.json",
+        "uri": "root://eospublic.cern.ch//eos/opendata/cms/mc/RunIISummer20ULPrePremix/Neutrino_E-10_gun/PREMIX/UL16_106X_mcRun2_asymptotic_v13-v1/file-indexes/CMS_mc_RunIISummer20ULPrePremix_Neutrino_E-10_gun_PREMIX_UL16_106X_mcRun2_asymptotic_v13-v1_280001_file_index.json"
+      },
+      {
+        "checksum": "adler32:afc7c1ba",
+        "description": "Neutrino_E-10_gunPREMIX dataset file index (138 of 166) for access to data via CMS virtual machine",
+        "size": 24228,
+        "type": "index.json",
+        "uri": "root://eospublic.cern.ch//eos/opendata/cms/mc/RunIISummer20ULPrePremix/Neutrino_E-10_gun/PREMIX/UL16_106X_mcRun2_asymptotic_v13-v1/file-indexes/CMS_mc_RunIISummer20ULPrePremix_Neutrino_E-10_gun_PREMIX_UL16_106X_mcRun2_asymptotic_v13-v1_280002_file_index.json"
+      },
+      {
+        "checksum": "adler32:7e8c3c8a",
+        "description": "Neutrino_E-10_gunPREMIX dataset file index (139 of 166) for access to data via CMS virtual machine",
+        "size": 62665,
+        "type": "index.json",
+        "uri": "root://eospublic.cern.ch//eos/opendata/cms/mc/RunIISummer20ULPrePremix/Neutrino_E-10_gun/PREMIX/UL16_106X_mcRun2_asymptotic_v13-v1/file-indexes/CMS_mc_RunIISummer20ULPrePremix_Neutrino_E-10_gun_PREMIX_UL16_106X_mcRun2_asymptotic_v13-v1_280003_file_index.json"
+      },
+      {
+        "checksum": "adler32:44485629",
+        "description": "Neutrino_E-10_gunPREMIX dataset file index (140 of 166) for access to data via CMS virtual machine",
+        "size": 60081,
+        "type": "index.json",
+        "uri": "root://eospublic.cern.ch//eos/opendata/cms/mc/RunIISummer20ULPrePremix/Neutrino_E-10_gun/PREMIX/UL16_106X_mcRun2_asymptotic_v13-v1/file-indexes/CMS_mc_RunIISummer20ULPrePremix_Neutrino_E-10_gun_PREMIX_UL16_106X_mcRun2_asymptotic_v13-v1_280004_file_index.json"
+      },
+      {
+        "checksum": "adler32:714ff10a",
+        "description": "Neutrino_E-10_gunPREMIX dataset file index (141 of 166) for access to data via CMS virtual machine",
+        "size": 86890,
+        "type": "index.json",
+        "uri": "root://eospublic.cern.ch//eos/opendata/cms/mc/RunIISummer20ULPrePremix/Neutrino_E-10_gun/PREMIX/UL16_106X_mcRun2_asymptotic_v13-v1/file-indexes/CMS_mc_RunIISummer20ULPrePremix_Neutrino_E-10_gun_PREMIX_UL16_106X_mcRun2_asymptotic_v13-v1_280005_file_index.json"
+      },
+      {
+        "checksum": "adler32:c0e01bad",
+        "description": "Neutrino_E-10_gunPREMIX dataset file index (142 of 166) for access to data via CMS virtual machine",
+        "size": 103363,
+        "type": "index.json",
+        "uri": "root://eospublic.cern.ch//eos/opendata/cms/mc/RunIISummer20ULPrePremix/Neutrino_E-10_gun/PREMIX/UL16_106X_mcRun2_asymptotic_v13-v1/file-indexes/CMS_mc_RunIISummer20ULPrePremix_Neutrino_E-10_gun_PREMIX_UL16_106X_mcRun2_asymptotic_v13-v1_280006_file_index.json"
+      },
+      {
+        "checksum": "adler32:4d25c7ff",
+        "description": "Neutrino_E-10_gunPREMIX dataset file index (143 of 166) for access to data via CMS virtual machine",
+        "size": 61373,
+        "type": "index.json",
+        "uri": "root://eospublic.cern.ch//eos/opendata/cms/mc/RunIISummer20ULPrePremix/Neutrino_E-10_gun/PREMIX/UL16_106X_mcRun2_asymptotic_v13-v1/file-indexes/CMS_mc_RunIISummer20ULPrePremix_Neutrino_E-10_gun_PREMIX_UL16_106X_mcRun2_asymptotic_v13-v1_280007_file_index.json"
+      },
+      {
+        "checksum": "adler32:fc5c0ec3",
+        "description": "Neutrino_E-10_gunPREMIX dataset file index (144 of 166) for access to data via CMS virtual machine",
+        "size": 42639,
+        "type": "index.json",
+        "uri": "root://eospublic.cern.ch//eos/opendata/cms/mc/RunIISummer20ULPrePremix/Neutrino_E-10_gun/PREMIX/UL16_106X_mcRun2_asymptotic_v13-v1/file-indexes/CMS_mc_RunIISummer20ULPrePremix_Neutrino_E-10_gun_PREMIX_UL16_106X_mcRun2_asymptotic_v13-v1_280008_file_index.json"
+      },
+      {
+        "checksum": "adler32:5f19cba2",
+        "description": "Neutrino_E-10_gunPREMIX dataset file index (145 of 166) for access to data via CMS virtual machine",
+        "size": 43285,
+        "type": "index.json",
+        "uri": "root://eospublic.cern.ch//eos/opendata/cms/mc/RunIISummer20ULPrePremix/Neutrino_E-10_gun/PREMIX/UL16_106X_mcRun2_asymptotic_v13-v1/file-indexes/CMS_mc_RunIISummer20ULPrePremix_Neutrino_E-10_gun_PREMIX_UL16_106X_mcRun2_asymptotic_v13-v1_280009_file_index.json"
+      },
+      {
+        "checksum": "adler32:5cfdb2d3",
+        "description": "Neutrino_E-10_gunPREMIX dataset file index (146 of 166) for access to data via CMS virtual machine",
+        "size": 69448,
+        "type": "index.json",
+        "uri": "root://eospublic.cern.ch//eos/opendata/cms/mc/RunIISummer20ULPrePremix/Neutrino_E-10_gun/PREMIX/UL16_106X_mcRun2_asymptotic_v13-v1/file-indexes/CMS_mc_RunIISummer20ULPrePremix_Neutrino_E-10_gun_PREMIX_UL16_106X_mcRun2_asymptotic_v13-v1_280010_file_index.json"
+      },
+      {
+        "checksum": "adler32:b4aabeda",
+        "description": "Neutrino_E-10_gunPREMIX dataset file index (147 of 166) for access to data via CMS virtual machine",
+        "size": 79461,
+        "type": "index.json",
+        "uri": "root://eospublic.cern.ch//eos/opendata/cms/mc/RunIISummer20ULPrePremix/Neutrino_E-10_gun/PREMIX/UL16_106X_mcRun2_asymptotic_v13-v1/file-indexes/CMS_mc_RunIISummer20ULPrePremix_Neutrino_E-10_gun_PREMIX_UL16_106X_mcRun2_asymptotic_v13-v1_280011_file_index.json"
+      },
+      {
+        "checksum": "adler32:47ebe822",
+        "description": "Neutrino_E-10_gunPREMIX dataset file index (148 of 166) for access to data via CMS virtual machine",
+        "size": 114022,
+        "type": "index.json",
+        "uri": "root://eospublic.cern.ch//eos/opendata/cms/mc/RunIISummer20ULPrePremix/Neutrino_E-10_gun/PREMIX/UL16_106X_mcRun2_asymptotic_v13-v1/file-indexes/CMS_mc_RunIISummer20ULPrePremix_Neutrino_E-10_gun_PREMIX_UL16_106X_mcRun2_asymptotic_v13-v1_280012_file_index.json"
+      },
+      {
+        "checksum": "adler32:d00a0240",
+        "description": "Neutrino_E-10_gunPREMIX dataset file index (149 of 166) for access to data via CMS virtual machine",
+        "size": 87859,
+        "type": "index.json",
+        "uri": "root://eospublic.cern.ch//eos/opendata/cms/mc/RunIISummer20ULPrePremix/Neutrino_E-10_gun/PREMIX/UL16_106X_mcRun2_asymptotic_v13-v1/file-indexes/CMS_mc_RunIISummer20ULPrePremix_Neutrino_E-10_gun_PREMIX_UL16_106X_mcRun2_asymptotic_v13-v1_280013_file_index.json"
+      },
+      {
+        "checksum": "adler32:89528dda",
+        "description": "Neutrino_E-10_gunPREMIX dataset file index (150 of 166) for access to data via CMS virtual machine",
+        "size": 44900,
+        "type": "index.json",
+        "uri": "root://eospublic.cern.ch//eos/opendata/cms/mc/RunIISummer20ULPrePremix/Neutrino_E-10_gun/PREMIX/UL16_106X_mcRun2_asymptotic_v13-v1/file-indexes/CMS_mc_RunIISummer20ULPrePremix_Neutrino_E-10_gun_PREMIX_UL16_106X_mcRun2_asymptotic_v13-v1_280014_file_index.json"
+      },
+      {
+        "checksum": "adler32:f96b9610",
+        "description": "Neutrino_E-10_gunPREMIX dataset file index (151 of 166) for access to data via CMS virtual machine",
+        "size": 40378,
+        "type": "index.json",
+        "uri": "root://eospublic.cern.ch//eos/opendata/cms/mc/RunIISummer20ULPrePremix/Neutrino_E-10_gun/PREMIX/UL16_106X_mcRun2_asymptotic_v13-v1/file-indexes/CMS_mc_RunIISummer20ULPrePremix_Neutrino_E-10_gun_PREMIX_UL16_106X_mcRun2_asymptotic_v13-v1_280015_file_index.json"
+      },
+      {
+        "checksum": "adler32:f499d0b9",
+        "description": "Neutrino_E-10_gunPREMIX dataset file index (152 of 166) for access to data via CMS virtual machine",
+        "size": 25197,
+        "type": "index.json",
+        "uri": "root://eospublic.cern.ch//eos/opendata/cms/mc/RunIISummer20ULPrePremix/Neutrino_E-10_gun/PREMIX/UL16_106X_mcRun2_asymptotic_v13-v1/file-indexes/CMS_mc_RunIISummer20ULPrePremix_Neutrino_E-10_gun_PREMIX_UL16_106X_mcRun2_asymptotic_v13-v1_280016_file_index.json"
+      },
+      {
+        "checksum": "adler32:907db55b",
+        "description": "Neutrino_E-10_gunPREMIX dataset file index (153 of 166) for access to data via CMS virtual machine",
+        "size": 55882,
+        "type": "index.json",
+        "uri": "root://eospublic.cern.ch//eos/opendata/cms/mc/RunIISummer20ULPrePremix/Neutrino_E-10_gun/PREMIX/UL16_106X_mcRun2_asymptotic_v13-v1/file-indexes/CMS_mc_RunIISummer20ULPrePremix_Neutrino_E-10_gun_PREMIX_UL16_106X_mcRun2_asymptotic_v13-v1_280017_file_index.json"
+      },
+      {
+        "checksum": "adler32:0265acc9",
+        "description": "Neutrino_E-10_gunPREMIX dataset file index (154 of 166) for access to data via CMS virtual machine",
+        "size": 51360,
+        "type": "index.json",
+        "uri": "root://eospublic.cern.ch//eos/opendata/cms/mc/RunIISummer20ULPrePremix/Neutrino_E-10_gun/PREMIX/UL16_106X_mcRun2_asymptotic_v13-v1/file-indexes/CMS_mc_RunIISummer20ULPrePremix_Neutrino_E-10_gun_PREMIX_UL16_106X_mcRun2_asymptotic_v13-v1_280018_file_index.json"
+      },
+      {
+        "checksum": "adler32:9a57a9b5",
+        "description": "Neutrino_E-10_gunPREMIX dataset file index (155 of 166) for access to data via CMS virtual machine",
+        "size": 54913,
+        "type": "index.json",
+        "uri": "root://eospublic.cern.ch//eos/opendata/cms/mc/RunIISummer20ULPrePremix/Neutrino_E-10_gun/PREMIX/UL16_106X_mcRun2_asymptotic_v13-v1/file-indexes/CMS_mc_RunIISummer20ULPrePremix_Neutrino_E-10_gun_PREMIX_UL16_106X_mcRun2_asymptotic_v13-v1_280019_file_index.json"
+      },
+      {
+        "checksum": "adler32:0fd872dd",
+        "description": "Neutrino_E-10_gunPREMIX dataset file index (156 of 166) for access to data via CMS virtual machine",
+        "size": 80107,
+        "type": "index.json",
+        "uri": "root://eospublic.cern.ch//eos/opendata/cms/mc/RunIISummer20ULPrePremix/Neutrino_E-10_gun/PREMIX/UL16_106X_mcRun2_asymptotic_v13-v1/file-indexes/CMS_mc_RunIISummer20ULPrePremix_Neutrino_E-10_gun_PREMIX_UL16_106X_mcRun2_asymptotic_v13-v1_280020_file_index.json"
+      },
+      {
+        "checksum": "adler32:3a82eafa",
+        "description": "Neutrino_E-10_gunPREMIX dataset file index (157 of 166) for access to data via CMS virtual machine",
+        "size": 54267,
+        "type": "index.json",
+        "uri": "root://eospublic.cern.ch//eos/opendata/cms/mc/RunIISummer20ULPrePremix/Neutrino_E-10_gun/PREMIX/UL16_106X_mcRun2_asymptotic_v13-v1/file-indexes/CMS_mc_RunIISummer20ULPrePremix_Neutrino_E-10_gun_PREMIX_UL16_106X_mcRun2_asymptotic_v13-v1_280021_file_index.json"
+      },
+      {
+        "checksum": "adler32:7da3a271",
+        "description": "Neutrino_E-10_gunPREMIX dataset file index (158 of 166) for access to data via CMS virtual machine",
+        "size": 69448,
+        "type": "index.json",
+        "uri": "root://eospublic.cern.ch//eos/opendata/cms/mc/RunIISummer20ULPrePremix/Neutrino_E-10_gun/PREMIX/UL16_106X_mcRun2_asymptotic_v13-v1/file-indexes/CMS_mc_RunIISummer20ULPrePremix_Neutrino_E-10_gun_PREMIX_UL16_106X_mcRun2_asymptotic_v13-v1_280022_file_index.json"
+      },
+      {
+        "checksum": "adler32:2955843c",
+        "description": "Neutrino_E-10_gunPREMIX dataset file index (159 of 166) for access to data via CMS virtual machine",
+        "size": 76554,
+        "type": "index.json",
+        "uri": "root://eospublic.cern.ch//eos/opendata/cms/mc/RunIISummer20ULPrePremix/Neutrino_E-10_gun/PREMIX/UL16_106X_mcRun2_asymptotic_v13-v1/file-indexes/CMS_mc_RunIISummer20ULPrePremix_Neutrino_E-10_gun_PREMIX_UL16_106X_mcRun2_asymptotic_v13-v1_280023_file_index.json"
+      },
+      {
+        "checksum": "adler32:2ae3f546",
+        "description": "Neutrino_E-10_gunPREMIX dataset file index (160 of 166) for access to data via CMS virtual machine",
+        "size": 64280,
+        "type": "index.json",
+        "uri": "root://eospublic.cern.ch//eos/opendata/cms/mc/RunIISummer20ULPrePremix/Neutrino_E-10_gun/PREMIX/UL16_106X_mcRun2_asymptotic_v13-v1/file-indexes/CMS_mc_RunIISummer20ULPrePremix_Neutrino_E-10_gun_PREMIX_UL16_106X_mcRun2_asymptotic_v13-v1_280024_file_index.json"
+      },
+      {
+        "checksum": "adler32:e5f56996",
+        "description": "Neutrino_E-10_gunPREMIX dataset file index (161 of 166) for access to data via CMS virtual machine",
+        "size": 56528,
+        "type": "index.json",
+        "uri": "root://eospublic.cern.ch//eos/opendata/cms/mc/RunIISummer20ULPrePremix/Neutrino_E-10_gun/PREMIX/UL16_106X_mcRun2_asymptotic_v13-v1/file-indexes/CMS_mc_RunIISummer20ULPrePremix_Neutrino_E-10_gun_PREMIX_UL16_106X_mcRun2_asymptotic_v13-v1_280025_file_index.json"
+      },
+      {
+        "checksum": "adler32:0237779f",
+        "description": "Neutrino_E-10_gunPREMIX dataset file index (162 of 166) for access to data via CMS virtual machine",
+        "size": 72032,
+        "type": "index.json",
+        "uri": "root://eospublic.cern.ch//eos/opendata/cms/mc/RunIISummer20ULPrePremix/Neutrino_E-10_gun/PREMIX/UL16_106X_mcRun2_asymptotic_v13-v1/file-indexes/CMS_mc_RunIISummer20ULPrePremix_Neutrino_E-10_gun_PREMIX_UL16_106X_mcRun2_asymptotic_v13-v1_280026_file_index.json"
+      },
+      {
+        "checksum": "adler32:18fb3e26",
+        "description": "Neutrino_E-10_gunPREMIX dataset file index (163 of 166) for access to data via CMS virtual machine",
+        "size": 68156,
+        "type": "index.json",
+        "uri": "root://eospublic.cern.ch//eos/opendata/cms/mc/RunIISummer20ULPrePremix/Neutrino_E-10_gun/PREMIX/UL16_106X_mcRun2_asymptotic_v13-v1/file-indexes/CMS_mc_RunIISummer20ULPrePremix_Neutrino_E-10_gun_PREMIX_UL16_106X_mcRun2_asymptotic_v13-v1_280027_file_index.json"
+      },
+      {
+        "checksum": "adler32:37d568a2",
+        "description": "Neutrino_E-10_gunPREMIX dataset file index (164 of 166) for access to data via CMS virtual machine",
+        "size": 65572,
+        "type": "index.json",
+        "uri": "root://eospublic.cern.ch//eos/opendata/cms/mc/RunIISummer20ULPrePremix/Neutrino_E-10_gun/PREMIX/UL16_106X_mcRun2_asymptotic_v13-v1/file-indexes/CMS_mc_RunIISummer20ULPrePremix_Neutrino_E-10_gun_PREMIX_UL16_106X_mcRun2_asymptotic_v13-v1_280028_file_index.json"
+      },
+      {
+        "checksum": "adler32:90650d08",
+        "description": "Neutrino_E-10_gunPREMIX dataset file index (165 of 166) for access to data via CMS virtual machine",
+        "size": 65249,
+        "type": "index.json",
+        "uri": "root://eospublic.cern.ch//eos/opendata/cms/mc/RunIISummer20ULPrePremix/Neutrino_E-10_gun/PREMIX/UL16_106X_mcRun2_asymptotic_v13-v1/file-indexes/CMS_mc_RunIISummer20ULPrePremix_Neutrino_E-10_gun_PREMIX_UL16_106X_mcRun2_asymptotic_v13-v1_280029_file_index.json"
+      },
+      {
+        "checksum": "adler32:38c44254",
+        "description": "Neutrino_E-10_gunPREMIX dataset file index (166 of 166) for access to data via CMS virtual machine",
+        "size": 63634,
+        "type": "index.json",
+        "uri": "root://eospublic.cern.ch//eos/opendata/cms/mc/RunIISummer20ULPrePremix/Neutrino_E-10_gun/PREMIX/UL16_106X_mcRun2_asymptotic_v13-v1/file-indexes/CMS_mc_RunIISummer20ULPrePremix_Neutrino_E-10_gun_PREMIX_UL16_106X_mcRun2_asymptotic_v13-v1_280030_file_index.json"
+      },
+      {
+        "checksum": "adler32:aeb07775",
+        "description": "Neutrino_E-10_gunPREMIX dataset file index (1 of 166) for access to data via CMS virtual machine",
+        "size": 34200,
+        "type": "index.txt",
+        "uri": "root://eospublic.cern.ch//eos/opendata/cms/mc/RunIISummer20ULPrePremix/Neutrino_E-10_gun/PREMIX/UL16_106X_mcRun2_asymptotic_v13-v1/file-indexes/CMS_mc_RunIISummer20ULPrePremix_Neutrino_E-10_gun_PREMIX_UL16_106X_mcRun2_asymptotic_v13-v1_120000_file_index.txt"
+      },
+      {
+        "checksum": "adler32:a1c2892c",
+        "description": "Neutrino_E-10_gunPREMIX dataset file index (2 of 166) for access to data via CMS virtual machine",
+        "size": 42300,
+        "type": "index.txt",
+        "uri": "root://eospublic.cern.ch//eos/opendata/cms/mc/RunIISummer20ULPrePremix/Neutrino_E-10_gun/PREMIX/UL16_106X_mcRun2_asymptotic_v13-v1/file-indexes/CMS_mc_RunIISummer20ULPrePremix_Neutrino_E-10_gun_PREMIX_UL16_106X_mcRun2_asymptotic_v13-v1_120001_file_index.txt"
+      },
+      {
+        "checksum": "adler32:318014a6",
+        "description": "Neutrino_E-10_gunPREMIX dataset file index (3 of 166) for access to data via CMS virtual machine",
+        "size": 11340,
+        "type": "index.txt",
+        "uri": "root://eospublic.cern.ch//eos/opendata/cms/mc/RunIISummer20ULPrePremix/Neutrino_E-10_gun/PREMIX/UL16_106X_mcRun2_asymptotic_v13-v1/file-indexes/CMS_mc_RunIISummer20ULPrePremix_Neutrino_E-10_gun_PREMIX_UL16_106X_mcRun2_asymptotic_v13-v1_120002_file_index.txt"
+      },
+      {
+        "checksum": "adler32:6ff8ec0a",
+        "description": "Neutrino_E-10_gunPREMIX dataset file index (4 of 166) for access to data via CMS virtual machine",
+        "size": 3960,
+        "type": "index.txt",
+        "uri": "root://eospublic.cern.ch//eos/opendata/cms/mc/RunIISummer20ULPrePremix/Neutrino_E-10_gun/PREMIX/UL16_106X_mcRun2_asymptotic_v13-v1/file-indexes/CMS_mc_RunIISummer20ULPrePremix_Neutrino_E-10_gun_PREMIX_UL16_106X_mcRun2_asymptotic_v13-v1_120003_file_index.txt"
+      },
+      {
+        "checksum": "adler32:098ebdf3",
+        "description": "Neutrino_E-10_gunPREMIX dataset file index (5 of 166) for access to data via CMS virtual machine",
+        "size": 10260,
+        "type": "index.txt",
+        "uri": "root://eospublic.cern.ch//eos/opendata/cms/mc/RunIISummer20ULPrePremix/Neutrino_E-10_gun/PREMIX/UL16_106X_mcRun2_asymptotic_v13-v1/file-indexes/CMS_mc_RunIISummer20ULPrePremix_Neutrino_E-10_gun_PREMIX_UL16_106X_mcRun2_asymptotic_v13-v1_120004_file_index.txt"
+      },
+      {
+        "checksum": "adler32:41c5306b",
+        "description": "Neutrino_E-10_gunPREMIX dataset file index (6 of 166) for access to data via CMS virtual machine",
+        "size": 9000,
+        "type": "index.txt",
+        "uri": "root://eospublic.cern.ch//eos/opendata/cms/mc/RunIISummer20ULPrePremix/Neutrino_E-10_gun/PREMIX/UL16_106X_mcRun2_asymptotic_v13-v1/file-indexes/CMS_mc_RunIISummer20ULPrePremix_Neutrino_E-10_gun_PREMIX_UL16_106X_mcRun2_asymptotic_v13-v1_120005_file_index.txt"
+      },
+      {
+        "checksum": "adler32:39406473",
+        "description": "Neutrino_E-10_gunPREMIX dataset file index (7 of 166) for access to data via CMS virtual machine",
+        "size": 7560,
+        "type": "index.txt",
+        "uri": "root://eospublic.cern.ch//eos/opendata/cms/mc/RunIISummer20ULPrePremix/Neutrino_E-10_gun/PREMIX/UL16_106X_mcRun2_asymptotic_v13-v1/file-indexes/CMS_mc_RunIISummer20ULPrePremix_Neutrino_E-10_gun_PREMIX_UL16_106X_mcRun2_asymptotic_v13-v1_120006_file_index.txt"
+      },
+      {
+        "checksum": "adler32:d4f9942d",
+        "description": "Neutrino_E-10_gunPREMIX dataset file index (8 of 166) for access to data via CMS virtual machine",
+        "size": 16560,
+        "type": "index.txt",
+        "uri": "root://eospublic.cern.ch//eos/opendata/cms/mc/RunIISummer20ULPrePremix/Neutrino_E-10_gun/PREMIX/UL16_106X_mcRun2_asymptotic_v13-v1/file-indexes/CMS_mc_RunIISummer20ULPrePremix_Neutrino_E-10_gun_PREMIX_UL16_106X_mcRun2_asymptotic_v13-v1_120007_file_index.txt"
+      },
+      {
+        "checksum": "adler32:32e08d91",
+        "description": "Neutrino_E-10_gunPREMIX dataset file index (9 of 166) for access to data via CMS virtual machine",
+        "size": 13320,
+        "type": "index.txt",
+        "uri": "root://eospublic.cern.ch//eos/opendata/cms/mc/RunIISummer20ULPrePremix/Neutrino_E-10_gun/PREMIX/UL16_106X_mcRun2_asymptotic_v13-v1/file-indexes/CMS_mc_RunIISummer20ULPrePremix_Neutrino_E-10_gun_PREMIX_UL16_106X_mcRun2_asymptotic_v13-v1_120008_file_index.txt"
+      },
+      {
+        "checksum": "adler32:40860221",
+        "description": "Neutrino_E-10_gunPREMIX dataset file index (10 of 166) for access to data via CMS virtual machine",
+        "size": 27360,
+        "type": "index.txt",
+        "uri": "root://eospublic.cern.ch//eos/opendata/cms/mc/RunIISummer20ULPrePremix/Neutrino_E-10_gun/PREMIX/UL16_106X_mcRun2_asymptotic_v13-v1/file-indexes/CMS_mc_RunIISummer20ULPrePremix_Neutrino_E-10_gun_PREMIX_UL16_106X_mcRun2_asymptotic_v13-v1_120009_file_index.txt"
+      },
+      {
+        "checksum": "adler32:21e9f630",
+        "description": "Neutrino_E-10_gunPREMIX dataset file index (11 of 166) for access to data via CMS virtual machine",
+        "size": 10440,
+        "type": "index.txt",
+        "uri": "root://eospublic.cern.ch//eos/opendata/cms/mc/RunIISummer20ULPrePremix/Neutrino_E-10_gun/PREMIX/UL16_106X_mcRun2_asymptotic_v13-v1/file-indexes/CMS_mc_RunIISummer20ULPrePremix_Neutrino_E-10_gun_PREMIX_UL16_106X_mcRun2_asymptotic_v13-v1_120010_file_index.txt"
+      },
+      {
+        "checksum": "adler32:16407f5d",
+        "description": "Neutrino_E-10_gunPREMIX dataset file index (12 of 166) for access to data via CMS virtual machine",
+        "size": 6840,
+        "type": "index.txt",
+        "uri": "root://eospublic.cern.ch//eos/opendata/cms/mc/RunIISummer20ULPrePremix/Neutrino_E-10_gun/PREMIX/UL16_106X_mcRun2_asymptotic_v13-v1/file-indexes/CMS_mc_RunIISummer20ULPrePremix_Neutrino_E-10_gun_PREMIX_UL16_106X_mcRun2_asymptotic_v13-v1_120011_file_index.txt"
+      },
+      {
+        "checksum": "adler32:ba8ef37b",
+        "description": "Neutrino_E-10_gunPREMIX dataset file index (13 of 166) for access to data via CMS virtual machine",
+        "size": 8820,
+        "type": "index.txt",
+        "uri": "root://eospublic.cern.ch//eos/opendata/cms/mc/RunIISummer20ULPrePremix/Neutrino_E-10_gun/PREMIX/UL16_106X_mcRun2_asymptotic_v13-v1/file-indexes/CMS_mc_RunIISummer20ULPrePremix_Neutrino_E-10_gun_PREMIX_UL16_106X_mcRun2_asymptotic_v13-v1_120012_file_index.txt"
+      },
+      {
+        "checksum": "adler32:80305c0a",
+        "description": "Neutrino_E-10_gunPREMIX dataset file index (14 of 166) for access to data via CMS virtual machine",
+        "size": 18000,
+        "type": "index.txt",
+        "uri": "root://eospublic.cern.ch//eos/opendata/cms/mc/RunIISummer20ULPrePremix/Neutrino_E-10_gun/PREMIX/UL16_106X_mcRun2_asymptotic_v13-v1/file-indexes/CMS_mc_RunIISummer20ULPrePremix_Neutrino_E-10_gun_PREMIX_UL16_106X_mcRun2_asymptotic_v13-v1_120013_file_index.txt"
+      },
+      {
+        "checksum": "adler32:a014ea16",
+        "description": "Neutrino_E-10_gunPREMIX dataset file index (15 of 166) for access to data via CMS virtual machine",
+        "size": 17640,
+        "type": "index.txt",
+        "uri": "root://eospublic.cern.ch//eos/opendata/cms/mc/RunIISummer20ULPrePremix/Neutrino_E-10_gun/PREMIX/UL16_106X_mcRun2_asymptotic_v13-v1/file-indexes/CMS_mc_RunIISummer20ULPrePremix_Neutrino_E-10_gun_PREMIX_UL16_106X_mcRun2_asymptotic_v13-v1_120014_file_index.txt"
+      },
+      {
+        "checksum": "adler32:8e8203bf",
+        "description": "Neutrino_E-10_gunPREMIX dataset file index (16 of 166) for access to data via CMS virtual machine",
+        "size": 15300,
+        "type": "index.txt",
+        "uri": "root://eospublic.cern.ch//eos/opendata/cms/mc/RunIISummer20ULPrePremix/Neutrino_E-10_gun/PREMIX/UL16_106X_mcRun2_asymptotic_v13-v1/file-indexes/CMS_mc_RunIISummer20ULPrePremix_Neutrino_E-10_gun_PREMIX_UL16_106X_mcRun2_asymptotic_v13-v1_120015_file_index.txt"
+      },
+      {
+        "checksum": "adler32:c6362a29",
+        "description": "Neutrino_E-10_gunPREMIX dataset file index (17 of 166) for access to data via CMS virtual machine",
+        "size": 21060,
+        "type": "index.txt",
+        "uri": "root://eospublic.cern.ch//eos/opendata/cms/mc/RunIISummer20ULPrePremix/Neutrino_E-10_gun/PREMIX/UL16_106X_mcRun2_asymptotic_v13-v1/file-indexes/CMS_mc_RunIISummer20ULPrePremix_Neutrino_E-10_gun_PREMIX_UL16_106X_mcRun2_asymptotic_v13-v1_120016_file_index.txt"
+      },
+      {
+        "checksum": "adler32:0827679c",
+        "description": "Neutrino_E-10_gunPREMIX dataset file index (18 of 166) for access to data via CMS virtual machine",
+        "size": 9180,
+        "type": "index.txt",
+        "uri": "root://eospublic.cern.ch//eos/opendata/cms/mc/RunIISummer20ULPrePremix/Neutrino_E-10_gun/PREMIX/UL16_106X_mcRun2_asymptotic_v13-v1/file-indexes/CMS_mc_RunIISummer20ULPrePremix_Neutrino_E-10_gun_PREMIX_UL16_106X_mcRun2_asymptotic_v13-v1_120017_file_index.txt"
+      },
+      {
+        "checksum": "adler32:b350b492",
+        "description": "Neutrino_E-10_gunPREMIX dataset file index (19 of 166) for access to data via CMS virtual machine",
+        "size": 19080,
+        "type": "index.txt",
+        "uri": "root://eospublic.cern.ch//eos/opendata/cms/mc/RunIISummer20ULPrePremix/Neutrino_E-10_gun/PREMIX/UL16_106X_mcRun2_asymptotic_v13-v1/file-indexes/CMS_mc_RunIISummer20ULPrePremix_Neutrino_E-10_gun_PREMIX_UL16_106X_mcRun2_asymptotic_v13-v1_120018_file_index.txt"
+      },
+      {
+        "checksum": "adler32:2a9c657b",
+        "description": "Neutrino_E-10_gunPREMIX dataset file index (20 of 166) for access to data via CMS virtual machine",
+        "size": 7560,
+        "type": "index.txt",
+        "uri": "root://eospublic.cern.ch//eos/opendata/cms/mc/RunIISummer20ULPrePremix/Neutrino_E-10_gun/PREMIX/UL16_106X_mcRun2_asymptotic_v13-v1/file-indexes/CMS_mc_RunIISummer20ULPrePremix_Neutrino_E-10_gun_PREMIX_UL16_106X_mcRun2_asymptotic_v13-v1_120019_file_index.txt"
+      },
+      {
+        "checksum": "adler32:5e473a74",
+        "description": "Neutrino_E-10_gunPREMIX dataset file index (21 of 166) for access to data via CMS virtual machine",
+        "size": 15480,
+        "type": "index.txt",
+        "uri": "root://eospublic.cern.ch//eos/opendata/cms/mc/RunIISummer20ULPrePremix/Neutrino_E-10_gun/PREMIX/UL16_106X_mcRun2_asymptotic_v13-v1/file-indexes/CMS_mc_RunIISummer20ULPrePremix_Neutrino_E-10_gun_PREMIX_UL16_106X_mcRun2_asymptotic_v13-v1_120020_file_index.txt"
+      },
+      {
+        "checksum": "adler32:dbbc947d",
+        "description": "Neutrino_E-10_gunPREMIX dataset file index (22 of 166) for access to data via CMS virtual machine",
+        "size": 2880,
+        "type": "index.txt",
+        "uri": "root://eospublic.cern.ch//eos/opendata/cms/mc/RunIISummer20ULPrePremix/Neutrino_E-10_gun/PREMIX/UL16_106X_mcRun2_asymptotic_v13-v1/file-indexes/CMS_mc_RunIISummer20ULPrePremix_Neutrino_E-10_gun_PREMIX_UL16_106X_mcRun2_asymptotic_v13-v1_120021_file_index.txt"
+      },
+      {
+        "checksum": "adler32:ea9f76ca",
+        "description": "Neutrino_E-10_gunPREMIX dataset file index (23 of 166) for access to data via CMS virtual machine",
+        "size": 1980,
+        "type": "index.txt",
+        "uri": "root://eospublic.cern.ch//eos/opendata/cms/mc/RunIISummer20ULPrePremix/Neutrino_E-10_gun/PREMIX/UL16_106X_mcRun2_asymptotic_v13-v1/file-indexes/CMS_mc_RunIISummer20ULPrePremix_Neutrino_E-10_gun_PREMIX_UL16_106X_mcRun2_asymptotic_v13-v1_120022_file_index.txt"
+      },
+      {
+        "checksum": "adler32:b516497b",
+        "description": "Neutrino_E-10_gunPREMIX dataset file index (24 of 166) for access to data via CMS virtual machine",
+        "size": 8280,
+        "type": "index.txt",
+        "uri": "root://eospublic.cern.ch//eos/opendata/cms/mc/RunIISummer20ULPrePremix/Neutrino_E-10_gun/PREMIX/UL16_106X_mcRun2_asymptotic_v13-v1/file-indexes/CMS_mc_RunIISummer20ULPrePremix_Neutrino_E-10_gun_PREMIX_UL16_106X_mcRun2_asymptotic_v13-v1_120023_file_index.txt"
+      },
+      {
+        "checksum": "adler32:559244aa",
+        "description": "Neutrino_E-10_gunPREMIX dataset file index (25 of 166) for access to data via CMS virtual machine",
+        "size": 20340,
+        "type": "index.txt",
+        "uri": "root://eospublic.cern.ch//eos/opendata/cms/mc/RunIISummer20ULPrePremix/Neutrino_E-10_gun/PREMIX/UL16_106X_mcRun2_asymptotic_v13-v1/file-indexes/CMS_mc_RunIISummer20ULPrePremix_Neutrino_E-10_gun_PREMIX_UL16_106X_mcRun2_asymptotic_v13-v1_120024_file_index.txt"
+      },
+      {
+        "checksum": "adler32:16a06f12",
+        "description": "Neutrino_E-10_gunPREMIX dataset file index (26 of 166) for access to data via CMS virtual machine",
+        "size": 12420,
+        "type": "index.txt",
+        "uri": "root://eospublic.cern.ch//eos/opendata/cms/mc/RunIISummer20ULPrePremix/Neutrino_E-10_gun/PREMIX/UL16_106X_mcRun2_asymptotic_v13-v1/file-indexes/CMS_mc_RunIISummer20ULPrePremix_Neutrino_E-10_gun_PREMIX_UL16_106X_mcRun2_asymptotic_v13-v1_120025_file_index.txt"
+      },
+      {
+        "checksum": "adler32:7f7986da",
+        "description": "Neutrino_E-10_gunPREMIX dataset file index (27 of 166) for access to data via CMS virtual machine",
+        "size": 10080,
+        "type": "index.txt",
+        "uri": "root://eospublic.cern.ch//eos/opendata/cms/mc/RunIISummer20ULPrePremix/Neutrino_E-10_gun/PREMIX/UL16_106X_mcRun2_asymptotic_v13-v1/file-indexes/CMS_mc_RunIISummer20ULPrePremix_Neutrino_E-10_gun_PREMIX_UL16_106X_mcRun2_asymptotic_v13-v1_120026_file_index.txt"
+      },
+      {
+        "checksum": "adler32:f7d61ba2",
+        "description": "Neutrino_E-10_gunPREMIX dataset file index (28 of 166) for access to data via CMS virtual machine",
+        "size": 12960,
+        "type": "index.txt",
+        "uri": "root://eospublic.cern.ch//eos/opendata/cms/mc/RunIISummer20ULPrePremix/Neutrino_E-10_gun/PREMIX/UL16_106X_mcRun2_asymptotic_v13-v1/file-indexes/CMS_mc_RunIISummer20ULPrePremix_Neutrino_E-10_gun_PREMIX_UL16_106X_mcRun2_asymptotic_v13-v1_120027_file_index.txt"
+      },
+      {
+        "checksum": "adler32:a9097ca7",
+        "description": "Neutrino_E-10_gunPREMIX dataset file index (29 of 166) for access to data via CMS virtual machine",
+        "size": 18900,
+        "type": "index.txt",
+        "uri": "root://eospublic.cern.ch//eos/opendata/cms/mc/RunIISummer20ULPrePremix/Neutrino_E-10_gun/PREMIX/UL16_106X_mcRun2_asymptotic_v13-v1/file-indexes/CMS_mc_RunIISummer20ULPrePremix_Neutrino_E-10_gun_PREMIX_UL16_106X_mcRun2_asymptotic_v13-v1_120028_file_index.txt"
+      },
+      {
+        "checksum": "adler32:8c518a54",
+        "description": "Neutrino_E-10_gunPREMIX dataset file index (30 of 166) for access to data via CMS virtual machine",
+        "size": 25380,
+        "type": "index.txt",
+        "uri": "root://eospublic.cern.ch//eos/opendata/cms/mc/RunIISummer20ULPrePremix/Neutrino_E-10_gun/PREMIX/UL16_106X_mcRun2_asymptotic_v13-v1/file-indexes/CMS_mc_RunIISummer20ULPrePremix_Neutrino_E-10_gun_PREMIX_UL16_106X_mcRun2_asymptotic_v13-v1_120029_file_index.txt"
+      },
+      {
+        "checksum": "adler32:93eeb445",
+        "description": "Neutrino_E-10_gunPREMIX dataset file index (31 of 166) for access to data via CMS virtual machine",
+        "size": 19080,
+        "type": "index.txt",
+        "uri": "root://eospublic.cern.ch//eos/opendata/cms/mc/RunIISummer20ULPrePremix/Neutrino_E-10_gun/PREMIX/UL16_106X_mcRun2_asymptotic_v13-v1/file-indexes/CMS_mc_RunIISummer20ULPrePremix_Neutrino_E-10_gun_PREMIX_UL16_106X_mcRun2_asymptotic_v13-v1_120030_file_index.txt"
+      },
+      {
+        "checksum": "adler32:0fa29074",
+        "description": "Neutrino_E-10_gunPREMIX dataset file index (32 of 166) for access to data via CMS virtual machine",
+        "size": 1260,
+        "type": "index.txt",
+        "uri": "root://eospublic.cern.ch//eos/opendata/cms/mc/RunIISummer20ULPrePremix/Neutrino_E-10_gun/PREMIX/UL16_106X_mcRun2_asymptotic_v13-v1/file-indexes/CMS_mc_RunIISummer20ULPrePremix_Neutrino_E-10_gun_PREMIX_UL16_106X_mcRun2_asymptotic_v13-v1_130000_file_index.txt"
+      },
+      {
+        "checksum": "adler32:c8a6cd19",
+        "description": "Neutrino_E-10_gunPREMIX dataset file index (33 of 166) for access to data via CMS virtual machine",
+        "size": 3060,
+        "type": "index.txt",
+        "uri": "root://eospublic.cern.ch//eos/opendata/cms/mc/RunIISummer20ULPrePremix/Neutrino_E-10_gun/PREMIX/UL16_106X_mcRun2_asymptotic_v13-v1/file-indexes/CMS_mc_RunIISummer20ULPrePremix_Neutrino_E-10_gun_PREMIX_UL16_106X_mcRun2_asymptotic_v13-v1_130001_file_index.txt"
+      },
+      {
+        "checksum": "adler32:b65de854",
+        "description": "Neutrino_E-10_gunPREMIX dataset file index (34 of 166) for access to data via CMS virtual machine",
+        "size": 2340,
+        "type": "index.txt",
+        "uri": "root://eospublic.cern.ch//eos/opendata/cms/mc/RunIISummer20ULPrePremix/Neutrino_E-10_gun/PREMIX/UL16_106X_mcRun2_asymptotic_v13-v1/file-indexes/CMS_mc_RunIISummer20ULPrePremix_Neutrino_E-10_gun_PREMIX_UL16_106X_mcRun2_asymptotic_v13-v1_130002_file_index.txt"
+      },
+      {
+        "checksum": "adler32:878f7852",
+        "description": "Neutrino_E-10_gunPREMIX dataset file index (35 of 166) for access to data via CMS virtual machine",
+        "size": 3600,
+        "type": "index.txt",
+        "uri": "root://eospublic.cern.ch//eos/opendata/cms/mc/RunIISummer20ULPrePremix/Neutrino_E-10_gun/PREMIX/UL16_106X_mcRun2_asymptotic_v13-v1/file-indexes/CMS_mc_RunIISummer20ULPrePremix_Neutrino_E-10_gun_PREMIX_UL16_106X_mcRun2_asymptotic_v13-v1_130003_file_index.txt"
+      },
+      {
+        "checksum": "adler32:e5d338e2",
+        "description": "Neutrino_E-10_gunPREMIX dataset file index (36 of 166) for access to data via CMS virtual machine",
+        "size": 180,
+        "type": "index.txt",
+        "uri": "root://eospublic.cern.ch//eos/opendata/cms/mc/RunIISummer20ULPrePremix/Neutrino_E-10_gun/PREMIX/UL16_106X_mcRun2_asymptotic_v13-v1/file-indexes/CMS_mc_RunIISummer20ULPrePremix_Neutrino_E-10_gun_PREMIX_UL16_106X_mcRun2_asymptotic_v13-v1_130004_file_index.txt"
+      },
+      {
+        "checksum": "adler32:89cd94a1",
+        "description": "Neutrino_E-10_gunPREMIX dataset file index (37 of 166) for access to data via CMS virtual machine",
+        "size": 2880,
+        "type": "index.txt",
+        "uri": "root://eospublic.cern.ch//eos/opendata/cms/mc/RunIISummer20ULPrePremix/Neutrino_E-10_gun/PREMIX/UL16_106X_mcRun2_asymptotic_v13-v1/file-indexes/CMS_mc_RunIISummer20ULPrePremix_Neutrino_E-10_gun_PREMIX_UL16_106X_mcRun2_asymptotic_v13-v1_130005_file_index.txt"
+      },
+      {
+        "checksum": "adler32:f0115997",
+        "description": "Neutrino_E-10_gunPREMIX dataset file index (38 of 166) for access to data via CMS virtual machine",
+        "size": 2700,
+        "type": "index.txt",
+        "uri": "root://eospublic.cern.ch//eos/opendata/cms/mc/RunIISummer20ULPrePremix/Neutrino_E-10_gun/PREMIX/UL16_106X_mcRun2_asymptotic_v13-v1/file-indexes/CMS_mc_RunIISummer20ULPrePremix_Neutrino_E-10_gun_PREMIX_UL16_106X_mcRun2_asymptotic_v13-v1_130006_file_index.txt"
+      },
+      {
+        "checksum": "adler32:543c6217",
+        "description": "Neutrino_E-10_gunPREMIX dataset file index (39 of 166) for access to data via CMS virtual machine",
+        "size": 5940,
+        "type": "index.txt",
+        "uri": "root://eospublic.cern.ch//eos/opendata/cms/mc/RunIISummer20ULPrePremix/Neutrino_E-10_gun/PREMIX/UL16_106X_mcRun2_asymptotic_v13-v1/file-indexes/CMS_mc_RunIISummer20ULPrePremix_Neutrino_E-10_gun_PREMIX_UL16_106X_mcRun2_asymptotic_v13-v1_130007_file_index.txt"
+      },
+      {
+        "checksum": "adler32:81eb7be9",
+        "description": "Neutrino_E-10_gunPREMIX dataset file index (40 of 166) for access to data via CMS virtual machine",
+        "size": 18900,
+        "type": "index.txt",
+        "uri": "root://eospublic.cern.ch//eos/opendata/cms/mc/RunIISummer20ULPrePremix/Neutrino_E-10_gun/PREMIX/UL16_106X_mcRun2_asymptotic_v13-v1/file-indexes/CMS_mc_RunIISummer20ULPrePremix_Neutrino_E-10_gun_PREMIX_UL16_106X_mcRun2_asymptotic_v13-v1_130008_file_index.txt"
+      },
+      {
+        "checksum": "adler32:34de94ab",
+        "description": "Neutrino_E-10_gunPREMIX dataset file index (41 of 166) for access to data via CMS virtual machine",
+        "size": 2880,
+        "type": "index.txt",
+        "uri": "root://eospublic.cern.ch//eos/opendata/cms/mc/RunIISummer20ULPrePremix/Neutrino_E-10_gun/PREMIX/UL16_106X_mcRun2_asymptotic_v13-v1/file-indexes/CMS_mc_RunIISummer20ULPrePremix_Neutrino_E-10_gun_PREMIX_UL16_106X_mcRun2_asymptotic_v13-v1_130009_file_index.txt"
+      },
+      {
+        "checksum": "adler32:01d0269b",
+        "description": "Neutrino_E-10_gunPREMIX dataset file index (42 of 166) for access to data via CMS virtual machine",
+        "size": 5760,
+        "type": "index.txt",
+        "uri": "root://eospublic.cern.ch//eos/opendata/cms/mc/RunIISummer20ULPrePremix/Neutrino_E-10_gun/PREMIX/UL16_106X_mcRun2_asymptotic_v13-v1/file-indexes/CMS_mc_RunIISummer20ULPrePremix_Neutrino_E-10_gun_PREMIX_UL16_106X_mcRun2_asymptotic_v13-v1_130010_file_index.txt"
+      },
+      {
+        "checksum": "adler32:c6285f59",
+        "description": "Neutrino_E-10_gunPREMIX dataset file index (43 of 166) for access to data via CMS virtual machine",
+        "size": 4320,
+        "type": "index.txt",
+        "uri": "root://eospublic.cern.ch//eos/opendata/cms/mc/RunIISummer20ULPrePremix/Neutrino_E-10_gun/PREMIX/UL16_106X_mcRun2_asymptotic_v13-v1/file-indexes/CMS_mc_RunIISummer20ULPrePremix_Neutrino_E-10_gun_PREMIX_UL16_106X_mcRun2_asymptotic_v13-v1_130011_file_index.txt"
+      },
+      {
+        "checksum": "adler32:2c672358",
+        "description": "Neutrino_E-10_gunPREMIX dataset file index (44 of 166) for access to data via CMS virtual machine",
+        "size": 4140,
+        "type": "index.txt",
+        "uri": "root://eospublic.cern.ch//eos/opendata/cms/mc/RunIISummer20ULPrePremix/Neutrino_E-10_gun/PREMIX/UL16_106X_mcRun2_asymptotic_v13-v1/file-indexes/CMS_mc_RunIISummer20ULPrePremix_Neutrino_E-10_gun_PREMIX_UL16_106X_mcRun2_asymptotic_v13-v1_130012_file_index.txt"
+      },
+      {
+        "checksum": "adler32:a59f97d0",
+        "description": "Neutrino_E-10_gunPREMIX dataset file index (45 of 166) for access to data via CMS virtual machine",
+        "size": 4500,
+        "type": "index.txt",
+        "uri": "root://eospublic.cern.ch//eos/opendata/cms/mc/RunIISummer20ULPrePremix/Neutrino_E-10_gun/PREMIX/UL16_106X_mcRun2_asymptotic_v13-v1/file-indexes/CMS_mc_RunIISummer20ULPrePremix_Neutrino_E-10_gun_PREMIX_UL16_106X_mcRun2_asymptotic_v13-v1_130013_file_index.txt"
+      },
+      {
+        "checksum": "adler32:9bef1d62",
+        "description": "Neutrino_E-10_gunPREMIX dataset file index (46 of 166) for access to data via CMS virtual machine",
+        "size": 41940,
+        "type": "index.txt",
+        "uri": "root://eospublic.cern.ch//eos/opendata/cms/mc/RunIISummer20ULPrePremix/Neutrino_E-10_gun/PREMIX/UL16_106X_mcRun2_asymptotic_v13-v1/file-indexes/CMS_mc_RunIISummer20ULPrePremix_Neutrino_E-10_gun_PREMIX_UL16_106X_mcRun2_asymptotic_v13-v1_130014_file_index.txt"
+      },
+      {
+        "checksum": "adler32:23f52511",
+        "description": "Neutrino_E-10_gunPREMIX dataset file index (47 of 166) for access to data via CMS virtual machine",
+        "size": 19440,
+        "type": "index.txt",
+        "uri": "root://eospublic.cern.ch//eos/opendata/cms/mc/RunIISummer20ULPrePremix/Neutrino_E-10_gun/PREMIX/UL16_106X_mcRun2_asymptotic_v13-v1/file-indexes/CMS_mc_RunIISummer20ULPrePremix_Neutrino_E-10_gun_PREMIX_UL16_106X_mcRun2_asymptotic_v13-v1_130015_file_index.txt"
+      },
+      {
+        "checksum": "adler32:6033d18f",
+        "description": "Neutrino_E-10_gunPREMIX dataset file index (48 of 166) for access to data via CMS virtual machine",
+        "size": 4680,
+        "type": "index.txt",
+        "uri": "root://eospublic.cern.ch//eos/opendata/cms/mc/RunIISummer20ULPrePremix/Neutrino_E-10_gun/PREMIX/UL16_106X_mcRun2_asymptotic_v13-v1/file-indexes/CMS_mc_RunIISummer20ULPrePremix_Neutrino_E-10_gun_PREMIX_UL16_106X_mcRun2_asymptotic_v13-v1_130016_file_index.txt"
+      },
+      {
+        "checksum": "adler32:1ccfef11",
+        "description": "Neutrino_E-10_gunPREMIX dataset file index (49 of 166) for access to data via CMS virtual machine",
+        "size": 5580,
+        "type": "index.txt",
+        "uri": "root://eospublic.cern.ch//eos/opendata/cms/mc/RunIISummer20ULPrePremix/Neutrino_E-10_gun/PREMIX/UL16_106X_mcRun2_asymptotic_v13-v1/file-indexes/CMS_mc_RunIISummer20ULPrePremix_Neutrino_E-10_gun_PREMIX_UL16_106X_mcRun2_asymptotic_v13-v1_130017_file_index.txt"
+      },
+      {
+        "checksum": "adler32:85ad54fb",
+        "description": "Neutrino_E-10_gunPREMIX dataset file index (50 of 166) for access to data via CMS virtual machine",
+        "size": 13140,
+        "type": "index.txt",
+        "uri": "root://eospublic.cern.ch//eos/opendata/cms/mc/RunIISummer20ULPrePremix/Neutrino_E-10_gun/PREMIX/UL16_106X_mcRun2_asymptotic_v13-v1/file-indexes/CMS_mc_RunIISummer20ULPrePremix_Neutrino_E-10_gun_PREMIX_UL16_106X_mcRun2_asymptotic_v13-v1_130018_file_index.txt"
+      },
+      {
+        "checksum": "adler32:ce515b3d",
+        "description": "Neutrino_E-10_gunPREMIX dataset file index (51 of 166) for access to data via CMS virtual machine",
+        "size": 2700,
+        "type": "index.txt",
+        "uri": "root://eospublic.cern.ch//eos/opendata/cms/mc/RunIISummer20ULPrePremix/Neutrino_E-10_gun/PREMIX/UL16_106X_mcRun2_asymptotic_v13-v1/file-indexes/CMS_mc_RunIISummer20ULPrePremix_Neutrino_E-10_gun_PREMIX_UL16_106X_mcRun2_asymptotic_v13-v1_130019_file_index.txt"
+      },
+      {
+        "checksum": "adler32:7dc9616b",
+        "description": "Neutrino_E-10_gunPREMIX dataset file index (52 of 166) for access to data via CMS virtual machine",
+        "size": 5940,
+        "type": "index.txt",
+        "uri": "root://eospublic.cern.ch//eos/opendata/cms/mc/RunIISummer20ULPrePremix/Neutrino_E-10_gun/PREMIX/UL16_106X_mcRun2_asymptotic_v13-v1/file-indexes/CMS_mc_RunIISummer20ULPrePremix_Neutrino_E-10_gun_PREMIX_UL16_106X_mcRun2_asymptotic_v13-v1_130020_file_index.txt"
+      },
+      {
+        "checksum": "adler32:c66fd04a",
+        "description": "Neutrino_E-10_gunPREMIX dataset file index (53 of 166) for access to data via CMS virtual machine",
+        "size": 4680,
+        "type": "index.txt",
+        "uri": "root://eospublic.cern.ch//eos/opendata/cms/mc/RunIISummer20ULPrePremix/Neutrino_E-10_gun/PREMIX/UL16_106X_mcRun2_asymptotic_v13-v1/file-indexes/CMS_mc_RunIISummer20ULPrePremix_Neutrino_E-10_gun_PREMIX_UL16_106X_mcRun2_asymptotic_v13-v1_130021_file_index.txt"
+      },
+      {
+        "checksum": "adler32:7d9b4d97",
+        "description": "Neutrino_E-10_gunPREMIX dataset file index (54 of 166) for access to data via CMS virtual machine",
+        "size": 9900,
+        "type": "index.txt",
+        "uri": "root://eospublic.cern.ch//eos/opendata/cms/mc/RunIISummer20ULPrePremix/Neutrino_E-10_gun/PREMIX/UL16_106X_mcRun2_asymptotic_v13-v1/file-indexes/CMS_mc_RunIISummer20ULPrePremix_Neutrino_E-10_gun_PREMIX_UL16_106X_mcRun2_asymptotic_v13-v1_130022_file_index.txt"
+      },
+      {
+        "checksum": "adler32:16582883",
+        "description": "Neutrino_E-10_gunPREMIX dataset file index (55 of 166) for access to data via CMS virtual machine",
+        "size": 19440,
+        "type": "index.txt",
+        "uri": "root://eospublic.cern.ch//eos/opendata/cms/mc/RunIISummer20ULPrePremix/Neutrino_E-10_gun/PREMIX/UL16_106X_mcRun2_asymptotic_v13-v1/file-indexes/CMS_mc_RunIISummer20ULPrePremix_Neutrino_E-10_gun_PREMIX_UL16_106X_mcRun2_asymptotic_v13-v1_130023_file_index.txt"
+      },
+      {
+        "checksum": "adler32:69718a98",
+        "description": "Neutrino_E-10_gunPREMIX dataset file index (56 of 166) for access to data via CMS virtual machine",
+        "size": 11700,
+        "type": "index.txt",
+        "uri": "root://eospublic.cern.ch//eos/opendata/cms/mc/RunIISummer20ULPrePremix/Neutrino_E-10_gun/PREMIX/UL16_106X_mcRun2_asymptotic_v13-v1/file-indexes/CMS_mc_RunIISummer20ULPrePremix_Neutrino_E-10_gun_PREMIX_UL16_106X_mcRun2_asymptotic_v13-v1_130024_file_index.txt"
+      },
+      {
+        "checksum": "adler32:8064774b",
+        "description": "Neutrino_E-10_gunPREMIX dataset file index (57 of 166) for access to data via CMS virtual machine",
+        "size": 15660,
+        "type": "index.txt",
+        "uri": "root://eospublic.cern.ch//eos/opendata/cms/mc/RunIISummer20ULPrePremix/Neutrino_E-10_gun/PREMIX/UL16_106X_mcRun2_asymptotic_v13-v1/file-indexes/CMS_mc_RunIISummer20ULPrePremix_Neutrino_E-10_gun_PREMIX_UL16_106X_mcRun2_asymptotic_v13-v1_130025_file_index.txt"
+      },
+      {
+        "checksum": "adler32:7e0ec3be",
+        "description": "Neutrino_E-10_gunPREMIX dataset file index (58 of 166) for access to data via CMS virtual machine",
+        "size": 11880,
+        "type": "index.txt",
+        "uri": "root://eospublic.cern.ch//eos/opendata/cms/mc/RunIISummer20ULPrePremix/Neutrino_E-10_gun/PREMIX/UL16_106X_mcRun2_asymptotic_v13-v1/file-indexes/CMS_mc_RunIISummer20ULPrePremix_Neutrino_E-10_gun_PREMIX_UL16_106X_mcRun2_asymptotic_v13-v1_130026_file_index.txt"
+      },
+      {
+        "checksum": "adler32:3d8e99cc",
+        "description": "Neutrino_E-10_gunPREMIX dataset file index (59 of 166) for access to data via CMS virtual machine",
+        "size": 6120,
+        "type": "index.txt",
+        "uri": "root://eospublic.cern.ch//eos/opendata/cms/mc/RunIISummer20ULPrePremix/Neutrino_E-10_gun/PREMIX/UL16_106X_mcRun2_asymptotic_v13-v1/file-indexes/CMS_mc_RunIISummer20ULPrePremix_Neutrino_E-10_gun_PREMIX_UL16_106X_mcRun2_asymptotic_v13-v1_130027_file_index.txt"
+      },
+      {
+        "checksum": "adler32:3446cade",
+        "description": "Neutrino_E-10_gunPREMIX dataset file index (60 of 166) for access to data via CMS virtual machine",
+        "size": 1440,
+        "type": "index.txt",
+        "uri": "root://eospublic.cern.ch//eos/opendata/cms/mc/RunIISummer20ULPrePremix/Neutrino_E-10_gun/PREMIX/UL16_106X_mcRun2_asymptotic_v13-v1/file-indexes/CMS_mc_RunIISummer20ULPrePremix_Neutrino_E-10_gun_PREMIX_UL16_106X_mcRun2_asymptotic_v13-v1_130028_file_index.txt"
+      },
+      {
+        "checksum": "adler32:88287a73",
+        "description": "Neutrino_E-10_gunPREMIX dataset file index (61 of 166) for access to data via CMS virtual machine",
+        "size": 3600,
+        "type": "index.txt",
+        "uri": "root://eospublic.cern.ch//eos/opendata/cms/mc/RunIISummer20ULPrePremix/Neutrino_E-10_gun/PREMIX/UL16_106X_mcRun2_asymptotic_v13-v1/file-indexes/CMS_mc_RunIISummer20ULPrePremix_Neutrino_E-10_gun_PREMIX_UL16_106X_mcRun2_asymptotic_v13-v1_130029_file_index.txt"
+      },
+      {
+        "checksum": "adler32:e774e7c1",
+        "description": "Neutrino_E-10_gunPREMIX dataset file index (62 of 166) for access to data via CMS virtual machine",
+        "size": 16020,
+        "type": "index.txt",
+        "uri": "root://eospublic.cern.ch//eos/opendata/cms/mc/RunIISummer20ULPrePremix/Neutrino_E-10_gun/PREMIX/UL16_106X_mcRun2_asymptotic_v13-v1/file-indexes/CMS_mc_RunIISummer20ULPrePremix_Neutrino_E-10_gun_PREMIX_UL16_106X_mcRun2_asymptotic_v13-v1_130030_file_index.txt"
+      },
+      {
+        "checksum": "adler32:29d57330",
+        "description": "Neutrino_E-10_gunPREMIX dataset file index (63 of 166) for access to data via CMS virtual machine",
+        "size": 362,
+        "type": "index.txt",
+        "uri": "root://eospublic.cern.ch//eos/opendata/cms/mc/RunIISummer20ULPrePremix/Neutrino_E-10_gun/PREMIX/UL16_106X_mcRun2_asymptotic_v13-v1/file-indexes/CMS_mc_RunIISummer20ULPrePremix_Neutrino_E-10_gun_PREMIX_UL16_106X_mcRun2_asymptotic_v13-v1_1320000_file_index.txt"
+      },
+      {
+        "checksum": "adler32:d6af3df5",
+        "description": "Neutrino_E-10_gunPREMIX dataset file index (64 of 166) for access to data via CMS virtual machine",
+        "size": 1810,
+        "type": "index.txt",
+        "uri": "root://eospublic.cern.ch//eos/opendata/cms/mc/RunIISummer20ULPrePremix/Neutrino_E-10_gun/PREMIX/UL16_106X_mcRun2_asymptotic_v13-v1/file-indexes/CMS_mc_RunIISummer20ULPrePremix_Neutrino_E-10_gun_PREMIX_UL16_106X_mcRun2_asymptotic_v13-v1_1320001_file_index.txt"
+      },
+      {
+        "checksum": "adler32:2c931f14",
+        "description": "Neutrino_E-10_gunPREMIX dataset file index (65 of 166) for access to data via CMS virtual machine",
+        "size": 905,
+        "type": "index.txt",
+        "uri": "root://eospublic.cern.ch//eos/opendata/cms/mc/RunIISummer20ULPrePremix/Neutrino_E-10_gun/PREMIX/UL16_106X_mcRun2_asymptotic_v13-v1/file-indexes/CMS_mc_RunIISummer20ULPrePremix_Neutrino_E-10_gun_PREMIX_UL16_106X_mcRun2_asymptotic_v13-v1_1320002_file_index.txt"
+      },
+      {
+        "checksum": "adler32:e9e9d0ae",
+        "description": "Neutrino_E-10_gunPREMIX dataset file index (66 of 166) for access to data via CMS virtual machine",
+        "size": 11946,
+        "type": "index.txt",
+        "uri": "root://eospublic.cern.ch//eos/opendata/cms/mc/RunIISummer20ULPrePremix/Neutrino_E-10_gun/PREMIX/UL16_106X_mcRun2_asymptotic_v13-v1/file-indexes/CMS_mc_RunIISummer20ULPrePremix_Neutrino_E-10_gun_PREMIX_UL16_106X_mcRun2_asymptotic_v13-v1_1320003_file_index.txt"
+      },
+      {
+        "checksum": "adler32:5d11d455",
+        "description": "Neutrino_E-10_gunPREMIX dataset file index (67 of 166) for access to data via CMS virtual machine",
+        "size": 4706,
+        "type": "index.txt",
+        "uri": "root://eospublic.cern.ch//eos/opendata/cms/mc/RunIISummer20ULPrePremix/Neutrino_E-10_gun/PREMIX/UL16_106X_mcRun2_asymptotic_v13-v1/file-indexes/CMS_mc_RunIISummer20ULPrePremix_Neutrino_E-10_gun_PREMIX_UL16_106X_mcRun2_asymptotic_v13-v1_1320004_file_index.txt"
+      },
+      {
+        "checksum": "adler32:18d061d9",
+        "description": "Neutrino_E-10_gunPREMIX dataset file index (68 of 166) for access to data via CMS virtual machine",
+        "size": 13213,
+        "type": "index.txt",
+        "uri": "root://eospublic.cern.ch//eos/opendata/cms/mc/RunIISummer20ULPrePremix/Neutrino_E-10_gun/PREMIX/UL16_106X_mcRun2_asymptotic_v13-v1/file-indexes/CMS_mc_RunIISummer20ULPrePremix_Neutrino_E-10_gun_PREMIX_UL16_106X_mcRun2_asymptotic_v13-v1_1320005_file_index.txt"
+      },
+      {
+        "checksum": "adler32:1817d186",
+        "description": "Neutrino_E-10_gunPREMIX dataset file index (69 of 166) for access to data via CMS virtual machine",
+        "size": 22444,
+        "type": "index.txt",
+        "uri": "root://eospublic.cern.ch//eos/opendata/cms/mc/RunIISummer20ULPrePremix/Neutrino_E-10_gun/PREMIX/UL16_106X_mcRun2_asymptotic_v13-v1/file-indexes/CMS_mc_RunIISummer20ULPrePremix_Neutrino_E-10_gun_PREMIX_UL16_106X_mcRun2_asymptotic_v13-v1_1320006_file_index.txt"
+      },
+      {
+        "checksum": "adler32:ec9a5cec",
+        "description": "Neutrino_E-10_gunPREMIX dataset file index (70 of 166) for access to data via CMS virtual machine",
+        "size": 29322,
+        "type": "index.txt",
+        "uri": "root://eospublic.cern.ch//eos/opendata/cms/mc/RunIISummer20ULPrePremix/Neutrino_E-10_gun/PREMIX/UL16_106X_mcRun2_asymptotic_v13-v1/file-indexes/CMS_mc_RunIISummer20ULPrePremix_Neutrino_E-10_gun_PREMIX_UL16_106X_mcRun2_asymptotic_v13-v1_1320007_file_index.txt"
+      },
+      {
+        "checksum": "adler32:cec0817b",
+        "description": "Neutrino_E-10_gunPREMIX dataset file index (71 of 166) for access to data via CMS virtual machine",
+        "size": 5249,
+        "type": "index.txt",
+        "uri": "root://eospublic.cern.ch//eos/opendata/cms/mc/RunIISummer20ULPrePremix/Neutrino_E-10_gun/PREMIX/UL16_106X_mcRun2_asymptotic_v13-v1/file-indexes/CMS_mc_RunIISummer20ULPrePremix_Neutrino_E-10_gun_PREMIX_UL16_106X_mcRun2_asymptotic_v13-v1_1320008_file_index.txt"
+      },
+      {
+        "checksum": "adler32:6f15ac2d",
+        "description": "Neutrino_E-10_gunPREMIX dataset file index (72 of 166) for access to data via CMS virtual machine",
+        "size": 543,
+        "type": "index.txt",
+        "uri": "root://eospublic.cern.ch//eos/opendata/cms/mc/RunIISummer20ULPrePremix/Neutrino_E-10_gun/PREMIX/UL16_106X_mcRun2_asymptotic_v13-v1/file-indexes/CMS_mc_RunIISummer20ULPrePremix_Neutrino_E-10_gun_PREMIX_UL16_106X_mcRun2_asymptotic_v13-v1_1320009_file_index.txt"
+      },
+      {
+        "checksum": "adler32:ed4a393c",
+        "description": "Neutrino_E-10_gunPREMIX dataset file index (73 of 166) for access to data via CMS virtual machine",
+        "size": 180,
+        "type": "index.txt",
+        "uri": "root://eospublic.cern.ch//eos/opendata/cms/mc/RunIISummer20ULPrePremix/Neutrino_E-10_gun/PREMIX/UL16_106X_mcRun2_asymptotic_v13-v1/file-indexes/CMS_mc_RunIISummer20ULPrePremix_Neutrino_E-10_gun_PREMIX_UL16_106X_mcRun2_asymptotic_v13-v1_250000_file_index.txt"
+      },
+      {
+        "checksum": "adler32:dd8f261e",
+        "description": "Neutrino_E-10_gunPREMIX dataset file index (74 of 166) for access to data via CMS virtual machine",
+        "size": 48420,
+        "type": "index.txt",
+        "uri": "root://eospublic.cern.ch//eos/opendata/cms/mc/RunIISummer20ULPrePremix/Neutrino_E-10_gun/PREMIX/UL16_106X_mcRun2_asymptotic_v13-v1/file-indexes/CMS_mc_RunIISummer20ULPrePremix_Neutrino_E-10_gun_PREMIX_UL16_106X_mcRun2_asymptotic_v13-v1_260000_file_index.txt"
+      },
+      {
+        "checksum": "adler32:5d12f576",
+        "description": "Neutrino_E-10_gunPREMIX dataset file index (75 of 166) for access to data via CMS virtual machine",
+        "size": 36180,
+        "type": "index.txt",
+        "uri": "root://eospublic.cern.ch//eos/opendata/cms/mc/RunIISummer20ULPrePremix/Neutrino_E-10_gun/PREMIX/UL16_106X_mcRun2_asymptotic_v13-v1/file-indexes/CMS_mc_RunIISummer20ULPrePremix_Neutrino_E-10_gun_PREMIX_UL16_106X_mcRun2_asymptotic_v13-v1_260001_file_index.txt"
+      },
+      {
+        "checksum": "adler32:3ad3854b",
+        "description": "Neutrino_E-10_gunPREMIX dataset file index (76 of 166) for access to data via CMS virtual machine",
+        "size": 34200,
+        "type": "index.txt",
+        "uri": "root://eospublic.cern.ch//eos/opendata/cms/mc/RunIISummer20ULPrePremix/Neutrino_E-10_gun/PREMIX/UL16_106X_mcRun2_asymptotic_v13-v1/file-indexes/CMS_mc_RunIISummer20ULPrePremix_Neutrino_E-10_gun_PREMIX_UL16_106X_mcRun2_asymptotic_v13-v1_260002_file_index.txt"
+      },
+      {
+        "checksum": "adler32:819d39c3",
+        "description": "Neutrino_E-10_gunPREMIX dataset file index (77 of 166) for access to data via CMS virtual machine",
+        "size": 13860,
+        "type": "index.txt",
+        "uri": "root://eospublic.cern.ch//eos/opendata/cms/mc/RunIISummer20ULPrePremix/Neutrino_E-10_gun/PREMIX/UL16_106X_mcRun2_asymptotic_v13-v1/file-indexes/CMS_mc_RunIISummer20ULPrePremix_Neutrino_E-10_gun_PREMIX_UL16_106X_mcRun2_asymptotic_v13-v1_260003_file_index.txt"
+      },
+      {
+        "checksum": "adler32:6cf881ff",
+        "description": "Neutrino_E-10_gunPREMIX dataset file index (78 of 166) for access to data via CMS virtual machine",
+        "size": 49500,
+        "type": "index.txt",
+        "uri": "root://eospublic.cern.ch//eos/opendata/cms/mc/RunIISummer20ULPrePremix/Neutrino_E-10_gun/PREMIX/UL16_106X_mcRun2_asymptotic_v13-v1/file-indexes/CMS_mc_RunIISummer20ULPrePremix_Neutrino_E-10_gun_PREMIX_UL16_106X_mcRun2_asymptotic_v13-v1_260004_file_index.txt"
+      },
+      {
+        "checksum": "adler32:1e6ba67a",
+        "description": "Neutrino_E-10_gunPREMIX dataset file index (79 of 166) for access to data via CMS virtual machine",
+        "size": 24660,
+        "type": "index.txt",
+        "uri": "root://eospublic.cern.ch//eos/opendata/cms/mc/RunIISummer20ULPrePremix/Neutrino_E-10_gun/PREMIX/UL16_106X_mcRun2_asymptotic_v13-v1/file-indexes/CMS_mc_RunIISummer20ULPrePremix_Neutrino_E-10_gun_PREMIX_UL16_106X_mcRun2_asymptotic_v13-v1_260005_file_index.txt"
+      },
+      {
+        "checksum": "adler32:5bc51ea1",
+        "description": "Neutrino_E-10_gunPREMIX dataset file index (80 of 166) for access to data via CMS virtual machine",
+        "size": 14580,
+        "type": "index.txt",
+        "uri": "root://eospublic.cern.ch//eos/opendata/cms/mc/RunIISummer20ULPrePremix/Neutrino_E-10_gun/PREMIX/UL16_106X_mcRun2_asymptotic_v13-v1/file-indexes/CMS_mc_RunIISummer20ULPrePremix_Neutrino_E-10_gun_PREMIX_UL16_106X_mcRun2_asymptotic_v13-v1_260006_file_index.txt"
+      },
+      {
+        "checksum": "adler32:c59a68c3",
+        "description": "Neutrino_E-10_gunPREMIX dataset file index (81 of 166) for access to data via CMS virtual machine",
+        "size": 21240,
+        "type": "index.txt",
+        "uri": "root://eospublic.cern.ch//eos/opendata/cms/mc/RunIISummer20ULPrePremix/Neutrino_E-10_gun/PREMIX/UL16_106X_mcRun2_asymptotic_v13-v1/file-indexes/CMS_mc_RunIISummer20ULPrePremix_Neutrino_E-10_gun_PREMIX_UL16_106X_mcRun2_asymptotic_v13-v1_260007_file_index.txt"
+      },
+      {
+        "checksum": "adler32:4807a200",
+        "description": "Neutrino_E-10_gunPREMIX dataset file index (82 of 166) for access to data via CMS virtual machine",
+        "size": 9360,
+        "type": "index.txt",
+        "uri": "root://eospublic.cern.ch//eos/opendata/cms/mc/RunIISummer20ULPrePremix/Neutrino_E-10_gun/PREMIX/UL16_106X_mcRun2_asymptotic_v13-v1/file-indexes/CMS_mc_RunIISummer20ULPrePremix_Neutrino_E-10_gun_PREMIX_UL16_106X_mcRun2_asymptotic_v13-v1_260008_file_index.txt"
+      },
+      {
+        "checksum": "adler32:9108bc7d",
+        "description": "Neutrino_E-10_gunPREMIX dataset file index (83 of 166) for access to data via CMS virtual machine",
+        "size": 20700,
+        "type": "index.txt",
+        "uri": "root://eospublic.cern.ch//eos/opendata/cms/mc/RunIISummer20ULPrePremix/Neutrino_E-10_gun/PREMIX/UL16_106X_mcRun2_asymptotic_v13-v1/file-indexes/CMS_mc_RunIISummer20ULPrePremix_Neutrino_E-10_gun_PREMIX_UL16_106X_mcRun2_asymptotic_v13-v1_260009_file_index.txt"
+      },
+      {
+        "checksum": "adler32:b852ca5a",
+        "description": "Neutrino_E-10_gunPREMIX dataset file index (84 of 166) for access to data via CMS virtual machine",
+        "size": 15120,
+        "type": "index.txt",
+        "uri": "root://eospublic.cern.ch//eos/opendata/cms/mc/RunIISummer20ULPrePremix/Neutrino_E-10_gun/PREMIX/UL16_106X_mcRun2_asymptotic_v13-v1/file-indexes/CMS_mc_RunIISummer20ULPrePremix_Neutrino_E-10_gun_PREMIX_UL16_106X_mcRun2_asymptotic_v13-v1_260010_file_index.txt"
+      },
+      {
+        "checksum": "adler32:084e9a22",
+        "description": "Neutrino_E-10_gunPREMIX dataset file index (85 of 166) for access to data via CMS virtual machine",
+        "size": 18180,
+        "type": "index.txt",
+        "uri": "root://eospublic.cern.ch//eos/opendata/cms/mc/RunIISummer20ULPrePremix/Neutrino_E-10_gun/PREMIX/UL16_106X_mcRun2_asymptotic_v13-v1/file-indexes/CMS_mc_RunIISummer20ULPrePremix_Neutrino_E-10_gun_PREMIX_UL16_106X_mcRun2_asymptotic_v13-v1_260011_file_index.txt"
+      },
+      {
+        "checksum": "adler32:6229c28b",
+        "description": "Neutrino_E-10_gunPREMIX dataset file index (86 of 166) for access to data via CMS virtual machine",
+        "size": 22320,
+        "type": "index.txt",
+        "uri": "root://eospublic.cern.ch//eos/opendata/cms/mc/RunIISummer20ULPrePremix/Neutrino_E-10_gun/PREMIX/UL16_106X_mcRun2_asymptotic_v13-v1/file-indexes/CMS_mc_RunIISummer20ULPrePremix_Neutrino_E-10_gun_PREMIX_UL16_106X_mcRun2_asymptotic_v13-v1_260012_file_index.txt"
+      },
+      {
+        "checksum": "adler32:e8b7dd52",
+        "description": "Neutrino_E-10_gunPREMIX dataset file index (87 of 166) for access to data via CMS virtual machine",
+        "size": 24840,
+        "type": "index.txt",
+        "uri": "root://eospublic.cern.ch//eos/opendata/cms/mc/RunIISummer20ULPrePremix/Neutrino_E-10_gun/PREMIX/UL16_106X_mcRun2_asymptotic_v13-v1/file-indexes/CMS_mc_RunIISummer20ULPrePremix_Neutrino_E-10_gun_PREMIX_UL16_106X_mcRun2_asymptotic_v13-v1_260013_file_index.txt"
+      },
+      {
+        "checksum": "adler32:d1858127",
+        "description": "Neutrino_E-10_gunPREMIX dataset file index (88 of 166) for access to data via CMS virtual machine",
+        "size": 22140,
+        "type": "index.txt",
+        "uri": "root://eospublic.cern.ch//eos/opendata/cms/mc/RunIISummer20ULPrePremix/Neutrino_E-10_gun/PREMIX/UL16_106X_mcRun2_asymptotic_v13-v1/file-indexes/CMS_mc_RunIISummer20ULPrePremix_Neutrino_E-10_gun_PREMIX_UL16_106X_mcRun2_asymptotic_v13-v1_260014_file_index.txt"
+      },
+      {
+        "checksum": "adler32:fc60a1cc",
+        "description": "Neutrino_E-10_gunPREMIX dataset file index (89 of 166) for access to data via CMS virtual machine",
+        "size": 21420,
+        "type": "index.txt",
+        "uri": "root://eospublic.cern.ch//eos/opendata/cms/mc/RunIISummer20ULPrePremix/Neutrino_E-10_gun/PREMIX/UL16_106X_mcRun2_asymptotic_v13-v1/file-indexes/CMS_mc_RunIISummer20ULPrePremix_Neutrino_E-10_gun_PREMIX_UL16_106X_mcRun2_asymptotic_v13-v1_260015_file_index.txt"
+      },
+      {
+        "checksum": "adler32:05f0f2af",
+        "description": "Neutrino_E-10_gunPREMIX dataset file index (90 of 166) for access to data via CMS virtual machine",
+        "size": 7200,
+        "type": "index.txt",
+        "uri": "root://eospublic.cern.ch//eos/opendata/cms/mc/RunIISummer20ULPrePremix/Neutrino_E-10_gun/PREMIX/UL16_106X_mcRun2_asymptotic_v13-v1/file-indexes/CMS_mc_RunIISummer20ULPrePremix_Neutrino_E-10_gun_PREMIX_UL16_106X_mcRun2_asymptotic_v13-v1_260016_file_index.txt"
+      },
+      {
+        "checksum": "adler32:b6e012a1",
+        "description": "Neutrino_E-10_gunPREMIX dataset file index (91 of 166) for access to data via CMS virtual machine",
+        "size": 20160,
+        "type": "index.txt",
+        "uri": "root://eospublic.cern.ch//eos/opendata/cms/mc/RunIISummer20ULPrePremix/Neutrino_E-10_gun/PREMIX/UL16_106X_mcRun2_asymptotic_v13-v1/file-indexes/CMS_mc_RunIISummer20ULPrePremix_Neutrino_E-10_gun_PREMIX_UL16_106X_mcRun2_asymptotic_v13-v1_260017_file_index.txt"
+      },
+      {
+        "checksum": "adler32:a2d2c469",
+        "description": "Neutrino_E-10_gunPREMIX dataset file index (92 of 166) for access to data via CMS virtual machine",
+        "size": 11880,
+        "type": "index.txt",
+        "uri": "root://eospublic.cern.ch//eos/opendata/cms/mc/RunIISummer20ULPrePremix/Neutrino_E-10_gun/PREMIX/UL16_106X_mcRun2_asymptotic_v13-v1/file-indexes/CMS_mc_RunIISummer20ULPrePremix_Neutrino_E-10_gun_PREMIX_UL16_106X_mcRun2_asymptotic_v13-v1_260018_file_index.txt"
+      },
+      {
+        "checksum": "adler32:23211f2a",
+        "description": "Neutrino_E-10_gunPREMIX dataset file index (93 of 166) for access to data via CMS virtual machine",
+        "size": 14580,
+        "type": "index.txt",
+        "uri": "root://eospublic.cern.ch//eos/opendata/cms/mc/RunIISummer20ULPrePremix/Neutrino_E-10_gun/PREMIX/UL16_106X_mcRun2_asymptotic_v13-v1/file-indexes/CMS_mc_RunIISummer20ULPrePremix_Neutrino_E-10_gun_PREMIX_UL16_106X_mcRun2_asymptotic_v13-v1_260019_file_index.txt"
+      },
+      {
+        "checksum": "adler32:e2d8acdc",
+        "description": "Neutrino_E-10_gunPREMIX dataset file index (94 of 166) for access to data via CMS virtual machine",
+        "size": 14220,
+        "type": "index.txt",
+        "uri": "root://eospublic.cern.ch//eos/opendata/cms/mc/RunIISummer20ULPrePremix/Neutrino_E-10_gun/PREMIX/UL16_106X_mcRun2_asymptotic_v13-v1/file-indexes/CMS_mc_RunIISummer20ULPrePremix_Neutrino_E-10_gun_PREMIX_UL16_106X_mcRun2_asymptotic_v13-v1_260020_file_index.txt"
+      },
+      {
+        "checksum": "adler32:109890c5",
+        "description": "Neutrino_E-10_gunPREMIX dataset file index (95 of 166) for access to data via CMS virtual machine",
+        "size": 14940,
+        "type": "index.txt",
+        "uri": "root://eospublic.cern.ch//eos/opendata/cms/mc/RunIISummer20ULPrePremix/Neutrino_E-10_gun/PREMIX/UL16_106X_mcRun2_asymptotic_v13-v1/file-indexes/CMS_mc_RunIISummer20ULPrePremix_Neutrino_E-10_gun_PREMIX_UL16_106X_mcRun2_asymptotic_v13-v1_260021_file_index.txt"
+      },
+      {
+        "checksum": "adler32:ff43e1f5",
+        "description": "Neutrino_E-10_gunPREMIX dataset file index (96 of 166) for access to data via CMS virtual machine",
+        "size": 12780,
+        "type": "index.txt",
+        "uri": "root://eospublic.cern.ch//eos/opendata/cms/mc/RunIISummer20ULPrePremix/Neutrino_E-10_gun/PREMIX/UL16_106X_mcRun2_asymptotic_v13-v1/file-indexes/CMS_mc_RunIISummer20ULPrePremix_Neutrino_E-10_gun_PREMIX_UL16_106X_mcRun2_asymptotic_v13-v1_260022_file_index.txt"
+      },
+      {
+        "checksum": "adler32:86957546",
+        "description": "Neutrino_E-10_gunPREMIX dataset file index (97 of 166) for access to data via CMS virtual machine",
+        "size": 15660,
+        "type": "index.txt",
+        "uri": "root://eospublic.cern.ch//eos/opendata/cms/mc/RunIISummer20ULPrePremix/Neutrino_E-10_gun/PREMIX/UL16_106X_mcRun2_asymptotic_v13-v1/file-indexes/CMS_mc_RunIISummer20ULPrePremix_Neutrino_E-10_gun_PREMIX_UL16_106X_mcRun2_asymptotic_v13-v1_260023_file_index.txt"
+      },
+      {
+        "checksum": "adler32:868ae803",
+        "description": "Neutrino_E-10_gunPREMIX dataset file index (98 of 166) for access to data via CMS virtual machine",
+        "size": 16020,
+        "type": "index.txt",
+        "uri": "root://eospublic.cern.ch//eos/opendata/cms/mc/RunIISummer20ULPrePremix/Neutrino_E-10_gun/PREMIX/UL16_106X_mcRun2_asymptotic_v13-v1/file-indexes/CMS_mc_RunIISummer20ULPrePremix_Neutrino_E-10_gun_PREMIX_UL16_106X_mcRun2_asymptotic_v13-v1_260024_file_index.txt"
+      },
+      {
+        "checksum": "adler32:e794f82a",
+        "description": "Neutrino_E-10_gunPREMIX dataset file index (99 of 166) for access to data via CMS virtual machine",
+        "size": 24120,
+        "type": "index.txt",
+        "uri": "root://eospublic.cern.ch//eos/opendata/cms/mc/RunIISummer20ULPrePremix/Neutrino_E-10_gun/PREMIX/UL16_106X_mcRun2_asymptotic_v13-v1/file-indexes/CMS_mc_RunIISummer20ULPrePremix_Neutrino_E-10_gun_PREMIX_UL16_106X_mcRun2_asymptotic_v13-v1_260025_file_index.txt"
+      },
+      {
+        "checksum": "adler32:2e561400",
+        "description": "Neutrino_E-10_gunPREMIX dataset file index (100 of 166) for access to data via CMS virtual machine",
+        "size": 21780,
+        "type": "index.txt",
+        "uri": "root://eospublic.cern.ch//eos/opendata/cms/mc/RunIISummer20ULPrePremix/Neutrino_E-10_gun/PREMIX/UL16_106X_mcRun2_asymptotic_v13-v1/file-indexes/CMS_mc_RunIISummer20ULPrePremix_Neutrino_E-10_gun_PREMIX_UL16_106X_mcRun2_asymptotic_v13-v1_260026_file_index.txt"
+      },
+      {
+        "checksum": "adler32:72f17ebc",
+        "description": "Neutrino_E-10_gunPREMIX dataset file index (101 of 166) for access to data via CMS virtual machine",
+        "size": 20520,
+        "type": "index.txt",
+        "uri": "root://eospublic.cern.ch//eos/opendata/cms/mc/RunIISummer20ULPrePremix/Neutrino_E-10_gun/PREMIX/UL16_106X_mcRun2_asymptotic_v13-v1/file-indexes/CMS_mc_RunIISummer20ULPrePremix_Neutrino_E-10_gun_PREMIX_UL16_106X_mcRun2_asymptotic_v13-v1_260027_file_index.txt"
+      },
+      {
+        "checksum": "adler32:f352b21e",
+        "description": "Neutrino_E-10_gunPREMIX dataset file index (102 of 166) for access to data via CMS virtual machine",
+        "size": 15840,
+        "type": "index.txt",
+        "uri": "root://eospublic.cern.ch//eos/opendata/cms/mc/RunIISummer20ULPrePremix/Neutrino_E-10_gun/PREMIX/UL16_106X_mcRun2_asymptotic_v13-v1/file-indexes/CMS_mc_RunIISummer20ULPrePremix_Neutrino_E-10_gun_PREMIX_UL16_106X_mcRun2_asymptotic_v13-v1_260028_file_index.txt"
+      },
+      {
+        "checksum": "adler32:4f168fc3",
+        "description": "Neutrino_E-10_gunPREMIX dataset file index (103 of 166) for access to data via CMS virtual machine",
+        "size": 13320,
+        "type": "index.txt",
+        "uri": "root://eospublic.cern.ch//eos/opendata/cms/mc/RunIISummer20ULPrePremix/Neutrino_E-10_gun/PREMIX/UL16_106X_mcRun2_asymptotic_v13-v1/file-indexes/CMS_mc_RunIISummer20ULPrePremix_Neutrino_E-10_gun_PREMIX_UL16_106X_mcRun2_asymptotic_v13-v1_260029_file_index.txt"
+      },
+      {
+        "checksum": "adler32:93c8fa4e",
+        "description": "Neutrino_E-10_gunPREMIX dataset file index (104 of 166) for access to data via CMS virtual machine",
+        "size": 10440,
+        "type": "index.txt",
+        "uri": "root://eospublic.cern.ch//eos/opendata/cms/mc/RunIISummer20ULPrePremix/Neutrino_E-10_gun/PREMIX/UL16_106X_mcRun2_asymptotic_v13-v1/file-indexes/CMS_mc_RunIISummer20ULPrePremix_Neutrino_E-10_gun_PREMIX_UL16_106X_mcRun2_asymptotic_v13-v1_260030_file_index.txt"
+      },
+      {
+        "checksum": "adler32:69dba4e9",
+        "description": "Neutrino_E-10_gunPREMIX dataset file index (105 of 166) for access to data via CMS virtual machine",
+        "size": 26280,
+        "type": "index.txt",
+        "uri": "root://eospublic.cern.ch//eos/opendata/cms/mc/RunIISummer20ULPrePremix/Neutrino_E-10_gun/PREMIX/UL16_106X_mcRun2_asymptotic_v13-v1/file-indexes/CMS_mc_RunIISummer20ULPrePremix_Neutrino_E-10_gun_PREMIX_UL16_106X_mcRun2_asymptotic_v13-v1_270000_file_index.txt"
+      },
+      {
+        "checksum": "adler32:fcf35765",
+        "description": "Neutrino_E-10_gunPREMIX dataset file index (106 of 166) for access to data via CMS virtual machine",
+        "size": 30060,
+        "type": "index.txt",
+        "uri": "root://eospublic.cern.ch//eos/opendata/cms/mc/RunIISummer20ULPrePremix/Neutrino_E-10_gun/PREMIX/UL16_106X_mcRun2_asymptotic_v13-v1/file-indexes/CMS_mc_RunIISummer20ULPrePremix_Neutrino_E-10_gun_PREMIX_UL16_106X_mcRun2_asymptotic_v13-v1_270001_file_index.txt"
+      },
+      {
+        "checksum": "adler32:b83f0773",
+        "description": "Neutrino_E-10_gunPREMIX dataset file index (107 of 166) for access to data via CMS virtual machine",
+        "size": 30600,
+        "type": "index.txt",
+        "uri": "root://eospublic.cern.ch//eos/opendata/cms/mc/RunIISummer20ULPrePremix/Neutrino_E-10_gun/PREMIX/UL16_106X_mcRun2_asymptotic_v13-v1/file-indexes/CMS_mc_RunIISummer20ULPrePremix_Neutrino_E-10_gun_PREMIX_UL16_106X_mcRun2_asymptotic_v13-v1_270002_file_index.txt"
+      },
+      {
+        "checksum": "adler32:bded6bfe",
+        "description": "Neutrino_E-10_gunPREMIX dataset file index (108 of 166) for access to data via CMS virtual machine",
+        "size": 38160,
+        "type": "index.txt",
+        "uri": "root://eospublic.cern.ch//eos/opendata/cms/mc/RunIISummer20ULPrePremix/Neutrino_E-10_gun/PREMIX/UL16_106X_mcRun2_asymptotic_v13-v1/file-indexes/CMS_mc_RunIISummer20ULPrePremix_Neutrino_E-10_gun_PREMIX_UL16_106X_mcRun2_asymptotic_v13-v1_270003_file_index.txt"
+      },
+      {
+        "checksum": "adler32:d69588aa",
+        "description": "Neutrino_E-10_gunPREMIX dataset file index (109 of 166) for access to data via CMS virtual machine",
+        "size": 40680,
+        "type": "index.txt",
+        "uri": "root://eospublic.cern.ch//eos/opendata/cms/mc/RunIISummer20ULPrePremix/Neutrino_E-10_gun/PREMIX/UL16_106X_mcRun2_asymptotic_v13-v1/file-indexes/CMS_mc_RunIISummer20ULPrePremix_Neutrino_E-10_gun_PREMIX_UL16_106X_mcRun2_asymptotic_v13-v1_270004_file_index.txt"
+      },
+      {
+        "checksum": "adler32:1eca7a63",
+        "description": "Neutrino_E-10_gunPREMIX dataset file index (110 of 166) for access to data via CMS virtual machine",
+        "size": 30960,
+        "type": "index.txt",
+        "uri": "root://eospublic.cern.ch//eos/opendata/cms/mc/RunIISummer20ULPrePremix/Neutrino_E-10_gun/PREMIX/UL16_106X_mcRun2_asymptotic_v13-v1/file-indexes/CMS_mc_RunIISummer20ULPrePremix_Neutrino_E-10_gun_PREMIX_UL16_106X_mcRun2_asymptotic_v13-v1_270005_file_index.txt"
+      },
+      {
+        "checksum": "adler32:f0a9b070",
+        "description": "Neutrino_E-10_gunPREMIX dataset file index (111 of 166) for access to data via CMS virtual machine",
+        "size": 29520,
+        "type": "index.txt",
+        "uri": "root://eospublic.cern.ch//eos/opendata/cms/mc/RunIISummer20ULPrePremix/Neutrino_E-10_gun/PREMIX/UL16_106X_mcRun2_asymptotic_v13-v1/file-indexes/CMS_mc_RunIISummer20ULPrePremix_Neutrino_E-10_gun_PREMIX_UL16_106X_mcRun2_asymptotic_v13-v1_270006_file_index.txt"
+      },
+      {
+        "checksum": "adler32:8404ec11",
+        "description": "Neutrino_E-10_gunPREMIX dataset file index (112 of 166) for access to data via CMS virtual machine",
+        "size": 17640,
+        "type": "index.txt",
+        "uri": "root://eospublic.cern.ch//eos/opendata/cms/mc/RunIISummer20ULPrePremix/Neutrino_E-10_gun/PREMIX/UL16_106X_mcRun2_asymptotic_v13-v1/file-indexes/CMS_mc_RunIISummer20ULPrePremix_Neutrino_E-10_gun_PREMIX_UL16_106X_mcRun2_asymptotic_v13-v1_270007_file_index.txt"
+      },
+      {
+        "checksum": "adler32:1d0b1002",
+        "description": "Neutrino_E-10_gunPREMIX dataset file index (113 of 166) for access to data via CMS virtual machine",
+        "size": 20160,
+        "type": "index.txt",
+        "uri": "root://eospublic.cern.ch//eos/opendata/cms/mc/RunIISummer20ULPrePremix/Neutrino_E-10_gun/PREMIX/UL16_106X_mcRun2_asymptotic_v13-v1/file-indexes/CMS_mc_RunIISummer20ULPrePremix_Neutrino_E-10_gun_PREMIX_UL16_106X_mcRun2_asymptotic_v13-v1_270008_file_index.txt"
+      },
+      {
+        "checksum": "adler32:b61796e2",
+        "description": "Neutrino_E-10_gunPREMIX dataset file index (114 of 166) for access to data via CMS virtual machine",
+        "size": 16560,
+        "type": "index.txt",
+        "uri": "root://eospublic.cern.ch//eos/opendata/cms/mc/RunIISummer20ULPrePremix/Neutrino_E-10_gun/PREMIX/UL16_106X_mcRun2_asymptotic_v13-v1/file-indexes/CMS_mc_RunIISummer20ULPrePremix_Neutrino_E-10_gun_PREMIX_UL16_106X_mcRun2_asymptotic_v13-v1_270009_file_index.txt"
+      },
+      {
+        "checksum": "adler32:25a2c702",
+        "description": "Neutrino_E-10_gunPREMIX dataset file index (115 of 166) for access to data via CMS virtual machine",
+        "size": 15120,
+        "type": "index.txt",
+        "uri": "root://eospublic.cern.ch//eos/opendata/cms/mc/RunIISummer20ULPrePremix/Neutrino_E-10_gun/PREMIX/UL16_106X_mcRun2_asymptotic_v13-v1/file-indexes/CMS_mc_RunIISummer20ULPrePremix_Neutrino_E-10_gun_PREMIX_UL16_106X_mcRun2_asymptotic_v13-v1_270010_file_index.txt"
+      },
+      {
+        "checksum": "adler32:a130f910",
+        "description": "Neutrino_E-10_gunPREMIX dataset file index (116 of 166) for access to data via CMS virtual machine",
+        "size": 25740,
+        "type": "index.txt",
+        "uri": "root://eospublic.cern.ch//eos/opendata/cms/mc/RunIISummer20ULPrePremix/Neutrino_E-10_gun/PREMIX/UL16_106X_mcRun2_asymptotic_v13-v1/file-indexes/CMS_mc_RunIISummer20ULPrePremix_Neutrino_E-10_gun_PREMIX_UL16_106X_mcRun2_asymptotic_v13-v1_270011_file_index.txt"
+      },
+      {
+        "checksum": "adler32:3cbefd34",
+        "description": "Neutrino_E-10_gunPREMIX dataset file index (117 of 166) for access to data via CMS virtual machine",
+        "size": 25740,
+        "type": "index.txt",
+        "uri": "root://eospublic.cern.ch//eos/opendata/cms/mc/RunIISummer20ULPrePremix/Neutrino_E-10_gun/PREMIX/UL16_106X_mcRun2_asymptotic_v13-v1/file-indexes/CMS_mc_RunIISummer20ULPrePremix_Neutrino_E-10_gun_PREMIX_UL16_106X_mcRun2_asymptotic_v13-v1_270012_file_index.txt"
+      },
+      {
+        "checksum": "adler32:af575d17",
+        "description": "Neutrino_E-10_gunPREMIX dataset file index (118 of 166) for access to data via CMS virtual machine",
+        "size": 18000,
+        "type": "index.txt",
+        "uri": "root://eospublic.cern.ch//eos/opendata/cms/mc/RunIISummer20ULPrePremix/Neutrino_E-10_gun/PREMIX/UL16_106X_mcRun2_asymptotic_v13-v1/file-indexes/CMS_mc_RunIISummer20ULPrePremix_Neutrino_E-10_gun_PREMIX_UL16_106X_mcRun2_asymptotic_v13-v1_270013_file_index.txt"
+      },
+      {
+        "checksum": "adler32:37ca7ffa",
+        "description": "Neutrino_E-10_gunPREMIX dataset file index (119 of 166) for access to data via CMS virtual machine",
+        "size": 18900,
+        "type": "index.txt",
+        "uri": "root://eospublic.cern.ch//eos/opendata/cms/mc/RunIISummer20ULPrePremix/Neutrino_E-10_gun/PREMIX/UL16_106X_mcRun2_asymptotic_v13-v1/file-indexes/CMS_mc_RunIISummer20ULPrePremix_Neutrino_E-10_gun_PREMIX_UL16_106X_mcRun2_asymptotic_v13-v1_270014_file_index.txt"
+      },
+      {
+        "checksum": "adler32:6eb2d3bc",
+        "description": "Neutrino_E-10_gunPREMIX dataset file index (120 of 166) for access to data via CMS virtual machine",
+        "size": 18360,
+        "type": "index.txt",
+        "uri": "root://eospublic.cern.ch//eos/opendata/cms/mc/RunIISummer20ULPrePremix/Neutrino_E-10_gun/PREMIX/UL16_106X_mcRun2_asymptotic_v13-v1/file-indexes/CMS_mc_RunIISummer20ULPrePremix_Neutrino_E-10_gun_PREMIX_UL16_106X_mcRun2_asymptotic_v13-v1_270015_file_index.txt"
+      },
+      {
+        "checksum": "adler32:f8d39516",
+        "description": "Neutrino_E-10_gunPREMIX dataset file index (121 of 166) for access to data via CMS virtual machine",
+        "size": 16560,
+        "type": "index.txt",
+        "uri": "root://eospublic.cern.ch//eos/opendata/cms/mc/RunIISummer20ULPrePremix/Neutrino_E-10_gun/PREMIX/UL16_106X_mcRun2_asymptotic_v13-v1/file-indexes/CMS_mc_RunIISummer20ULPrePremix_Neutrino_E-10_gun_PREMIX_UL16_106X_mcRun2_asymptotic_v13-v1_270016_file_index.txt"
+      },
+      {
+        "checksum": "adler32:2251e4bb",
+        "description": "Neutrino_E-10_gunPREMIX dataset file index (122 of 166) for access to data via CMS virtual machine",
+        "size": 12780,
+        "type": "index.txt",
+        "uri": "root://eospublic.cern.ch//eos/opendata/cms/mc/RunIISummer20ULPrePremix/Neutrino_E-10_gun/PREMIX/UL16_106X_mcRun2_asymptotic_v13-v1/file-indexes/CMS_mc_RunIISummer20ULPrePremix_Neutrino_E-10_gun_PREMIX_UL16_106X_mcRun2_asymptotic_v13-v1_270017_file_index.txt"
+      },
+      {
+        "checksum": "adler32:56e1a456",
+        "description": "Neutrino_E-10_gunPREMIX dataset file index (123 of 166) for access to data via CMS virtual machine",
+        "size": 9360,
+        "type": "index.txt",
+        "uri": "root://eospublic.cern.ch//eos/opendata/cms/mc/RunIISummer20ULPrePremix/Neutrino_E-10_gun/PREMIX/UL16_106X_mcRun2_asymptotic_v13-v1/file-indexes/CMS_mc_RunIISummer20ULPrePremix_Neutrino_E-10_gun_PREMIX_UL16_106X_mcRun2_asymptotic_v13-v1_270018_file_index.txt"
+      },
+      {
+        "checksum": "adler32:eef3e109",
+        "description": "Neutrino_E-10_gunPREMIX dataset file index (124 of 166) for access to data via CMS virtual machine",
+        "size": 11160,
+        "type": "index.txt",
+        "uri": "root://eospublic.cern.ch//eos/opendata/cms/mc/RunIISummer20ULPrePremix/Neutrino_E-10_gun/PREMIX/UL16_106X_mcRun2_asymptotic_v13-v1/file-indexes/CMS_mc_RunIISummer20ULPrePremix_Neutrino_E-10_gun_PREMIX_UL16_106X_mcRun2_asymptotic_v13-v1_270019_file_index.txt"
+      },
+      {
+        "checksum": "adler32:aa9784cc",
+        "description": "Neutrino_E-10_gunPREMIX dataset file index (125 of 166) for access to data via CMS virtual machine",
+        "size": 10080,
+        "type": "index.txt",
+        "uri": "root://eospublic.cern.ch//eos/opendata/cms/mc/RunIISummer20ULPrePremix/Neutrino_E-10_gun/PREMIX/UL16_106X_mcRun2_asymptotic_v13-v1/file-indexes/CMS_mc_RunIISummer20ULPrePremix_Neutrino_E-10_gun_PREMIX_UL16_106X_mcRun2_asymptotic_v13-v1_270020_file_index.txt"
+      },
+      {
+        "checksum": "adler32:b223de9f",
+        "description": "Neutrino_E-10_gunPREMIX dataset file index (126 of 166) for access to data via CMS virtual machine",
+        "size": 11160,
+        "type": "index.txt",
+        "uri": "root://eospublic.cern.ch//eos/opendata/cms/mc/RunIISummer20ULPrePremix/Neutrino_E-10_gun/PREMIX/UL16_106X_mcRun2_asymptotic_v13-v1/file-indexes/CMS_mc_RunIISummer20ULPrePremix_Neutrino_E-10_gun_PREMIX_UL16_106X_mcRun2_asymptotic_v13-v1_270021_file_index.txt"
+      },
+      {
+        "checksum": "adler32:a2abd5fe",
+        "description": "Neutrino_E-10_gunPREMIX dataset file index (127 of 166) for access to data via CMS virtual machine",
+        "size": 7920,
+        "type": "index.txt",
+        "uri": "root://eospublic.cern.ch//eos/opendata/cms/mc/RunIISummer20ULPrePremix/Neutrino_E-10_gun/PREMIX/UL16_106X_mcRun2_asymptotic_v13-v1/file-indexes/CMS_mc_RunIISummer20ULPrePremix_Neutrino_E-10_gun_PREMIX_UL16_106X_mcRun2_asymptotic_v13-v1_270022_file_index.txt"
+      },
+      {
+        "checksum": "adler32:5302acbc",
+        "description": "Neutrino_E-10_gunPREMIX dataset file index (128 of 166) for access to data via CMS virtual machine",
+        "size": 15840,
+        "type": "index.txt",
+        "uri": "root://eospublic.cern.ch//eos/opendata/cms/mc/RunIISummer20ULPrePremix/Neutrino_E-10_gun/PREMIX/UL16_106X_mcRun2_asymptotic_v13-v1/file-indexes/CMS_mc_RunIISummer20ULPrePremix_Neutrino_E-10_gun_PREMIX_UL16_106X_mcRun2_asymptotic_v13-v1_270023_file_index.txt"
+      },
+      {
+        "checksum": "adler32:77e558f9",
+        "description": "Neutrino_E-10_gunPREMIX dataset file index (129 of 166) for access to data via CMS virtual machine",
+        "size": 14760,
+        "type": "index.txt",
+        "uri": "root://eospublic.cern.ch//eos/opendata/cms/mc/RunIISummer20ULPrePremix/Neutrino_E-10_gun/PREMIX/UL16_106X_mcRun2_asymptotic_v13-v1/file-indexes/CMS_mc_RunIISummer20ULPrePremix_Neutrino_E-10_gun_PREMIX_UL16_106X_mcRun2_asymptotic_v13-v1_270024_file_index.txt"
+      },
+      {
+        "checksum": "adler32:7edaf719",
+        "description": "Neutrino_E-10_gunPREMIX dataset file index (130 of 166) for access to data via CMS virtual machine",
+        "size": 8820,
+        "type": "index.txt",
+        "uri": "root://eospublic.cern.ch//eos/opendata/cms/mc/RunIISummer20ULPrePremix/Neutrino_E-10_gun/PREMIX/UL16_106X_mcRun2_asymptotic_v13-v1/file-indexes/CMS_mc_RunIISummer20ULPrePremix_Neutrino_E-10_gun_PREMIX_UL16_106X_mcRun2_asymptotic_v13-v1_270025_file_index.txt"
+      },
+      {
+        "checksum": "adler32:3db7286a",
+        "description": "Neutrino_E-10_gunPREMIX dataset file index (131 of 166) for access to data via CMS virtual machine",
+        "size": 17820,
+        "type": "index.txt",
+        "uri": "root://eospublic.cern.ch//eos/opendata/cms/mc/RunIISummer20ULPrePremix/Neutrino_E-10_gun/PREMIX/UL16_106X_mcRun2_asymptotic_v13-v1/file-indexes/CMS_mc_RunIISummer20ULPrePremix_Neutrino_E-10_gun_PREMIX_UL16_106X_mcRun2_asymptotic_v13-v1_270026_file_index.txt"
+      },
+      {
+        "checksum": "adler32:4db2a011",
+        "description": "Neutrino_E-10_gunPREMIX dataset file index (132 of 166) for access to data via CMS virtual machine",
+        "size": 19800,
+        "type": "index.txt",
+        "uri": "root://eospublic.cern.ch//eos/opendata/cms/mc/RunIISummer20ULPrePremix/Neutrino_E-10_gun/PREMIX/UL16_106X_mcRun2_asymptotic_v13-v1/file-indexes/CMS_mc_RunIISummer20ULPrePremix_Neutrino_E-10_gun_PREMIX_UL16_106X_mcRun2_asymptotic_v13-v1_270027_file_index.txt"
+      },
+      {
+        "checksum": "adler32:147c4d39",
+        "description": "Neutrino_E-10_gunPREMIX dataset file index (133 of 166) for access to data via CMS virtual machine",
+        "size": 21960,
+        "type": "index.txt",
+        "uri": "root://eospublic.cern.ch//eos/opendata/cms/mc/RunIISummer20ULPrePremix/Neutrino_E-10_gun/PREMIX/UL16_106X_mcRun2_asymptotic_v13-v1/file-indexes/CMS_mc_RunIISummer20ULPrePremix_Neutrino_E-10_gun_PREMIX_UL16_106X_mcRun2_asymptotic_v13-v1_270028_file_index.txt"
+      },
+      {
+        "checksum": "adler32:27afdfab",
+        "description": "Neutrino_E-10_gunPREMIX dataset file index (134 of 166) for access to data via CMS virtual machine",
+        "size": 11160,
+        "type": "index.txt",
+        "uri": "root://eospublic.cern.ch//eos/opendata/cms/mc/RunIISummer20ULPrePremix/Neutrino_E-10_gun/PREMIX/UL16_106X_mcRun2_asymptotic_v13-v1/file-indexes/CMS_mc_RunIISummer20ULPrePremix_Neutrino_E-10_gun_PREMIX_UL16_106X_mcRun2_asymptotic_v13-v1_270029_file_index.txt"
+      },
+      {
+        "checksum": "adler32:3096e374",
+        "description": "Neutrino_E-10_gunPREMIX dataset file index (135 of 166) for access to data via CMS virtual machine",
+        "size": 14400,
+        "type": "index.txt",
+        "uri": "root://eospublic.cern.ch//eos/opendata/cms/mc/RunIISummer20ULPrePremix/Neutrino_E-10_gun/PREMIX/UL16_106X_mcRun2_asymptotic_v13-v1/file-indexes/CMS_mc_RunIISummer20ULPrePremix_Neutrino_E-10_gun_PREMIX_UL16_106X_mcRun2_asymptotic_v13-v1_270030_file_index.txt"
+      },
+      {
+        "checksum": "adler32:65cc5924",
+        "description": "Neutrino_E-10_gunPREMIX dataset file index (136 of 166) for access to data via CMS virtual machine",
+        "size": 16380,
+        "type": "index.txt",
+        "uri": "root://eospublic.cern.ch//eos/opendata/cms/mc/RunIISummer20ULPrePremix/Neutrino_E-10_gun/PREMIX/UL16_106X_mcRun2_asymptotic_v13-v1/file-indexes/CMS_mc_RunIISummer20ULPrePremix_Neutrino_E-10_gun_PREMIX_UL16_106X_mcRun2_asymptotic_v13-v1_280000_file_index.txt"
+      },
+      {
+        "checksum": "adler32:51116f74",
+        "description": "Neutrino_E-10_gunPREMIX dataset file index (137 of 166) for access to data via CMS virtual machine",
+        "size": 26100,
+        "type": "index.txt",
+        "uri": "root://eospublic.cern.ch//eos/opendata/cms/mc/RunIISummer20ULPrePremix/Neutrino_E-10_gun/PREMIX/UL16_106X_mcRun2_asymptotic_v13-v1/file-indexes/CMS_mc_RunIISummer20ULPrePremix_Neutrino_E-10_gun_PREMIX_UL16_106X_mcRun2_asymptotic_v13-v1_280001_file_index.txt"
+      },
+      {
+        "checksum": "adler32:25b7c89b",
+        "description": "Neutrino_E-10_gunPREMIX dataset file index (138 of 166) for access to data via CMS virtual machine",
+        "size": 13500,
+        "type": "index.txt",
+        "uri": "root://eospublic.cern.ch//eos/opendata/cms/mc/RunIISummer20ULPrePremix/Neutrino_E-10_gun/PREMIX/UL16_106X_mcRun2_asymptotic_v13-v1/file-indexes/CMS_mc_RunIISummer20ULPrePremix_Neutrino_E-10_gun_PREMIX_UL16_106X_mcRun2_asymptotic_v13-v1_280002_file_index.txt"
+      },
+      {
+        "checksum": "adler32:80776905",
+        "description": "Neutrino_E-10_gunPREMIX dataset file index (139 of 166) for access to data via CMS virtual machine",
+        "size": 34920,
+        "type": "index.txt",
+        "uri": "root://eospublic.cern.ch//eos/opendata/cms/mc/RunIISummer20ULPrePremix/Neutrino_E-10_gun/PREMIX/UL16_106X_mcRun2_asymptotic_v13-v1/file-indexes/CMS_mc_RunIISummer20ULPrePremix_Neutrino_E-10_gun_PREMIX_UL16_106X_mcRun2_asymptotic_v13-v1_280003_file_index.txt"
+      },
+      {
+        "checksum": "adler32:7bc59aa4",
+        "description": "Neutrino_E-10_gunPREMIX dataset file index (140 of 166) for access to data via CMS virtual machine",
+        "size": 33480,
+        "type": "index.txt",
+        "uri": "root://eospublic.cern.ch//eos/opendata/cms/mc/RunIISummer20ULPrePremix/Neutrino_E-10_gun/PREMIX/UL16_106X_mcRun2_asymptotic_v13-v1/file-indexes/CMS_mc_RunIISummer20ULPrePremix_Neutrino_E-10_gun_PREMIX_UL16_106X_mcRun2_asymptotic_v13-v1_280004_file_index.txt"
+      },
+      {
+        "checksum": "adler32:dd013061",
+        "description": "Neutrino_E-10_gunPREMIX dataset file index (141 of 166) for access to data via CMS virtual machine",
+        "size": 48420,
+        "type": "index.txt",
+        "uri": "root://eospublic.cern.ch//eos/opendata/cms/mc/RunIISummer20ULPrePremix/Neutrino_E-10_gun/PREMIX/UL16_106X_mcRun2_asymptotic_v13-v1/file-indexes/CMS_mc_RunIISummer20ULPrePremix_Neutrino_E-10_gun_PREMIX_UL16_106X_mcRun2_asymptotic_v13-v1_280005_file_index.txt"
+      },
+      {
+        "checksum": "adler32:04f297ee",
+        "description": "Neutrino_E-10_gunPREMIX dataset file index (142 of 166) for access to data via CMS virtual machine",
+        "size": 57600,
+        "type": "index.txt",
+        "uri": "root://eospublic.cern.ch//eos/opendata/cms/mc/RunIISummer20ULPrePremix/Neutrino_E-10_gun/PREMIX/UL16_106X_mcRun2_asymptotic_v13-v1/file-indexes/CMS_mc_RunIISummer20ULPrePremix_Neutrino_E-10_gun_PREMIX_UL16_106X_mcRun2_asymptotic_v13-v1_280006_file_index.txt"
+      },
+      {
+        "checksum": "adler32:b04186dc",
+        "description": "Neutrino_E-10_gunPREMIX dataset file index (143 of 166) for access to data via CMS virtual machine",
+        "size": 34200,
+        "type": "index.txt",
+        "uri": "root://eospublic.cern.ch//eos/opendata/cms/mc/RunIISummer20ULPrePremix/Neutrino_E-10_gun/PREMIX/UL16_106X_mcRun2_asymptotic_v13-v1/file-indexes/CMS_mc_RunIISummer20ULPrePremix_Neutrino_E-10_gun_PREMIX_UL16_106X_mcRun2_asymptotic_v13-v1_280007_file_index.txt"
+      },
+      {
+        "checksum": "adler32:7a448853",
+        "description": "Neutrino_E-10_gunPREMIX dataset file index (144 of 166) for access to data via CMS virtual machine",
+        "size": 23760,
+        "type": "index.txt",
+        "uri": "root://eospublic.cern.ch//eos/opendata/cms/mc/RunIISummer20ULPrePremix/Neutrino_E-10_gun/PREMIX/UL16_106X_mcRun2_asymptotic_v13-v1/file-indexes/CMS_mc_RunIISummer20ULPrePremix_Neutrino_E-10_gun_PREMIX_UL16_106X_mcRun2_asymptotic_v13-v1_280008_file_index.txt"
+      },
+      {
+        "checksum": "adler32:7345fd91",
+        "description": "Neutrino_E-10_gunPREMIX dataset file index (145 of 166) for access to data via CMS virtual machine",
+        "size": 24120,
+        "type": "index.txt",
+        "uri": "root://eospublic.cern.ch//eos/opendata/cms/mc/RunIISummer20ULPrePremix/Neutrino_E-10_gun/PREMIX/UL16_106X_mcRun2_asymptotic_v13-v1/file-indexes/CMS_mc_RunIISummer20ULPrePremix_Neutrino_E-10_gun_PREMIX_UL16_106X_mcRun2_asymptotic_v13-v1_280009_file_index.txt"
+      },
+      {
+        "checksum": "adler32:7f2217f6",
+        "description": "Neutrino_E-10_gunPREMIX dataset file index (146 of 166) for access to data via CMS virtual machine",
+        "size": 38700,
+        "type": "index.txt",
+        "uri": "root://eospublic.cern.ch//eos/opendata/cms/mc/RunIISummer20ULPrePremix/Neutrino_E-10_gun/PREMIX/UL16_106X_mcRun2_asymptotic_v13-v1/file-indexes/CMS_mc_RunIISummer20ULPrePremix_Neutrino_E-10_gun_PREMIX_UL16_106X_mcRun2_asymptotic_v13-v1_280010_file_index.txt"
+      },
+      {
+        "checksum": "adler32:30f40800",
+        "description": "Neutrino_E-10_gunPREMIX dataset file index (147 of 166) for access to data via CMS virtual machine",
+        "size": 44280,
+        "type": "index.txt",
+        "uri": "root://eospublic.cern.ch//eos/opendata/cms/mc/RunIISummer20ULPrePremix/Neutrino_E-10_gun/PREMIX/UL16_106X_mcRun2_asymptotic_v13-v1/file-indexes/CMS_mc_RunIISummer20ULPrePremix_Neutrino_E-10_gun_PREMIX_UL16_106X_mcRun2_asymptotic_v13-v1_280011_file_index.txt"
+      },
+      {
+        "checksum": "adler32:65f4f851",
+        "description": "Neutrino_E-10_gunPREMIX dataset file index (148 of 166) for access to data via CMS virtual machine",
+        "size": 63540,
+        "type": "index.txt",
+        "uri": "root://eospublic.cern.ch//eos/opendata/cms/mc/RunIISummer20ULPrePremix/Neutrino_E-10_gun/PREMIX/UL16_106X_mcRun2_asymptotic_v13-v1/file-indexes/CMS_mc_RunIISummer20ULPrePremix_Neutrino_E-10_gun_PREMIX_UL16_106X_mcRun2_asymptotic_v13-v1_280012_file_index.txt"
+      },
+      {
+        "checksum": "adler32:06b1d9df",
+        "description": "Neutrino_E-10_gunPREMIX dataset file index (149 of 166) for access to data via CMS virtual machine",
+        "size": 48960,
+        "type": "index.txt",
+        "uri": "root://eospublic.cern.ch//eos/opendata/cms/mc/RunIISummer20ULPrePremix/Neutrino_E-10_gun/PREMIX/UL16_106X_mcRun2_asymptotic_v13-v1/file-indexes/CMS_mc_RunIISummer20ULPrePremix_Neutrino_E-10_gun_PREMIX_UL16_106X_mcRun2_asymptotic_v13-v1_280013_file_index.txt"
+      },
+      {
+        "checksum": "adler32:2b211722",
+        "description": "Neutrino_E-10_gunPREMIX dataset file index (150 of 166) for access to data via CMS virtual machine",
+        "size": 25020,
+        "type": "index.txt",
+        "uri": "root://eospublic.cern.ch//eos/opendata/cms/mc/RunIISummer20ULPrePremix/Neutrino_E-10_gun/PREMIX/UL16_106X_mcRun2_asymptotic_v13-v1/file-indexes/CMS_mc_RunIISummer20ULPrePremix_Neutrino_E-10_gun_PREMIX_UL16_106X_mcRun2_asymptotic_v13-v1_280014_file_index.txt"
+      },
+      {
+        "checksum": "adler32:b4aef8b6",
+        "description": "Neutrino_E-10_gunPREMIX dataset file index (151 of 166) for access to data via CMS virtual machine",
+        "size": 22500,
+        "type": "index.txt",
+        "uri": "root://eospublic.cern.ch//eos/opendata/cms/mc/RunIISummer20ULPrePremix/Neutrino_E-10_gun/PREMIX/UL16_106X_mcRun2_asymptotic_v13-v1/file-indexes/CMS_mc_RunIISummer20ULPrePremix_Neutrino_E-10_gun_PREMIX_UL16_106X_mcRun2_asymptotic_v13-v1_280015_file_index.txt"
+      },
+      {
+        "checksum": "adler32:f7c772ec",
+        "description": "Neutrino_E-10_gunPREMIX dataset file index (152 of 166) for access to data via CMS virtual machine",
+        "size": 14040,
+        "type": "index.txt",
+        "uri": "root://eospublic.cern.ch//eos/opendata/cms/mc/RunIISummer20ULPrePremix/Neutrino_E-10_gun/PREMIX/UL16_106X_mcRun2_asymptotic_v13-v1/file-indexes/CMS_mc_RunIISummer20ULPrePremix_Neutrino_E-10_gun_PREMIX_UL16_106X_mcRun2_asymptotic_v13-v1_280016_file_index.txt"
+      },
+      {
+        "checksum": "adler32:288ab7ac",
+        "description": "Neutrino_E-10_gunPREMIX dataset file index (153 of 166) for access to data via CMS virtual machine",
+        "size": 31140,
+        "type": "index.txt",
+        "uri": "root://eospublic.cern.ch//eos/opendata/cms/mc/RunIISummer20ULPrePremix/Neutrino_E-10_gun/PREMIX/UL16_106X_mcRun2_asymptotic_v13-v1/file-indexes/CMS_mc_RunIISummer20ULPrePremix_Neutrino_E-10_gun_PREMIX_UL16_106X_mcRun2_asymptotic_v13-v1_280017_file_index.txt"
+      },
+      {
+        "checksum": "adler32:1801933a",
+        "description": "Neutrino_E-10_gunPREMIX dataset file index (154 of 166) for access to data via CMS virtual machine",
+        "size": 28620,
+        "type": "index.txt",
+        "uri": "root://eospublic.cern.ch//eos/opendata/cms/mc/RunIISummer20ULPrePremix/Neutrino_E-10_gun/PREMIX/UL16_106X_mcRun2_asymptotic_v13-v1/file-indexes/CMS_mc_RunIISummer20ULPrePremix_Neutrino_E-10_gun_PREMIX_UL16_106X_mcRun2_asymptotic_v13-v1_280018_file_index.txt"
+      },
+      {
+        "checksum": "adler32:039c0f18",
+        "description": "Neutrino_E-10_gunPREMIX dataset file index (155 of 166) for access to data via CMS virtual machine",
+        "size": 30600,
+        "type": "index.txt",
+        "uri": "root://eospublic.cern.ch//eos/opendata/cms/mc/RunIISummer20ULPrePremix/Neutrino_E-10_gun/PREMIX/UL16_106X_mcRun2_asymptotic_v13-v1/file-indexes/CMS_mc_RunIISummer20ULPrePremix_Neutrino_E-10_gun_PREMIX_UL16_106X_mcRun2_asymptotic_v13-v1_280019_file_index.txt"
+      },
+      {
+        "checksum": "adler32:af727cbb",
+        "description": "Neutrino_E-10_gunPREMIX dataset file index (156 of 166) for access to data via CMS virtual machine",
+        "size": 44640,
+        "type": "index.txt",
+        "uri": "root://eospublic.cern.ch//eos/opendata/cms/mc/RunIISummer20ULPrePremix/Neutrino_E-10_gun/PREMIX/UL16_106X_mcRun2_asymptotic_v13-v1/file-indexes/CMS_mc_RunIISummer20ULPrePremix_Neutrino_E-10_gun_PREMIX_UL16_106X_mcRun2_asymptotic_v13-v1_280020_file_index.txt"
+      },
+      {
+        "checksum": "adler32:b70e9545",
+        "description": "Neutrino_E-10_gunPREMIX dataset file index (157 of 166) for access to data via CMS virtual machine",
+        "size": 30240,
+        "type": "index.txt",
+        "uri": "root://eospublic.cern.ch//eos/opendata/cms/mc/RunIISummer20ULPrePremix/Neutrino_E-10_gun/PREMIX/UL16_106X_mcRun2_asymptotic_v13-v1/file-indexes/CMS_mc_RunIISummer20ULPrePremix_Neutrino_E-10_gun_PREMIX_UL16_106X_mcRun2_asymptotic_v13-v1_280021_file_index.txt"
+      },
+      {
+        "checksum": "adler32:89a6163f",
+        "description": "Neutrino_E-10_gunPREMIX dataset file index (158 of 166) for access to data via CMS virtual machine",
+        "size": 38700,
+        "type": "index.txt",
+        "uri": "root://eospublic.cern.ch//eos/opendata/cms/mc/RunIISummer20ULPrePremix/Neutrino_E-10_gun/PREMIX/UL16_106X_mcRun2_asymptotic_v13-v1/file-indexes/CMS_mc_RunIISummer20ULPrePremix_Neutrino_E-10_gun_PREMIX_UL16_106X_mcRun2_asymptotic_v13-v1_280022_file_index.txt"
+      },
+      {
+        "checksum": "adler32:eacc0498",
+        "description": "Neutrino_E-10_gunPREMIX dataset file index (159 of 166) for access to data via CMS virtual machine",
+        "size": 42660,
+        "type": "index.txt",
+        "uri": "root://eospublic.cern.ch//eos/opendata/cms/mc/RunIISummer20ULPrePremix/Neutrino_E-10_gun/PREMIX/UL16_106X_mcRun2_asymptotic_v13-v1/file-indexes/CMS_mc_RunIISummer20ULPrePremix_Neutrino_E-10_gun_PREMIX_UL16_106X_mcRun2_asymptotic_v13-v1_280023_file_index.txt"
+      },
+      {
+        "checksum": "adler32:82c6872b",
+        "description": "Neutrino_E-10_gunPREMIX dataset file index (160 of 166) for access to data via CMS virtual machine",
+        "size": 35820,
+        "type": "index.txt",
+        "uri": "root://eospublic.cern.ch//eos/opendata/cms/mc/RunIISummer20ULPrePremix/Neutrino_E-10_gun/PREMIX/UL16_106X_mcRun2_asymptotic_v13-v1/file-indexes/CMS_mc_RunIISummer20ULPrePremix_Neutrino_E-10_gun_PREMIX_UL16_106X_mcRun2_asymptotic_v13-v1_280024_file_index.txt"
+      },
+      {
+        "checksum": "adler32:e74f294c",
+        "description": "Neutrino_E-10_gunPREMIX dataset file index (161 of 166) for access to data via CMS virtual machine",
+        "size": 31500,
+        "type": "index.txt",
+        "uri": "root://eospublic.cern.ch//eos/opendata/cms/mc/RunIISummer20ULPrePremix/Neutrino_E-10_gun/PREMIX/UL16_106X_mcRun2_asymptotic_v13-v1/file-indexes/CMS_mc_RunIISummer20ULPrePremix_Neutrino_E-10_gun_PREMIX_UL16_106X_mcRun2_asymptotic_v13-v1_280025_file_index.txt"
+      },
+      {
+        "checksum": "adler32:7e4ddf95",
+        "description": "Neutrino_E-10_gunPREMIX dataset file index (162 of 166) for access to data via CMS virtual machine",
+        "size": 40140,
+        "type": "index.txt",
+        "uri": "root://eospublic.cern.ch//eos/opendata/cms/mc/RunIISummer20ULPrePremix/Neutrino_E-10_gun/PREMIX/UL16_106X_mcRun2_asymptotic_v13-v1/file-indexes/CMS_mc_RunIISummer20ULPrePremix_Neutrino_E-10_gun_PREMIX_UL16_106X_mcRun2_asymptotic_v13-v1_280026_file_index.txt"
+      },
+      {
+        "checksum": "adler32:960437e4",
+        "description": "Neutrino_E-10_gunPREMIX dataset file index (163 of 166) for access to data via CMS virtual machine",
+        "size": 37980,
+        "type": "index.txt",
+        "uri": "root://eospublic.cern.ch//eos/opendata/cms/mc/RunIISummer20ULPrePremix/Neutrino_E-10_gun/PREMIX/UL16_106X_mcRun2_asymptotic_v13-v1/file-indexes/CMS_mc_RunIISummer20ULPrePremix_Neutrino_E-10_gun_PREMIX_UL16_106X_mcRun2_asymptotic_v13-v1_280027_file_index.txt"
+      },
+      {
+        "checksum": "adler32:6b066d98",
+        "description": "Neutrino_E-10_gunPREMIX dataset file index (164 of 166) for access to data via CMS virtual machine",
+        "size": 36540,
+        "type": "index.txt",
+        "uri": "root://eospublic.cern.ch//eos/opendata/cms/mc/RunIISummer20ULPrePremix/Neutrino_E-10_gun/PREMIX/UL16_106X_mcRun2_asymptotic_v13-v1/file-indexes/CMS_mc_RunIISummer20ULPrePremix_Neutrino_E-10_gun_PREMIX_UL16_106X_mcRun2_asymptotic_v13-v1_280028_file_index.txt"
+      },
+      {
+        "checksum": "adler32:861635a0",
+        "description": "Neutrino_E-10_gunPREMIX dataset file index (165 of 166) for access to data via CMS virtual machine",
+        "size": 36360,
+        "type": "index.txt",
+        "uri": "root://eospublic.cern.ch//eos/opendata/cms/mc/RunIISummer20ULPrePremix/Neutrino_E-10_gun/PREMIX/UL16_106X_mcRun2_asymptotic_v13-v1/file-indexes/CMS_mc_RunIISummer20ULPrePremix_Neutrino_E-10_gun_PREMIX_UL16_106X_mcRun2_asymptotic_v13-v1_280029_file_index.txt"
+      },
+      {
+        "checksum": "adler32:727f10d9",
+        "description": "Neutrino_E-10_gunPREMIX dataset file index (166 of 166) for access to data via CMS virtual machine",
+        "size": 35460,
+        "type": "index.txt",
+        "uri": "root://eospublic.cern.ch//eos/opendata/cms/mc/RunIISummer20ULPrePremix/Neutrino_E-10_gun/PREMIX/UL16_106X_mcRun2_asymptotic_v13-v1/file-indexes/CMS_mc_RunIISummer20ULPrePremix_Neutrino_E-10_gun_PREMIX_UL16_106X_mcRun2_asymptotic_v13-v1_280030_file_index.txt"
+      }
     ],
     "license": {
       "attribution": "CC0"
@@ -110,7 +2437,7 @@
       "description": "<p>To make these simulated data comparable with the collision data, <a href=\"/docs/cms-guide-pileup-simulation\">pile-up events</a> from the dataset <code>/MinBias_TuneCP5_13TeV-pythia8/RunIISummer20UL16SIM-106X_mcRun2_asymptotic_v13-v2/GEN-SIM</code> are added to the simulated event in the DIGI step.</p>"
     },
     "publisher": "CERN Open Data Portal",
-    "recid": "30566",
+    "recid": "30595",
     "run_period": [
       "Run2016G",
       "Run2016H"
@@ -142,11 +2469,11 @@
       "links": [
         {
           "description": "Running CMS analysis code using Docker",
-          "url": "/docs/cms-guide-docker"
+          "url": "/docs/cms-guide-docker#images"
         },
         {
           "description": "How to install the CMS Virtual Machine",
-          "url": "/docs/cms-virtual-machine-2016-2018"
+          "url": "/docs/cms-virtual-machine-cc7"
         },
         {
           "description": "Getting started with CMS open data",

--- a/cernopendata/modules/fixtures/data/records/cms-simulated-datasets-2016-pileup.json
+++ b/cernopendata/modules/fixtures/data/records/cms-simulated-datasets-2016-pileup.json
@@ -1,0 +1,161 @@
+[
+  {
+    "abstract": {
+      "description": "<p>Simulated dataset Neutrino_E-10_gun in PREMIX format for 2016 collision data. Events are sampled from this dataset and added to simulated data to make them comparable with the 2016 collision data, see <a href=\"/docs/cms-guide-pileup-simulation\">the guide to pile-up simulation</a>.</p><p>See the description of the simulated dataset names in: <a href=\"/about/CMS-Simulated-Dataset-Names\">About CMS simulated dataset names</a>.</p><p>This is a sample (10%) of the original dataset.</p>"
+    },
+    "accelerator": "CERN-LHC",
+    "categories": {
+      "primary": "Pileup",
+      "source": "CMS Collaboration"
+    },
+    "collaboration": {
+      "name": "CMS Collaboration",
+      "recid": ""
+    },
+    "collections": [
+      "CMS-Simulated-Datasets"
+    ],
+    "collision_information": {
+      "energy": "13TeV",
+      "type": "pp"
+    },
+    "date_created": [
+      "2016"
+    ],
+    "date_published": "2023",
+    "date_reprocessed": "2020",
+    "distribution": {
+      "formats": [
+        "premix",
+        "root"
+      ],
+      "number_events": 27646400,
+      "number_files": 17279,
+      "size": 0
+    },
+    "experiment": [
+      "CMS"
+    ],
+    "license": {
+      "attribution": "CC0"
+    },
+    "methodology": {
+      "description": "<p>These data were generated in several steps (see also <a href=\"/docs/cms-mc-production-overview\">CMS Monte Carlo production overview</a>):</p>",
+      "steps": [
+        {
+          "configuration_files": [
+            {
+              "script": "#!/bin/bash\n\n# GEN Script begin\nrm -f request_fragment_check.py\nwget -q https://raw.githubusercontent.com/cms-sw/genproductions/master/bin/utils/request_fragment_check.py\nchmod +x request_fragment_check.py\n./request_fragment_check.py --bypass_status --prepid PPD-RunIISummer20UL16GEN-00001\nGEN_ERR=$?\nif [ $GEN_ERR -ne 0 ]; then\n  echo \"GEN Checking Script returned exit code $GEN_ERR which means there are $GEN_ERR errors\"\n  echo \"Validation WILL NOT RUN\"\n  echo \"Please correct errors in the request and run validation again\"\n  exit $GEN_ERR\nfi\necho \"Running VALIDATION. GEN Request Checking Script returned no errors\"\n# GEN Script end\n\n# Download fragment from McM\ncurl -s -k https://cms-pdmv-prod.web.cern.ch/mcm/public/restapi/requests/get_fragment/PPD-RunIISummer20UL16GEN-00001 --retry 3 --create-dirs -o Configuration/GenProduction/python/PPD-RunIISummer20UL16GEN-00001-fragment.py\n[ -s Configuration/GenProduction/python/PPD-RunIISummer20UL16GEN-00001-fragment.py ] || exit $?;\n\n# Check if fragment contais gridpack path ant that it is in cvmfs\nif grep -q \"gridpacks\" Configuration/GenProduction/python/PPD-RunIISummer20UL16GEN-00001-fragment.py; then\n  if ! grep -q \"/cvmfs/cms.cern.ch/phys_generator/gridpacks\" Configuration/GenProduction/python/PPD-RunIISummer20UL16GEN-00001-fragment.py; then\n    echo \"Gridpack inside fragment is not in cvmfs.\"\n    exit -1\n  fi\nfi\n\n# Dump actual test code to a PPD-RunIISummer20UL16GEN-00001_test.sh file that can be run in Singularity\ncat <<'EndOfTestFile' > PPD-RunIISummer20UL16GEN-00001_test.sh\n#!/bin/bash\n\nexport SCRAM_ARCH=slc7_amd64_gcc700\n\nsource /cvmfs/cms.cern.ch/cmsset_default.sh\nif [ -r CMSSW_10_6_17_patch1/src ] ; then\n  echo release CMSSW_10_6_17_patch1 already exists\nelse\n  scram p CMSSW CMSSW_10_6_17_patch1\nfi\ncd CMSSW_10_6_17_patch1/src\neval `scram runtime -sh`\n\nmv ../../Configuration .\nscram b\ncd ../..\n\n# Maximum validation duration: 28800s\n# Margin for validation duration: 30%\n# Validation duration with margin: 28800 * (1 - 0.30) = 20160s\n# Time per event for each sequence: 0.0474s\n# Threads for each sequence: 1\n# Time per event for single thread for each sequence: 1 * 0.0474s = 0.0474s\n# Which adds up to 0.0474s per event\n# Single core events that fit in validation duration: 20160s / 0.0474s = 425652\n# Produced events limit in McM is 10000\n# According to 1.0000 efficiency, validation should run 10000 / 1.0000 = 10000 events to reach the limit of 10000\n# Take the minimum of 425652 and 10000, but more than 0 -> 10000\n# It is estimated that this validation will produce: 10000 * 1.0000 = 10000 events\nEVENTS=10000\n\n\n# cmsDriver command\ncmsDriver.py Configuration/GenProduction/python/PPD-RunIISummer20UL16GEN-00001-fragment.py --python_filename PPD-RunIISummer20UL16GEN-00001_1_cfg.py --eventcontent RAWSIM --customise Configuration/DataProcessing/Utils.addMonitoring --datatier GEN --fileout file:PPD-RunIISummer20UL16GEN-00001.root --conditions 106X_mcRun2_asymptotic_v13 --beamspot Realistic25ns13TeV2016Collision --customise_commands process.source.numberEventsInLuminosityBlock=\"cms.untracked.uint32(100)\" --step GEN --geometry DB:Extended --era Run2_2016 --no_exec --mc -n $EVENTS || exit $? ;\n\n# Run generated config\nREPORT_NAME=PPD-RunIISummer20UL16GEN-00001_report.xml\n# Run the cmsRun\ncmsRun -e -j $REPORT_NAME PPD-RunIISummer20UL16GEN-00001_1_cfg.py || exit $? ;\n\n# Parse values from PPD-RunIISummer20UL16GEN-00001_report.xml report\nprocessedEvents=$(grep -Po \"(?<=<Metric Name=\\\"NumberEvents\\\" Value=\\\")(.*)(?=\\\"/>)\" $REPORT_NAME | tail -n 1)\nproducedEvents=$(grep -Po \"(?<=<TotalEvents>)(\\d*)(?=</TotalEvents>)\" $REPORT_NAME | tail -n 1)\nthreads=$(grep -Po \"(?<=<Metric Name=\\\"NumberOfThreads\\\" Value=\\\")(.*)(?=\\\"/>)\" $REPORT_NAME | tail -n 1)\npeakValueRss=$(grep -Po \"(?<=<Metric Name=\\\"PeakValueRss\\\" Value=\\\")(.*)(?=\\\"/>)\" $REPORT_NAME | tail -n 1)\npeakValueVsize=$(grep -Po \"(?<=<Metric Name=\\\"PeakValueVsize\\\" Value=\\\")(.*)(?=\\\"/>)\" $REPORT_NAME | tail -n 1)\ntotalSize=$(grep -Po \"(?<=<Metric Name=\\\"Timing-tstoragefile-write-totalMegabytes\\\" Value=\\\")(.*)(?=\\\"/>)\" $REPORT_NAME | tail -n 1)\ntotalSizeAlt=$(grep -Po \"(?<=<Metric Name=\\\"Timing-file-write-totalMegabytes\\\" Value=\\\")(.*)(?=\\\"/>)\" $REPORT_NAME | tail -n 1)\ntotalJobTime=$(grep -Po \"(?<=<Metric Name=\\\"TotalJobTime\\\" Value=\\\")(.*)(?=\\\"/>)\" $REPORT_NAME | tail -n 1)\ntotalJobCPU=$(grep -Po \"(?<=<Metric Name=\\\"TotalJobCPU\\\" Value=\\\")(.*)(?=\\\"/>)\" $REPORT_NAME | tail -n 1)\neventThroughput=$(grep -Po \"(?<=<Metric Name=\\\"EventThroughput\\\" Value=\\\")(.*)(?=\\\"/>)\" $REPORT_NAME | tail -n 1)\navgEventTime=$(grep -Po \"(?<=<Metric Name=\\\"AvgEventTime\\\" Value=\\\")(.*)(?=\\\"/>)\" $REPORT_NAME | tail -n 1)\nif [ -z \"$threads\" ]; then\n  echo \"Could not find NumberOfThreads in report, defaulting to 1\"\n  threads=1\nfi\nif [ -z \"$eventThroughput\" ]; then\n  eventThroughput=$(bc -l <<< \"scale=4; 1 / ($avgEventTime / $threads)\")\nfi\nif [ -z \"$totalSize\" ]; then\n  totalSize=$totalSizeAlt\nfi\nif [ -z \"$processedEvents\" ]; then\n  processedEvents=$EVENTS\nfi\necho \"Validation report of PPD-RunIISummer20UL16GEN-00001 sequence 1/1\"\necho \"Processed events: $processedEvents\"\necho \"Produced events: $producedEvents\"\necho \"Threads: $threads\"\necho \"Peak value RSS: $peakValueRss MB\"\necho \"Peak value Vsize: $peakValueVsize MB\"\necho \"Total size: $totalSize MB\"\necho \"Total job time: $totalJobTime s\"\necho \"Total CPU time: $totalJobCPU s\"\necho \"Event throughput: $eventThroughput\"\necho \"CPU efficiency: \"$(bc -l <<< \"scale=2; ($totalJobCPU * 100) / ($threads * $totalJobTime)\")\" %\"\necho \"Size per event: \"$(bc -l <<< \"scale=4; ($totalSize * 1024 / $producedEvents)\")\" kB\"\necho \"Time per event: \"$(bc -l <<< \"scale=4; (1 / $eventThroughput)\")\" s\"\necho \"Filter efficiency percent: \"$(bc -l <<< \"scale=8; ($producedEvents * 100) / $processedEvents\")\" %\"\necho \"Filter efficiency fraction: \"$(bc -l <<< \"scale=10; ($producedEvents) / $processedEvents\")\n\n# End of PPD-RunIISummer20UL16GEN-00001_test.sh file\nEndOfTestFile\n\n# Make file executable\nchmod +x PPD-RunIISummer20UL16GEN-00001_test.sh\n\nif [ -e \"/cvmfs/unpacked.cern.ch/registry.hub.docker.com/cmssw/el7:amd64\" ]; then\n  CONTAINER_NAME=\"el7:amd64\"\nelif [ -e \"/cvmfs/unpacked.cern.ch/registry.hub.docker.com/cmssw/el7:x86_64\" ]; then\n  CONTAINER_NAME=\"el7:x86_64\"\nelse\n  echo \"Could not find amd64 or x86_64 for el7\"\n  exit 1\nfi\n# Run in singularity container\n# Mount afs, eos, cvmfs\n# Mount /etc/grid-security for xrootd\nexport SINGULARITY_CACHEDIR=\"/tmp/$(whoami)/singularity\"\nsingularity run -B /afs -B /eos -B /cvmfs -B /etc/grid-security -B /etc/pki/ca-trust --home $PWD:$PWD /cvmfs/unpacked.cern.ch/registry.hub.docker.com/cmssw/$CONTAINER_NAME $(echo $(pwd)/PPD-RunIISummer20UL16GEN-00001_test.sh)\n",
+              "title": "Production script"
+            },
+            {
+              "script": "import FWCore.ParameterSet.Config as cms\n\nfrom Configuration.Generator.Pythia8CommonSettings_cfi import *\nfrom Configuration.Generator.MCTunes2017.PythiaCP5Settings_cfi import *\n\ngenerator = cms.EDFilter(\"Pythia8GeneratorFilter\",\n    maxEventsToPrint = cms.untracked.int32(1),\n    pythiaPylistVerbosity = cms.untracked.int32(1),\n    filterEfficiency = cms.untracked.double(1.0),\n    pythiaHepMCVerbosity = cms.untracked.bool(False),\n    comEnergy = cms.double(13000.),\n    PythiaParameters = cms.PSet(\n        pythia8CommonSettingsBlock,\n        pythia8CP5SettingsBlock,\n        processParameters = cms.vstring(\n            'SoftQCD:inelastic = on',\n       ),\n        parameterSets = cms.vstring('pythia8CommonSettings',\n                                    'pythia8CP5Settings',\n                                    'processParameters',\n                                    )\n    )\n)",
+              "title": "Generator parameters",
+              "url": "https://cms-pdmv-prod.web.cern.ch/mcm/public/restapi/requests/get_fragment/PPD-RunIISummer20UL16GEN-00001"
+            },
+            {
+              "cms_confdb_id": "d762e23304ef73cf0335517bd6e0563c",
+              "process": "GEN",
+              "title": "Configuration file"
+            }
+          ],
+          "generators": [
+            "Pythia8"
+          ],
+          "global_tag": "106X_mcRun2_asymptotic_v13",
+          "output_dataset": "/MinBias_TuneCP5_13TeV-pythia8/RunIISummer20UL16GEN-106X_mcRun2_asymptotic_v13-v2/GEN",
+          "release": "CMSSW_10_6_17_patch1",
+          "type": "GEN"
+        },
+        {
+          "configuration_files": [
+            {
+              "script": "#!/bin/bash\n\n\n# Dump actual test code to a PPD-RunIISummer20UL16SIM-00001_test.sh file that can be run in Singularity\ncat <<'EndOfTestFile' > PPD-RunIISummer20UL16SIM-00001_test.sh\n#!/bin/bash\n\nexport SCRAM_ARCH=slc7_amd64_gcc700\n\nsource /cvmfs/cms.cern.ch/cmsset_default.sh\nif [ -r CMSSW_10_6_17_patch1/src ] ; then\n  echo release CMSSW_10_6_17_patch1 already exists\nelse\n  scram p CMSSW CMSSW_10_6_17_patch1\nfi\ncd CMSSW_10_6_17_patch1/src\neval `scram runtime -sh`\n\nmv ../../Configuration .\nscram b\ncd ../..\n\n# Maximum validation duration: 28800s\n# Margin for validation duration: 30%\n# Validation duration with margin: 28800 * (1 - 0.30) = 20160s\n# Time per event for each sequence: 13.3371s\n# Threads for each sequence: 8\n# Time per event for single thread for each sequence: 8 * 13.3371s = 106.6968s\n# Which adds up to 106.6968s per event\n# Single core events that fit in validation duration: 20160s / 106.6968s = 188\n# Produced events limit in McM is 10000\n# According to 1.0000 efficiency, validation should run 10000 / 1.0000 = 10000 events to reach the limit of 10000\n# Take the minimum of 188 and 10000, but more than 0 -> 188\n# It is estimated that this validation will produce: 188 * 1.0000 = 188 events\nEVENTS=188\n\n\n# cmsDriver command\ncmsDriver.py  --python_filename PPD-RunIISummer20UL16SIM-00001_1_cfg.py --eventcontent RAWSIM --customise Configuration/DataProcessing/Utils.addMonitoring --datatier GEN-SIM --fileout file:PPD-RunIISummer20UL16SIM-00001.root --conditions 106X_mcRun2_asymptotic_v13 --beamspot Realistic25ns13TeV2016Collision --step SIM --geometry DB:Extended --filein \"dbs:/MinBias_TuneCP5_13TeV-pythia8/RunIISummer20UL16GEN-106X_mcRun2_asymptotic_v13-v2/GEN\" --era Run2_2016 --runUnscheduled --no_exec --mc -n $EVENTS || exit $? ;\n\n# Run generated config\nREPORT_NAME=PPD-RunIISummer20UL16SIM-00001_report.xml\n# Run the cmsRun\ncmsRun -e -j $REPORT_NAME PPD-RunIISummer20UL16SIM-00001_1_cfg.py || exit $? ;\n\n# Parse values from PPD-RunIISummer20UL16SIM-00001_report.xml report\nprocessedEvents=$(grep -Po \"(?<=<Metric Name=\\\"NumberEvents\\\" Value=\\\")(.*)(?=\\\"/>)\" $REPORT_NAME | tail -n 1)\nproducedEvents=$(grep -Po \"(?<=<TotalEvents>)(\\d*)(?=</TotalEvents>)\" $REPORT_NAME | tail -n 1)\nthreads=$(grep -Po \"(?<=<Metric Name=\\\"NumberOfThreads\\\" Value=\\\")(.*)(?=\\\"/>)\" $REPORT_NAME | tail -n 1)\npeakValueRss=$(grep -Po \"(?<=<Metric Name=\\\"PeakValueRss\\\" Value=\\\")(.*)(?=\\\"/>)\" $REPORT_NAME | tail -n 1)\npeakValueVsize=$(grep -Po \"(?<=<Metric Name=\\\"PeakValueVsize\\\" Value=\\\")(.*)(?=\\\"/>)\" $REPORT_NAME | tail -n 1)\ntotalSize=$(grep -Po \"(?<=<Metric Name=\\\"Timing-tstoragefile-write-totalMegabytes\\\" Value=\\\")(.*)(?=\\\"/>)\" $REPORT_NAME | tail -n 1)\ntotalSizeAlt=$(grep -Po \"(?<=<Metric Name=\\\"Timing-file-write-totalMegabytes\\\" Value=\\\")(.*)(?=\\\"/>)\" $REPORT_NAME | tail -n 1)\ntotalJobTime=$(grep -Po \"(?<=<Metric Name=\\\"TotalJobTime\\\" Value=\\\")(.*)(?=\\\"/>)\" $REPORT_NAME | tail -n 1)\ntotalJobCPU=$(grep -Po \"(?<=<Metric Name=\\\"TotalJobCPU\\\" Value=\\\")(.*)(?=\\\"/>)\" $REPORT_NAME | tail -n 1)\neventThroughput=$(grep -Po \"(?<=<Metric Name=\\\"EventThroughput\\\" Value=\\\")(.*)(?=\\\"/>)\" $REPORT_NAME | tail -n 1)\navgEventTime=$(grep -Po \"(?<=<Metric Name=\\\"AvgEventTime\\\" Value=\\\")(.*)(?=\\\"/>)\" $REPORT_NAME | tail -n 1)\nif [ -z \"$threads\" ]; then\n  echo \"Could not find NumberOfThreads in report, defaulting to 1\"\n  threads=1\nfi\nif [ -z \"$eventThroughput\" ]; then\n  eventThroughput=$(bc -l <<< \"scale=4; 1 / ($avgEventTime / $threads)\")\nfi\nif [ -z \"$totalSize\" ]; then\n  totalSize=$totalSizeAlt\nfi\nif [ -z \"$processedEvents\" ]; then\n  processedEvents=$EVENTS\nfi\necho \"Validation report of PPD-RunIISummer20UL16SIM-00001 sequence 1/1\"\necho \"Processed events: $processedEvents\"\necho \"Produced events: $producedEvents\"\necho \"Threads: $threads\"\necho \"Peak value RSS: $peakValueRss MB\"\necho \"Peak value Vsize: $peakValueVsize MB\"\necho \"Total size: $totalSize MB\"\necho \"Total job time: $totalJobTime s\"\necho \"Total CPU time: $totalJobCPU s\"\necho \"Event throughput: $eventThroughput\"\necho \"CPU efficiency: \"$(bc -l <<< \"scale=2; ($totalJobCPU * 100) / ($threads * $totalJobTime)\")\" %\"\necho \"Size per event: \"$(bc -l <<< \"scale=4; ($totalSize * 1024 / $producedEvents)\")\" kB\"\necho \"Time per event: \"$(bc -l <<< \"scale=4; (1 / $eventThroughput)\")\" s\"\necho \"Filter efficiency percent: \"$(bc -l <<< \"scale=8; ($producedEvents * 100) / $processedEvents\")\" %\"\necho \"Filter efficiency fraction: \"$(bc -l <<< \"scale=10; ($producedEvents) / $processedEvents\")\n\n# End of PPD-RunIISummer20UL16SIM-00001_test.sh file\nEndOfTestFile\n\n# Make file executable\nchmod +x PPD-RunIISummer20UL16SIM-00001_test.sh\n\nif [ -e \"/cvmfs/unpacked.cern.ch/registry.hub.docker.com/cmssw/el7:amd64\" ]; then\n  CONTAINER_NAME=\"el7:amd64\"\nelif [ -e \"/cvmfs/unpacked.cern.ch/registry.hub.docker.com/cmssw/el7:x86_64\" ]; then\n  CONTAINER_NAME=\"el7:x86_64\"\nelse\n  echo \"Could not find amd64 or x86_64 for el7\"\n  exit 1\nfi\n# Run in singularity container\n# Mount afs, eos, cvmfs\n# Mount /etc/grid-security for xrootd\nexport SINGULARITY_CACHEDIR=\"/tmp/$(whoami)/singularity\"\nsingularity run -B /afs -B /eos -B /cvmfs -B /etc/grid-security -B /etc/pki/ca-trust --home $PWD:$PWD /cvmfs/unpacked.cern.ch/registry.hub.docker.com/cmssw/$CONTAINER_NAME $(echo $(pwd)/PPD-RunIISummer20UL16SIM-00001_test.sh)\n",
+              "title": "Production script"
+            },
+            {
+              "cms_confdb_id": "d762e23304ef73cf0335517bd6e08158",
+              "process": "SIM",
+              "title": "Configuration file"
+            }
+          ],
+          "global_tag": "106X_mcRun2_asymptotic_v13",
+          "output_dataset": "/MinBias_TuneCP5_13TeV-pythia8/RunIISummer20UL16SIM-106X_mcRun2_asymptotic_v13-v2/GEN-SIM",
+          "release": "CMSSW_10_6_17_patch1",
+          "type": "SIM"
+        },
+        {
+          "configuration_files": [
+            {
+              "script": "#!/bin/bash\n\n# GEN Script begin\nrm -f request_fragment_check.py\nwget -q https://raw.githubusercontent.com/cms-sw/genproductions/master/bin/utils/request_fragment_check.py\nchmod +x request_fragment_check.py\n./request_fragment_check.py --bypass_status --prepid PPD-RunIISummer20ULPrePremix-00003\nGEN_ERR=$?\nif [ $GEN_ERR -ne 0 ]; then\n  echo \"GEN Checking Script returned exit code $GEN_ERR which means there are $GEN_ERR errors\"\n  echo \"Validation WILL NOT RUN\"\n  echo \"Please correct errors in the request and run validation again\"\n  exit $GEN_ERR\nfi\necho \"Running VALIDATION. GEN Request Checking Script returned no errors\"\n# GEN Script end\n\n# Download fragment from McM\ncurl -s -k https://cms-pdmv-prod.web.cern.ch/mcm/public/restapi/requests/get_fragment/PPD-RunIISummer20ULPrePremix-00003 --retry 3 --create-dirs -o Configuration/GenProduction/python/PPD-RunIISummer20ULPrePremix-00003-fragment.py\n[ -s Configuration/GenProduction/python/PPD-RunIISummer20ULPrePremix-00003-fragment.py ] || exit $?;\n\n# Check if fragment contais gridpack path ant that it is in cvmfs\nif grep -q \"gridpacks\" Configuration/GenProduction/python/PPD-RunIISummer20ULPrePremix-00003-fragment.py; then\n  if ! grep -q \"/cvmfs/cms.cern.ch/phys_generator/gridpacks\" Configuration/GenProduction/python/PPD-RunIISummer20ULPrePremix-00003-fragment.py; then\n    echo \"Gridpack inside fragment is not in cvmfs.\"\n    exit -1\n  fi\nfi\n\n# Dump actual test code to a PPD-RunIISummer20ULPrePremix-00003_test.sh file that can be run in Singularity\ncat <<'EndOfTestFile' > PPD-RunIISummer20ULPrePremix-00003_test.sh\n#!/bin/bash\n\nexport SCRAM_ARCH=slc7_amd64_gcc700\n\nsource /cvmfs/cms.cern.ch/cmsset_default.sh\nif [ -r CMSSW_10_6_17_patch1/src ] ; then\n  echo release CMSSW_10_6_17_patch1 already exists\nelse\n  scram p CMSSW CMSSW_10_6_17_patch1\nfi\ncd CMSSW_10_6_17_patch1/src\neval `scram runtime -sh`\n\nmv ../../Configuration .\nscram b\ncd ../..\n\n# Maximum validation duration: 28800s\n# Margin for validation duration: 30%\n# Validation duration with margin: 28800 * (1 - 0.30) = 20160s\n# Time per event for each sequence: 17.7118s\n# Threads for each sequence: 1\n# Time per event for single thread for each sequence: 1 * 17.7118s = 17.7118s\n# Which adds up to 17.7118s per event\n# Single core events that fit in validation duration: 20160s / 17.7118s = 1138\n# Produced events limit in McM is 10000\n# According to 1.0000 efficiency, validation should run 10000 / 1.0000 = 10000 events to reach the limit of 10000\n# Take the minimum of 1138 and 10000, but more than 0 -> 1138\n# It is estimated that this validation will produce: 1138 * 1.0000 = 1138 events\nEVENTS=1138\n\n\n# cmsDriver command\ncmsDriver.py Configuration/GenProduction/python/PPD-RunIISummer20ULPrePremix-00003-fragment.py --python_filename PPD-RunIISummer20ULPrePremix-00003_1_cfg.py --eventcontent PREMIX --pileup 2016_25ns_UltraLegacy_PoissonOOTPU --customise Configuration/DataProcessing/Utils.addMonitoring --datatier PREMIX --fileout file:PPD-RunIISummer20ULPrePremix-00003.root --pileup_input \"dbs:/MinBias_TuneCP5_13TeV-pythia8/RunIISummer20UL16SIM-106X_mcRun2_asymptotic_v13-v2/GEN-SIM\" --conditions 106X_mcRun2_asymptotic_v13 --customise_commands process.source.numberEventsInLuminosityBlock=\"cms.untracked.uint32(100)\" --step GEN,SIM,DIGI --procModifiers premix_stage1 --geometry DB:Extended --era Run2_2016 --no_exec --mc -n $EVENTS || exit $? ;\n\n# Run generated config\nREPORT_NAME=PPD-RunIISummer20ULPrePremix-00003_report.xml\n# Run the cmsRun\ncmsRun -e -j $REPORT_NAME PPD-RunIISummer20ULPrePremix-00003_1_cfg.py || exit $? ;\n\n# Parse values from PPD-RunIISummer20ULPrePremix-00003_report.xml report\nprocessedEvents=$(grep -Po \"(?<=<Metric Name=\\\"NumberEvents\\\" Value=\\\")(.*)(?=\\\"/>)\" $REPORT_NAME | tail -n 1)\nproducedEvents=$(grep -Po \"(?<=<TotalEvents>)(\\d*)(?=</TotalEvents>)\" $REPORT_NAME | tail -n 1)\nthreads=$(grep -Po \"(?<=<Metric Name=\\\"NumberOfThreads\\\" Value=\\\")(.*)(?=\\\"/>)\" $REPORT_NAME | tail -n 1)\npeakValueRss=$(grep -Po \"(?<=<Metric Name=\\\"PeakValueRss\\\" Value=\\\")(.*)(?=\\\"/>)\" $REPORT_NAME | tail -n 1)\npeakValueVsize=$(grep -Po \"(?<=<Metric Name=\\\"PeakValueVsize\\\" Value=\\\")(.*)(?=\\\"/>)\" $REPORT_NAME | tail -n 1)\ntotalSize=$(grep -Po \"(?<=<Metric Name=\\\"Timing-tstoragefile-write-totalMegabytes\\\" Value=\\\")(.*)(?=\\\"/>)\" $REPORT_NAME | tail -n 1)\ntotalSizeAlt=$(grep -Po \"(?<=<Metric Name=\\\"Timing-file-write-totalMegabytes\\\" Value=\\\")(.*)(?=\\\"/>)\" $REPORT_NAME | tail -n 1)\ntotalJobTime=$(grep -Po \"(?<=<Metric Name=\\\"TotalJobTime\\\" Value=\\\")(.*)(?=\\\"/>)\" $REPORT_NAME | tail -n 1)\ntotalJobCPU=$(grep -Po \"(?<=<Metric Name=\\\"TotalJobCPU\\\" Value=\\\")(.*)(?=\\\"/>)\" $REPORT_NAME | tail -n 1)\neventThroughput=$(grep -Po \"(?<=<Metric Name=\\\"EventThroughput\\\" Value=\\\")(.*)(?=\\\"/>)\" $REPORT_NAME | tail -n 1)\navgEventTime=$(grep -Po \"(?<=<Metric Name=\\\"AvgEventTime\\\" Value=\\\")(.*)(?=\\\"/>)\" $REPORT_NAME | tail -n 1)\nif [ -z \"$threads\" ]; then\n  echo \"Could not find NumberOfThreads in report, defaulting to 1\"\n  threads=1\nfi\nif [ -z \"$eventThroughput\" ]; then\n  eventThroughput=$(bc -l <<< \"scale=4; 1 / ($avgEventTime / $threads)\")\nfi\nif [ -z \"$totalSize\" ]; then\n  totalSize=$totalSizeAlt\nfi\nif [ -z \"$processedEvents\" ]; then\n  processedEvents=$EVENTS\nfi\necho \"Validation report of PPD-RunIISummer20ULPrePremix-00003 sequence 1/1\"\necho \"Processed events: $processedEvents\"\necho \"Produced events: $producedEvents\"\necho \"Threads: $threads\"\necho \"Peak value RSS: $peakValueRss MB\"\necho \"Peak value Vsize: $peakValueVsize MB\"\necho \"Total size: $totalSize MB\"\necho \"Total job time: $totalJobTime s\"\necho \"Total CPU time: $totalJobCPU s\"\necho \"Event throughput: $eventThroughput\"\necho \"CPU efficiency: \"$(bc -l <<< \"scale=2; ($totalJobCPU * 100) / ($threads * $totalJobTime)\")\" %\"\necho \"Size per event: \"$(bc -l <<< \"scale=4; ($totalSize * 1024 / $producedEvents)\")\" kB\"\necho \"Time per event: \"$(bc -l <<< \"scale=4; (1 / $eventThroughput)\")\" s\"\necho \"Filter efficiency percent: \"$(bc -l <<< \"scale=8; ($producedEvents * 100) / $processedEvents\")\" %\"\necho \"Filter efficiency fraction: \"$(bc -l <<< \"scale=10; ($producedEvents) / $processedEvents\")\n\n# End of PPD-RunIISummer20ULPrePremix-00003_test.sh file\nEndOfTestFile\n\n# Make file executable\nchmod +x PPD-RunIISummer20ULPrePremix-00003_test.sh\n\nif [ -e \"/cvmfs/unpacked.cern.ch/registry.hub.docker.com/cmssw/el7:amd64\" ]; then\n  CONTAINER_NAME=\"el7:amd64\"\nelif [ -e \"/cvmfs/unpacked.cern.ch/registry.hub.docker.com/cmssw/el7:x86_64\" ]; then\n  CONTAINER_NAME=\"el7:x86_64\"\nelse\n  echo \"Could not find amd64 or x86_64 for el7\"\n  exit 1\nfi\n# Run in singularity container\n# Mount afs, eos, cvmfs\n# Mount /etc/grid-security for xrootd\nexport SINGULARITY_CACHEDIR=\"/tmp/$(whoami)/singularity\"\nsingularity run -B /afs -B /eos -B /cvmfs -B /etc/grid-security -B /etc/pki/ca-trust --home $PWD:$PWD /cvmfs/unpacked.cern.ch/registry.hub.docker.com/cmssw/$CONTAINER_NAME $(echo $(pwd)/PPD-RunIISummer20ULPrePremix-00003_test.sh)\n",
+              "title": "Production script"
+            },
+            {
+              "cms_confdb_id": "bd6fc1859c555ba6f366001d9c1c61e5",
+              "process": "DIGI",
+              "title": "Configuration file"
+            }
+          ],
+          "generators": [
+            "Pythia8"
+          ],
+          "global_tag": "106X_mcRun2_asymptotic_v13",
+          "output_dataset": "/Neutrino_E-10_gun/RunIISummer20ULPrePremix-UL16_106X_mcRun2_asymptotic_v13-v1/PREMIX",
+          "release": "CMSSW_10_6_17_patch1",
+          "type": "DIGI"
+        }
+      ]
+    },
+    "pileup": {
+      "description": "<p>To make these simulated data comparable with the collision data, <a href=\"/docs/cms-guide-pileup-simulation\">pile-up events</a> from the dataset <code>/MinBias_TuneCP5_13TeV-pythia8/RunIISummer20UL16SIM-106X_mcRun2_asymptotic_v13-v2/GEN-SIM</code> are added to the simulated event in the DIGI step.</p>"
+    },
+    "publisher": "CERN Open Data Portal",
+    "recid": "30566",
+    "run_period": [
+      "Run2016G",
+      "Run2016H"
+    ],
+    "system_details": {
+      "container_images": [
+        {
+          "name": "docker.io/cmsopendata/cmssw_10_6_30-slc7_amd64_gcc700:latest",
+          "registry": "dockerhub"
+        },
+        {
+          "name": "gitlab-registry.cern.ch/cms-cloud/cmssw-docker-opendata/cmssw_10_6_30-slc7_amd64_gcc700:latest",
+          "registry": "gitlab"
+        }
+      ],
+      "global_tag": "106X_mcRun2_asymptotic_v17",
+      "release": "CMSSW_10_6_30"
+    },
+    "title": "/Neutrino_E-10_gun/RunIISummer20ULPrePremix-UL16_106X_mcRun2_asymptotic_v13-v1/PREMIX",
+    "title_additional": "Simulated dataset Neutrino_E-10_gun in PREMIX format for 2016 collision data",
+    "type": {
+      "primary": "Dataset",
+      "secondary": [
+        "Simulated"
+      ]
+    },
+    "usage": {
+      "description": "These simulated data are not meant to be analysed on their own. The dataset can be used to add pile-up events to newly simulated event samples using CMS experiment software, available through the CMS Open Data container or the CMS Virtual Machine. See the instructions for setting up one of the two alternative environments and getting started in",
+      "links": [
+        {
+          "description": "Running CMS analysis code using Docker",
+          "url": "/docs/cms-guide-docker"
+        },
+        {
+          "description": "How to install the CMS Virtual Machine",
+          "url": "/docs/cms-virtual-machine-2016-2018"
+        },
+        {
+          "description": "Getting started with CMS open data",
+          "url": "/docs/cms-getting-started-miniaod"
+        }
+      ]
+    },
+    "validation": {
+      "description": "The generation and simulation of Monte Carlo data has been validated through general CMS validation procedures."
+    }
+  }
+]

--- a/requirements-production.txt
+++ b/requirements-production.txt
@@ -582,7 +582,7 @@ wtforms==2.3.3
     # via
     #   flask-wtf
     #   invenio-files-rest
-xrootd==5.6.7
+xrootd==5.6.8
     # via
     #   cernopendata (setup.py)
     #   xrootdpyfs

--- a/setup.py
+++ b/setup.py
@@ -117,7 +117,7 @@ install_requires = [
     # Pin Celery due to worker runtime issues
     "celery==5.2.7",
     # Pin XRootD consistently with Dockerfile
-    "xrootd==5.6.7",
+    "xrootd==5.6.8",
     # Pin Flask/gevent/greenlet/raven to make master work again
     "Flask==2.2.5",
     "Flask-Alembic==2.0.1",


### PR DESCRIPTION
(closes #3569)

Adds the record for the 2016 pileup sample.

To-do:

- check the actual size from eos (it is not taken from DAS as this is a 10% fraction of the original 500 TB dataset)
- ~~modify the template so that the related dataset field won't appear for PREMIX~~
  ![image](https://github.com/cernopendata/opendata.cern.ch/assets/5859918/0598f38b-8327-4d56-8d37-4a0e7d28d48d)


The related dataset field might have come from some local cache, does not appear anymore.
