### PR TITLE
WIP: GT db record for 2017 MC

### DIFF
--- a/data/records/cms-condition-data-2017.json
+++ b/data/records/cms-condition-data-2017.json
@@ -1,10 +1,10 @@
 [
   {
     "abstract": {
-      "description": "<p>Condition database includes non-event-related information (Alignment, Calibration, Temperature, etc.) and parameters for simulation/reconstruction/analysis software.</p>\n    <p> These files are needed when running a CMSSW job on the open data environment (VM or container), and they are available in the /cvmfs/cms-opendata-conddb.cern.ch file system. They are automatically read from /cvmfs/cms-opendata-conddb.cern.ch/106X_dataRun2_v37.db runtime.</p>\n       <p>106X_dataRun2_v37.db is to be used with the proton-proton collision data at 13 TeV from 2016.</p>\n      <p>See further information in <a href=\"/docs/cms-guide-for-condition-database\">the guide to CMS condition database</a>.</p></p>\n       <p>For condition data to be used with 2016 CMS simulated datasets see:</p>",
+      "description": "<p>Condition database includes non-event-related information (Alignment, Calibration, Temperature, etc.) and parameters for simulation/reconstruction/analysis software.</p>\n    <p> These files are needed when running a CMSSW job on the open data environment (VM or container), and they are available in the /cvmfs/cms-opendata-conddb.cern.ch file system. They are automatically read from /cvmfs/cms-opendata-conddb.cern.ch/106X_dataRun2_v37.db runtime.</p>\n       <p>106X_dataRun2_v37.db is to be used with the proton-proton collision data at 13 TeV from 2017.</p>\n      <p>See further information in <a href=\"/docs/cms-guide-for-condition-database\">the guide to CMS condition database</a>.</p></p>\n       <p>For condition data to be used with 2017 CMS simulated datasets see:</p>",
       "links": [
         {
-          "recid": "1819"
+          "recid": "XXXX"
         }
       ]
     },
@@ -16,7 +16,7 @@
       "CMS-Condition-Data"
     ],
     "date_created": [
-      "2016"
+      "2017"
     ],
     "date_published": "2024",
     "distribution": {
@@ -37,12 +37,12 @@
       }
     ],
     "publisher": "CERN Open Data Portal",
-    "recid": "1818",
+    "recid": "YYYY",
     "run_period": [
-      "Run2016G",
-      "Run2016H"
+	"Run2017C",
+	"Run2017E"
     ],
-    "title": "Condition data for 2016 CMS proton-proton collision data at 13 TeV",
+    "title": "Condition data for 2017 CMS proton-proton collision data at 13 TeV",
     "type": {
       "primary": "Environment",
       "secondary": [
@@ -55,10 +55,10 @@
   },
   {
     "abstract": {
-      "description": "<p>Condition database includes non-event-related information (Alignment, Calibration, Temperature, etc.) and parameters for simulation/reconstruction/analysis software.</p>\n    <p> These files are needed when running a CMSSW job on the open data environment (VM or container), and they are available in the /cvmfs/cms-opendata-conddb.cern.ch file system. They are automatically read from /cvmfs/cms-opendata-conddb.cern.ch/106X_mcRun2_asymptotic_v17.db runtime.</p>\n       <p>106X_mcRun2_asymptotic_v17.db is to be used with the proton-proton simulated data at 13 TeV from 2016.</p>\n      <p>See further information in <a href=\"/docs/cms-guide-for-condition-database\">the guide to CMS condition database</a>.</p></p>\n       <p>For condition data to be used with 2016 CMS collision datasets see:</p>",
+      "description": "<p>Condition database includes non-event-related information (Alignment, Calibration, Temperature, etc.) and parameters for simulation/reconstruction/analysis software.</p>\n    <p> These files are needed when running a CMSSW job on the open data environment (VM or container), and they are available in the /cvmfs/cms-opendata-conddb.cern.ch file system. They are automatically read from /cvmfs/cms-opendata-conddb.cern.ch/106X_mc2017_realistic_v9.db runtime.</p>\n       <p>106X_mc2017_realistic_v9.db is to be used with the proton-proton simulated data at 13 TeV from 2017.</p>\n      <p>See further information in <a href=\"/docs/cms-guide-for-condition-database\">the guide to CMS condition database</a>.</p></p>\n       <p>For condition data to be used with 2017 CMS collision datasets see:</p>",
       "links": [
         {
-          "recid": "1818"
+          "recid": "YYYY"
         }
       ]
     },
@@ -70,7 +70,7 @@
       "CMS-Condition-Data"
     ],
     "date_created": [
-      "2016"
+      "2017"
     ],
     "date_published": "2024",
     "distribution": {
@@ -78,7 +78,7 @@
         "db"
       ],
       "number_files": 1,
-      "size": 664346624
+      "size": 858624000
     },
     "experiment": [
       "CMS"
@@ -86,13 +86,13 @@
     "files": [
       {
         "checksum": "adler32:c1e9b4f0",
-        "size": 664346624,
-        "uri": "root://eospublic.cern.ch//eos/opendata/cms/conddb/106X_mcRun2_asymptotic_v17.db"
+        "size": 858624000,
+        "uri": "root://eospublic.cern.ch//eos/opendata/cms/conddb/106X_mc2017_realistic_v9.db"
       }
     ],
     "publisher": "CERN Open Data Portal",
-    "recid": "1819",
-    "title": "Condition data for 2016 CMS proton-proton simulated data at 13 TeV",
+    "recid": "XXXX",
+    "title": "Condition data for 2017 CMS proton-proton simulated data at 13 TeV",
     "type": {
       "primary": "Environment",
       "secondary": [


### PR DESCRIPTION
* Create a record for the 2017 MC GT db
* Additionally create a record for the 2017 collision GT db
* Fix a typo in the 2016 MC GT db record
* Closes #3695

One question to resolve is whether or not to have a separate record for the 2016 and 2017 collision GT db when they point to the same file. The other option would be to make a new record for the GT MC db, modify the GT for collision data to include references to 2017, adding a new link. 

The XXXX and YYYY in the json file refer to the as-yet-undefined record ids