### PR TITLE
records: CMS 2016 collision datasets RECO checksums

### DIFF
--- a/cernopendata/modules/fixtures/data/records/cms-reco-configuration-files-2015.json
+++ b/cernopendata/modules/fixtures/data/records/cms-reco-configuration-files-2015.json
@@ -30,7 +30,7 @@
     ],
     "files": [
       {
-        "checksum": "adler32:a48dd1062517325932854f3bad3cffd376618dd8",
+        "checksum": "adler32:5268c3c8",
         "size": 10000,
         "uri": "root://eospublic.cern.ch//eos/opendata/cms/configuration-files/2015/reco_2015D_Charmonium.py"
       }
@@ -82,7 +82,7 @@
     ],
     "files": [
       {
-        "checksum": "adler32:ae7defe3a6fab273ebd489b8f82342fe35872fa7",
+        "checksum": "adler32:bc393891",
         "size": 15946,
         "uri": "root://eospublic.cern.ch//eos/opendata/cms/configuration-files/2015/reco_2015D_SingleMuon.py"
       }
@@ -134,7 +134,7 @@
     ],
     "files": [
       {
-        "checksum": "adler32:79d4f767c1dbe534fd0647919cca084e7a8e314b",
+        "checksum": "adler32:52becee1",
         "size": 10039,
         "uri": "root://eospublic.cern.ch//eos/opendata/cms/configuration-files/2015/reco_2015D_SinglePhoton.py"
       }
@@ -186,7 +186,7 @@
     ],
     "files": [
       {
-        "checksum": "adler32:dff3fa1253340b9b8711fecf9f7eb11132940737",
+        "checksum": "adler32:c04640d6",
         "size": 8823,
         "uri": "root://eospublic.cern.ch//eos/opendata/cms/configuration-files/2015/reco_2015D_MuonEG.py"
       }
@@ -238,7 +238,7 @@
     ],
     "files": [
       {
-        "checksum": "adler32:4b5672fc9dc67a25404990a2c60c62f16fddf025",
+        "checksum": "adler32:32491533",
         "size": 13353,
         "uri": "root://eospublic.cern.ch//eos/opendata/cms/configuration-files/2015/reco_2015D_ZeroBias.py"
       }
@@ -290,7 +290,7 @@
     ],
     "files": [
       {
-        "checksum": "adler32:3a6d031ec3e4995975e10e289a75b8183c8a5776",
+        "checksum": "adler32:ce54357",
         "size": 8829,
         "uri": "root://eospublic.cern.ch//eos/opendata/cms/configuration-files/2015/reco_2015D_DisplacedJet.py"
       }
@@ -342,7 +342,7 @@
     ],
     "files": [
       {
-        "checksum": "adler32:838ea9ed862e0149eb738d414da38d213da30838",
+        "checksum": "adler32:7fb4c7ee",
         "size": 10019,
         "uri": "root://eospublic.cern.ch//eos/opendata/cms/configuration-files/2015/reco_2015D_JetHT.py"
       }
@@ -394,7 +394,7 @@
     ],
     "files": [
       {
-        "checksum": "adler32:d750abe1e078b4df270da380eec3cf908ff78bfc",
+        "checksum": "adler32:61a040f5",
         "size": 8824,
         "uri": "root://eospublic.cern.ch//eos/opendata/cms/configuration-files/2015/reco_2015D_BTagCSV.py"
       }
@@ -446,7 +446,7 @@
     ],
     "files": [
       {
-        "checksum": "adler32:20db9e997def973e5660dc1646089829129cb2dc",
+        "checksum": "adler32:24323fd5",
         "size": 8820,
         "uri": "root://eospublic.cern.ch//eos/opendata/cms/configuration-files/2015/reco_2015D_Tau.py"
       }
@@ -498,7 +498,7 @@
     ],
     "files": [
       {
-        "checksum": "adler32:ef552117097df605e0e5d23768f5146cea9432f0",
+        "checksum": "adler32:a158392",
         "size": 9792,
         "uri": "root://eospublic.cern.ch//eos/opendata/cms/configuration-files/2015/reco_2015D_MET.py"
       }
@@ -550,7 +550,7 @@
     ],
     "files": [
       {
-        "checksum": "adler32:1c967a5eeeff8905992cd2144f0a8172ea4c1b16",
+        "checksum": "adler32:10714030",
         "size": 8822,
         "uri": "root://eospublic.cern.ch//eos/opendata/cms/configuration-files/2015/reco_2015D_HTMHT.py"
       }
@@ -602,7 +602,7 @@
     ],
     "files": [
       {
-        "checksum": "adler32:303b17cdb563cef8ca3a6b3030f21215c52ca209",
+        "checksum": "adler32:4435ac30",
         "size": 14773,
         "uri": "root://eospublic.cern.ch//eos/opendata/cms/configuration-files/2015/reco_2015D_DoubleMuon.py"
       }
@@ -654,7 +654,7 @@
     ],
     "files": [
       {
-        "checksum": "adler32:61e0d8bfcaf6a57477fa6a2084f66c1086b87e9f",
+        "checksum": "adler32:5bbb40cb",
         "size": 8823,
         "uri": "root://eospublic.cern.ch//eos/opendata/cms/configuration-files/2015/reco_2015D_BTagMu.py"
       }
@@ -706,7 +706,7 @@
     ],
     "files": [
       {
-        "checksum": "adler32:40e1ddc585f39042eaee8cbdfdb029d58044d295",
+        "checksum": "adler32:e723456b",
         "size": 8834,
         "uri": "root://eospublic.cern.ch//eos/opendata/cms/configuration-files/2015/reco_2015D_DoubleMuonLowMass.py"
       }
@@ -758,7 +758,7 @@
     ],
     "files": [
       {
-        "checksum": "adler32:78e34075a6d116aee9cde5f3b80239c225fed72d",
+        "checksum": "adler32:336a527",
         "size": 15624,
         "uri": "root://eospublic.cern.ch//eos/opendata/cms/configuration-files/2015/reco_2015D_DoubleEG.py"
       }
@@ -810,7 +810,7 @@
     ],
     "files": [
       {
-        "checksum": "adler32:445a2bff7b9ed710295eac983b9f2c45a1a7137a",
+        "checksum": "adler32:5b9b4eba",
         "size": 21084,
         "uri": "root://eospublic.cern.ch//eos/opendata/cms/configuration-files/2015/reco_2015D_SingleElectron.py"
       }
@@ -862,7 +862,7 @@
     ],
     "files": [
       {
-        "checksum": "adler32:f3c898aedc2800c63648ff768af673462c369ad5",
+        "checksum": "adler32:867e3159",
         "size": 11109,
         "uri": "root://eospublic.cern.ch//eos/opendata/cms/configuration-files/2015/reco_2015D_MuOnia.py"
       }

--- a/cernopendata/modules/fixtures/data/records/cms-reco-configuration-files-2016.json
+++ b/cernopendata/modules/fixtures/data/records/cms-reco-configuration-files-2016.json
@@ -31,7 +31,7 @@
     ],
     "files": [
       {
-        "checksum": "adler32:8c2f95a4d6c27139ca5e799e373d1f32891cf4ed",
+        "checksum": "adler32:17d76f17",
         "size": 4672,
         "uri": "root://eospublic.cern.ch//eos/opendata/cms/configuration-files/2016/ReReco-Run2016G-DoubleEG-UL2016_MiniAODv2_JMENanoAODv9.py"
       }
@@ -84,7 +84,7 @@
     ],
     "files": [
       {
-        "checksum": "adler32:7333eca0eac2a8c0716ce9448dcf83806cd3dfba",
+        "checksum": "adler32:97786b9f",
         "size": 4663,
         "uri": "root://eospublic.cern.ch//eos/opendata/cms/configuration-files/2016/ReReco-Run2016G-JetHT-UL2016_MiniAODv2_JMENanoAODv9.py"
       }
@@ -137,7 +137,7 @@
     ],
     "files": [
       {
-        "checksum": "adler32:1afd6a81b942b487483959cb2fe4c5cb64749026",
+        "checksum": "adler32:ad387265",
         "size": 4678,
         "uri": "root://eospublic.cern.ch//eos/opendata/cms/configuration-files/2016/ReReco-Run2016G-SingleMuon-UL2016_MiniAODv2_JMENanoAODv9.py"
       }
@@ -190,7 +190,7 @@
     ],
     "files": [
       {
-        "checksum": "adler32:cba2f124f2adc7165a9736fed7f273d91ecd3442",
+        "checksum": "adler32:8e757250",
         "size": 4678,
         "uri": "root://eospublic.cern.ch//eos/opendata/cms/configuration-files/2016/ReReco-Run2016G-DoubleMuon-UL2016_MiniAODv2_JMENanoAODv9.py"
       }
@@ -243,7 +243,7 @@
     ],
     "files": [
       {
-        "checksum": "adler32:d495cdcdbfd8f1f0d4ae8386b2c4c0c6f995624e",
+        "checksum": "adler32:ebc4773c",
         "size": 4690,
         "uri": "root://eospublic.cern.ch//eos/opendata/cms/configuration-files/2016/ReReco-Run2016G-SingleElectron-UL2016_MiniAODv2_JMENanoAODv9.py"
       }
@@ -296,7 +296,7 @@
     ],
     "files": [
       {
-        "checksum": "adler32:7f88d21e6260737782487d371737c61966a2d43b",
+        "checksum": "adler32:d6317268",
         "size": 4678,
         "uri": "root://eospublic.cern.ch//eos/opendata/cms/configuration-files/2016/ReReco-Run2016H-SingleMuon-UL2016_MiniAODv2_JMENanoAODv9.py"
       }
@@ -349,7 +349,7 @@
     ],
     "files": [
       {
-        "checksum": "adler32:0701a1dfa5f195d9040c52d7c08e824dd855520c",
+        "checksum": "adler32:40c46f1a",
         "size": 4672,
         "uri": "root://eospublic.cern.ch//eos/opendata/cms/configuration-files/2016/ReReco-Run2016H-DoubleEG-UL2016_MiniAODv2_JMENanoAODv9.py"
       }
@@ -402,7 +402,7 @@
     ],
     "files": [
       {
-        "checksum": "adler32:44731173b77543b06bff231ff6854ced539abf44",
+        "checksum": "adler32:14e4773f",
         "size": 4690,
         "uri": "root://eospublic.cern.ch//eos/opendata/cms/configuration-files/2016/ReReco-Run2016H-SingleElectron-UL2016_MiniAODv2_JMENanoAODv9.py"
       }
@@ -455,7 +455,7 @@
     ],
     "files": [
       {
-        "checksum": "adler32:3de0d729b5f14b6c45e18d63f13cad954f82a8b0",
+        "checksum": "adler32:c0536ba2",
         "size": 4663,
         "uri": "root://eospublic.cern.ch//eos/opendata/cms/configuration-files/2016/ReReco-Run2016H-JetHT-UL2016_MiniAODv2_JMENanoAODv9.py"
       }
@@ -508,7 +508,7 @@
     ],
     "files": [
       {
-        "checksum": "adler32:53378b2d0ef9d2cab8e013367e8d5f2f9c910c2f",
+        "checksum": "adler32:b76e7253",
         "size": 4678,
         "uri": "root://eospublic.cern.ch//eos/opendata/cms/configuration-files/2016/ReReco-Run2016H-DoubleMuon-UL2016_MiniAODv2_JMENanoAODv9.py"
       }
@@ -561,7 +561,7 @@
     ],
     "files": [
       {
-        "checksum": "adler32:08feaccd5389d410d426e93260c31edf52fa192f",
+        "checksum": "adler32:8a634fa1",
         "size": 11968,
         "uri": "root://eospublic.cern.ch//eos/opendata/cms/configuration-files/2016/ReReco-Run2016H-DoubleMuonLowMass-21Feb2020_UL2016.py"
       }
@@ -614,7 +614,7 @@
     ],
     "files": [
       {
-        "checksum": "adler32:ad0efcfe07947cee3a168596e134a98b90b1f524",
+        "checksum": "adler32:eb384f9d",
         "size": 11968,
         "uri": "root://eospublic.cern.ch//eos/opendata/cms/configuration-files/2016/ReReco-Run2016G-DoubleMuonLowMass-21Feb2020_UL2016.py"
       }
@@ -667,7 +667,7 @@
     ],
     "files": [
       {
-        "checksum": "adler32:faa6bc539541a2692231ef294d294c32617f9420",
+        "checksum": "adler32:da5f1f69",
         "size": 11112,
         "uri": "root://eospublic.cern.ch//eos/opendata/cms/configuration-files/2016/ReReco-Run2016H-Charmonium-UL2016_MiniAODv2_BParking.py"
       }
@@ -720,7 +720,7 @@
     ],
     "files": [
       {
-        "checksum": "adler32:06e71166daea4d135b5df11f1ddad42f6a0ff1b7",
+        "checksum": "adler32:672e1f66",
         "size": 11112,
         "uri": "root://eospublic.cern.ch//eos/opendata/cms/configuration-files/2016/ReReco-Run2016G-Charmonium-UL2016_MiniAODv2_BParking.py"
       }
@@ -773,7 +773,7 @@
     ],
     "files": [
       {
-        "checksum": "adler32:4062343cd4c9ce87b696f15bf9398984701830df",
+        "checksum": "adler32:9cf71f1e",
         "size": 11112,
         "uri": "root://eospublic.cern.ch//eos/opendata/cms/configuration-files/2016/ReReco-Run2016H-DoubleMuon-UL2016_MiniAODv2_BParking.py"
       }
@@ -826,7 +826,7 @@
     ],
     "files": [
       {
-        "checksum": "adler32:45b3634600d305442ff73152ab6fb04b6fa75195",
+        "checksum": "adler32:29c61f1b",
         "size": 11112,
         "uri": "root://eospublic.cern.ch//eos/opendata/cms/configuration-files/2016/ReReco-Run2016G-DoubleMuon-UL2016_MiniAODv2_BParking.py"
       }
@@ -879,7 +879,7 @@
     ],
     "files": [
       {
-        "checksum": "adler32:0b20b156eb6908686877d2bfb206751305ccea7b",
+        "checksum": "adler32:c471be2",
         "size": 11106,
         "uri": "root://eospublic.cern.ch//eos/opendata/cms/configuration-files/2016/ReReco-Run2016G-DoubleEG-UL2016_MiniAODv2_BParking.py"
       }
@@ -932,7 +932,7 @@
     ],
     "files": [
       {
-        "checksum": "adler32:dea33d8f18f60d1ab382edffbf283b5fe784450f",
+        "checksum": "adler32:7f6c1be5",
         "size": 11106,
         "uri": "root://eospublic.cern.ch//eos/opendata/cms/configuration-files/2016/ReReco-Run2016H-DoubleEG-UL2016_MiniAODv2_BParking.py"
       }
@@ -985,7 +985,7 @@
     ],
     "files": [
       {
-        "checksum": "adler32:71a0b653979ce78eb8f05c495d7169751b8aec5a",
+        "checksum": "adler32:222d2407",
         "size": 11124,
         "uri": "root://eospublic.cern.ch//eos/opendata/cms/configuration-files/2016/ReReco-Run2016G-SingleElectron-UL2016_MiniAODv2_BParking.py"
       }
@@ -1038,7 +1038,7 @@
     ],
     "files": [
       {
-        "checksum": "adler32:7d1b0269f0244205004b5a4a563f059ec02200fb",
+        "checksum": "adler32:6b2f21bb",
         "size": 11118,
         "uri": "root://eospublic.cern.ch//eos/opendata/cms/configuration-files/2016/ReReco-Run2016G-SinglePhoton-UL2016_MiniAODv2_BParking.py"
       }
@@ -1091,7 +1091,7 @@
     ],
     "files": [
       {
-        "checksum": "adler32:b532c0ea4ab5c95712a4a12087d418f2ce1d73c0",
+        "checksum": "adler32:de6c21be",
         "size": 11118,
         "uri": "root://eospublic.cern.ch//eos/opendata/cms/configuration-files/2016/ReReco-Run2016H-SinglePhoton-UL2016_MiniAODv2_BParking.py"
       }
@@ -1144,7 +1144,7 @@
     ],
     "files": [
       {
-        "checksum": "adler32:9850bcd60dcdd073f1f7072c75fcd928e0eb7e28",
+        "checksum": "adler32:502f1f30",
         "size": 11112,
         "uri": "root://eospublic.cern.ch//eos/opendata/cms/configuration-files/2016/ReReco-Run2016G-SingleMuon-UL2016_MiniAODv2_BParking.py"
       }
@@ -1197,7 +1197,7 @@
     ],
     "files": [
       {
-        "checksum": "adler32:e255e600e84d39d52f972ce55bb3da9b2e67ccfe",
+        "checksum": "adler32:c3601f33",
         "size": 11112,
         "uri": "root://eospublic.cern.ch//eos/opendata/cms/configuration-files/2016/ReReco-Run2016H-SingleMuon-UL2016_MiniAODv2_BParking.py"
       }
@@ -1250,7 +1250,7 @@
     ],
     "files": [
       {
-        "checksum": "adler32:7aed79f2f7ca3bc8724dfa49b98a427d22db93d0",
+        "checksum": "adler32:82e9276d",
         "size": 11133,
         "uri": "root://eospublic.cern.ch//eos/opendata/cms/configuration-files/2016/ReReco-Run2016G-DoubleMuonLowMass-UL2016_MiniAODv2_BParking.py"
       }
@@ -1303,7 +1303,7 @@
     ],
     "files": [
       {
-        "checksum": "adler32:d39cbe40a3f70e4bfd887f46a64eb8b84981a4e2",
+        "checksum": "adler32:f6442770",
         "size": 11133,
         "uri": "root://eospublic.cern.ch//eos/opendata/cms/configuration-files/2016/ReReco-Run2016H-DoubleMuonLowMass-UL2016_MiniAODv2_BParking.py"
       }
@@ -1356,7 +1356,7 @@
     ],
     "files": [
       {
-        "checksum": "adler32:b2a463d7f5ae65eb2c9a1ac1b69caa87076f1e46",
+        "checksum": "adler32:94661a08",
         "size": 11100,
         "uri": "root://eospublic.cern.ch//eos/opendata/cms/configuration-files/2016/ReReco-Run2016G-MuOnia-UL2016_MiniAODv2_BParking.py"
       }
@@ -1409,7 +1409,7 @@
     ],
     "files": [
       {
-        "checksum": "adler32:803ea88c1b2d52b79f2a6c626ebcf752e4cdfe9b",
+        "checksum": "adler32:78e1a0b",
         "size": 11100,
         "uri": "root://eospublic.cern.ch//eos/opendata/cms/configuration-files/2016/ReReco-Run2016H-MuOnia-UL2016_MiniAODv2_BParking.py"
       }
@@ -1462,7 +1462,7 @@
     ],
     "files": [
       {
-        "checksum": "adler32:87197bb40e44b6f44d71d769e50f44b9ca54e494",
+        "checksum": "adler32:426d4ee",
         "size": 4242,
         "uri": "root://eospublic.cern.ch//eos/opendata/cms/configuration-files/2016/ReReco-Run2016H-BTagCSV-UL2016_MiniAODv2_NanoAODv9.py"
       }
@@ -1515,7 +1515,7 @@
     ],
     "files": [
       {
-        "checksum": "adler32:3db79afdbda7acde92d338b68410d8441a2b0008",
+        "checksum": "adler32:eaebe24d",
         "size": 4272,
         "uri": "root://eospublic.cern.ch//eos/opendata/cms/configuration-files/2016/ReReco-Run2016H-DoubleMuonLowMass-UL2016_MiniAODv2_NanoAODv9.py"
       }
@@ -1568,7 +1568,7 @@
     ],
     "files": [
       {
-        "checksum": "adler32:100638403b079377f396729c0b8c04b727674499",
+        "checksum": "adler32:9c9dd299",
         "size": 4236,
         "uri": "root://eospublic.cern.ch//eos/opendata/cms/configuration-files/2016/ReReco-Run2016G-HTMHT-UL2016_MiniAODv2_NanoAODv9.py"
       }
@@ -1621,7 +1621,7 @@
     ],
     "files": [
       {
-        "checksum": "adler32:77218fcefb314d957bf2e5b6bf7d98147ce7cec0",
+        "checksum": "adler32:d08fdc11",
         "size": 4257,
         "uri": "root://eospublic.cern.ch//eos/opendata/cms/configuration-files/2016/ReReco-Run2016H-DisplacedJet-UL2016_MiniAODv2_NanoAODv9.py"
       }
@@ -1674,7 +1674,7 @@
     ],
     "files": [
       {
-        "checksum": "adler32:2f71e42f88203acdc843927b4b550f84371566c8",
+        "checksum": "adler32:68e2d46d",
         "size": 4239,
         "uri": "root://eospublic.cern.ch//eos/opendata/cms/configuration-files/2016/ReReco-Run2016H-BTagMu-UL2016_MiniAODv2_NanoAODv9.py"
       }
@@ -1727,7 +1727,7 @@
     ],
     "files": [
       {
-        "checksum": "adler32:7f974e70145a462eefe8a12e774dd3c57662f05c",
+        "checksum": "adler32:6cd4dc9b",
         "size": 4257,
         "uri": "root://eospublic.cern.ch//eos/opendata/cms/configuration-files/2016/ReReco-Run2016G-SinglePhoton-UL2016_MiniAODv2_NanoAODv9.py"
       }
@@ -1780,7 +1780,7 @@
     ],
     "files": [
       {
-        "checksum": "adler32:d5d3759723dda066b9380e85b8731ca596d98962",
+        "checksum": "adler32:927c8fe1",
         "size": 10008,
         "uri": "root://eospublic.cern.ch//eos/opendata/cms/configuration-files/2016/ReReco-Run2016H-BTagCSV-UL2016_MiniAODv2.py"
       }
@@ -1833,7 +1833,7 @@
     ],
     "files": [
       {
-        "checksum": "adler32:ef7aab447c3289142d13eee5706f11f9aec064a1",
+        "checksum": "adler32:314e9791",
         "size": 10023,
         "uri": "root://eospublic.cern.ch//eos/opendata/cms/configuration-files/2016/ReReco-Run2016G-SinglePhoton-UL2016_MiniAODv2.py"
       }
@@ -1886,7 +1886,7 @@
     ],
     "files": [
       {
-        "checksum": "adler32:21de8499459c725ac1802bd12d15ba517f0aa77e",
+        "checksum": "adler32:bb5ad188",
         "size": 4230,
         "uri": "root://eospublic.cern.ch//eos/opendata/cms/configuration-files/2016/ReReco-Run2016G-Tau-UL2016_MiniAODv2_NanoAODv9.py"
       }
@@ -1939,7 +1939,7 @@
     ],
     "files": [
       {
-        "checksum": "adler32:0ffaf58fb01ed0e9af925c2f3bcfd359b089c8e3",
+        "checksum": "adler32:26dcd4e5",
         "size": 4239,
         "uri": "root://eospublic.cern.ch//eos/opendata/cms/configuration-files/2016/ReReco-Run2016G-MuOnia-UL2016_MiniAODv2_NanoAODv9.py"
       }
@@ -1992,7 +1992,7 @@
     ],
     "files": [
       {
-        "checksum": "adler32:057e8b46b5e00ef7bdd3eba18381a645c3bd4a65",
+        "checksum": "adler32:b74eda43",
         "size": 4251,
         "uri": "root://eospublic.cern.ch//eos/opendata/cms/configuration-files/2016/ReReco-Run2016G-Charmonium-UL2016_MiniAODv2_NanoAODv9.py"
       }
@@ -2045,7 +2045,7 @@
     ],
     "files": [
       {
-        "checksum": "adler32:e11b4ae00c312ea08853e19d3e32764bd9f4016d",
+        "checksum": "adler32:1b50953c",
         "size": 10017,
         "uri": "root://eospublic.cern.ch//eos/opendata/cms/configuration-files/2016/ReReco-Run2016H-Charmonium-UL2016_MiniAODv2.py"
       }
@@ -2098,7 +2098,7 @@
     ],
     "files": [
       {
-        "checksum": "adler32:c7fe1b68b442c89b965ef8bce4ae782bea1ffb68",
+        "checksum": "adler32:55da94f4",
         "size": 10017,
         "uri": "root://eospublic.cern.ch//eos/opendata/cms/configuration-files/2016/ReReco-Run2016H-DoubleMuon-UL2016_MiniAODv2.py"
       }
@@ -2151,7 +2151,7 @@
     ],
     "files": [
       {
-        "checksum": "adler32:5d39f87d1bcbb0b5a0a382d48250f711e49e1e7f",
+        "checksum": "adler32:fa126a9d",
         "size": 9894,
         "uri": "root://eospublic.cern.ch//eos/opendata/cms/configuration-files/2016/ReReco-Run2016H-MuOnia-UL2016_MiniAODv2.py"
       }
@@ -2204,7 +2204,7 @@
     ],
     "files": [
       {
-        "checksum": "adler32:53152e01c9f6602f79f56638476f53a54a5367e3",
+        "checksum": "adler32:10028e40",
         "size": 10002,
         "uri": "root://eospublic.cern.ch//eos/opendata/cms/configuration-files/2016/ReReco-Run2016H-JetHT-UL2016_MiniAODv2.py"
       }
@@ -2257,7 +2257,7 @@
     ],
     "files": [
       {
-        "checksum": "adler32:11593afc0c3186f6018a9795066c060f1703ce00",
+        "checksum": "adler32:a7c18e3d",
         "size": 10002,
         "uri": "root://eospublic.cern.ch//eos/opendata/cms/configuration-files/2016/ReReco-Run2016G-JetHT-UL2016_MiniAODv2.py"
       }
@@ -2310,7 +2310,7 @@
     ],
     "files": [
       {
-        "checksum": "adler32:bfe41f6f8a3e14bc619ce7e58f0faffe7ae023f9",
+        "checksum": "adler32:c24e8fdb",
         "size": 10008,
         "uri": "root://eospublic.cern.ch//eos/opendata/cms/configuration-files/2016/ReReco-Run2016G-BTagCSV-UL2016_MiniAODv2.py"
       }
@@ -2363,7 +2363,7 @@
     ],
     "files": [
       {
-        "checksum": "adler32:d071f59ba37d8843c016f215fc8f28444e8b04e4",
+        "checksum": "adler32:f4969d43",
         "size": 10038,
         "uri": "root://eospublic.cern.ch//eos/opendata/cms/configuration-files/2016/ReReco-Run2016H-DoubleMuonLowMass-UL2016_MiniAODv2.py"
       }
@@ -2416,7 +2416,7 @@
     ],
     "files": [
       {
-        "checksum": "adler32:8ecd6be82cd59f04454e5e636afd953e7b487f2c",
+        "checksum": "adler32:c9bb978e",
         "size": 10023,
         "uri": "root://eospublic.cern.ch//eos/opendata/cms/configuration-files/2016/ReReco-Run2016H-SinglePhoton-UL2016_MiniAODv2.py"
       }
@@ -2469,7 +2469,7 @@
     ],
     "files": [
       {
-        "checksum": "adler32:2538bcc4badc0bf8cdd3afe310b3f64aaba7380b",
+        "checksum": "adler32:b4ea8c7b",
         "size": 9996,
         "uri": "root://eospublic.cern.ch//eos/opendata/cms/configuration-files/2016/ReReco-Run2016G-Tau-UL2016_MiniAODv2.py"
       }
@@ -2522,7 +2522,7 @@
     ],
     "files": [
       {
-        "checksum": "adler32:f3c85fcb7a89ccbe91bb7056be581cf01b012fa8",
+        "checksum": "adler32:1d1f8c7e",
         "size": 9996,
         "uri": "root://eospublic.cern.ch//eos/opendata/cms/configuration-files/2016/ReReco-Run2016H-Tau-UL2016_MiniAODv2.py"
       }
@@ -2575,7 +2575,7 @@
     ],
     "files": [
       {
-        "checksum": "adler32:63f38fe70dde31f4f6f37dc6ab43a3f4f5dd94ed",
+        "checksum": "adler32:2fd38f5d",
         "size": 10005,
         "uri": "root://eospublic.cern.ch//eos/opendata/cms/configuration-files/2016/ReReco-Run2016G-BTagMu-UL2016_MiniAODv2.py"
       }
@@ -2628,7 +2628,7 @@
     ],
     "files": [
       {
-        "checksum": "adler32:4c313e10833a11f3ed99b722ea6884ad4fdb1fec",
+        "checksum": "adler32:a5a38d8c",
         "size": 10002,
         "uri": "root://eospublic.cern.ch//eos/opendata/cms/configuration-files/2016/ReReco-Run2016G-HTMHT-UL2016_MiniAODv2.py"
       }
@@ -2681,7 +2681,7 @@
     ],
     "files": [
       {
-        "checksum": "adler32:a7391be6dad08903fda5777fe6c9e8b33967000d",
+        "checksum": "adler32:980b8f60",
         "size": 10005,
         "uri": "root://eospublic.cern.ch//eos/opendata/cms/configuration-files/2016/ReReco-Run2016H-BTagMu-UL2016_MiniAODv2.py"
       }
@@ -2734,7 +2734,7 @@
     ],
     "files": [
       {
-        "checksum": "adler32:dd3dc0ce1f8b672e923304d7fa0a2a9a4044c6c1",
+        "checksum": "adler32:de48d8f",
         "size": 10002,
         "uri": "root://eospublic.cern.ch//eos/opendata/cms/configuration-files/2016/ReReco-Run2016H-HTMHT-UL2016_MiniAODv2.py"
       }
@@ -2787,7 +2787,7 @@
     ],
     "files": [
       {
-        "checksum": "adler32:ff002c7541feafff4f211fb82bd965b81be08844",
+        "checksum": "adler32:bef8baf",
         "size": 9996,
         "uri": "root://eospublic.cern.ch//eos/opendata/cms/configuration-files/2016/ReReco-Run2016G-MET-UL2016_MiniAODv2.py"
       }
@@ -2840,7 +2840,7 @@
     ],
     "files": [
       {
-        "checksum": "adler32:b21dc18608ccfb0aca84c57eeaf24a1ca06c2b03",
+        "checksum": "adler32:74158bb2",
         "size": 9996,
         "uri": "root://eospublic.cern.ch//eos/opendata/cms/configuration-files/2016/ReReco-Run2016H-MET-UL2016_MiniAODv2.py"
       }
@@ -2893,7 +2893,7 @@
     ],
     "files": [
       {
-        "checksum": "adler32:5778aa97dc1561a00dd392893a0d38ddfa1f9faa",
+        "checksum": "adler32:ac518f7e",
         "size": 10005,
         "uri": "root://eospublic.cern.ch//eos/opendata/cms/configuration-files/2016/ReReco-Run2016G-MuonEG-UL2016_MiniAODv2.py"
       }
@@ -2946,7 +2946,7 @@
     ],
     "files": [
       {
-        "checksum": "adler32:ce776f1bc083af08fc82064d4f19acf9394a996f",
+        "checksum": "adler32:14988f81",
         "size": 10005,
         "uri": "root://eospublic.cern.ch//eos/opendata/cms/configuration-files/2016/ReReco-Run2016H-MuonEG-UL2016_MiniAODv2.py"
       }
@@ -2999,7 +2999,7 @@
     ],
     "files": [
       {
-        "checksum": "adler32:90187c7ebd473d13f84bf25576dc68bcff407fab",
+        "checksum": "adler32:f7da9500",
         "size": 10017,
         "uri": "root://eospublic.cern.ch//eos/opendata/cms/configuration-files/2016/ReReco-Run2016G-SingleMuon-UL2016_MiniAODv2.py"
       }
@@ -3052,7 +3052,7 @@
     ],
     "files": [
       {
-        "checksum": "adler32:80a3a12ff50366022529c9da671476f784c2d787",
+        "checksum": "adler32:60399503",
         "size": 10017,
         "uri": "root://eospublic.cern.ch//eos/opendata/cms/configuration-files/2016/ReReco-Run2016H-SingleMuon-UL2016_MiniAODv2.py"
       }
@@ -3105,7 +3105,7 @@
     ],
     "files": [
       {
-        "checksum": "adler32:169321b92dffe2ab3c03a1e0fbb693fa96c0fb9f",
+        "checksum": "adler32:4b5799d7",
         "size": 10029,
         "uri": "root://eospublic.cern.ch//eos/opendata/cms/configuration-files/2016/ReReco-Run2016G-SingleElectron-UL2016_MiniAODv2.py"
       }
@@ -3158,7 +3158,7 @@
     ],
     "files": [
       {
-        "checksum": "adler32:e1b36fb8e02fa7bad0150ee87cfde373375fa2bb",
+        "checksum": "adler32:b3bf99da",
         "size": 10029,
         "uri": "root://eospublic.cern.ch//eos/opendata/cms/configuration-files/2016/ReReco-Run2016H-SingleElectron-UL2016_MiniAODv2.py"
       }
@@ -3211,7 +3211,7 @@
     ],
     "files": [
       {
-        "checksum": "adler32:e166632710533ee19ece42aa7919c54a0875a49d",
+        "checksum": "adler32:c15dd29c",
         "size": 4236,
         "uri": "root://eospublic.cern.ch//eos/opendata/cms/configuration-files/2016/ReReco-Run2016H-HTMHT-UL2016_MiniAODv2_NanoAODv9.py"
       }
@@ -3264,7 +3264,7 @@
     ],
     "files": [
       {
-        "checksum": "adler32:3f596623716fb2ccafff00b6b1bf496416a9ca15",
+        "checksum": "adler32:aba5dc0e",
         "size": 4257,
         "uri": "root://eospublic.cern.ch//eos/opendata/cms/configuration-files/2016/ReReco-Run2016G-DisplacedJet-UL2016_MiniAODv2_NanoAODv9.py"
       }
@@ -3317,7 +3317,7 @@
     ],
     "files": [
       {
-        "checksum": "adler32:74c73c579c1447a0022191bd79909b006eb9b531",
+        "checksum": "adler32:12ebd34a",
         "size": 4236,
         "uri": "root://eospublic.cern.ch//eos/opendata/cms/configuration-files/2016/ReReco-Run2016H-JetHT-UL2016_MiniAODv2_NanoAODv9.py"
       }
@@ -3370,7 +3370,7 @@
     ],
     "files": [
       {
-        "checksum": "adler32:2c289ed2be693678c77ddcdefdb99128561a5900",
+        "checksum": "adler32:441cd46a",
         "size": 4239,
         "uri": "root://eospublic.cern.ch//eos/opendata/cms/configuration-files/2016/ReReco-Run2016G-BTagMu-UL2016_MiniAODv2_NanoAODv9.py"
       }
@@ -3423,7 +3423,7 @@
     ],
     "files": [
       {
-        "checksum": "adler32:627508647457448bc0d33bdd057d8b2d6ae4289a",
+        "checksum": "adler32:90ae91b5",
         "size": 10011,
         "uri": "root://eospublic.cern.ch//eos/opendata/cms/configuration-files/2016/ReReco-Run2016G-DoubleEG-UL2016_MiniAODv2.py"
       }
@@ -3476,7 +3476,7 @@
     ],
     "files": [
       {
-        "checksum": "adler32:37c878e8fe09f42334b808e20153bdf959c019b9",
+        "checksum": "adler32:859194ee",
         "size": 10017,
         "uri": "root://eospublic.cern.ch//eos/opendata/cms/configuration-files/2016/ReReco-Run2016G-DoubleMuon-UL2016_MiniAODv2.py"
       }
@@ -3529,7 +3529,7 @@
     ],
     "files": [
       {
-        "checksum": "adler32:634199b7f0376878df797b8fe36b9d3273fb0f35",
+        "checksum": "adler32:f8f291b8",
         "size": 10011,
         "uri": "root://eospublic.cern.ch//eos/opendata/cms/configuration-files/2016/ReReco-Run2016H-DoubleEG-UL2016_MiniAODv2.py"
       }
@@ -3582,7 +3582,7 @@
     ],
     "files": [
       {
-        "checksum": "adler32:90fe5dc8edcf6fe21abecc167ff4a2960dbff7b2",
+        "checksum": "adler32:da87d48b",
         "size": 4239,
         "uri": "root://eospublic.cern.ch//eos/opendata/cms/configuration-files/2016/ReReco-Run2016G-MuonEG-UL2016_MiniAODv2_NanoAODv9.py"
       }
@@ -3635,7 +3635,7 @@
     ],
     "files": [
       {
-        "checksum": "adler32:e8d347336a755534ba8878226a94b0453ec7822d",
+        "checksum": "adler32:6d5edc9b",
         "size": 4257,
         "uri": "root://eospublic.cern.ch//eos/opendata/cms/configuration-files/2016/ReReco-Run2016H-SinglePhoton-UL2016_MiniAODv2_NanoAODv9.py"
       }
@@ -3688,7 +3688,7 @@
     ],
     "files": [
       {
-        "checksum": "adler32:ca7cb920d3fffa5699132d3fe32726365f581381",
+        "checksum": "adler32:227fda0d",
         "size": 4251,
         "uri": "root://eospublic.cern.ch//eos/opendata/cms/configuration-files/2016/ReReco-Run2016G-SingleMuon-UL2016_MiniAODv2_NanoAODv9.py"
       }
@@ -3741,7 +3741,7 @@
     ],
     "files": [
       {
-        "checksum": "adler32:ddedffe8bfe8871c93a87b9c0a10dc6eabf4ff05",
+        "checksum": "adler32:2269d0bf",
         "size": 4230,
         "uri": "root://eospublic.cern.ch//eos/opendata/cms/configuration-files/2016/ReReco-Run2016H-MET-UL2016_MiniAODv2_NanoAODv9.py"
       }
@@ -3794,7 +3794,7 @@
     ],
     "files": [
       {
-        "checksum": "adler32:3f784d199ef4fb1a305cae09456d0f17f79c3550",
+        "checksum": "adler32:ff4dd48e",
         "size": 4239,
         "uri": "root://eospublic.cern.ch//eos/opendata/cms/configuration-files/2016/ReReco-Run2016H-MuonEG-UL2016_MiniAODv2_NanoAODv9.py"
       }
@@ -3847,7 +3847,7 @@
     ],
     "files": [
       {
-        "checksum": "adler32:1b50054093f5fc1a0197c0e6ed3fe808438cad4f",
+        "checksum": "adler32:9c86dee7",
         "size": 4263,
         "uri": "root://eospublic.cern.ch//eos/opendata/cms/configuration-files/2016/ReReco-Run2016H-SingleElectron-UL2016_MiniAODv2_NanoAODv9.py"
       }
@@ -3900,7 +3900,7 @@
     ],
     "files": [
       {
-        "checksum": "adler32:a8cca218492bc676cb326a5906118a37dc673277",
+        "checksum": "adler32:475dda10",
         "size": 4251,
         "uri": "root://eospublic.cern.ch//eos/opendata/cms/configuration-files/2016/ReReco-Run2016H-SingleMuon-UL2016_MiniAODv2_NanoAODv9.py"
       }
@@ -3953,7 +3953,7 @@
     ],
     "files": [
       {
-        "checksum": "adler32:24c1d71ad326f15032d4e6c82d7981c573c8a7e6",
+        "checksum": "adler32:e00ed18b",
         "size": 4230,
         "uri": "root://eospublic.cern.ch//eos/opendata/cms/configuration-files/2016/ReReco-Run2016H-Tau-UL2016_MiniAODv2_NanoAODv9.py"
       }
@@ -4006,7 +4006,7 @@
     ],
     "files": [
       {
-        "checksum": "adler32:4cba9c2d1a12656a95bd4ab5dc9fb8a4cd2f5dd0",
+        "checksum": "adler32:dca4d6c2",
         "size": 4245,
         "uri": "root://eospublic.cern.ch//eos/opendata/cms/configuration-files/2016/ReReco-Run2016H-DoubleEG-UL2016_MiniAODv2_NanoAODv9.py"
       }
@@ -4059,7 +4059,7 @@
     ],
     "files": [
       {
-        "checksum": "adler32:7c6d62488a08a45fe614c0aa98d6bcf7f1b06860",
+        "checksum": "adler32:ea52e24d",
         "size": 4272,
         "uri": "root://eospublic.cern.ch//eos/opendata/cms/configuration-files/2016/ReReco-Run2016G-DoubleMuonLowMass-UL2016_MiniAODv2_NanoAODv9.py"
       }
@@ -4112,7 +4112,7 @@
     ],
     "files": [
       {
-        "checksum": "adler32:7244d3924ff55dd0ac65e2d2566377c272368a47",
+        "checksum": "adler32:c3be9260",
         "size": 10011,
         "uri": "root://eospublic.cern.ch//eos/opendata/cms/configuration-files/2016/ReReco-Run2016H-ZeroBias-UL2016_MiniAODv2.py"
       }
@@ -4165,7 +4165,7 @@
     ],
     "files": [
       {
-        "checksum": "adler32:4dfad2d5b1f57b899d2277c4f7516efc8be287f8",
+        "checksum": "adler32:5b7a925d",
         "size": 10011,
         "uri": "root://eospublic.cern.ch//eos/opendata/cms/configuration-files/2016/ReReco-Run2016G-ZeroBias-UL2016_MiniAODv2.py"
       }
@@ -4218,7 +4218,7 @@
     ],
     "files": [
       {
-        "checksum": "adler32:fbba5ead035451e9ad8cf7c7eef01b5d3d2c8b4a",
+        "checksum": "adler32:de546fbc",
         "size": 4672,
         "uri": "root://eospublic.cern.ch//eos/opendata/cms/configuration-files/2016/ReReco-Run2016G-ZeroBias-UL2016_MiniAODv2_JMENanoAODv9.py"
       }
@@ -4271,7 +4271,7 @@
     ],
     "files": [
       {
-        "checksum": "adler32:895e37339ffbcfeca1de8e6e1d6f34744537a250",
+        "checksum": "adler32:8c1c9d40",
         "size": 10038,
         "uri": "root://eospublic.cern.ch//eos/opendata/cms/configuration-files/2016/ReReco-Run2016G-DoubleMuonLowMass-UL2016_MiniAODv2.py"
       }
@@ -4324,7 +4324,7 @@
     ],
     "files": [
       {
-        "checksum": "adler32:13eadf3812ff47499eac28848d9e6654339de5df",
+        "checksum": "adler32:95da49",
         "size": 4251,
         "uri": "root://eospublic.cern.ch//eos/opendata/cms/configuration-files/2016/ReReco-Run2016H-Charmonium-UL2016_MiniAODv2_NanoAODv9.py"
       }
@@ -4377,7 +4377,7 @@
     ],
     "files": [
       {
-        "checksum": "adler32:fa2df9f335fa2327446081d993af58794dba422f",
+        "checksum": "adler32:44d3d9fb",
         "size": 4251,
         "uri": "root://eospublic.cern.ch//eos/opendata/cms/configuration-files/2016/ReReco-Run2016G-DoubleMuon-UL2016_MiniAODv2_NanoAODv9.py"
       }
@@ -4430,7 +4430,7 @@
     ],
     "files": [
       {
-        "checksum": "adler32:f29c00bb05da4382f76a568231586aab068d0378",
+        "checksum": "adler32:ee1cd347",
         "size": 4236,
         "uri": "root://eospublic.cern.ch//eos/opendata/cms/configuration-files/2016/ReReco-Run2016G-JetHT-UL2016_MiniAODv2_NanoAODv9.py"
       }
@@ -4483,7 +4483,7 @@
     ],
     "files": [
       {
-        "checksum": "adler32:6ce9228ff38a4f36f43ad47f596a5692b0aa5358",
+        "checksum": "adler32:7790dee4",
         "size": 4263,
         "uri": "root://eospublic.cern.ch//eos/opendata/cms/configuration-files/2016/ReReco-Run2016G-SingleElectron-UL2016_MiniAODv2_NanoAODv9.py"
       }
@@ -4536,7 +4536,7 @@
     ],
     "files": [
       {
-        "checksum": "adler32:7b29747770d5add9e730d8dda2839b65bdf83137",
+        "checksum": "adler32:bafad4e8",
         "size": 4242,
         "uri": "root://eospublic.cern.ch//eos/opendata/cms/configuration-files/2016/ReReco-Run2016G-BTagCSV-UL2016_MiniAODv2_NanoAODv9.py"
       }
@@ -4589,7 +4589,7 @@
     ],
     "files": [
       {
-        "checksum": "adler32:b34d99ace9eed68bed043700aa7bd8817443eaa9",
+        "checksum": "adler32:7506fbf",
         "size": 4672,
         "uri": "root://eospublic.cern.ch//eos/opendata/cms/configuration-files/2016/ReReco-Run2016H-ZeroBias-UL2016_MiniAODv2_JMENanoAODv9.py"
       }
@@ -4642,7 +4642,7 @@
     ],
     "files": [
       {
-        "checksum": "adler32:50423ac5123398d8e8b8b283319d07bbf6e5d9c7",
+        "checksum": "adler32:b7d2d6bf",
         "size": 4245,
         "uri": "root://eospublic.cern.ch//eos/opendata/cms/configuration-files/2016/ReReco-Run2016G-DoubleEG-UL2016_MiniAODv2_NanoAODv9.py"
       }
@@ -4695,7 +4695,7 @@
     ],
     "files": [
       {
-        "checksum": "adler32:47ec8681641e3226b3ba4bddeb5548af59f73b93",
+        "checksum": "adler32:81d40dd9",
         "size": 104967,
         "uri": "root://eospublic.cern.ch//eos/opendata/cms/configuration-files/2016/recoskim_Run2016G_DoubleEG.py"
       }
@@ -4748,7 +4748,7 @@
     ],
     "files": [
       {
-        "checksum": "adler32:8eed18aa9dc374f4942c54c6bd36897a04e2b998",
+        "checksum": "adler32:3f427af8",
         "size": 51530,
         "uri": "root://eospublic.cern.ch//eos/opendata/cms/configuration-files/2016/recoskim_Run2016G_DoubleMuon.py"
       }
@@ -4801,7 +4801,7 @@
     ],
     "files": [
       {
-        "checksum": "adler32:424880802cd255a330ab8cc06c5b879bc83f53a0",
+        "checksum": "adler32:beb5ba18",
         "size": 73534,
         "uri": "root://eospublic.cern.ch//eos/opendata/cms/configuration-files/2016/recoskim_Run2016G_JetHT.py"
       }
@@ -4854,7 +4854,7 @@
     ],
     "files": [
       {
-        "checksum": "adler32:ff8ae2dd972b1f9bb301a16db335044002bcc1df",
+        "checksum": "adler32:318df04e",
         "size": 93063,
         "uri": "root://eospublic.cern.ch//eos/opendata/cms/configuration-files/2016/recoskim_Run2016G_MET.py"
       }
@@ -4907,7 +4907,7 @@
     ],
     "files": [
       {
-        "checksum": "adler32:ac4f968fce857bce43be070449250d4118f79645",
+        "checksum": "adler32:57f56520",
         "size": 55032,
         "uri": "root://eospublic.cern.ch//eos/opendata/cms/configuration-files/2016/recoskim_Run2016G_SingleElectron.py"
       }
@@ -4960,7 +4960,7 @@
     ],
     "files": [
       {
-        "checksum": "adler32:ca1ad991a3e0dcf4ee2aa862eceaebf8332c1394",
+        "checksum": "adler32:e07ff21e",
         "size": 89997,
         "uri": "root://eospublic.cern.ch//eos/opendata/cms/configuration-files/2016/recoskim_Run2016G_SingleMuon.py"
       }
@@ -5013,7 +5013,7 @@
     ],
     "files": [
       {
-        "checksum": "adler32:add8d973b11b24c5124556f6f5cde2ec7500887e",
+        "checksum": "adler32:26199ae",
         "size": 47428,
         "uri": "root://eospublic.cern.ch//eos/opendata/cms/configuration-files/2016/recoskim_Run2016G_ZeroBias.py"
       }
@@ -5066,7 +5066,7 @@
     ],
     "files": [
       {
-        "checksum": "adler32:80ed3587c5cb9a398be2fc787fa42147fe4e83c1",
+        "checksum": "adler32:192a0dda",
         "size": 104967,
         "uri": "root://eospublic.cern.ch//eos/opendata/cms/configuration-files/2016/recoskim_Run2016H_DoubleEG.py"
       }
@@ -5119,7 +5119,7 @@
     ],
     "files": [
       {
-        "checksum": "adler32:9df5397f1c843e604e7792a3761ac8391dda861a",
+        "checksum": "adler32:5db7af9",
         "size": 51530,
         "uri": "root://eospublic.cern.ch//eos/opendata/cms/configuration-files/2016/recoskim_Run2016H_DoubleMuon.py"
       }
@@ -5172,7 +5172,7 @@
     ],
     "files": [
       {
-        "checksum": "adler32:2c0125b85b209c77ae86a7b5efa349042d93873b",
+        "checksum": "adler32:db48ba19",
         "size": 73534,
         "uri": "root://eospublic.cern.ch//eos/opendata/cms/configuration-files/2016/recoskim_Run2016H_JetHT.py"
       }
@@ -5225,7 +5225,7 @@
     ],
     "files": [
       {
-        "checksum": "adler32:8441da5d781ee03d524f11e9efa70f9fc18e7071",
+        "checksum": "adler32:9a98f04f",
         "size": 93063,
         "uri": "root://eospublic.cern.ch//eos/opendata/cms/configuration-files/2016/recoskim_Run2016H_MET.py"
       }
@@ -5278,7 +5278,7 @@
     ],
     "files": [
       {
-        "checksum": "adler32:d5709905d24e71234be43e3ef2d1c0139bfa093d",
+        "checksum": "adler32:2c496521",
         "size": 55032,
         "uri": "root://eospublic.cern.ch//eos/opendata/cms/configuration-files/2016/recoskim_Run2016H_SingleElectron.py"
       }
@@ -5331,7 +5331,7 @@
     ],
     "files": [
       {
-        "checksum": "adler32:b8cfc38a8ee33f36956b1f1b04c5e86cfee3430e",
+        "checksum": "adler32:3d04f21f",
         "size": 89997,
         "uri": "root://eospublic.cern.ch//eos/opendata/cms/configuration-files/2016/recoskim_Run2016H_SingleMuon.py"
       }
@@ -5384,7 +5384,7 @@
     ],
     "files": [
       {
-        "checksum": "adler32:5e8fb50b4def84c67d16e38e0ecb59234603b413",
+        "checksum": "adler32:b8de99af",
         "size": 47428,
         "uri": "root://eospublic.cern.ch//eos/opendata/cms/configuration-files/2016/recoskim_Run2016H_ZeroBias.py"
       }
@@ -5437,7 +5437,7 @@
     ],
     "files": [
       {
-        "checksum": "adler32:46b1314b12de926e430cd3b19d25297d5e90b598",
+        "checksum": "adler32:fda6d0bc",
         "size": 4230,
         "uri": "root://eospublic.cern.ch//eos/opendata/cms/configuration-files/2016/ReReco-Run2016G-MET-UL2016_MiniAODv2_NanoAODv9.py"
       }
@@ -5490,7 +5490,7 @@
     ],
     "files": [
       {
-        "checksum": "adler32:0ff88e0d5e959d413af203932cabe84e374dd5db",
+        "checksum": "adler32:6ff0d4eb",
         "size": 4239,
         "uri": "root://eospublic.cern.ch//eos/opendata/cms/configuration-files/2016/ReReco-Run2016H-MuOnia-UL2016_MiniAODv2_NanoAODv9.py"
       }
@@ -5543,7 +5543,7 @@
     ],
     "files": [
       {
-        "checksum": "adler32:b0bbcf5720b136ee3b74f5c5949ffd33760a829d",
+        "checksum": "adler32:69b1d9fe",
         "size": 4251,
         "uri": "root://eospublic.cern.ch//eos/opendata/cms/configuration-files/2016/ReReco-Run2016H-DoubleMuon-UL2016_MiniAODv2_NanoAODv9.py"
       }
@@ -5596,7 +5596,7 @@
     ],
     "files": [
       {
-        "checksum": "adler32:c247d38eddd392802db75fe00134585eede453d8",
+        "checksum": "adler32:4b079536",
         "size": 10017,
         "uri": "root://eospublic.cern.ch//eos/opendata/cms/configuration-files/2016/ReReco-Run2016G-Charmonium-UL2016_MiniAODv2.py"
       }
@@ -5649,7 +5649,7 @@
     ],
     "files": [
       {
-        "checksum": "adler32:8434b01136c978719f07ba93b4baf79eb0a28c01",
+        "checksum": "adler32:151671c0",
         "size": 9912,
         "uri": "root://eospublic.cern.ch//eos/opendata/cms/configuration-files/2016/ReReco-Run2016G-DisplacedJet-UL2016_MiniAODv2.py"
       }
@@ -5702,7 +5702,7 @@
     ],
     "files": [
       {
-        "checksum": "adler32:565d6448ed9b7e4e5e41512c7ec0d35355942b88",
+        "checksum": "adler32:7c9a71c3",
         "size": 9912,
         "uri": "root://eospublic.cern.ch//eos/opendata/cms/configuration-files/2016/ReReco-Run2016H-DisplacedJet-UL2016_MiniAODv2.py"
       }
@@ -5755,7 +5755,7 @@
     ],
     "files": [
       {
-        "checksum": "adler32:4abdc79ff72e86e886e38c2a931d2ca229e6152f",
+        "checksum": "adler32:2bac6a97",
         "size": 9894,
         "uri": "root://eospublic.cern.ch//eos/opendata/cms/configuration-files/2016/ReReco-Run2016G-MuOnia-UL2016_MiniAODv2.py"
       }
@@ -5808,7 +5808,7 @@
     ],
     "files": [
       {
-        "checksum": "adler32:ba3c41989107a26017ffb72cfcac34127b47cdbd",
+        "checksum": "adler32:9456801d",
         "size": 41858,
         "uri": "root://eospublic.cern.ch//eos/opendata/cms/configuration-files/2016/recoskim_Run2016G_BTagCSV.py"
       }
@@ -5861,7 +5861,7 @@
     ],
     "files": [
       {
-        "checksum": "adler32:2481a53f851a70041c2a04aaf3ab6b884f836c78",
+        "checksum": "adler32:516b7ff3",
         "size": 41857,
         "uri": "root://eospublic.cern.ch//eos/opendata/cms/configuration-files/2016/recoskim_Run2016G_BTagMu.py"
       }
@@ -5914,7 +5914,7 @@
     ],
     "files": [
       {
-        "checksum": "adler32:033d3fc519b22a15b45e95d2e9b0f762b2fc568a",
+        "checksum": "adler32:f986ca80",
         "size": 45336,
         "uri": "root://eospublic.cern.ch//eos/opendata/cms/configuration-files/2016/recoskim_Run2016G_Charmonium.py"
       }
@@ -5967,7 +5967,7 @@
     ],
     "files": [
       {
-        "checksum": "adler32:7b3b327185c817989a24a0eefb28bba49a12f496",
+        "checksum": "adler32:abaf827f",
         "size": 41863,
         "uri": "root://eospublic.cern.ch//eos/opendata/cms/configuration-files/2016/recoskim_Run2016G_DisplacedJet.py"
       }
@@ -6020,7 +6020,7 @@
     ],
     "files": [
       {
-        "checksum": "adler32:5df273f409b0c1434b03db21e928f5a0973113ae",
+        "checksum": "adler32:f0137f58",
         "size": 41856,
         "uri": "root://eospublic.cern.ch//eos/opendata/cms/configuration-files/2016/recoskim_Run2016G_HTMHT.py"
       }
@@ -6073,7 +6073,7 @@
     ],
     "files": [
       {
-        "checksum": "adler32:51850e6c3064204d83343fbad5015a8bcb188187",
+        "checksum": "adler32:aeb36c93",
         "size": 44203,
         "uri": "root://eospublic.cern.ch//eos/opendata/cms/configuration-files/2016/recoskim_Run2016G_MuOnia.py"
       }
@@ -6126,7 +6126,7 @@
     ],
     "files": [
       {
-        "checksum": "adler32:018214f8c674adecafaa905c4dfec23843e757c4",
+        "checksum": "adler32:7ea4b67b",
         "size": 69594,
         "uri": "root://eospublic.cern.ch//eos/opendata/cms/configuration-files/2016/recoskim_Run2016G_MuonEG.py"
       }
@@ -6179,7 +6179,7 @@
     ],
     "files": [
       {
-        "checksum": "adler32:46c51ec40bf133ec68595da0d469cd07a1f28d79",
+        "checksum": "adler32:a7a3cf9e",
         "size": 95212,
         "uri": "root://eospublic.cern.ch//eos/opendata/cms/configuration-files/2016/recoskim_Run2016G_SinglePhoton.py"
       }
@@ -6232,7 +6232,7 @@
     ],
     "files": [
       {
-        "checksum": "adler32:66411983f801bfd314a4ca4d6e915cf86714ad02",
+        "checksum": "adler32:44d7efd",
         "size": 41854,
         "uri": "root://eospublic.cern.ch//eos/opendata/cms/configuration-files/2016/recoskim_Run2016G_Tau.py"
       }
@@ -6285,7 +6285,7 @@
     ],
     "files": [
       {
-        "checksum": "adler32:19a56581f3f5cacc2f00e41c082027abb8b2bcc3",
+        "checksum": "adler32:3582801e",
         "size": 41858,
         "uri": "root://eospublic.cern.ch//eos/opendata/cms/configuration-files/2016/recoskim_Run2016H_BTagCSV.py"
       }
@@ -6338,7 +6338,7 @@
     ],
     "files": [
       {
-        "checksum": "adler32:cfe1fb8958374510c07bf1c729af24eb94f5c266",
+        "checksum": "adler32:f2877ff4",
         "size": 41857,
         "uri": "root://eospublic.cern.ch//eos/opendata/cms/configuration-files/2016/recoskim_Run2016H_BTagMu.py"
       }
@@ -6391,7 +6391,7 @@
     ],
     "files": [
       {
-        "checksum": "adler32:e178cb8f3bee59cfb3952078f2a596e067cf316e",
+        "checksum": "adler32:a81eca81",
         "size": 45336,
         "uri": "root://eospublic.cern.ch//eos/opendata/cms/configuration-files/2016/recoskim_Run2016H_Charmonium.py"
       }
@@ -6444,7 +6444,7 @@
     ],
     "files": [
       {
-        "checksum": "adler32:61bf17545eafd8e77d3804dc41dc6b5c3401cfb9",
+        "checksum": "adler32:4ce08280",
         "size": 41863,
         "uri": "root://eospublic.cern.ch//eos/opendata/cms/configuration-files/2016/recoskim_Run2016H_DisplacedJet.py"
       }
@@ -6497,7 +6497,7 @@
     ],
     "files": [
       {
-        "checksum": "adler32:75c66c16020dae88c49395decc92ae6e9349b140",
+        "checksum": "adler32:913d7f59",
         "size": 41856,
         "uri": "root://eospublic.cern.ch//eos/opendata/cms/configuration-files/2016/recoskim_Run2016H_HTMHT.py"
       }
@@ -6550,7 +6550,7 @@
     ],
     "files": [
       {
-        "checksum": "adler32:4b468b7bbe91b63637842d9dfaac7c9e3a82fc2e",
+        "checksum": "adler32:58eb6c94",
         "size": 44203,
         "uri": "root://eospublic.cern.ch//eos/opendata/cms/configuration-files/2016/recoskim_Run2016H_MuOnia.py"
       }
@@ -6603,7 +6603,7 @@
     ],
     "files": [
       {
-        "checksum": "adler32:3ebf4abdeb36f9fec76761a1825567ff3eeb2272",
+        "checksum": "adler32:8c20b67c",
         "size": 69594,
         "uri": "root://eospublic.cern.ch//eos/opendata/cms/configuration-files/2016/recoskim_Run2016H_MuonEG.py"
       }
@@ -6656,7 +6656,7 @@
     ],
     "files": [
       {
-        "checksum": "adler32:dbb2c7dfd12c717ed8f0010f177d0405e579699b",
+        "checksum": "adler32:190bcf9f",
         "size": 95212,
         "uri": "root://eospublic.cern.ch//eos/opendata/cms/configuration-files/2016/recoskim_Run2016H_SinglePhoton.py"
       }
@@ -6709,7 +6709,7 @@
     ],
     "files": [
       {
-        "checksum": "adler32:132e652c95aaf2256a34191ce5513b05c0a6db96",
+        "checksum": "adler32:a5667efe",
         "size": 41854,
         "uri": "root://eospublic.cern.ch//eos/opendata/cms/configuration-files/2016/recoskim_Run2016H_Tau.py"
       }
@@ -6762,7 +6762,7 @@
     ],
     "files": [
       {
-        "checksum": "adler32:585e0ba6ada691b41d9da2978a23dcd751a398e9",
+        "checksum": "adler32:841240d",
         "size": 11124,
         "uri": "root://eospublic.cern.ch//eos/opendata/cms/configuration-files/2016/ReReco-Run2016H-SingleElectron-UL2016_MiniAODv2_BParking.py"
       }


### PR DESCRIPTION
Fixes the checksum information for CMS 2016 RECO configuration files to Adler32 that is being used on EOSPUBLIC.

Closes #3591