### PR TITLE
Adapt documentation for DELPHI containers to the latest version

### DIFF
--- a/data/docs/delphi-getting-started/delphi-getting-started.md
+++ b/data/docs/delphi-getting-started/delphi-getting-started.md
@@ -54,7 +54,7 @@ Here is a selection for getting started:
 * [DST contents](/record/80504)
 
 ## <a name="sources">Source code</a>
-The sources are available from https://gitlab.cern.ch/delphi. Some modules still requires CERN authentication. The plan is to release the software in the near future.
+The sources are available from <https://gitlab.cern.ch/delphi>. Some modules still requires CERN authentication. The plan is to release the software in the near future.
 
 ## <a name="compilers">Compilers</a>
 The DELPHI stack is mostly written in `Fortran`, with some bits written in `C`. Only `gfortran` and `GNU gcc` are supported. We use the `gfortran` version which comes with the
@@ -62,11 +62,14 @@ supported operating system. Recommended compiler and linker flags are set by the
 
 ## <a name="help">Getting help</a>
 
-The collaboration main contact for data preservation is the mailing list DELPHI-data-preservation-board@cern.ch. Support can only be given on a best effort basis.
-Suggestions and feedback is of course welcome!
+The collaboration main contact for data preservation is the mailing list DELPHI-data-preservation-board@cern.ch. Support can only be given on a best effort basis though. In addition, there is a [discussion forum](https://opendata-forum.cern.ch/c/delphi/20) which you are invited to join, to exchange experiences and get in touch with former members of the collaboration.
+
+Suggestions and feedback is welcome!
+
+
 
 # <a name="examples">Examples</a>
-Some basic examples of how to run the software stack and perform various tasks can be found in the `/cvmfs/delphi.cern.ch/examples` tree.
+Some basic examples of how to run the software stack and perform various tasks can be found in the repository <https://gitlab.cern.ch/delphi/examples>. In addition, the repository <https://gitlab.cern.ch/delphi/modern-delphi-examples> has some proof-of-concept level examples about how to access the DELPHI data from e.g. C++.
 
 In the following, we will
 
@@ -152,4 +155,4 @@ For convenience, copy the files you want to scan to `~/graexe/data`.
 Please take a look at the [DELGRA guide](delphi-guide-delgra) on how to proceed.
 
 ## <a name="more">More examples</a>
-More examples can be found at https://gitlab.cern.ch/delphi/examples.
+More examples can be found at <https://gitlab.cern.ch/delphi/examples>.

--- a/data/docs/delphi-guide-docker/delphi-guide-docker.md
+++ b/data/docs/delphi-guide-docker/delphi-guide-docker.md
@@ -19,6 +19,11 @@ The image is configured with a local user called `delphi`. For the commands belo
 * a prompt `$ xyz` indicates that the command `xyz` is to be run on your local machine or VM.
 * a prompt `[delphi ~] $ xyz` indicates that the command `xyz` is to be run inside the started container.
 
+The Alma9 images come with support for `EOS`: when launched on a system which supports fuse file systems, the DELPHI data will be available inside the container beneath the path `/eos/opendata/delphi`. In addition, they support reading data over the network using the xrootd protocol.
+
+Be aware that due to the --rm option, the container will be destroyed when you exit it, and all the work done inside the container will be lost.
+
+### On a Linux based system
 To start the container on a Linux based system, use:
 
 ```
@@ -28,7 +33,22 @@ $ docker run --privileged --rm -it -e DISPLAY --network host -v /tmp/.X11-unix:/
 
 This command will download the Alma9 based container and create a login shell for the DELPHI user.
 
-This image comes with support for `EOS`: when launched on a system which supports fuse file systems, the DELPHI data will be available inside the container beneath the path `/eos/opendata/delphi`. Note that due to the --rm option, the container will be destroyed when you exit it, and all the work done inside the container will be lost.
+### On MacOS
+On recent Macs with M1, M2 or M3 CPUs it is better to use the ARM64 image, to avoid issues when linking executables inside the container. Also, if you are running MacOS, the command to start the container is a bit different.
+
+```
+podman run --privileged -it -e DISPLAY=host.docker.internal:0 --network host -v /tmp/.X11-unix:/tmp/.X11-unix -v ~/.Xauthority:/home/delphi/.Xauthority --user delphi gitlab-registry.cern.ch/delphi/deployment/delphi/al9_aarch64 /bin/bash -l
+```
+
+Also, the X server settings must allow connections from external sources. In addition, you may have to set
+```
+export LIBGL_ALWAYS_INDIRECT=1
+```
+in the container shell if you plan to run the event display.
+
+### On Windows
+Running the container images on Windows has not been tested. Feedback is welcome.
+
 
 <p><center><img src="/static/docs/delphi-guide-docker/delphi-container-start.png" width="60%"></center></p>
 

--- a/data/docs/delphi-guide-docker/delphi-guide-docker.md
+++ b/data/docs/delphi-guide-docker/delphi-guide-docker.md
@@ -28,7 +28,7 @@ To start the container on a Linux based system, use:
 
 ```
 $ xhost + local:docker
-$ docker run --privileged --rm -it -e DISPLAY --network host -v /tmp/.X11-unix:/tmp/.X11-unix -v ~/.Xauthority:/home/delphi/.Xauthority --user delphi gitlab-registry.cern.ch/delphi/deployment/delphi/al9_64 /bin/bash -l
+$ docker run --privileged --rm -it -e DISPLAY --network host -v /tmp/.X11-unix:/tmp/.X11-unix -v ~/.Xauthority:/home/delphi/.Xauthority --user delphi gitlab-registry.cern.ch/delphi/deployment/delphi/al9_64_xrd /bin/bash -l
 ```
 
 This command will download the Alma9 based container and create a login shell for the DELPHI user.


### PR DESCRIPTION
Some work has been done on supporting remote reading of the data. This is supported by the containers. 
In addition, some hints are added on how to run the container image on MacOS.