### PR TITLE
CMS: 2 new tools records

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -25,8 +25,8 @@
 # Use Invenio's alma image with Python-3.9
 FROM registry.cern.ch/inveniosoftware/almalinux:1
 
-# Use XRootD 5.6.8
-ENV XROOTD_VERSION=5.6.8
+# Use XRootD 5.6.9
+ENV XROOTD_VERSION=5.6.9
 
 # Install CERN Open Data Portal web node pre-requisites
 # hadolint ignore=DL3033

--- a/cernopendata/modules/fixtures/data/docs/cms-getting-started-nanoaod/cms-getting-started-nanoaod.md
+++ b/cernopendata/modules/fixtures/data/docs/cms-getting-started-nanoaod/cms-getting-started-nanoaod.md
@@ -149,7 +149,7 @@ Before exiting the ROOT session, your histogram canvas should look something lik
 
 #### NanoAOD skimming and analysis with `NanoAOD-tools`
 
-The [NanoAOD-tools](https://github.com/cms-nanoAOD/nanoAOD-tools/) repository provides a toolkit to perform operations on NanoAOD files outside the CMSSW software environment. This program can be used to:
+The [NanoAOD-tools](/record/12507) software provides a toolkit to perform operations on NanoAOD files outside the CMSSW software environment. This program can be used to:
 
 * skim events that fail the validation
 * skim events that fail an analysis condition based on NanoAOD branch contents
@@ -157,10 +157,10 @@ The [NanoAOD-tools](https://github.com/cms-nanoAOD/nanoAOD-tools/) repository pr
 * compute many common corrections for simulation
 * compute new observables in user-created modules
 
-Skimming data events that fail the validation is a critical feature, so let's see how to do it by following instructions from the [NanoAOD-tools](https://github.com/cms-nanoAOD/nanoAOD-tools/) page. This example will be performed in the ROOT docker container using files from the [Tau 2016H dataset](/record/30565).
+Skimming data events that fail the validation is a critical feature, so let's see how to do it by following instructions from the [NanoAOD-tools repository](https://github.com/cms-opendata-analyses/nanoAOD-tools/). This example will be performed in the [ROOT docker container](/docs/cms-guide-docker#nanoaod) using files from the [Tau 2016H dataset](/record/30565). The instructions here download files via `git clone`, but it is also possible to download a `.zip` file of the NanoAOD-tools repository from the [record page](/record/12507)
 
 ```shell
-$ git clone https://github.com/cms-nanoAOD/nanoAOD-tools.git NanoAODTools
+$ git clone https://github.com/cms-opendata-analyses/nanoAOD-tools.git NanoAODTools
 Cloning into 'NanoAODTools'...
 remote: Enumerating objects: 4269, done.
 remote: Counting objects: 100% (110/110), done.
@@ -215,13 +215,13 @@ Done ./03DD0FB3-219B-C54D-A476-EE8937CC214E_Skim.root
 Total time 4721.5 sec. to process 2160343 events. Rate = 457.6 Hz.
 ```
 
-As before, the `TClass` warnings from ROOT can be safely ignored. The [NanoAOD-tools README](https://github.com/cms-nanoAOD/nanoAOD-tools/) page shows more options for this command and discusses their "module" format for applying corrections, performing further event selection, and storing user analysis variables in the file.
+As before, the `TClass` warnings from ROOT can be safely ignored. The [NanoAOD-tools README](https://github.com/cms-opendata-analyses/nanoAOD-tools/) page shows more options for this command and discusses their "module" format for applying corrections, performing further event selection, and storing user analysis variables in the file.
 
 #### More example analysis frameworks
 
 The ROOT Trees within NanoAOD files have been a common HEP data structure for many years, and classic "event loop" methods (primarily written in C++) are an effective and understandable model for analyzing NanoAOD. However, as the overall CMS data size has grown, "columnar" analysis methods have become more and more popular within CMS, and can reduce the computing resources needed for the analysis. The core message is that **NanoAOD is extremely flexible**!
 
-* Event loop: as a generic example, see the [ROOT TTree](https://root.cern/doc/master/tree1_8C.html) tutorials. In the Open Data context, the [example analyses using "NanoAODRun1"](https://github.com/cms-opendata-analyses/NanoAODRun1Examples) derived data can be replicated for newer NanoAOD files.
+* Event loop: as a generic example, see the [ROOT TTree](https://root.cern/doc/master/tree1_8C.html) tutorials. In the Open Data context, the [example analyses using "NanoAODRun1"](/record/12506) derived data can be replicated for newer NanoAOD files.
 * RDataframe: ROOT has developed the [RDataFrame](https://root.cern/doc/master/classROOT_1_1RDataFrame.html) package to integrate columnar analysis natively. Several outreach examples using older Open Data in NanoAOD format, such as this [Higgs analysis example](/record/12360) use RDataFrame in the `skim.cxx` scriptto select events and reconstruct a particle. Some example analyses in the [NanoAODRun1Examples](https://github.com/cms-opendata-analyses/NanoAODRun1Examples) repository also use RDataFrame, in both C++ and Python.
 * Coffea/Scikit-HEP tools: significant work has gone into developing HEP software tools within a scientific python ecosystem. The [Analysis Grand Challenge](https://agc.readthedocs.io/en/latest/index.html) from the [IRIS-HEP](https://iris-hep.org/projects/agc.html) project have created an analysis example that reads NanoAOD files to measure the top quark pair production cross section. The example uses 2015 Open Data that was independently processed as NanoAOD, but the methods can be applied to newer NanoAOD files.
 

--- a/cernopendata/modules/fixtures/data/records/cms-tools-Run1-nano-examples.json
+++ b/cernopendata/modules/fixtures/data/records/cms-tools-Run1-nano-examples.json
@@ -18,8 +18,22 @@
       "2012"
     ],
     "date_published": "2024",
+    "distribution": {
+      "formats": [
+        "zip"
+      ],
+      "number_files": 1,
+      "size": 106807
+    },
     "experiment": [
       "CMS"
+    ],
+    "files": [
+      {
+        "checksum": "adler32:f198da5e",
+        "size": 106807,
+        "uri": "root://eospublic.cern.ch//eos/opendata/cms/software/NanoAODRun1Examples/NanoAODRun1Examples-1.0.zip"
+      }
     ],
     "license": {
       "attribution": "GNU General Public License (GPL) version 3"

--- a/cernopendata/modules/fixtures/data/records/cms-tools-Run1-nano-examples.json
+++ b/cernopendata/modules/fixtures/data/records/cms-tools-Run1-nano-examples.json
@@ -1,0 +1,59 @@
+[
+  {
+    "abstract": {
+      "description": "<p>This repository contains example analysis scripts using NanoAODRun1 derived data from 2010, 2011, or 2012 CMS Open Data. These are pedagogical examples that show users how to analyze NanoAOD-format ROOT files using event loops in C++ as well as ROOT's RDataFrame package in C++ and Python. The examples all reproduce a public dimuon mass spectrum histogram from data, highlighting the mass peaks of various particles. The scripts provide real-life examples of creating complex histograms with publication-style labels in ROOT.</p><br><p>For use with nanoaod-run1 <a href=\"/search?q=CMS&f=file_type%3Ananoaod-run1\">data</a> and <a href=\"/search?q=CMS&f=file_type%3Ananoaodsim-run1\">simulation</a> samples on this portal.</p>"
+    },
+    "accelerator": "CERN-LHC",
+    "authors": [
+      {
+        "name": "CMS Open data group"
+      }
+    ],
+    "collections": [
+      "CMS-Tools"
+    ],
+    "date_created": [
+      "2010",
+      "2011",
+      "2012"
+    ],
+    "date_published": "2024",
+    "experiment": [
+      "CMS"
+    ],
+    "license": {
+      "attribution": "GNU General Public License (GPL) version 3"
+    },
+    "publisher": "CERN Open Data Portal",
+    "recid": "12506",
+    "run_period": [
+      "Run2010A",
+      "Run2010B",
+      "Run2011A",
+      "Run2011B",
+      "Run2012A",
+      "Run2012B",
+      "Run2012C",
+      "Run2012D"
+    ],
+    "source_code_repository": {
+      "url": "https://github.com/cms-opendata-analyses/NanoAODRun1Examples"
+    },
+    "system_details": {
+      "release": "ROOT 6.30 or later"
+    },
+    "title": "Analysis examples using CMS 2010, 2011, or 2012 derived data in the NanoAODRun1 format",
+    "type": {
+      "primary": "Software",
+      "secondary": [
+        "Analysis"
+      ]
+    },
+    "usage": {
+      "description": "<p>The analysis can be run with a plain ROOT installation. Go to <a href=\"https://root.cern\">root.cern</a> for instructions how to install the software, or use the ROOT docker container documented on the <a href=\"/docs/cms-guide-docker\">CMS docker guide</a>.</p><p>To download the files, you can either use directly the web browser or the following command.</p><p><code>$ git clone https://github.com/cms-opendata-analyses/NanoAODRun1Examples</code></p><p>To run an example, enter one of the <code>dimuon_20XX</code> directories and execute the ROOT macro inside with a command such as:</p><p><code>$ root -l Dimuon2011_eospublic.C</code></p><p>Step-by-step commands and output examples are provided on the <a href=\"https://github.com/cms-opendata-analyses/NanoAODRun1Examples\">Github repository</a>. The final plots of the analysis are also included in the source code repository.</p>"
+    },
+    "use_with": {
+      "description": "These examples can be run with the datasets in the nanoaod-run1 or nanoaodsim-run1 formats"
+    }
+  }
+]

--- a/cernopendata/modules/fixtures/data/records/cms-tools-nanoaodtools-skimmer.json
+++ b/cernopendata/modules/fixtures/data/records/cms-tools-nanoaodtools-skimmer.json
@@ -16,8 +16,22 @@
       "2016"
     ],
     "date_published": "2024",
+    "distribution": {
+      "formats": [
+        "zip"
+      ],
+      "number_files": 1,
+      "size": 79336934
+    },
     "experiment": [
       "CMS"
+    ],
+    "files": [
+      {
+        "checksum": "adler32:e8787a12",
+        "size": 79336934,
+        "uri": "root://eospublic.cern.ch//eos/opendata/cms/software/nanoAOD-tools/nanoAOD-tools-1.0.zip"
+      }
     ],
     "license": {
       "attribution": "GNU General Public License (GPL) version 3"

--- a/cernopendata/modules/fixtures/data/records/cms-tools-nanoaodtools-skimmer.json
+++ b/cernopendata/modules/fixtures/data/records/cms-tools-nanoaodtools-skimmer.json
@@ -1,0 +1,51 @@
+[
+  {
+    "abstract": {
+      "description": "<p>This software can be used to apply selections and other analysis computations to NanoAOD files. Input NanoAOD files are processed through pre-defined or user-defined modules to produce output NanoAOD files with new content and/or fewer events.</p><br><p>For use with NanoAOD <a href=\"/search?q=CMS&f=file_type%3Ananoaod\">data</a> and <a href=\"/search?q=CMS&f=file_type%3Ananoaodsim\">simulation</a> samples on this portal.</p>"
+    },
+    "accelerator": "CERN-LHC",
+    "authors": [
+      {
+        "name": "CMS Open data group"
+      }
+    ],
+    "collections": [
+      "CMS-Tools"
+    ],
+    "date_created": [
+      "2016"
+    ],
+    "date_published": "2024",
+    "experiment": [
+      "CMS"
+    ],
+    "license": {
+      "attribution": "GNU General Public License (GPL) version 3"
+    },
+    "publisher": "CERN Open Data Portal",
+    "recid": "12507",
+    "run_period": [
+      "Run2016G",
+      "Run2016H"
+    ],
+    "source_code_repository": {
+      "url": "https://github.com/cms-opendata-analyses/nanoAOD-tools"
+    },
+    "system_details": {
+      "release": "This software requires python 2.7 and a recent ROOT version."
+    },
+    "title": "Tool for processing CMS NanoAOD data",
+    "type": {
+      "primary": "Software",
+      "secondary": [
+        "Analysis"
+      ]
+    },
+    "usage": {
+      "description": "<p>This software can be run with a plain ROOT installation. Go to <a href=\"https://root.cern\">root.cern</a> for instructions how to install the software, or use the ROOT docker container documented on the <a href=\"/docs/cms-guide-docker\">CMS docker guide</a>.</p><p>To download the files, you can either use directly the web browser or follow the instructions given in the <a href=\"/docs/cms-getting-started-nanoaod\">NanoAOD Getting Started page</a>.The Getting Started page provides an example for using NanoAOD-tools to skim NanoAOD and keep only the validated runs, and other examples are provided in the README file of the repository.</p>"
+    },
+    "use_with": {
+      "description": "This software can be run with the datasets in the nanoaod or nanoaodsim formats"
+    }
+  }
+]

--- a/requirements-production.txt
+++ b/requirements-production.txt
@@ -582,7 +582,7 @@ wtforms==2.3.3
     # via
     #   flask-wtf
     #   invenio-files-rest
-xrootd==5.6.8
+xrootd==5.6.9
     # via
     #   cernopendata (setup.py)
     #   xrootdpyfs

--- a/setup.py
+++ b/setup.py
@@ -117,7 +117,7 @@ install_requires = [
     # Pin Celery due to worker runtime issues
     "celery==5.2.7",
     # Pin XRootD consistently with Dockerfile
-    "xrootd==5.6.8",
+    "xrootd==5.6.9",
     # Pin Flask/gevent/greenlet/raven to make master work again
     "Flask==2.2.5",
     "Flask-Alembic==2.0.1",


### PR DESCRIPTION
Adding records for the NanoAODRun1Examples (12506) and nanoAOD-tools (12507) code repositories. 
Corresponding link changes in the NanoAOD getting started page. 

The zip files are in /eos/opendata/cms/upload/: 
NanoAODRun1Examples-1.0.zip
nanoAOD-tools-1.0.zip

