### PR TITLE
Update flags for the ATLAS 2020 Open Data records

### DIFF
--- a/AUTHORS.rst
+++ b/AUTHORS.rst
@@ -23,6 +23,7 @@ The list of contributors in alphabetical order:
 - `Eric Engestrom <https://github.com/1ace>`_
 - `Felix Socher <https://github.com/fsocher>`_
 - `Filip Maxin <https://orcid.org/0000-0002-2726-3535>`_
+- `Giovanni Guerrieri <https://github.com/Soap2G>`_
 - `Giuliana Galati <https://github.com/galatigiuliana>`_
 - `Harri Hirvonsalo <https://orcid.org/0000-0002-5503-510X>`_
 - `Heitor Pascoal de Bittencourt <https://github.com/heitorPB>`_

--- a/data/records/atlas-2020-1largeRjet1lep.json
+++ b/data/records/atlas-2020-1largeRjet1lep.json
@@ -48,7 +48,8 @@
     "type": {
       "primary": "Dataset",
       "secondary": [
-        "Derived"
+        "Derived",
+        "Simulated"
       ]
     },
     "usage": {

--- a/data/records/atlas-2020-1lep.json
+++ b/data/records/atlas-2020-1lep.json
@@ -58,7 +58,8 @@
     "type": {
       "primary": "Dataset",
       "secondary": [
-        "Derived"
+        "Derived",
+        "Simulated"
       ]
     },
     "usage": {

--- a/data/records/atlas-2020-1lep1tau.json
+++ b/data/records/atlas-2020-1lep1tau.json
@@ -48,7 +48,8 @@
     "type": {
       "primary": "Dataset",
       "secondary": [
-        "Derived"
+        "Derived",
+        "Simulated"
       ]
     },
     "usage": {

--- a/data/records/atlas-2020-2lep.json
+++ b/data/records/atlas-2020-2lep.json
@@ -48,7 +48,8 @@
     "type": {
       "primary": "Dataset",
       "secondary": [
-        "Derived"
+        "Derived",
+        "Simulated"
       ]
     },
     "usage": {

--- a/data/records/atlas-2020-3lep.json
+++ b/data/records/atlas-2020-3lep.json
@@ -48,7 +48,8 @@
     "type": {
       "primary": "Dataset",
       "secondary": [
-        "Derived"
+        "Derived",
+        "Simulated"
       ]
     },
     "usage": {

--- a/data/records/atlas-2020-4lep.json
+++ b/data/records/atlas-2020-4lep.json
@@ -48,7 +48,8 @@
     "type": {
       "primary": "Dataset",
       "secondary": [
-        "Derived"
+        "Derived",
+        "Simulated"
       ]
     },
     "usage": {

--- a/data/records/atlas-2020-GamGam.json
+++ b/data/records/atlas-2020-GamGam.json
@@ -48,7 +48,8 @@
     "type": {
       "primary": "Dataset",
       "secondary": [
-        "Derived"
+       "Derived",
+        "Simulated"
       ]
     },
     "usage": {

--- a/data/records/atlas-2020-exactly2lep.json
+++ b/data/records/atlas-2020-exactly2lep.json
@@ -48,7 +48,8 @@
     "type": {
       "primary": "Dataset",
       "secondary": [
-        "Derived"
+        "Derived",
+        "Simulated"
       ]
     },
     "usage": {

--- a/data/records/atlas-2020-mc-jet-reconstruction.json
+++ b/data/records/atlas-2020-mc-jet-reconstruction.json
@@ -98,7 +98,7 @@
     "type": {
       "primary": "Dataset",
       "secondary": [
-        "Derived"
+        "Simulated"
       ]
     },
     "usage": {

--- a/data/records/atlas-ATL-PHYS-PUB-2021-002.json
+++ b/data/records/atlas-ATL-PHYS-PUB-2021-002.json
@@ -106,7 +106,7 @@
     "type": {
       "primary": "Dataset",
       "secondary": [
-        "Derived"
+        "Simulated"
       ]
     },
     "usage": {

--- a/data/records/atlas-CERN-EP-2023-174.json
+++ b/data/records/atlas-CERN-EP-2023-174.json
@@ -235,7 +235,8 @@
     "type": {
       "primary": "Dataset",
       "secondary": [
-        "Derived"
+        "Derived",
+        "Simulated"
       ]
     }
   }

--- a/data/records/atlas-CERN-EP-2024-159.json
+++ b/data/records/atlas-CERN-EP-2024-159.json
@@ -245,7 +245,8 @@
     "type": {
       "primary": "Dataset",
       "secondary": [
-        "Derived"
+        "Derived",
+        "Simulated"
       ]
     },
     "usage": {

--- a/data/records/atlas-SIMU-2018-04.json
+++ b/data/records/atlas-SIMU-2018-04.json
@@ -71,7 +71,7 @@
     "type": {
       "primary": "Dataset",
       "secondary": [
-        "Derived"
+        "Simulated"
       ]
     },
     "usage": {


### PR DESCRIPTION
Several records belonging to the 2020 release were not including the proper flag for `Simulated` samples.

Updated flags according to the content of the records.