### PR TITLE
docker: pin OpenSearch version

### DIFF
--- a/docker-compose-dev.yml
+++ b/docker-compose-dev.yml
@@ -1,7 +1,7 @@
 # -*- coding: utf-8 -*-
 #
 # This file is part of CERN Open Data Portal.
-# Copyright (C) 2015, 2016, 2017, 2018, 2021, 2022, 2023 CERN.
+# Copyright (C) 2015, 2016, 2017, 2018, 2021, 2022, 2023, 2024 CERN.
 #
 # CERN Open Data Portal is free software; you can redistribute it
 # and/or modify it under the terms of the GNU General Public License as
@@ -179,7 +179,7 @@ services:
 
   opensearch:
     restart: "unless-stopped"
-    image: docker.io/opensearchproject/opensearch:2
+    image: docker.io/opensearchproject/opensearch:2.11.1
     environment:
       - bootstrap.memory_lock=true
       # set to reasonable values on production
@@ -194,7 +194,7 @@ services:
       - 9200:9200
 
   opensearch-dashboards:
-    image: docker.io/opensearchproject/opensearch-dashboards:2 # Make sure the version of opensearch-dashboards matches the version of opensearch installed on other nodes
+    image: docker.io/opensearchproject/opensearch-dashboards:2.11.1 # Make sure the version of opensearch-dashboards matches the version of opensearch installed on other nodes
     ports:
       - 5601:5601 # Map host port 5601 to container port 5601
     expose:

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -1,7 +1,7 @@
 # -*- coding: utf-8 -*-
 #
 # This file is part of CERN Open Data Portal.
-# Copyright (C) 2015, 2016, 2017, 2018, 2021, 2022, 2023 CERN.
+# Copyright (C) 2015, 2016, 2017, 2018, 2021, 2022, 2023, 2024 CERN.
 #
 # CERN Open Data Portal is free software; you can redistribute it
 # and/or modify it under the terms of the GNU General Public License as
@@ -155,7 +155,7 @@ services:
 
   opensearch:
     restart: "always"
-    image: docker.io/opensearchproject/opensearch:2
+    image: docker.io/opensearchproject/opensearch:2.11.1
     environment:
       - bootstrap.memory_lock=true
       # set to reasonable values on production
@@ -172,7 +172,7 @@ services:
       - 9200:9200
 
   opensearch-dashboards:
-    image: docker.io/opensearchproject/opensearch-dashboards:2 # Make sure the version of opensearch-dashboards matches the version of opensearch installed on other nodes
+    image: docker.io/opensearchproject/opensearch-dashboards:2.11.1 # Make sure the version of opensearch-dashboards matches the version of opensearch installed on other nodes
     ports:
       - 5601:5601 # Map host port 5601 to container port 5601
     expose:

--- a/setup.py
+++ b/setup.py
@@ -110,7 +110,8 @@ install_requires = [
     "uwsgitop>=0.11",
     # Pin SQLAlchemy version due to sqlalchemy-utils compatibility
     # <https://github.com/kvesteri/sqlalchemy-utils/issues/505>
-    "SQLAlchemy==1.4.49 ",
+    "SQLAlchemy==1.4.49",
+    "SQLAlchemy-Continuum==1.4.1",
     # Pin Flask-SQLAlchemy version due to apply_driver_hacks
     "Flask-SQLAlchemy==3.0.0",
     "Flask-Alembic==2.0.1",


### PR DESCRIPTION
Fixes OpenSearch starting troubles by pinning the OpenSearch version to the last one not requiring to set the
`OPENSEARCH_INITIAL_ADMIN_PASSWORD` environment variable.

Closes #3634