### PR TITLE
setup: pin invenio-app to 1.4.0

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -67,7 +67,7 @@ setup_requires = [
 
 install_requires = [
     # General Invenio dependencies
-    "invenio-app>=1.3.0,<2.0.0",
+    "invenio-app>=1.3.0,<1.5.0",
     "invenio-base>=1.3.0,<2.0.0",
     "invenio-config>=1.0.3,<2.0.0",
     # Custom Invenio `base` bundle


### PR DESCRIPTION
Pins invenio-app to less than 1.5.0, fixing the issue with Flask-Limiter and the detailed record page display.

Closes #3593