### PR TITLE
CMS: add record for corrections

### DIFF
--- a/cernopendata/modules/fixtures/data/docs/cms-getting-started-nanoaod/cms-getting-started-nanoaod.md
+++ b/cernopendata/modules/fixtures/data/docs/cms-getting-started-nanoaod/cms-getting-started-nanoaod.md
@@ -129,7 +129,7 @@ Warning in <TClass::Init>: no dictionary for class pair<edm::Hash<1>,edm::Parame
 root [1] TTree *t = (TTree*)_file0->Get("Events")
 (TTree *) 0x55f8837d3910
 
-root [2] t->Draw("Muon_pt,"Muon_pt < 2000")  # draws pT of all muons below 2 TeV
+root [2] t->Draw("Muon_pt","Muon_pt < 2000")  # draws pT of all muons below 2 TeV
 Info in <TCanvas::MakeDefCanvas>:  created default TCanvas with name c1
 (long long) 4804238
 

--- a/cernopendata/modules/fixtures/data/records/cms-corrections-run2.json
+++ b/cernopendata/modules/fixtures/data/records/cms-corrections-run2.json
@@ -1,0 +1,61 @@
+[
+  {
+    "abstract": {
+      "description": "<p>CMS supports corrections for various physics objects, either to improve modeling of data by simulation, or to correct for imperfect detector response. For Run 2 data, the official corrections are stored in a common JSON format that can be read with the correctionlib library.</p>"
+    },
+    "accelerator": "CERN-LHC",
+    "authors": [
+      {
+        "name": "CMS Open data group"
+      }
+    ],
+    "collections": [
+      "CMS-Tools"
+    ],
+    "date_created": [
+      "2016"
+    ],
+    "date_published": "2024",
+    "distribution": {
+      "formats": [
+        "zip"
+      ],
+      "number_files": 1,
+      "size": 10494603
+    },
+    "experiment": [
+      "CMS"
+    ],
+    "files": [
+      {
+        "checksum": "adler32:7ccaf136",
+        "size": 10494603,
+        "uri": "root://eospublic.cern.ch//eos/opendata/cms/corrections/jsonpog-integration-2016post.tar"
+      }
+    ],
+    "license": {
+      "attribution": "CC0"
+    },
+    "publisher": "CERN Open Data Portal",
+    "recid": "12508",
+    "run_period": [
+      "Run2016"
+    ],
+    "system_details": {
+      "description": "Use this software in the CMS Open Data <a href=\"/docs/cms-guide-docker\">Docker container</a>, beginning with 2016 data. Correctionlib can be installed for use with either C++ or Python."
+    },
+    "title": "Physics object corrections for Run 2",
+    "type": {
+      "primary": "Supplementaries",
+      "secondary": [
+        "Correction"
+      ]
+    },
+    "usage": {
+      "description": "<p>The physics object correction files provided here are intended to be read using the <a href=\"https://cms-nanoaod.github.io/correctionlib/index.html\">correctionlib software</a>. The correction files are a type of structured json, and correctionlib provides an \"evaluate\" function to access appropriate values within the json file. The contents of the correction files can be explored <a href=\"https://opendata.cern.ch/eos/opendata/cms/corrections/jsonpog-integration-summary/index.html\">on this web summary page</a>. Correctionlib can be installed in the CMS Docker containers or VM images.</p><p>To use the correction files, download the file from this record and unpack it in a location that is accessible to your software container or image. Install correctionlib following the instructions at <a href=\"https://cms-nanoaod.github.io/correctionlib/install.html\">https://cms-nanoaod.github.io/correctionlib/install.html</a>.</p>\n<p>For more information about physics object access and the individual corrections, see the <a href=\"https://cms-opendata-guide.web.cern.ch/\">CMS Open Data Guide</a> web site.</p>"
+    },
+    "use_with": {
+      "description": "Use these corrections with any CMS Run 2 (2016 and onward) proton-proton collision or Monte Carlo datasets."
+    }
+  }
+]


### PR DESCRIPTION
Adding record 12508 (appears unused) for CMS Run 2 corrections files. There are two items in the upload folder that would be needed for this record:

* opendata/cms/upload/jsonpog-integration-2016postVFP.tar --> this is the actual file to be attached
* opendata/cms/upload/commonJSONSFs/index.html --> this is a web page that will show the contents of the file. It's linked in one of the description segments. 

We would like to make a new folder and put both the .tar file and the directory of html files there: opendata/cms/corrections/


