### PR TITLE
CMS: contents fix for /HIAllPhysics/HIRun2010-ZS-v2/RECO

### DIFF
--- a/data/records/cms-primary-datasets-HIRun2010.json
+++ b/data/records/cms-primary-datasets-HIRun2010.json
@@ -170,9 +170,9 @@
         "root",
         "reco"
       ],
-      "number_events": 75482193,
-      "number_files": 28954,
-      "size": 166030973333340
+      "number_events": 79329398,
+      "number_files": 32715,
+      "size": 190908704707416
     },
     "doi": "10.7483/OPENDATA.305G.POEC",
     "experiment": [


### PR DESCRIPTION
Missing files were transferred, so fixing number of events, number of files, and size. 

Closes #3683 