### PR TITLE
docker: move to PostgreSQL 14.10

### DIFF
--- a/docker-compose-dev.yml
+++ b/docker-compose-dev.yml
@@ -1,7 +1,7 @@
 # -*- coding: utf-8 -*-
 #
 # This file is part of CERN Open Data Portal.
-# Copyright (C) 2015, 2016, 2017, 2018, 2021, 2022, 2023 CERN.
+# Copyright (C) 2015, 2016, 2017, 2018, 2021, 2022, 2023, 2024 CERN.
 #
 # CERN Open Data Portal is free software; you can redistribute it
 # and/or modify it under the terms of the GNU General Public License as
@@ -163,7 +163,7 @@ services:
 
   postgresql:
     restart: "unless-stopped"
-    image: docker.io/library/postgres:14.8
+    image: docker.io/library/postgres:14.10
     environment:
       - POSTGRES_USER=cernopendata
       - POSTGRES_DB=cernopendata

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -1,7 +1,7 @@
 # -*- coding: utf-8 -*-
 #
 # This file is part of CERN Open Data Portal.
-# Copyright (C) 2015, 2016, 2017, 2018, 2021, 2022, 2023 CERN.
+# Copyright (C) 2015, 2016, 2017, 2018, 2021, 2022, 2023, 2024 CERN.
 #
 # CERN Open Data Portal is free software; you can redistribute it
 # and/or modify it under the terms of the GNU General Public License as
@@ -137,7 +137,7 @@ services:
 
   postgresql:
     restart: "always"
-    image: docker.io/library/postgres:14.8
+    image: docker.io/library/postgres:14.10
     environment:
       - POSTGRES_USER=cernopendata
       - POSTGRES_DB=cernopendata


### PR DESCRIPTION
Changes database version to PostgreSQL 14.10, keeping parity with the recommended DBoD deployment version.