### PR TITLE
Adding inspire links to records

### DIFF
--- a/cernopendata/templates/cernopendata_records_ui/records/record_detail.html
+++ b/cernopendata/templates/cernopendata_records_ui/records/record_detail.html
@@ -45,7 +45,7 @@
             {% if record.collaboration %} {{ record.collaboration.name }} {% endif %}
             {% if record.date_published %} ({{ record.date_published }}). {% endif %}
             {{ record.title_additional or record.title }}. CERN Open Data Portal.
-            DOI:<a href="http://doi.org/{{record.doi}}">{{record.doi}}</a> (<a href="https://inspirehep.net/literature?sort=mostrecent&size=25&page=1&q=references.reference.dois%3A{{record.doi}}">Citations</a> via <a href="https://inspirehep.net"><img src="https://inspirehep.net/favicon.ico" height=14 alt="INSPIRE-HEP"></a>)
+            DOI:<a href="http://doi.org/{{record.doi}}">{{record.doi}}</a> (<a href="https://inspirehep.net/literature?sort=mostrecent&size=25&page=1&q=references.reference.urls.value%3Ahttps%3A%2F%2Fopendata.cern.ch%2Frecord%2F{{record.recid}}%20or%20references.reference.dois%3A{{record.doi}}">Citations</a> via <a href="https://inspirehep.net"><img src="https://inspirehep.net/favicon.ico" height=14 alt="INSPIRE-HEP"></a>)
         </span>
     </p>
     {% endif %}

--- a/cernopendata/templates/cernopendata_records_ui/records/record_detail.html
+++ b/cernopendata/templates/cernopendata_records_ui/records/record_detail.html
@@ -45,7 +45,7 @@
             {% if record.collaboration %} {{ record.collaboration.name }} {% endif %}
             {% if record.date_published %} ({{ record.date_published }}). {% endif %}
             {{ record.title_additional or record.title }}. CERN Open Data Portal.
-            DOI:<a href="http://doi.org/{{record.doi}}">{{record.doi}}</a>
+            DOI:<a href="http://doi.org/{{record.doi}}">{{record.doi}}</a> (<a href="https://inspirehep.net/literature?sort=mostrecent&size=25&page=1&q=references.reference.dois%3A{{record.doi}}">Citations</a> via <a href="https://inspirehep.net"><img src="https://inspirehep.net/favicon.ico" height=14 alt="INSPIRE-HEP"></a>)
         </span>
     </p>
     {% endif %}


### PR DESCRIPTION
This should add a citations link with the inspire logo to the records.

Not sure if it's desirable to check if there are citations before providing the link - because of this formatting, it's no overhead to just have the link, but checking for citations would create overhead in generating the pages.

Using the inspire favored icon for the image, happy to change if there's a preferred icon or logo that anyone is aware of.

This is a quick attempt to address https://github.com/cernopendata/opendata.cern.ch/issues/3659