### PR TITLE
feat(records): add ATLAS ODEO February 2025 datasets

### DIFF
--- a/data/docs/atlas-heavy-ion-open-data-for-research-release-2024/atlas-heavy-ion-open-data-for-research-release-2024.json
+++ b/data/docs/atlas-heavy-ion-open-data-for-research-release-2024/atlas-heavy-ion-open-data-for-research-release-2024.json
@@ -9,7 +9,7 @@
     "experiment": [
       "ATLAS"
     ],
-    "featured": 1,
+    "featured": 2,
     "short_description": {
       "content": "The ATLAS Collaboration has released its first open data of heavy-ion collisions for research purposes. This dataset features lead-ion (Pb-Pb) collisions at an energy of 5 TeV per nucleon pair, recorded in 2015 as part of the Large Hadron Collider’s second operation period (LHC Run 2)."
     },

--- a/data/docs/atlas-open-data-for-education-outreach-release-2025-beta/atlas-open-data-for-education-outreach-release-2025-beta.json
+++ b/data/docs/atlas-open-data-for-education-outreach-release-2025-beta/atlas-open-data-for-education-outreach-release-2025-beta.json
@@ -5,7 +5,7 @@
       "content": "atlas-open-data-for-education-outreach-release-2025-beta.md",
       "format": "md"
     },
-    "date_published": "2025-04-11",
+    "date_published": "2025-07-03",
     "experiment": [
       "ATLAS"
     ],

--- a/data/docs/atlas-open-data-for-education-outreach-release-2025-beta/atlas-open-data-for-education-outreach-release-2025-beta.json
+++ b/data/docs/atlas-open-data-for-education-outreach-release-2025-beta/atlas-open-data-for-education-outreach-release-2025-beta.json
@@ -1,0 +1,22 @@
+[
+  {
+    "author": "ATLAS Collaboration",
+    "body": {
+      "content": "atlas-open-data-for-education-outreach-release-2025-beta.md",
+      "format": "md"
+    },
+    "date_published": "2025-04-11",
+    "experiment": [
+      "ATLAS"
+    ],
+    "featured": 1,
+    "short_description": {
+      "content": "The ATLAS Collaboration releases 25 datasets for education and outreach in a public 2025 \"beta\" release."
+    },
+    "slug": "atlas-open-data-for-education-outreach-release-2025-beta",
+    "title": "ATLAS releases 2025 beta open data for education and outreach",
+    "type": {
+      "primary": "News"
+    }
+  }
+]

--- a/data/docs/atlas-open-data-for-education-outreach-release-2025-beta/atlas-open-data-for-education-outreach-release-2025-beta.md
+++ b/data/docs/atlas-open-data-for-education-outreach-release-2025-beta/atlas-open-data-for-education-outreach-release-2025-beta.md
@@ -1,1 +1,32 @@
-FIXME here comes the release announcement body in Markdown.
+**A major update for the 13 TeV ATLAS Education and Outreach Open Data**
+
+The ATLAS Collaboration has just launched a new release of open data designed
+to empower education, outreach and citizen science. Building on a commitment to
+open access, the new 2025 Open Data for Education and Outreach (beta) release
+offers a significant upgrade in usability, scale and technical support.
+
+This release simplifies and expands on previous open data releases with a
+dedicated, open-source framework, now publicly available, alongside enhanced
+tools and documentation. It includes:
+
+- Guided workbooks and code to help users analyse real LHC collision data
+- Modules to build computing skills, perfect for students and independent
+  learners
+- Support for educators to create custom courses and projects using real LHC
+  data
+
+If you’ve used ATLAS Open Data before – this is also a big refresh. With
+increased statistical power and updated tools, you can pursue all-new physics
+analyses and revisit previous ones with enhanced precision.
+
+So whether you’re a student, teacher, citizen scientist or just curious about
+the Universe – dive into ATLAS Open Data for Education. Explore real LHC
+collisions, develop valuable computing skills and uncover the properties of
+fundamental particles for yourself.
+
+The data are all available now on the [CERN Open Data Portal](/record/93910).
+You can also [explore the documentation of the new
+release](https://opendata.atlas.cern/docs/data/for_education/13TeV25_details)
+or [visit the ATLAS Open Data Portal](https://opendata.atlas.cern) for more. We
+will be building on this beta release with additional data selections,
+analyses, and tools that will all be arriving soon!

--- a/data/docs/atlas-open-data-for-education-outreach-release-2025-beta/atlas-open-data-for-education-outreach-release-2025-beta.md
+++ b/data/docs/atlas-open-data-for-education-outreach-release-2025-beta/atlas-open-data-for-education-outreach-release-2025-beta.md
@@ -1,0 +1,1 @@
+FIXME here comes the release announcement body in Markdown.

--- a/data/docs/atlas-open-data-for-research-release-2024/atlas-open-data-for-research-release-2024.json
+++ b/data/docs/atlas-open-data-for-research-release-2024/atlas-open-data-for-research-release-2024.json
@@ -9,7 +9,7 @@
     "experiment": [
       "ATLAS"
     ],
-    "featured": 3,
+    "featured": 5,
     "short_description": {
       "content": "Explore over 75 billion LHC collision events — from home"
     },

--- a/data/docs/delphi-data-release-2024/delphi-data-release-2024.json
+++ b/data/docs/delphi-data-release-2024/delphi-data-release-2024.json
@@ -9,7 +9,7 @@
     "experiment": [
       "DELPHI"
     ],
-    "featured": 2,
+    "featured": 4,
     "short_description": {
       "content": "The DELPHI Collaboration has released its data collection to the general public. Regardless of whether you are a researcher, teacher, student or just interested, start your journey through this exciting datasets from LEP."
     },

--- a/data/docs/totem-releases-first-set-of-open-data/totem-releases-first-set-of-open-data.json
+++ b/data/docs/totem-releases-first-set-of-open-data/totem-releases-first-set-of-open-data.json
@@ -6,7 +6,7 @@
       "format": "md"
     },
     "date_published": "2024-12-05",
-    "featured": 1,
+    "featured": 3,
     "short_description": {
       "content": "Today, the TOTEM Collaboration published the first data set on the CERN Open Data Portal. Data recorded by TOTEM is used to measure the total cross section and to study elastic scattering in proton-proton collisions at the LHC for different centre-of-mass energies."
     },

--- a/data/records/atlas-odeo-FEB2025-1lmet30-data.json
+++ b/data/records/atlas-odeo-FEB2025-1lmet30-data.json
@@ -154,15 +154,15 @@
         },
         {
           "description": "Resources to understand and use the open data for education and outreach",
-          "url": "https://opendata.atlas.cern/docs/category/13-tev-tutorials-for-education"
+          "url": "https://opendata.atlas.cern/docs/category/13-tev-2025-beta-release"
         },
         {
           "description": "More about this ntuple format",
-          "url": "https://opendata.atlas.cern/docs/data/for_education/13TeV25_details"
+          "url": "https://opendata.atlas.cern/docs/data/for_education/13TeV25_details#variable-list"
         },
         {
-          "description": "Ntuple making framework",
-          "url": "http://gitlab.cern.ch/atlas-outreach-data-tools/physlitetoopendata"
+          "description": "Ntuple making framework (PhysLiteToOpenData)",
+          "url": "https://doi.org/10.5281/zenodo.15791091"
         },
         {
           "description": "Citation policy",

--- a/data/records/atlas-odeo-FEB2025-1lmet30-data.json
+++ b/data/records/atlas-odeo-FEB2025-1lmet30-data.json
@@ -1,0 +1,174 @@
+[
+  {
+    "abstract": {
+      "description": "Run 2 2015+2016 proton-proton collision data beta release, 1LMET30 skim from the ATLAS experiment"
+    },
+    "accelerator": "CERN-LHC",
+    "categories": {
+      "source": "ATLAS Collaboration"
+    },
+    "collaboration": {
+      "name": "ATLAS collaboration"
+    },
+    "collections": [
+      "ATLAS-Primary-Datasets"
+    ],
+    "collision_information": {
+      "energy": "13TeV",
+      "type": "pp"
+    },
+    "date_created": [
+      "2015",
+      "2016"
+    ],
+    "date_published": "2025",
+    "date_reprocessed": "2020",
+    "distribution": {
+      "formats": [
+        "root"
+      ],
+      "number_events": 605490333,
+      "number_files": 16,
+      "size": 143262134403
+    },
+    "doi": "10.7483/OPENDATA.ATLAS.KPYL.P0EE",
+    "experiment": [
+      "ATLAS"
+    ],
+    "files": [
+      {
+        "checksum": "adler32:04d90a6c",
+        "size": 364145700,
+        "uri": "root://eospublic.cern.ch//eos/opendata/atlas/rucio/opendata/ODEO_FEB2025_v0_1LMET30_data15_periodD.1LMET30.root"
+      },
+      {
+        "checksum": "adler32:6a4308e1",
+        "size": 2749574171,
+        "uri": "root://eospublic.cern.ch//eos/opendata/atlas/rucio/opendata/ODEO_FEB2025_v0_1LMET30_data15_periodE.1LMET30.root"
+      },
+      {
+        "checksum": "adler32:743d4306",
+        "size": 1808841136,
+        "uri": "root://eospublic.cern.ch//eos/opendata/atlas/rucio/opendata/ODEO_FEB2025_v0_1LMET30_data15_periodF.1LMET30.root"
+      },
+      {
+        "checksum": "adler32:69bf93f3",
+        "size": 4224070355,
+        "uri": "root://eospublic.cern.ch//eos/opendata/atlas/rucio/opendata/ODEO_FEB2025_v0_1LMET30_data15_periodG.1LMET30.root"
+      },
+      {
+        "checksum": "adler32:283da96d",
+        "size": 1427007909,
+        "uri": "root://eospublic.cern.ch//eos/opendata/atlas/rucio/opendata/ODEO_FEB2025_v0_1LMET30_data15_periodH.1LMET30.root"
+      },
+      {
+        "checksum": "adler32:35ae7a1c",
+        "size": 8015067539,
+        "uri": "root://eospublic.cern.ch//eos/opendata/atlas/rucio/opendata/ODEO_FEB2025_v0_1LMET30_data15_periodJ.1LMET30.root"
+      },
+      {
+        "checksum": "adler32:11bd089e",
+        "size": 3013438459,
+        "uri": "root://eospublic.cern.ch//eos/opendata/atlas/rucio/opendata/ODEO_FEB2025_v0_1LMET30_data16_periodA.1LMET30.root"
+      },
+      {
+        "checksum": "adler32:b2825572",
+        "size": 7635390021,
+        "uri": "root://eospublic.cern.ch//eos/opendata/atlas/rucio/opendata/ODEO_FEB2025_v0_1LMET30_data16_periodB.1LMET30.root"
+      },
+      {
+        "checksum": "adler32:3930a54d",
+        "size": 9798279463,
+        "uri": "root://eospublic.cern.ch//eos/opendata/atlas/rucio/opendata/ODEO_FEB2025_v0_1LMET30_data16_periodC.1LMET30.root"
+      },
+      {
+        "checksum": "adler32:a6be3a61",
+        "size": 19051229140,
+        "uri": "root://eospublic.cern.ch//eos/opendata/atlas/rucio/opendata/ODEO_FEB2025_v0_1LMET30_data16_periodD.1LMET30.root"
+      },
+      {
+        "checksum": "adler32:2981135d",
+        "size": 5974992023,
+        "uri": "root://eospublic.cern.ch//eos/opendata/atlas/rucio/opendata/ODEO_FEB2025_v0_1LMET30_data16_periodE.1LMET30.root"
+      },
+      {
+        "checksum": "adler32:39d98307",
+        "size": 12635992724,
+        "uri": "root://eospublic.cern.ch//eos/opendata/atlas/rucio/opendata/ODEO_FEB2025_v0_1LMET30_data16_periodF.1LMET30.root"
+      },
+      {
+        "checksum": "adler32:72f562af",
+        "size": 14018912469,
+        "uri": "root://eospublic.cern.ch//eos/opendata/atlas/rucio/opendata/ODEO_FEB2025_v0_1LMET30_data16_periodG.1LMET30.root"
+      },
+      {
+        "checksum": "adler32:18897cb2",
+        "size": 21263631265,
+        "uri": "root://eospublic.cern.ch//eos/opendata/atlas/rucio/opendata/ODEO_FEB2025_v0_1LMET30_data16_periodI.1LMET30.root"
+      },
+      {
+        "checksum": "adler32:16c2c31d",
+        "size": 8247922459,
+        "uri": "root://eospublic.cern.ch//eos/opendata/atlas/rucio/opendata/ODEO_FEB2025_v0_1LMET30_data16_periodK.1LMET30.root"
+      },
+      {
+        "checksum": "adler32:1965f759",
+        "size": 23033639570,
+        "uri": "root://eospublic.cern.ch//eos/opendata/atlas/rucio/opendata/ODEO_FEB2025_v0_1LMET30_data16_periodL.1LMET30.root"
+      }
+    ],
+    "license": {
+      "attribution": "CC0-1.0"
+    },
+    "methodology": {
+      "description": "<p>These data were created during LS2 as part of a major reprocessing campaign of the Run 2 data. All data were reprocessed using Athena Release 22, and new corresponding MC simulation samples were produced. These data and MC simulation datasets were processed into ROOT ntuple files from the DAOD_PHYSLITE format that is released as open data for research. For the files in this record, the following skimming selection was applied: At least one lepton with at least 7 GeV of p<sub>T</sub> and 30 GeV of missing transverse momentum (i.e. a leptonically-decaying W-boson enhanced selection)"
+    },
+    "publisher": "CERN Open Data Portal",
+    "recid": "93929",
+    "relations": [
+      {
+        "description": "For citing all the Open Data for Education and Outreach from this release, and to find other related datasets, please see",
+        "doi": "10.7483/OPENDATA.ATLAS.B5M9.44TN",
+        "recid": "93910",
+        "title": "ROOT ntuple format 2015-2016 proton-proton Open Data for Education and Outreach from the ATLAS experiment",
+        "type": "isChildOf"
+      }
+    ],
+    "run_period": [
+      "2015",
+      "2016"
+    ],
+    "title": "ATLAS ROOT ntuple format Run 2 2015+2016 proton-proton collision data beta release, 1LMET30 skim",
+    "type": {
+      "primary": "Dataset",
+      "secondary": [
+        "Collision"
+      ]
+    },
+    "usage": {
+      "description": "<p> The data and MC simulation provided by the ATLAS experiment in root ntuple format is released under a CC0 license; citation of the data and acknowledgement of the collaboration is requested. This format can be used directly using ROOT or uproot for simple studies and is primarily intended for educational and outreach purposes. <p>Extensive instructions for interacting with the data, as well as documentation of the dataset naming conventions and their contents, are provided on the ATLAS Open Data website linked below. For those interested in implementing a research-quality data analysis, the open data designed for research (also linked below) may be a better starting point. Please be sure to cite the Open Data that you use, in line with the policy below.",
+      "links": [
+        {
+          "description": "ATLAS Open Data Website",
+          "url": "http://opendata.atlas.cern"
+        },
+        {
+          "description": "Resources to understand and use the open data for education and outreach",
+          "url": "https://opendata.atlas.cern/docs/category/13-tev-tutorials-for-education"
+        },
+        {
+          "description": "More about this ntuple format",
+          "url": "https://opendata.atlas.cern/docs/data/for_education/13TeV25_details"
+        },
+        {
+          "description": "Ntuple making framework",
+          "url": "http://gitlab.cern.ch/atlas-outreach-data-tools/physlitetoopendata"
+        },
+        {
+          "description": "Citation policy",
+          "url": "https://opendata.atlas.cern/docs/documentation/ethical_legal/citation_policy"
+        }
+      ]
+    }
+  }
+]

--- a/data/records/atlas-odeo-FEB2025-1lmet30-mc.json
+++ b/data/records/atlas-odeo-FEB2025-1lmet30-mc.json
@@ -1939,15 +1939,15 @@
         },
         {
           "description": "Resources to understand and use the open data for education and outreach",
-          "url": "https://opendata.atlas.cern/docs/category/13-tev-tutorials-for-education"
+          "url": "https://opendata.atlas.cern/docs/category/13-tev-2025-beta-release"
         },
         {
           "description": "More about this ntuple format",
-          "url": "https://opendata.atlas.cern/docs/data/for_education/13TeV25_details"
+          "url": "https://opendata.atlas.cern/docs/data/for_education/13TeV25_details#variable-list"
         },
         {
-          "description": "Ntuple making framework",
-          "url": "http://gitlab.cern.ch/atlas-outreach-data-tools/physlitetoopendata"
+          "description": "Ntuple making framework (PhysLiteToOpenData)",
+          "url": "https://doi.org/10.5281/zenodo.15791091"
         },
         {
           "description": "Citation policy",

--- a/data/records/atlas-odeo-FEB2025-1lmet30-mc.json
+++ b/data/records/atlas-odeo-FEB2025-1lmet30-mc.json
@@ -1,0 +1,1959 @@
+[
+  {
+    "abstract": {
+      "description": "MC simulation, 2015+2016 proton-proton collisions beta release, 1LMET30 skim from the ATLAS experiment"
+    },
+    "accelerator": "CERN-LHC",
+    "categories": {
+      "source": "ATLAS Collaboration"
+    },
+    "collaboration": {
+      "name": "ATLAS collaboration"
+    },
+    "collections": [
+      "ATLAS-Primary-Datasets"
+    ],
+    "collision_information": {
+      "energy": "13TeV",
+      "type": "pp"
+    },
+    "date_created": [
+      "2015",
+      "2016"
+    ],
+    "date_published": "2025",
+    "date_reprocessed": "2020",
+    "distribution": {
+      "formats": [
+        "root"
+      ],
+      "number_events": 567081264,
+      "number_files": 373,
+      "size": 228935630506
+    },
+    "doi": "10.7483/OPENDATA.ATLAS.9VTD.OT28",
+    "experiment": [
+      "ATLAS"
+    ],
+    "files": [
+      {
+        "checksum": "adler32:896a5cea",
+        "size": 2761228,
+        "uri": "root://eospublic.cern.ch//eos/opendata/atlas/rucio/opendata/ODEO_FEB2025_v0_1LMET30_mc_301204.Pythia8EvtGen_A14MSTW2008LO_Zprime_NoInt_ee_SSM3000.1LMET30.root"
+      },
+      {
+        "checksum": "adler32:f7ffb17e",
+        "size": 6586110,
+        "uri": "root://eospublic.cern.ch//eos/opendata/atlas/rucio/opendata/ODEO_FEB2025_v0_1LMET30_mc_301209.Pythia8EvtGen_A14MSTW2008LO_Zprime_NoInt_mumu_SSM3000.1LMET30.root"
+      },
+      {
+        "checksum": "adler32:726fc24e",
+        "size": 2268204,
+        "uri": "root://eospublic.cern.ch//eos/opendata/atlas/rucio/opendata/ODEO_FEB2025_v0_1LMET30_mc_301243.Pythia8EvtGen_A14NNPDF23LO_Wprime_enu_SSM3000.1LMET30.root"
+      },
+      {
+        "checksum": "adler32:e6b9a992",
+        "size": 5369318,
+        "uri": "root://eospublic.cern.ch//eos/opendata/atlas/rucio/opendata/ODEO_FEB2025_v0_1LMET30_mc_301247.Pythia8EvtGen_A14NNPDF23LO_Wprime_munu_SSM3000.1LMET30.root"
+      },
+      {
+        "checksum": "adler32:40c19d48",
+        "size": 4317421,
+        "uri": "root://eospublic.cern.ch//eos/opendata/atlas/rucio/opendata/ODEO_FEB2025_v0_1LMET30_mc_301333.Pythia8EvtGen_A14NNPDF23LO_zprime3000_tt.1LMET30.root"
+      },
+      {
+        "checksum": "adler32:c25336b4",
+        "size": 361298,
+        "uri": "root://eospublic.cern.ch//eos/opendata/atlas/rucio/opendata/ODEO_FEB2025_v0_1LMET30_mc_301826.Pythia8EvtGen_A14NNPDF23LO_Wprime_qq_3000.1LMET30.root"
+      },
+      {
+        "checksum": "adler32:889b67a8",
+        "size": 114734,
+        "uri": "root://eospublic.cern.ch//eos/opendata/atlas/rucio/opendata/ODEO_FEB2025_v0_1LMET30_mc_301928.Pythia8EvtGen_A14NNPDF23LO_Zprimebb3000.1LMET30.root"
+      },
+      {
+        "checksum": "adler32:60194b92",
+        "size": 4893920,
+        "uri": "root://eospublic.cern.ch//eos/opendata/atlas/rucio/opendata/ODEO_FEB2025_v0_1LMET30_mc_302520.Pythia8EvtGen_A14NNPDF23LO_2DP20_Mass_55_100.1LMET30.root"
+      },
+      {
+        "checksum": "adler32:e13eba1a",
+        "size": 1469963,
+        "uri": "root://eospublic.cern.ch//eos/opendata/atlas/rucio/opendata/ODEO_FEB2025_v0_1LMET30_mc_302521.Pythia8EvtGen_A14NNPDF23LO_2DP20_Mass_100_160.1LMET30.root"
+      },
+      {
+        "checksum": "adler32:602d3e90",
+        "size": 539822,
+        "uri": "root://eospublic.cern.ch//eos/opendata/atlas/rucio/opendata/ODEO_FEB2025_v0_1LMET30_mc_302522.Pythia8EvtGen_A14NNPDF23LO_2DP20_Mass_160_250.1LMET30.root"
+      },
+      {
+        "checksum": "adler32:ebb4a5b4",
+        "size": 354556,
+        "uri": "root://eospublic.cern.ch//eos/opendata/atlas/rucio/opendata/ODEO_FEB2025_v0_1LMET30_mc_302523.Pythia8EvtGen_A14NNPDF23LO_2DP20_Mass_250_400.1LMET30.root"
+      },
+      {
+        "checksum": "adler32:8f2d80b4",
+        "size": 837827,
+        "uri": "root://eospublic.cern.ch//eos/opendata/atlas/rucio/opendata/ODEO_FEB2025_v0_1LMET30_mc_302524.Pythia8EvtGen_A14NNPDF23LO_2DP20_Mass_400_650.1LMET30.root"
+      },
+      {
+        "checksum": "adler32:054170ed",
+        "size": 406388,
+        "uri": "root://eospublic.cern.ch//eos/opendata/atlas/rucio/opendata/ODEO_FEB2025_v0_1LMET30_mc_302525.Pythia8EvtGen_A14NNPDF23LO_2DP20_Mass_650_1000.1LMET30.root"
+      },
+      {
+        "checksum": "adler32:9c5d5f32",
+        "size": 935517,
+        "uri": "root://eospublic.cern.ch//eos/opendata/atlas/rucio/opendata/ODEO_FEB2025_v0_1LMET30_mc_302526.Pythia8EvtGen_A14NNPDF23LO_2DP20_Mass_1000_1500.1LMET30.root"
+      },
+      {
+        "checksum": "adler32:692e1d3b",
+        "size": 1064741,
+        "uri": "root://eospublic.cern.ch//eos/opendata/atlas/rucio/opendata/ODEO_FEB2025_v0_1LMET30_mc_302527.Pythia8EvtGen_A14NNPDF23LO_2DP20_Mass_1500_2000.1LMET30.root"
+      },
+      {
+        "checksum": "adler32:0ff1374d",
+        "size": 1730959,
+        "uri": "root://eospublic.cern.ch//eos/opendata/atlas/rucio/opendata/ODEO_FEB2025_v0_1LMET30_mc_302528.Pythia8EvtGen_A14NNPDF23LO_2DP20_Mass_2000_2500.1LMET30.root"
+      },
+      {
+        "checksum": "adler32:c816fa6a",
+        "size": 1234554,
+        "uri": "root://eospublic.cern.ch//eos/opendata/atlas/rucio/opendata/ODEO_FEB2025_v0_1LMET30_mc_302529.Pythia8EvtGen_A14NNPDF23LO_2DP20_Mass_2500_3000.1LMET30.root"
+      },
+      {
+        "checksum": "adler32:464c657c",
+        "size": 2075960,
+        "uri": "root://eospublic.cern.ch//eos/opendata/atlas/rucio/opendata/ODEO_FEB2025_v0_1LMET30_mc_302530.Pythia8EvtGen_A14NNPDF23LO_2DP20_Mass_3000_3500.1LMET30.root"
+      },
+      {
+        "checksum": "adler32:d2cf0e0b",
+        "size": 1041373,
+        "uri": "root://eospublic.cern.ch//eos/opendata/atlas/rucio/opendata/ODEO_FEB2025_v0_1LMET30_mc_302531.Pythia8EvtGen_A14NNPDF23LO_2DP20_Mass_3500_4000.1LMET30.root"
+      },
+      {
+        "checksum": "adler32:fbd34d14",
+        "size": 1865768,
+        "uri": "root://eospublic.cern.ch//eos/opendata/atlas/rucio/opendata/ODEO_FEB2025_v0_1LMET30_mc_302532.Pythia8EvtGen_A14NNPDF23LO_2DP20_Mass_4000_4500.1LMET30.root"
+      },
+      {
+        "checksum": "adler32:4d42e022",
+        "size": 768753,
+        "uri": "root://eospublic.cern.ch//eos/opendata/atlas/rucio/opendata/ODEO_FEB2025_v0_1LMET30_mc_302533.Pythia8EvtGen_A14NNPDF23LO_2DP20_Mass_4500_5000.1LMET30.root"
+      },
+      {
+        "checksum": "adler32:93887ebe",
+        "size": 1966708,
+        "uri": "root://eospublic.cern.ch//eos/opendata/atlas/rucio/opendata/ODEO_FEB2025_v0_1LMET30_mc_302534.Pythia8EvtGen_A14NNPDF23LO_2DP20_Mass_5000_inf.1LMET30.root"
+      },
+      {
+        "checksum": "adler32:68349fbe",
+        "size": 6788223,
+        "uri": "root://eospublic.cern.ch//eos/opendata/atlas/rucio/opendata/ODEO_FEB2025_v0_1LMET30_mc_302733.MadGraphPythia8EvtGen_A14NNPDF23LO_WpL_tblep_M3000.1LMET30.root"
+      },
+      {
+        "checksum": "adler32:2bb1b28f",
+        "size": 11043128,
+        "uri": "root://eospublic.cern.ch//eos/opendata/atlas/rucio/opendata/ODEO_FEB2025_v0_1LMET30_mc_304014.MadGraphPythia8EvtGen_A14NNPDF23_3top_SM.1LMET30.root"
+      },
+      {
+        "checksum": "adler32:886fd8f6",
+        "size": 324341,
+        "uri": "root://eospublic.cern.ch//eos/opendata/atlas/rucio/opendata/ODEO_FEB2025_v0_1LMET30_mc_306149.MadGraphPythia8EvtGen_A14NNPDF23LO_WpL_tbhad_M3000.1LMET30.root"
+      },
+      {
+        "checksum": "adler32:ef44e794",
+        "size": 149252,
+        "uri": "root://eospublic.cern.ch//eos/opendata/atlas/rucio/opendata/ODEO_FEB2025_v0_1LMET30_mc_311490.PowhegPy8EG_A14N23LO_DMA_500_700_gq0p25.1LMET30.root"
+      },
+      {
+        "checksum": "adler32:3ff2cb9a",
+        "size": 18709628,
+        "uri": "root://eospublic.cern.ch//eos/opendata/atlas/rucio/opendata/ODEO_FEB2025_v0_1LMET30_mc_312613.aMcAtNloPy8EG_A14N30NLO_LQd_gstML_0p3_nonallhad_M1000.1LMET30.root"
+      },
+      {
+        "checksum": "adler32:ad1fa83f",
+        "size": 3363291,
+        "uri": "root://eospublic.cern.ch//eos/opendata/atlas/rucio/opendata/ODEO_FEB2025_v0_1LMET30_mc_341456.PowhegPythia8EvtGen_CT10_AZNLO_ZH125J_MINLO_veveWWlvqq_VpT.1LMET30.root"
+      },
+      {
+        "checksum": "adler32:f22e6802",
+        "size": 6804137,
+        "uri": "root://eospublic.cern.ch//eos/opendata/atlas/rucio/opendata/ODEO_FEB2025_v0_1LMET30_mc_341458.PowhegPythia8EvtGen_CT10_AZNLO_ZH125J_MINLO_vmuvmuWWlvqq_VpT.1LMET30.root"
+      },
+      {
+        "checksum": "adler32:66234579",
+        "size": 6782709,
+        "uri": "root://eospublic.cern.ch//eos/opendata/atlas/rucio/opendata/ODEO_FEB2025_v0_1LMET30_mc_341460.PowhegPy8EG_CT10_AZNLO_ZH125J_MINLO_vtauvtauWWlvqq_VpT.1LMET30.root"
+      },
+      {
+        "checksum": "adler32:2e70caeb",
+        "size": 1195024,
+        "uri": "root://eospublic.cern.ch//eos/opendata/atlas/rucio/opendata/ODEO_FEB2025_v0_1LMET30_mc_343981.PowhegPythia8EvtGen_NNLOPS_nnlo_30_ggH125_gamgam.1LMET30.root"
+      },
+      {
+        "checksum": "adler32:f35a2731",
+        "size": 20735740,
+        "uri": "root://eospublic.cern.ch//eos/opendata/atlas/rucio/opendata/ODEO_FEB2025_v0_1LMET30_mc_344158.aMcAtNloPythia8EvtGen_A14NNPDF23LO_ppx0_FxFx_Np012_SM.1LMET30.root"
+      },
+      {
+        "checksum": "adler32:425006de",
+        "size": 1395514,
+        "uri": "root://eospublic.cern.ch//eos/opendata/atlas/rucio/opendata/ODEO_FEB2025_v0_1LMET30_mc_345056.PowhegPythia8EvtGen_NNPDF3_AZNLO_ZH125J_MINLO_vvbb_VpT.1LMET30.root"
+      },
+      {
+        "checksum": "adler32:6d0d3479",
+        "size": 1424301,
+        "uri": "root://eospublic.cern.ch//eos/opendata/atlas/rucio/opendata/ODEO_FEB2025_v0_1LMET30_mc_345058.PowhegPythia8EvtGen_NNPDF3_AZNLO_ggZH125_vvbb.1LMET30.root"
+      },
+      {
+        "checksum": "adler32:1974474c",
+        "size": 294928518,
+        "uri": "root://eospublic.cern.ch//eos/opendata/atlas/rucio/opendata/ODEO_FEB2025_v0_1LMET30_mc_345060.PowhegPythia8EvtGen_NNLOPS_nnlo_30_ggH125_ZZ4l.1LMET30.root"
+      },
+      {
+        "checksum": "adler32:5843dd73",
+        "size": 1559971,
+        "uri": "root://eospublic.cern.ch//eos/opendata/atlas/rucio/opendata/ODEO_FEB2025_v0_1LMET30_mc_345061.PowhegPythia8EvtGen_NNPDF3_AZNLO_ggZH125_HgamgamZinc.1LMET30.root"
+      },
+      {
+        "checksum": "adler32:8c12c085",
+        "size": 13906227,
+        "uri": "root://eospublic.cern.ch//eos/opendata/atlas/rucio/opendata/ODEO_FEB2025_v0_1LMET30_mc_345066.PowhegPythia8EvtGen_NNPDF3_AZNLO_ggZH125_ZZ4lepZinc.1LMET30.root"
+      },
+      {
+        "checksum": "adler32:5b252791",
+        "size": 30574935,
+        "uri": "root://eospublic.cern.ch//eos/opendata/atlas/rucio/opendata/ODEO_FEB2025_v0_1LMET30_mc_345097.PowhegPythia8EvtGen_NNLOPS_nnlo_30_ggH125_mumu.1LMET30.root"
+      },
+      {
+        "checksum": "adler32:493e5c90",
+        "size": 14013866,
+        "uri": "root://eospublic.cern.ch//eos/opendata/atlas/rucio/opendata/ODEO_FEB2025_v0_1LMET30_mc_345098.PowhegPythia8EvtGen_NNPDF3_AZNLO_ggZH125_Hmumu_Zinc.1LMET30.root"
+      },
+      {
+        "checksum": "adler32:da3de24a",
+        "size": 14564790,
+        "uri": "root://eospublic.cern.ch//eos/opendata/atlas/rucio/opendata/ODEO_FEB2025_v0_1LMET30_mc_345103.PowhegPythia8EvtGen_NNPDF30_AZNLO_ZH125J_Hmumu_Zincl_MINLO.1LMET30.root"
+      },
+      {
+        "checksum": "adler32:34e03612",
+        "size": 14903855,
+        "uri": "root://eospublic.cern.ch//eos/opendata/atlas/rucio/opendata/ODEO_FEB2025_v0_1LMET30_mc_345104.PowhegPythia8EvtGen_NNPDF30_AZNLO_WpH125J_Hmumu_Wincl_MINLO.1LMET30.root"
+      },
+      {
+        "checksum": "adler32:0493c5b5",
+        "size": 8984780,
+        "uri": "root://eospublic.cern.ch//eos/opendata/atlas/rucio/opendata/ODEO_FEB2025_v0_1LMET30_mc_345105.PowhegPythia8EvtGen_NNPDF30_AZNLO_WmH125J_Hmumu_Wincl_MINLO.1LMET30.root"
+      },
+      {
+        "checksum": "adler32:7d9b1831",
+        "size": 30638027,
+        "uri": "root://eospublic.cern.ch//eos/opendata/atlas/rucio/opendata/ODEO_FEB2025_v0_1LMET30_mc_345106.PowhegPythia8EvtGen_NNPDF30_AZNLOCTEQ6L1_VBFH125_mumu.1LMET30.root"
+      },
+      {
+        "checksum": "adler32:d4ed58cd",
+        "size": 700458,
+        "uri": "root://eospublic.cern.ch//eos/opendata/atlas/rucio/opendata/ODEO_FEB2025_v0_1LMET30_mc_345112.PowhegPythia8EvtGen_NNPDF3_AZNLO_ZH125J_MINLO_vvcc_VpT.1LMET30.root"
+      },
+      {
+        "checksum": "adler32:88aa05f5",
+        "size": 652577,
+        "uri": "root://eospublic.cern.ch//eos/opendata/atlas/rucio/opendata/ODEO_FEB2025_v0_1LMET30_mc_345114.PowhegPythia8EvtGen_NNPDF3_AZNLO_ggZH125_vvcc.1LMET30.root"
+      },
+      {
+        "checksum": "adler32:1d586df8",
+        "size": 30657307,
+        "uri": "root://eospublic.cern.ch//eos/opendata/atlas/rucio/opendata/ODEO_FEB2025_v0_1LMET30_mc_345120.PowhegPy8EG_NNLOPS_nnlo_30_ggH125_tautaul13l7.1LMET30.root"
+      },
+      {
+        "checksum": "adler32:a8654f10",
+        "size": 18236366,
+        "uri": "root://eospublic.cern.ch//eos/opendata/atlas/rucio/opendata/ODEO_FEB2025_v0_1LMET30_mc_345121.PowhegPy8EG_NNLOPS_nnlo_30_ggH125_tautaulm15hp20.1LMET30.root"
+      },
+      {
+        "checksum": "adler32:161c6f9c",
+        "size": 25943857,
+        "uri": "root://eospublic.cern.ch//eos/opendata/atlas/rucio/opendata/ODEO_FEB2025_v0_1LMET30_mc_345122.PowhegPy8EG_NNLOPS_nnlo_30_ggH125_tautaulp15hm20.1LMET30.root"
+      },
+      {
+        "checksum": "adler32:44c1293d",
+        "size": 1171767,
+        "uri": "root://eospublic.cern.ch//eos/opendata/atlas/rucio/opendata/ODEO_FEB2025_v0_1LMET30_mc_345123.PowhegPy8EG_NNLOPS_nnlo_30_ggH125_tautauh30h20.1LMET30.root"
+      },
+      {
+        "checksum": "adler32:501f18e8",
+        "size": 173090896,
+        "uri": "root://eospublic.cern.ch//eos/opendata/atlas/rucio/opendata/ODEO_FEB2025_v0_1LMET30_mc_345124.PowhegPy8EG_NNLOPS_nnlo_30_ggH125_etau_filt.1LMET30.root"
+      },
+      {
+        "checksum": "adler32:cb242e27",
+        "size": 315215102,
+        "uri": "root://eospublic.cern.ch//eos/opendata/atlas/rucio/opendata/ODEO_FEB2025_v0_1LMET30_mc_345125.PowhegPy8EG_NNLOPS_nnlo_30_ggH125_mutau_filt.1LMET30.root"
+      },
+      {
+        "checksum": "adler32:c368f910",
+        "size": 5546396,
+        "uri": "root://eospublic.cern.ch//eos/opendata/atlas/rucio/opendata/ODEO_FEB2025_v0_1LMET30_mc_345211.PowhegPy8EG_NNPDF30_AZNLO_WmH125J_Winc_MINLO_tautau.1LMET30.root"
+      },
+      {
+        "checksum": "adler32:e5364eff",
+        "size": 6974900,
+        "uri": "root://eospublic.cern.ch//eos/opendata/atlas/rucio/opendata/ODEO_FEB2025_v0_1LMET30_mc_345212.PowhegPy8EG_NNPDF30_AZNLO_WpH125J_Winc_MINLO_tautau.1LMET30.root"
+      },
+      {
+        "checksum": "adler32:ebc241e2",
+        "size": 10355175,
+        "uri": "root://eospublic.cern.ch//eos/opendata/atlas/rucio/opendata/ODEO_FEB2025_v0_1LMET30_mc_345213.PowhegPy8EG_NNPDF30_AZNLO_WmH125J_Winc_MINLO_etau.1LMET30.root"
+      },
+      {
+        "checksum": "adler32:48bfd78f",
+        "size": 17994849,
+        "uri": "root://eospublic.cern.ch//eos/opendata/atlas/rucio/opendata/ODEO_FEB2025_v0_1LMET30_mc_345214.PowhegPy8EG_NNPDF30_AZNLO_WpH125J_Winc_MINLO_etau.1LMET30.root"
+      },
+      {
+        "checksum": "adler32:3a0288f8",
+        "size": 14463426,
+        "uri": "root://eospublic.cern.ch//eos/opendata/atlas/rucio/opendata/ODEO_FEB2025_v0_1LMET30_mc_345215.PowhegPy8EG_NNPDF30_AZNLO_WmH125J_Winc_MINLO_mutau.1LMET30.root"
+      },
+      {
+        "checksum": "adler32:60b9378b",
+        "size": 26027373,
+        "uri": "root://eospublic.cern.ch//eos/opendata/atlas/rucio/opendata/ODEO_FEB2025_v0_1LMET30_mc_345216.PowhegPy8EG_NNPDF30_AZNLO_WpH125J_Winc_MINLO_mutau.1LMET30.root"
+      },
+      {
+        "checksum": "adler32:05346e32",
+        "size": 8462634,
+        "uri": "root://eospublic.cern.ch//eos/opendata/atlas/rucio/opendata/ODEO_FEB2025_v0_1LMET30_mc_345217.PowhegPy8EG_NNPDF30_AZNLO_ZH125J_Zinc_MINLO_tautau.1LMET30.root"
+      },
+      {
+        "checksum": "adler32:bd6f0979",
+        "size": 17309211,
+        "uri": "root://eospublic.cern.ch//eos/opendata/atlas/rucio/opendata/ODEO_FEB2025_v0_1LMET30_mc_345218.PowhegPy8EG_NNPDF30_AZNLO_ZH125J_Zinc_MINLO_etau.1LMET30.root"
+      },
+      {
+        "checksum": "adler32:21c2053e",
+        "size": 19304908,
+        "uri": "root://eospublic.cern.ch//eos/opendata/atlas/rucio/opendata/ODEO_FEB2025_v0_1LMET30_mc_345219.PowhegPy8EG_NNPDF30_AZNLO_ZH125J_Zinc_MINLO_mutau.1LMET30.root"
+      },
+      {
+        "checksum": "adler32:ffdb1751",
+        "size": 83825854,
+        "uri": "root://eospublic.cern.ch//eos/opendata/atlas/rucio/opendata/ODEO_FEB2025_v0_1LMET30_mc_345316.PowhegPythia8EvtGen_NNLOPS_nnlo_30_ggH125_Zy_Zll.1LMET30.root"
+      },
+      {
+        "checksum": "adler32:a3b9e30a",
+        "size": 14664037,
+        "uri": "root://eospublic.cern.ch//eos/opendata/atlas/rucio/opendata/ODEO_FEB2025_v0_1LMET30_mc_345317.PowhegPythia8EvtGen_NNPDF30_AZNLO_WmH125J_Hyy_Wincl_MINLO.1LMET30.root"
+      },
+      {
+        "checksum": "adler32:a1f9bf51",
+        "size": 8777725,
+        "uri": "root://eospublic.cern.ch//eos/opendata/atlas/rucio/opendata/ODEO_FEB2025_v0_1LMET30_mc_345318.PowhegPythia8EvtGen_NNPDF30_AZNLO_WpH125J_Hyy_Wincl_MINLO.1LMET30.root"
+      },
+      {
+        "checksum": "adler32:64bf1288",
+        "size": 2225020,
+        "uri": "root://eospublic.cern.ch//eos/opendata/atlas/rucio/opendata/ODEO_FEB2025_v0_1LMET30_mc_345319.PowhegPythia8EvtGen_NNPDF30_AZNLO_ZH125J_Hyy_Zincl_MINLO.1LMET30.root"
+      },
+      {
+        "checksum": "adler32:c8700a6b",
+        "size": 4678748,
+        "uri": "root://eospublic.cern.ch//eos/opendata/atlas/rucio/opendata/ODEO_FEB2025_v0_1LMET30_mc_345320.PowhegPythia8EvtGen_NNPDF30_AZNLO_WmH125J_HZy_Wincl_MINLO.1LMET30.root"
+      },
+      {
+        "checksum": "adler32:2892f5cd",
+        "size": 4655288,
+        "uri": "root://eospublic.cern.ch//eos/opendata/atlas/rucio/opendata/ODEO_FEB2025_v0_1LMET30_mc_345321.PowhegPythia8EvtGen_NNPDF30_AZNLO_WpH125J_HZy_Wincl_MINLO.1LMET30.root"
+      },
+      {
+        "checksum": "adler32:e79d3250",
+        "size": 8635477,
+        "uri": "root://eospublic.cern.ch//eos/opendata/atlas/rucio/opendata/ODEO_FEB2025_v0_1LMET30_mc_345322.PowhegPythia8EvtGen_NNPDF30_AZNLO_ZH125J_HZy_Zincl_MINLO.1LMET30.root"
+      },
+      {
+        "checksum": "adler32:ee0a675f",
+        "size": 42955713,
+        "uri": "root://eospublic.cern.ch//eos/opendata/atlas/rucio/opendata/ODEO_FEB2025_v0_1LMET30_mc_345324.PowhegPythia8EvtGen_NNLOPS_NN30_ggH125_WWlvlv_EF_15_5.1LMET30.root"
+      },
+      {
+        "checksum": "adler32:dcc49909",
+        "size": 26467640,
+        "uri": "root://eospublic.cern.ch//eos/opendata/atlas/rucio/opendata/ODEO_FEB2025_v0_1LMET30_mc_345325.PowhegPythia8EvtGen_NNPDF3_AZNLO_WpH125J_MINLO_qqWWlvlv.1LMET30.root"
+      },
+      {
+        "checksum": "adler32:b794db5f",
+        "size": 32644903,
+        "uri": "root://eospublic.cern.ch//eos/opendata/atlas/rucio/opendata/ODEO_FEB2025_v0_1LMET30_mc_345433.PowhegPythia8EvtGen_NNPDF3_AZNLO_WmH125J_MINLO_qqWWlvlv.1LMET30.root"
+      },
+      {
+        "checksum": "adler32:1a2be871",
+        "size": 12371898,
+        "uri": "root://eospublic.cern.ch//eos/opendata/atlas/rucio/opendata/ODEO_FEB2025_v0_1LMET30_mc_345445.PowhegPythia8EvtGen_NNPDF3_AZNLO_ZH125J_MINLO_vvWWlvlv.1LMET30.root"
+      },
+      {
+        "checksum": "adler32:84b52860",
+        "size": 1385832,
+        "uri": "root://eospublic.cern.ch//eos/opendata/atlas/rucio/opendata/ODEO_FEB2025_v0_1LMET30_mc_345596.PowhegPythia8EvtGen_NNPDF3_AZNLO_ggZH125_Zinc_HZZinv.1LMET30.root"
+      },
+      {
+        "checksum": "adler32:8d588d2f",
+        "size": 45933072,
+        "uri": "root://eospublic.cern.ch//eos/opendata/atlas/rucio/opendata/ODEO_FEB2025_v0_1LMET30_mc_345697.MadGraphPythia8EvtGen_AZNLOCTEQ6L1_ggfhtautaullNp2.1LMET30.root"
+      },
+      {
+        "checksum": "adler32:8d17b07f",
+        "size": 57191445,
+        "uri": "root://eospublic.cern.ch//eos/opendata/atlas/rucio/opendata/ODEO_FEB2025_v0_1LMET30_mc_345698.MadGraphPythia8EvtGen_AZNLOCTEQ6L1_ggfhtautaulhNp2.1LMET30.root"
+      },
+      {
+        "checksum": "adler32:001f2980",
+        "size": 2479294,
+        "uri": "root://eospublic.cern.ch//eos/opendata/atlas/rucio/opendata/ODEO_FEB2025_v0_1LMET30_mc_345699.MadGraphPythia8EvtGen_AZNLOCTEQ6L1_ggfhtautauhhNp2.1LMET30.root"
+      },
+      {
+        "checksum": "adler32:52fb2bfb",
+        "size": 53332352,
+        "uri": "root://eospublic.cern.ch//eos/opendata/atlas/rucio/opendata/ODEO_FEB2025_v0_1LMET30_mc_345833.PowhegPythia8EvtGen_NNPDF30_AZNLOCTEQ6L1_VBFH125_Zllgam.1LMET30.root"
+      },
+      {
+        "checksum": "adler32:0016fea4",
+        "size": 4170143,
+        "uri": "root://eospublic.cern.ch//eos/opendata/atlas/rucio/opendata/ODEO_FEB2025_v0_1LMET30_mc_345834.PowhegPythia8EvtGen_NNPDF30_AZNLOCTEQ6L1_VBFH125_gamstargam.1LMET30.root"
+      },
+      {
+        "checksum": "adler32:5a4b57a3",
+        "size": 8491668,
+        "uri": "root://eospublic.cern.ch//eos/opendata/atlas/rucio/opendata/ODEO_FEB2025_v0_1LMET30_mc_345876.PowhegPythia8EvtGen_NNPDF30_AZNLO_ZH125J_Hee__Zincl_MINLO.1LMET30.root"
+      },
+      {
+        "checksum": "adler32:f65d68d6",
+        "size": 5326717,
+        "uri": "root://eospublic.cern.ch//eos/opendata/atlas/rucio/opendata/ODEO_FEB2025_v0_1LMET30_mc_345877.PowhegPythia8EvtGen_NNPDF30_AZNLO_WpH125J_Hee_Wincl_MINLO.1LMET30.root"
+      },
+      {
+        "checksum": "adler32:32697413",
+        "size": 5477827,
+        "uri": "root://eospublic.cern.ch//eos/opendata/atlas/rucio/opendata/ODEO_FEB2025_v0_1LMET30_mc_345878.PowhegPythia8EvtGen_NNPDF30_AZNLO_WmH125J_Hee_Wincl_MINLO.1LMET30.root"
+      },
+      {
+        "checksum": "adler32:1096ba54",
+        "size": 1362184,
+        "uri": "root://eospublic.cern.ch//eos/opendata/atlas/rucio/opendata/ODEO_FEB2025_v0_1LMET30_mc_345944.aMcAtNloPy8EG_A14NNPDF23LO_ppx0yy_FxFx_Np012_SM.1LMET30.root"
+      },
+      {
+        "checksum": "adler32:aaf76e74",
+        "size": 53751873,
+        "uri": "root://eospublic.cern.ch//eos/opendata/atlas/rucio/opendata/ODEO_FEB2025_v0_1LMET30_mc_345948.PowhegPy8EG_NNPDF30_AZNLOCTEQ6L1_VBFH125_WWlvlv.1LMET30.root"
+      },
+      {
+        "checksum": "adler32:44784775",
+        "size": 1204078,
+        "uri": "root://eospublic.cern.ch//eos/opendata/atlas/rucio/opendata/ODEO_FEB2025_v0_1LMET30_mc_345949.PowhegPythia8EvtGen_NNPDF30_AZNLOCTEQ6L1_VBFH125_bb.1LMET30.root"
+      },
+      {
+        "checksum": "adler32:49fc3aa8",
+        "size": 7744501,
+        "uri": "root://eospublic.cern.ch//eos/opendata/atlas/rucio/opendata/ODEO_FEB2025_v0_1LMET30_mc_345961.PowhegPythia8EvtGen_NNLOPS_nnlo_30_ggH125_gamstargam.1LMET30.root"
+      },
+      {
+        "checksum": "adler32:74a380c0",
+        "size": 3328430,
+        "uri": "root://eospublic.cern.ch//eos/opendata/atlas/rucio/opendata/ODEO_FEB2025_v0_1LMET30_mc_345963.PowhegPythia8EvtGen_NNPDF30_AZNLO_WmH125J_Hgamstargam_MINLO.1LMET30.root"
+      },
+      {
+        "checksum": "adler32:b6de4941",
+        "size": 3326627,
+        "uri": "root://eospublic.cern.ch//eos/opendata/atlas/rucio/opendata/ODEO_FEB2025_v0_1LMET30_mc_345964.PowhegPythia8EvtGen_NNPDF30_AZNLO_WpH125J_Hgamstargam_MINLO.1LMET30.root"
+      },
+      {
+        "checksum": "adler32:9ea20d74",
+        "size": 5708513,
+        "uri": "root://eospublic.cern.ch//eos/opendata/atlas/rucio/opendata/ODEO_FEB2025_v0_1LMET30_mc_345965.PowhegPythia8EvtGen_NNPDF30_AZNLO_ZH125J_Hgamstargam_MINLO.1LMET30.root"
+      },
+      {
+        "checksum": "adler32:511d68bf",
+        "size": 4490516,
+        "uri": "root://eospublic.cern.ch//eos/opendata/atlas/rucio/opendata/ODEO_FEB2025_v0_1LMET30_mc_346188.aMcAtNloPythia8EvtGen_tHjb125_4fl_gamgam.1LMET30.root"
+      },
+      {
+        "checksum": "adler32:0874cbf0",
+        "size": 11715132,
+        "uri": "root://eospublic.cern.ch//eos/opendata/atlas/rucio/opendata/ODEO_FEB2025_v0_1LMET30_mc_346189.aMcAtNloPythia8EvtGen_ttH_gamgam.1LMET30.root"
+      },
+      {
+        "checksum": "adler32:13b29fdb",
+        "size": 39715932,
+        "uri": "root://eospublic.cern.ch//eos/opendata/atlas/rucio/opendata/ODEO_FEB2025_v0_1LMET30_mc_346190.PowhegPy8EG_NNPDF30_AZNLOCTEQ6L1_VBFH125_tautaul13l7.1LMET30.root"
+      },
+      {
+        "checksum": "adler32:1cb4223c",
+        "size": 18172110,
+        "uri": "root://eospublic.cern.ch//eos/opendata/atlas/rucio/opendata/ODEO_FEB2025_v0_1LMET30_mc_346191.PowhegPy8EG_NNPDF30_AZNLOCTEQ6L1_VBFH125_tautaulm15hp20.1LMET30.root"
+      },
+      {
+        "checksum": "adler32:453f974a",
+        "size": 18032698,
+        "uri": "root://eospublic.cern.ch//eos/opendata/atlas/rucio/opendata/ODEO_FEB2025_v0_1LMET30_mc_346192.PowhegPy8EG_NNPDF30_AZNLOCTEQ6L1_VBFH125_tautaulp15hm20.1LMET30.root"
+      },
+      {
+        "checksum": "adler32:7da90d39",
+        "size": 881806,
+        "uri": "root://eospublic.cern.ch//eos/opendata/atlas/rucio/opendata/ODEO_FEB2025_v0_1LMET30_mc_346193.PowhegPy8EG_NNPDF30_AZNLOCTEQ6L1_VBFH125_tautauh30h20.1LMET30.root"
+      },
+      {
+        "checksum": "adler32:29a7c704",
+        "size": 53298361,
+        "uri": "root://eospublic.cern.ch//eos/opendata/atlas/rucio/opendata/ODEO_FEB2025_v0_1LMET30_mc_346194.PowhegPy8EG_NNPDF30_AZNLOCTEQ6L1_VBFH125_etau_filt.1LMET30.root"
+      },
+      {
+        "checksum": "adler32:fea7681f",
+        "size": 64231138,
+        "uri": "root://eospublic.cern.ch//eos/opendata/atlas/rucio/opendata/ODEO_FEB2025_v0_1LMET30_mc_346195.PowhegPy8EG_NNPDF30_AZNLOCTEQ6L1_VBFH125_mutau_filt.1LMET30.root"
+      },
+      {
+        "checksum": "adler32:16ba4c00",
+        "size": 41102122,
+        "uri": "root://eospublic.cern.ch//eos/opendata/atlas/rucio/opendata/ODEO_FEB2025_v0_1LMET30_mc_346198.PhPy8EG_A14NNPDF23_NNPDF30ME_ttH125_Zgam.1LMET30.root"
+      },
+      {
+        "checksum": "adler32:79d21f6c",
+        "size": 630505,
+        "uri": "root://eospublic.cern.ch//eos/opendata/atlas/rucio/opendata/ODEO_FEB2025_v0_1LMET30_mc_346214.PowhegPy8EG_NNPDF30_AZNLOCTEQ6L1_VBFH125_gamgam.1LMET30.root"
+      },
+      {
+        "checksum": "adler32:e8fa40ef",
+        "size": 69057448,
+        "uri": "root://eospublic.cern.ch//eos/opendata/atlas/rucio/opendata/ODEO_FEB2025_v0_1LMET30_mc_346228.PowhegPy8EG_NNPDF30_AZNLOCTEQ6L1_VBFH125_ZZ4lep_notau.1LMET30.root"
+      },
+      {
+        "checksum": "adler32:b5f8952e",
+        "size": 3958016,
+        "uri": "root://eospublic.cern.ch//eos/opendata/atlas/rucio/opendata/ODEO_FEB2025_v0_1LMET30_mc_346310.PowhegPythia8EvtGen_NNPDF30_AZNLO_ZH125J_Zincl_H_incl_MINLO.1LMET30.root"
+      },
+      {
+        "checksum": "adler32:d4157d1c",
+        "size": 4274754,
+        "uri": "root://eospublic.cern.ch//eos/opendata/atlas/rucio/opendata/ODEO_FEB2025_v0_1LMET30_mc_346311.PowhegPythia8EvtGen_NNPDF30_AZNLO_WpH125J_Wincl_H_incl_MINLO.1LMET30.root"
+      },
+      {
+        "checksum": "adler32:6d6ab988",
+        "size": 3268358,
+        "uri": "root://eospublic.cern.ch//eos/opendata/atlas/rucio/opendata/ODEO_FEB2025_v0_1LMET30_mc_346312.PowhegPythia8EvtGen_NNPDF30_AZNLO_WmH125J_Wincl_H_incl_MINLO.1LMET30.root"
+      },
+      {
+        "checksum": "adler32:3732df24",
+        "size": 9149084,
+        "uri": "root://eospublic.cern.ch//eos/opendata/atlas/rucio/opendata/ODEO_FEB2025_v0_1LMET30_mc_346317.PowhegPy8EG_NNPDF30_AZNLOCTEQ6L1_VBFH125_incl.1LMET30.root"
+      },
+      {
+        "checksum": "adler32:1e65cd01",
+        "size": 14330842,
+        "uri": "root://eospublic.cern.ch//eos/opendata/atlas/rucio/opendata/ODEO_FEB2025_v0_1LMET30_mc_346340.PowhegPy8EG_A14NNPDF23_NNPDF30ME_ttH125_ZZ4l_allhad.1LMET30.root"
+      },
+      {
+        "checksum": "adler32:4655419d",
+        "size": 18281485,
+        "uri": "root://eospublic.cern.ch//eos/opendata/atlas/rucio/opendata/ODEO_FEB2025_v0_1LMET30_mc_346341.PowhegPy8EG_A14NNPDF23_NNPDF30ME_ttH125_ZZ4l_semilep.1LMET30.root"
+      },
+      {
+        "checksum": "adler32:05cbe32e",
+        "size": 18367355,
+        "uri": "root://eospublic.cern.ch//eos/opendata/atlas/rucio/opendata/ODEO_FEB2025_v0_1LMET30_mc_346342.PowhegPy8EG_A14NNPDF23_NNPDF30ME_ttH125_ZZ4l_dilep.1LMET30.root"
+      },
+      {
+        "checksum": "adler32:c2e37a54",
+        "size": 8194424,
+        "uri": "root://eospublic.cern.ch//eos/opendata/atlas/rucio/opendata/ODEO_FEB2025_v0_1LMET30_mc_346343.PhPy8EG_A14NNPDF23_NNPDF30ME_ttH125_allhad.1LMET30.root"
+      },
+      {
+        "checksum": "adler32:b3dc2d45",
+        "size": 29839377,
+        "uri": "root://eospublic.cern.ch//eos/opendata/atlas/rucio/opendata/ODEO_FEB2025_v0_1LMET30_mc_346344.PhPy8EG_A14NNPDF23_NNPDF30ME_ttH125_semilep.1LMET30.root"
+      },
+      {
+        "checksum": "adler32:b7b2817f",
+        "size": 81612261,
+        "uri": "root://eospublic.cern.ch//eos/opendata/atlas/rucio/opendata/ODEO_FEB2025_v0_1LMET30_mc_346345.PhPy8EG_A14NNPDF23_NNPDF30ME_ttH125_dilep.1LMET30.root"
+      },
+      {
+        "checksum": "adler32:f5de8933",
+        "size": 874151,
+        "uri": "root://eospublic.cern.ch//eos/opendata/atlas/rucio/opendata/ODEO_FEB2025_v0_1LMET30_mc_346398.PowhegHerwig7EvtGen_NNPDF3_AZNLO_ZH125J_MINLO_vvbb_VpT.1LMET30.root"
+      },
+      {
+        "checksum": "adler32:77e133d7",
+        "size": 1299611,
+        "uri": "root://eospublic.cern.ch//eos/opendata/atlas/rucio/opendata/ODEO_FEB2025_v0_1LMET30_mc_346400.PowhegHerwig7EvtGen_NNPDF3_AZNLO_ggZH125J_vvbb.1LMET30.root"
+      },
+      {
+        "checksum": "adler32:6bbea612",
+        "size": 11838683,
+        "uri": "root://eospublic.cern.ch//eos/opendata/atlas/rucio/opendata/ODEO_FEB2025_v0_1LMET30_mc_346414.aMcAtNloPythia8EvtGen_tHjb125_4fl_ZZ4l.1LMET30.root"
+      },
+      {
+        "checksum": "adler32:7a856d5e",
+        "size": 180898078,
+        "uri": "root://eospublic.cern.ch//eos/opendata/atlas/rucio/opendata/ODEO_FEB2025_v0_1LMET30_mc_346446.PhH7EG_H7UE_NNLOPS_nnlo_30_ggH125_ZZ4l_noTau.1LMET30.root"
+      },
+      {
+        "checksum": "adler32:1371b975",
+        "size": 72320643,
+        "uri": "root://eospublic.cern.ch//eos/opendata/atlas/rucio/opendata/ODEO_FEB2025_v0_1LMET30_mc_346447.PhH7EG_H7UE_NNPDF30_VBFH125_ZZ4lep_noTau.1LMET30.root"
+      },
+      {
+        "checksum": "adler32:8cde2b88",
+        "size": 26421236,
+        "uri": "root://eospublic.cern.ch//eos/opendata/atlas/rucio/opendata/ODEO_FEB2025_v0_1LMET30_mc_346448.PhH7EG_H7UE_NNPDF30_ZH125J_Zincl_MINLO.1LMET30.root"
+      },
+      {
+        "checksum": "adler32:03c07320",
+        "size": 21941770,
+        "uri": "root://eospublic.cern.ch//eos/opendata/atlas/rucio/opendata/ODEO_FEB2025_v0_1LMET30_mc_346449.PhH7EG_H7UE_NNPDF30_WpH125J_Wincl_MINLO.1LMET30.root"
+      },
+      {
+        "checksum": "adler32:4f4c4f97",
+        "size": 10951740,
+        "uri": "root://eospublic.cern.ch//eos/opendata/atlas/rucio/opendata/ODEO_FEB2025_v0_1LMET30_mc_346450.PhH7EG_H7UE_NNPDF30_WmH125J_Wincl_MINLO.1LMET30.root"
+      },
+      {
+        "checksum": "adler32:0ae3cf7f",
+        "size": 13878803,
+        "uri": "root://eospublic.cern.ch//eos/opendata/atlas/rucio/opendata/ODEO_FEB2025_v0_1LMET30_mc_346451.PhH7EG_H7UE_NNPDF3_ggZH125_ZZ4lepZinc.1LMET30.root"
+      },
+      {
+        "checksum": "adler32:aa4f56cb",
+        "size": 14437800,
+        "uri": "root://eospublic.cern.ch//eos/opendata/atlas/rucio/opendata/ODEO_FEB2025_v0_1LMET30_mc_346452.PhH7EG_H7UE_NNPDF30ME_ttH125_ZZ4l_allhad_noTau.1LMET30.root"
+      },
+      {
+        "checksum": "adler32:79b9152c",
+        "size": 18315438,
+        "uri": "root://eospublic.cern.ch//eos/opendata/atlas/rucio/opendata/ODEO_FEB2025_v0_1LMET30_mc_346453.PhH7EG_H7UE_NNPDF30ME_ttH125_ZZ4l_semilep_noTau.1LMET30.root"
+      },
+      {
+        "checksum": "adler32:d05ed6f3",
+        "size": 18548953,
+        "uri": "root://eospublic.cern.ch//eos/opendata/atlas/rucio/opendata/ODEO_FEB2025_v0_1LMET30_mc_346454.PhH7EG_H7UE_NNPDF30ME_ttH125_ZZ4l_dilep_noTau.1LMET30.root"
+      },
+      {
+        "checksum": "adler32:3ef34aa5",
+        "size": 6384375,
+        "uri": "root://eospublic.cern.ch//eos/opendata/atlas/rucio/opendata/ODEO_FEB2025_v0_1LMET30_mc_346486.aMcAtNloPythia8EvtGen_tWH125_yy.1LMET30.root"
+      },
+      {
+        "checksum": "adler32:6f32efd5",
+        "size": 15185629,
+        "uri": "root://eospublic.cern.ch//eos/opendata/atlas/rucio/opendata/ODEO_FEB2025_v0_1LMET30_mc_346511.aMcAtNloPythia8EvtGen_tWH125_ZZ4l.1LMET30.root"
+      },
+      {
+        "checksum": "adler32:2aaa91d9",
+        "size": 13258208,
+        "uri": "root://eospublic.cern.ch//eos/opendata/atlas/rucio/opendata/ODEO_FEB2025_v0_1LMET30_mc_346524.PowhegPythia8EvtGen_NNPDF3_AZNLO_ggZH125J_MINLO_ZinclWWlvlv.1LMET30.root"
+      },
+      {
+        "checksum": "adler32:eaa25164",
+        "size": 25611938,
+        "uri": "root://eospublic.cern.ch//eos/opendata/atlas/rucio/opendata/ODEO_FEB2025_v0_1LMET30_mc_346525.PowhegPythia8EvtGen_A14NNPDF23_NNPDF30ME_ttH125_gamgam.1LMET30.root"
+      },
+      {
+        "checksum": "adler32:30f656de",
+        "size": 27258188,
+        "uri": "root://eospublic.cern.ch//eos/opendata/atlas/rucio/opendata/ODEO_FEB2025_v0_1LMET30_mc_346526.PowhegHerwig7EvtGen_H7UE_NNPDF30ME_ttH125_gamgam.1LMET30.root"
+      },
+      {
+        "checksum": "adler32:2d8bb695",
+        "size": 527399,
+        "uri": "root://eospublic.cern.ch//eos/opendata/atlas/rucio/opendata/ODEO_FEB2025_v0_1LMET30_mc_346588.PowhegPythia8EvtGen_NNLOPS_nnlo_30_ggH125_ZZ4nu_MET75.1LMET30.root"
+      },
+      {
+        "checksum": "adler32:aa407e92",
+        "size": 19118113,
+        "uri": "root://eospublic.cern.ch//eos/opendata/atlas/rucio/opendata/ODEO_FEB2025_v0_1LMET30_mc_346601.aMcAtNloHerwig7EvtGen_MEN30NLO_ttH125_gamgam.1LMET30.root"
+      },
+      {
+        "checksum": "adler32:07306f82",
+        "size": 4029323,
+        "uri": "root://eospublic.cern.ch//eos/opendata/atlas/rucio/opendata/ODEO_FEB2025_v0_1LMET30_mc_346602.aMcAtNloHerwig7EvtGen_MEN30NLO_tHjb125_gamgam.1LMET30.root"
+      },
+      {
+        "checksum": "adler32:343e1f39",
+        "size": 4939076,
+        "uri": "root://eospublic.cern.ch//eos/opendata/atlas/rucio/opendata/ODEO_FEB2025_v0_1LMET30_mc_346605.PowhegPythia8EvtGen_NNPDF30_AZNLO_WpH125J_WinclHinv_MET75.1LMET30.root"
+      },
+      {
+        "checksum": "adler32:d15a6d0a",
+        "size": 4911002,
+        "uri": "root://eospublic.cern.ch//eos/opendata/atlas/rucio/opendata/ODEO_FEB2025_v0_1LMET30_mc_346606.PowhegPythia8EvtGen_NNPDF30_AZNLO_WmH125J_WinclHinv_MET75.1LMET30.root"
+      },
+      {
+        "checksum": "adler32:4b977639",
+        "size": 4970778,
+        "uri": "root://eospublic.cern.ch//eos/opendata/atlas/rucio/opendata/ODEO_FEB2025_v0_1LMET30_mc_346607.PowhegPythia8EvtGen_NNPDF30_AZNLO_ZH125J_ZinclHinv_MET75.1LMET30.root"
+      },
+      {
+        "checksum": "adler32:339d41a4",
+        "size": 49104202,
+        "uri": "root://eospublic.cern.ch//eos/opendata/atlas/rucio/opendata/ODEO_FEB2025_v0_1LMET30_mc_346632.PowhegPy8EG_A14NNPDF23_NNPDF30ME_ttH125_ZZ4nu_semilep.1LMET30.root"
+      },
+      {
+        "checksum": "adler32:1ca591b5",
+        "size": 2979774,
+        "uri": "root://eospublic.cern.ch//eos/opendata/atlas/rucio/opendata/ODEO_FEB2025_v0_1LMET30_mc_346633.PowhegPy8EG_A14NNPDF23_NNPDF30ME_ttH125_ZZ4nu_allhad.1LMET30.root"
+      },
+      {
+        "checksum": "adler32:d9b1105e",
+        "size": 15951372,
+        "uri": "root://eospublic.cern.ch//eos/opendata/atlas/rucio/opendata/ODEO_FEB2025_v0_1LMET30_mc_346634.PowhegPy8EG_A14NNPDF23_NNPDF30ME_ttH125_ZZ4nu_dilep.1LMET30.root"
+      },
+      {
+        "checksum": "adler32:c5f132a4",
+        "size": 37312598,
+        "uri": "root://eospublic.cern.ch//eos/opendata/atlas/rucio/opendata/ODEO_FEB2025_v0_1LMET30_mc_346645.PowhegPythia8EvtGen_NNPDF30_AZNLO_ZH125J_Zincl_MINLO_shw.1LMET30.root"
+      },
+      {
+        "checksum": "adler32:97c2148d",
+        "size": 22033798,
+        "uri": "root://eospublic.cern.ch//eos/opendata/atlas/rucio/opendata/ODEO_FEB2025_v0_1LMET30_mc_346646.PowhegPythia8EvtGen_NNPDF30_AZNLO_WpH125J_Wincl_MINLO_shw.1LMET30.root"
+      },
+      {
+        "checksum": "adler32:bf540714",
+        "size": 11073939,
+        "uri": "root://eospublic.cern.ch//eos/opendata/atlas/rucio/opendata/ODEO_FEB2025_v0_1LMET30_mc_346647.PowhegPythia8EvtGen_NNPDF30_AZNLO_WmH125J_Wincl_MINLO_shw.1LMET30.root"
+      },
+      {
+        "checksum": "adler32:938c2cff",
+        "size": 1022155,
+        "uri": "root://eospublic.cern.ch//eos/opendata/atlas/rucio/opendata/ODEO_FEB2025_v0_1LMET30_mc_346726.PowhegHerwig7EvtGen_NNPDF3_AZNLO_ZH125J_MINLO_vvcc_VpT.1LMET30.root"
+      },
+      {
+        "checksum": "adler32:be9e1edd",
+        "size": 320660,
+        "uri": "root://eospublic.cern.ch//eos/opendata/atlas/rucio/opendata/ODEO_FEB2025_v0_1LMET30_mc_346728.PowhegHerwig7EvtGen_NNPDF3_AZNLO_ggZH125J_vvcc.1LMET30.root"
+      },
+      {
+        "checksum": "adler32:945dfa6c",
+        "size": 7693525,
+        "uri": "root://eospublic.cern.ch//eos/opendata/atlas/rucio/opendata/ODEO_FEB2025_v0_1LMET30_mc_346797.PhH7EG_H7UE_NNLOPS_nnlo_30_ggH125_gamgam.1LMET30.root"
+      },
+      {
+        "checksum": "adler32:a5df347c",
+        "size": 275307978,
+        "uri": "root://eospublic.cern.ch//eos/opendata/atlas/rucio/opendata/ODEO_FEB2025_v0_1LMET30_mc_346802.PhH7EG_NNLOPS_nnlo_30_ggH125_WWlvlv_noTau.1LMET30.root"
+      },
+      {
+        "checksum": "adler32:8b9ecdff",
+        "size": 44905444,
+        "uri": "root://eospublic.cern.ch//eos/opendata/atlas/rucio/opendata/ODEO_FEB2025_v0_1LMET30_mc_346877.PhH7EG_NNPDF30_VBFH125_WWlvlv.1LMET30.root"
+      },
+      {
+        "checksum": "adler32:25dfdb62",
+        "size": 1720700,
+        "uri": "root://eospublic.cern.ch//eos/opendata/atlas/rucio/opendata/ODEO_FEB2025_v0_1LMET30_mc_346878.PhH7EG_H7UE_NNPDF30_VBF125_gammagamma.1LMET30.root"
+      },
+      {
+        "checksum": "adler32:264098c6",
+        "size": 2442729,
+        "uri": "root://eospublic.cern.ch//eos/opendata/atlas/rucio/opendata/ODEO_FEB2025_v0_1LMET30_mc_346879.PhH7EG_H7UE_NNPDF30_ZH125J_Zincl_MINLO_gammagamma.1LMET30.root"
+      },
+      {
+        "checksum": "adler32:82626889",
+        "size": 3194880,
+        "uri": "root://eospublic.cern.ch//eos/opendata/atlas/rucio/opendata/ODEO_FEB2025_v0_1LMET30_mc_346880.PhH7EG_H7UE_NNPDF30_WmH125J_Wincl_MINLO_gammagamma.1LMET30.root"
+      },
+      {
+        "checksum": "adler32:734fce14",
+        "size": 7033280,
+        "uri": "root://eospublic.cern.ch//eos/opendata/atlas/rucio/opendata/ODEO_FEB2025_v0_1LMET30_mc_346881.PhH7EG_H7UE_NNPDF30_WpH125J_Wincl_MINLO_gammagamma.1LMET30.root"
+      },
+      {
+        "checksum": "adler32:b9cfdad7",
+        "size": 1374255,
+        "uri": "root://eospublic.cern.ch//eos/opendata/atlas/rucio/opendata/ODEO_FEB2025_v0_1LMET30_mc_346882.PhH7EG_H7UE_NNPDF30_ggZH125_gammagamma.1LMET30.root"
+      },
+      {
+        "checksum": "adler32:d53a3229",
+        "size": 27283033,
+        "uri": "root://eospublic.cern.ch//eos/opendata/atlas/rucio/opendata/ODEO_FEB2025_v0_1LMET30_mc_346919.PhPy8EG_A14NNPDF23_NNPDF30ME_ttH125_allhad_tautau_unpol.1LMET30.root"
+      },
+      {
+        "checksum": "adler32:533a5f23",
+        "size": 48816289,
+        "uri": "root://eospublic.cern.ch//eos/opendata/atlas/rucio/opendata/ODEO_FEB2025_v0_1LMET30_mc_346923.PhPy8EG_A14NNPDF23_NNPDF30ME_ttH125_semilep_tautau_unpol.1LMET30.root"
+      },
+      {
+        "checksum": "adler32:7bb74bfc",
+        "size": 39446962,
+        "uri": "root://eospublic.cern.ch//eos/opendata/atlas/rucio/opendata/ODEO_FEB2025_v0_1LMET30_mc_346927.PhPy8EG_A14NNPDF23_NNPDF30ME_ttH125_dilep_tautau_unpol.1LMET30.root"
+      },
+      {
+        "checksum": "adler32:3e2a4043",
+        "size": 59398497,
+        "uri": "root://eospublic.cern.ch//eos/opendata/atlas/rucio/opendata/ODEO_FEB2025_v0_1LMET30_mc_364242.Sherpa_222_NNPDF30NNLO_WWW_3l3v_EW6.1LMET30.root"
+      },
+      {
+        "checksum": "adler32:015fa739",
+        "size": 21777612,
+        "uri": "root://eospublic.cern.ch//eos/opendata/atlas/rucio/opendata/ODEO_FEB2025_v0_1LMET30_mc_364243.Sherpa_222_NNPDF30NNLO_WWZ_4l2v_EW6.1LMET30.root"
+      },
+      {
+        "checksum": "adler32:97848d26",
+        "size": 14942993,
+        "uri": "root://eospublic.cern.ch//eos/opendata/atlas/rucio/opendata/ODEO_FEB2025_v0_1LMET30_mc_364244.Sherpa_222_NNPDF30NNLO_WWZ_2l4v_EW6.1LMET30.root"
+      },
+      {
+        "checksum": "adler32:96a31f89",
+        "size": 18905231,
+        "uri": "root://eospublic.cern.ch//eos/opendata/atlas/rucio/opendata/ODEO_FEB2025_v0_1LMET30_mc_364245.Sherpa_222_NNPDF30NNLO_WZZ_5l1v_EW6.1LMET30.root"
+      },
+      {
+        "checksum": "adler32:a9ee8495",
+        "size": 18545731,
+        "uri": "root://eospublic.cern.ch//eos/opendata/atlas/rucio/opendata/ODEO_FEB2025_v0_1LMET30_mc_364246.Sherpa_222_NNPDF30NNLO_WZZ_3l3v_EW6.1LMET30.root"
+      },
+      {
+        "checksum": "adler32:2812596c",
+        "size": 12455798,
+        "uri": "root://eospublic.cern.ch//eos/opendata/atlas/rucio/opendata/ODEO_FEB2025_v0_1LMET30_mc_364247.Sherpa_222_NNPDF30NNLO_ZZZ_6l0v_EW6.1LMET30.root"
+      },
+      {
+        "checksum": "adler32:04ca15a5",
+        "size": 3960773,
+        "uri": "root://eospublic.cern.ch//eos/opendata/atlas/rucio/opendata/ODEO_FEB2025_v0_1LMET30_mc_364248.Sherpa_222_NNPDF30NNLO_ZZZ_4l2v_EW6.1LMET30.root"
+      },
+      {
+        "checksum": "adler32:3811a147",
+        "size": 7072914,
+        "uri": "root://eospublic.cern.ch//eos/opendata/atlas/rucio/opendata/ODEO_FEB2025_v0_1LMET30_mc_364249.Sherpa_222_NNPDF30NNLO_ZZZ_2l4v_EW6.1LMET30.root"
+      },
+      {
+        "checksum": "adler32:69f98031",
+        "size": 16496895,
+        "uri": "root://eospublic.cern.ch//eos/opendata/atlas/rucio/opendata/ODEO_FEB2025_v0_1LMET30_mc_364336.Sherpa_222_NNPDF30NNLO_WpWpWn_sslvlvjj_EW6.1LMET30.root"
+      },
+      {
+        "checksum": "adler32:54f9078d",
+        "size": 12362975,
+        "uri": "root://eospublic.cern.ch//eos/opendata/atlas/rucio/opendata/ODEO_FEB2025_v0_1LMET30_mc_364337.Sherpa_222_NNPDF30NNLO_WnWnWp_sslvlvjj_EW6.1LMET30.root"
+      },
+      {
+        "checksum": "adler32:59ac4482",
+        "size": 5957972,
+        "uri": "root://eospublic.cern.ch//eos/opendata/atlas/rucio/opendata/ODEO_FEB2025_v0_1LMET30_mc_364338.Sherpa_222_NNPDF30NNLO_WpWpWn_oslvlvjj_EW6.1LMET30.root"
+      },
+      {
+        "checksum": "adler32:db263260",
+        "size": 2011972,
+        "uri": "root://eospublic.cern.ch//eos/opendata/atlas/rucio/opendata/ODEO_FEB2025_v0_1LMET30_mc_364339.Sherpa_222_NNPDF30NNLO_WnWnWp_oslvlvjj_EW6.1LMET30.root"
+      },
+      {
+        "checksum": "adler32:519ae14f",
+        "size": 2922659,
+        "uri": "root://eospublic.cern.ch//eos/opendata/atlas/rucio/opendata/ODEO_FEB2025_v0_1LMET30_mc_364350.Sherpa_224_NNPDF30NNLO_Diphoton_myy_0_50.1LMET30.root"
+      },
+      {
+        "checksum": "adler32:a76accde",
+        "size": 28953698,
+        "uri": "root://eospublic.cern.ch//eos/opendata/atlas/rucio/opendata/ODEO_FEB2025_v0_1LMET30_mc_364351.Sherpa_224_NNPDF30NNLO_Diphoton_myy_50_90.1LMET30.root"
+      },
+      {
+        "checksum": "adler32:d740e26e",
+        "size": 13045082,
+        "uri": "root://eospublic.cern.ch//eos/opendata/atlas/rucio/opendata/ODEO_FEB2025_v0_1LMET30_mc_364352.Sherpa_224_NNPDF30NNLO_Diphoton_myy_90_175.1LMET30.root"
+      },
+      {
+        "checksum": "adler32:a8889229",
+        "size": 3961463,
+        "uri": "root://eospublic.cern.ch//eos/opendata/atlas/rucio/opendata/ODEO_FEB2025_v0_1LMET30_mc_364353.Sherpa_224_NNPDF30NNLO_Diphoton_myy_175_2000.1LMET30.root"
+      },
+      {
+        "checksum": "adler32:534a5509",
+        "size": 550523,
+        "uri": "root://eospublic.cern.ch//eos/opendata/atlas/rucio/opendata/ODEO_FEB2025_v0_1LMET30_mc_364354.Sherpa_224_NNPDF30NNLO_Diphoton_myy_2000_E_CMS.1LMET30.root"
+      },
+      {
+        "checksum": "adler32:51d0a702",
+        "size": 10608481,
+        "uri": "root://eospublic.cern.ch//eos/opendata/atlas/rucio/opendata/ODEO_FEB2025_v0_1LMET30_mc_364541.Sherpa_222_NNPDF30NNLO_SinglePhoton_pty_17_35.1LMET30.root"
+      },
+      {
+        "checksum": "adler32:499ab337",
+        "size": 23810519,
+        "uri": "root://eospublic.cern.ch//eos/opendata/atlas/rucio/opendata/ODEO_FEB2025_v0_1LMET30_mc_364542.Sherpa_222_NNPDF30NNLO_SinglePhoton_pty_35_70.1LMET30.root"
+      },
+      {
+        "checksum": "adler32:37f4b890",
+        "size": 30644386,
+        "uri": "root://eospublic.cern.ch//eos/opendata/atlas/rucio/opendata/ODEO_FEB2025_v0_1LMET30_mc_364543.Sherpa_222_NNPDF30NNLO_SinglePhoton_pty_70_140.1LMET30.root"
+      },
+      {
+        "checksum": "adler32:aa8e7ab3",
+        "size": 41335849,
+        "uri": "root://eospublic.cern.ch//eos/opendata/atlas/rucio/opendata/ODEO_FEB2025_v0_1LMET30_mc_364544.Sherpa_222_NNPDF30NNLO_SinglePhoton_pty_140_280.1LMET30.root"
+      },
+      {
+        "checksum": "adler32:9b09f973",
+        "size": 9968071,
+        "uri": "root://eospublic.cern.ch//eos/opendata/atlas/rucio/opendata/ODEO_FEB2025_v0_1LMET30_mc_364545.Sherpa_222_NNPDF30NNLO_SinglePhoton_pty_280_500.1LMET30.root"
+      },
+      {
+        "checksum": "adler32:5c707a0b",
+        "size": 1051665,
+        "uri": "root://eospublic.cern.ch//eos/opendata/atlas/rucio/opendata/ODEO_FEB2025_v0_1LMET30_mc_364546.Sherpa_222_NNPDF30NNLO_SinglePhoton_pty_500_1000.1LMET30.root"
+      },
+      {
+        "checksum": "adler32:5b54f861",
+        "size": 1539331,
+        "uri": "root://eospublic.cern.ch//eos/opendata/atlas/rucio/opendata/ODEO_FEB2025_v0_1LMET30_mc_364547.Sherpa_222_NNPDF30NNLO_SinglePhoton_pty_1000_E_CMS.1LMET30.root"
+      },
+      {
+        "checksum": "adler32:1de47ba2",
+        "size": 6436486,
+        "uri": "root://eospublic.cern.ch//eos/opendata/atlas/rucio/opendata/ODEO_FEB2025_v0_1LMET30_mc_364700.Pythia8EvtGen_A14NNPDF23LO_jetjet_JZ0WithSW.1LMET30.root"
+      },
+      {
+        "checksum": "adler32:8c118614",
+        "size": 13587901,
+        "uri": "root://eospublic.cern.ch//eos/opendata/atlas/rucio/opendata/ODEO_FEB2025_v0_1LMET30_mc_364701.Pythia8EvtGen_A14NNPDF23LO_jetjet_JZ1WithSW.1LMET30.root"
+      },
+      {
+        "checksum": "adler32:8e708984",
+        "size": 75641762,
+        "uri": "root://eospublic.cern.ch//eos/opendata/atlas/rucio/opendata/ODEO_FEB2025_v0_1LMET30_mc_364702.Pythia8EvtGen_A14NNPDF23LO_jetjet_JZ2WithSW.1LMET30.root"
+      },
+      {
+        "checksum": "adler32:236b0849",
+        "size": 132763283,
+        "uri": "root://eospublic.cern.ch//eos/opendata/atlas/rucio/opendata/ODEO_FEB2025_v0_1LMET30_mc_364703.Pythia8EvtGen_A14NNPDF23LO_jetjet_JZ3WithSW.1LMET30.root"
+      },
+      {
+        "checksum": "adler32:6a4e2fea",
+        "size": 261734388,
+        "uri": "root://eospublic.cern.ch//eos/opendata/atlas/rucio/opendata/ODEO_FEB2025_v0_1LMET30_mc_364704.Pythia8EvtGen_A14NNPDF23LO_jetjet_JZ4WithSW.1LMET30.root"
+      },
+      {
+        "checksum": "adler32:63e32c8f",
+        "size": 49653652,
+        "uri": "root://eospublic.cern.ch//eos/opendata/atlas/rucio/opendata/ODEO_FEB2025_v0_1LMET30_mc_364705.Pythia8EvtGen_A14NNPDF23LO_jetjet_JZ5WithSW.1LMET30.root"
+      },
+      {
+        "checksum": "adler32:4e3403fa",
+        "size": 3143293,
+        "uri": "root://eospublic.cern.ch//eos/opendata/atlas/rucio/opendata/ODEO_FEB2025_v0_1LMET30_mc_364706.Pythia8EvtGen_A14NNPDF23LO_jetjet_JZ6WithSW.1LMET30.root"
+      },
+      {
+        "checksum": "adler32:93c416fa",
+        "size": 2399186,
+        "uri": "root://eospublic.cern.ch//eos/opendata/atlas/rucio/opendata/ODEO_FEB2025_v0_1LMET30_mc_364707.Pythia8EvtGen_A14NNPDF23LO_jetjet_JZ7WithSW.1LMET30.root"
+      },
+      {
+        "checksum": "adler32:84e5030c",
+        "size": 5678692,
+        "uri": "root://eospublic.cern.ch//eos/opendata/atlas/rucio/opendata/ODEO_FEB2025_v0_1LMET30_mc_364708.Pythia8EvtGen_A14NNPDF23LO_jetjet_JZ8WithSW.1LMET30.root"
+      },
+      {
+        "checksum": "adler32:af045d4d",
+        "size": 2849470,
+        "uri": "root://eospublic.cern.ch//eos/opendata/atlas/rucio/opendata/ODEO_FEB2025_v0_1LMET30_mc_364709.Pythia8EvtGen_A14NNPDF23LO_jetjet_JZ9WithSW.1LMET30.root"
+      },
+      {
+        "checksum": "adler32:5344faee",
+        "size": 9614571,
+        "uri": "root://eospublic.cern.ch//eos/opendata/atlas/rucio/opendata/ODEO_FEB2025_v0_1LMET30_mc_364710.Pythia8EvtGen_A14NNPDF23LO_jetjet_JZ10WithSW.1LMET30.root"
+      },
+      {
+        "checksum": "adler32:1be04af9",
+        "size": 4603893,
+        "uri": "root://eospublic.cern.ch//eos/opendata/atlas/rucio/opendata/ODEO_FEB2025_v0_1LMET30_mc_364711.Pythia8EvtGen_A14NNPDF23LO_jetjet_JZ11WithSW.1LMET30.root"
+      },
+      {
+        "checksum": "adler32:260a3ba1",
+        "size": 5904033,
+        "uri": "root://eospublic.cern.ch//eos/opendata/atlas/rucio/opendata/ODEO_FEB2025_v0_1LMET30_mc_364712.Pythia8EvtGen_A14NNPDF23LO_jetjet_JZ12WithSW.1LMET30.root"
+      },
+      {
+        "checksum": "adler32:1c5c1078",
+        "size": 3889487,
+        "uri": "root://eospublic.cern.ch//eos/opendata/atlas/rucio/opendata/ODEO_FEB2025_v0_1LMET30_mc_375884.MGPy8EG_A14N_GG_ttn1_2000_5000_200.1LMET30.root"
+      },
+      {
+        "checksum": "adler32:84198f83",
+        "size": 468198,
+        "uri": "root://eospublic.cern.ch//eos/opendata/atlas/rucio/opendata/ODEO_FEB2025_v0_1LMET30_mc_376359.MGPy8EG_A14N23LO_SS_onestepCC_1600_900_200.1LMET30.root"
+      },
+      {
+        "checksum": "adler32:dd8a371d",
+        "size": 73576,
+        "uri": "root://eospublic.cern.ch//eos/opendata/atlas/rucio/opendata/ODEO_FEB2025_v0_1LMET30_mc_376518.MadGraphPythia8EvtGen_A14NNPDF23LO_GG_direct_2400_200.1LMET30.root"
+      },
+      {
+        "checksum": "adler32:270a27bf",
+        "size": 4409399,
+        "uri": "root://eospublic.cern.ch//eos/opendata/atlas/rucio/opendata/ODEO_FEB2025_v0_1LMET30_mc_392202.MGPy8EG_A14N23LO_C1N2_WZ_500p0_100p0_3L_2L7.1LMET30.root"
+      },
+      {
+        "checksum": "adler32:94159471",
+        "size": 1560241,
+        "uri": "root://eospublic.cern.ch//eos/opendata/atlas/rucio/opendata/ODEO_FEB2025_v0_1LMET30_mc_394997.MGPy8EG_A14N23LO_SM_N2C1p_105_100_2L2MET75_MadSpin.1LMET30.root"
+      },
+      {
+        "checksum": "adler32:6350b871",
+        "size": 3483092,
+        "uri": "root://eospublic.cern.ch//eos/opendata/atlas/rucio/opendata/ODEO_FEB2025_v0_1LMET30_mc_398384.MGPy8EG_A14N23LO_C1N2N1_GGMHinoZh50_800_noFilter.1LMET30.root"
+      },
+      {
+        "checksum": "adler32:55554db2",
+        "size": 10046895,
+        "uri": "root://eospublic.cern.ch//eos/opendata/atlas/rucio/opendata/ODEO_FEB2025_v0_1LMET30_mc_410081.MadGraphPythia8EvtGen_A14NNPDF23_ttbarWW.1LMET30.root"
+      },
+      {
+        "checksum": "adler32:19157686",
+        "size": 106501446,
+        "uri": "root://eospublic.cern.ch//eos/opendata/atlas/rucio/opendata/ODEO_FEB2025_v0_1LMET30_mc_410082.MadGraphPythia8EvtGen_A14NNPDF23LO_ttgamma_noallhad.1LMET30.root"
+      },
+      {
+        "checksum": "adler32:b15e9894",
+        "size": 4333187,
+        "uri": "root://eospublic.cern.ch//eos/opendata/atlas/rucio/opendata/ODEO_FEB2025_v0_1LMET30_mc_410087.MadGraphPythia8EvtGen_A14NNPDF23LO_ttgamma_allhad.1LMET30.root"
+      },
+      {
+        "checksum": "adler32:53366a78",
+        "size": 23835886,
+        "uri": "root://eospublic.cern.ch//eos/opendata/atlas/rucio/opendata/ODEO_FEB2025_v0_1LMET30_mc_410155.aMcAtNloPythia8EvtGen_MEN30NLO_A14N23LO_ttW.1LMET30.root"
+      },
+      {
+        "checksum": "adler32:f22316a0",
+        "size": 20770919,
+        "uri": "root://eospublic.cern.ch//eos/opendata/atlas/rucio/opendata/ODEO_FEB2025_v0_1LMET30_mc_410156.aMcAtNloPythia8EvtGen_MEN30NLO_A14N23LO_ttZnunu.1LMET30.root"
+      },
+      {
+        "checksum": "adler32:becc9313",
+        "size": 28766085,
+        "uri": "root://eospublic.cern.ch//eos/opendata/atlas/rucio/opendata/ODEO_FEB2025_v0_1LMET30_mc_410157.aMcAtNloPythia8EvtGen_MEN30NLO_A14N23LO_ttZqq.1LMET30.root"
+      },
+      {
+        "checksum": "adler32:05b85d35",
+        "size": 31150574,
+        "uri": "root://eospublic.cern.ch//eos/opendata/atlas/rucio/opendata/ODEO_FEB2025_v0_1LMET30_mc_410218.aMcAtNloPythia8EvtGen_MEN30NLO_A14N23LO_ttee.1LMET30.root"
+      },
+      {
+        "checksum": "adler32:4835ed11",
+        "size": 58588308,
+        "uri": "root://eospublic.cern.ch//eos/opendata/atlas/rucio/opendata/ODEO_FEB2025_v0_1LMET30_mc_410219.aMcAtNloPythia8EvtGen_MEN30NLO_A14N23LO_ttmumu.1LMET30.root"
+      },
+      {
+        "checksum": "adler32:24dd4c99",
+        "size": 45077758,
+        "uri": "root://eospublic.cern.ch//eos/opendata/atlas/rucio/opendata/ODEO_FEB2025_v0_1LMET30_mc_410220.aMcAtNloPythia8EvtGen_MEN30NLO_A14N23LO_tttautau.1LMET30.root"
+      },
+      {
+        "checksum": "adler32:a006ecdd",
+        "size": 149504646,
+        "uri": "root://eospublic.cern.ch//eos/opendata/atlas/rucio/opendata/ODEO_FEB2025_v0_1LMET30_mc_410389.MadGraphPythia8EvtGen_A14NNPDF23_ttgamma_nonallhadronic.1LMET30.root"
+      },
+      {
+        "checksum": "adler32:9bc12360",
+        "size": 136892697,
+        "uri": "root://eospublic.cern.ch//eos/opendata/atlas/rucio/opendata/ODEO_FEB2025_v0_1LMET30_mc_410395.MGH7EG_H7UE_ttgamma_nonallhadronic.1LMET30.root"
+      },
+      {
+        "checksum": "adler32:129d0658",
+        "size": 5558649,
+        "uri": "root://eospublic.cern.ch//eos/opendata/atlas/rucio/opendata/ODEO_FEB2025_v0_1LMET30_mc_410396.MGH7EG_H7UE_ttgamma_allhadronic.1LMET30.root"
+      },
+      {
+        "checksum": "adler32:0816dfe0",
+        "size": 12402113,
+        "uri": "root://eospublic.cern.ch//eos/opendata/atlas/rucio/opendata/ODEO_FEB2025_v0_1LMET30_mc_410408.aMcAtNloPythia8EvtGen_tWZ_Ztoll_minDR1.1LMET30.root"
+      },
+      {
+        "checksum": "adler32:5c7358e8",
+        "size": 8962874353,
+        "uri": "root://eospublic.cern.ch//eos/opendata/atlas/rucio/opendata/ODEO_FEB2025_v0_1LMET30_mc_410470.PhPy8EG_A14_ttbar_hdamp258p75_nonallhad.1LMET30.root"
+      },
+      {
+        "checksum": "adler32:11ce7b1b",
+        "size": 254256703,
+        "uri": "root://eospublic.cern.ch//eos/opendata/atlas/rucio/opendata/ODEO_FEB2025_v0_1LMET30_mc_410471.PhPy8EG_A14_ttbar_hdamp258p75_allhad.1LMET30.root"
+      },
+      {
+        "checksum": "adler32:30fa3692",
+        "size": 33771945,
+        "uri": "root://eospublic.cern.ch//eos/opendata/atlas/rucio/opendata/ODEO_FEB2025_v0_1LMET30_mc_410560.MadGraphPythia8EvtGen_A14_tZ_4fl_tchan_noAllHad.1LMET30.root"
+      },
+      {
+        "checksum": "adler32:185f8064",
+        "size": 31973221,
+        "uri": "root://eospublic.cern.ch//eos/opendata/atlas/rucio/opendata/ODEO_FEB2025_v0_1LMET30_mc_410644.PowhegPythia8EvtGen_A14_singletop_schan_lept_top.1LMET30.root"
+      },
+      {
+        "checksum": "adler32:c9c750e3",
+        "size": 21450390,
+        "uri": "root://eospublic.cern.ch//eos/opendata/atlas/rucio/opendata/ODEO_FEB2025_v0_1LMET30_mc_410645.PowhegPythia8EvtGen_A14_singletop_schan_lept_antitop.1LMET30.root"
+      },
+      {
+        "checksum": "adler32:a45fd93f",
+        "size": 621183639,
+        "uri": "root://eospublic.cern.ch//eos/opendata/atlas/rucio/opendata/ODEO_FEB2025_v0_1LMET30_mc_410658.PhPy8EG_A14_tchan_BW50_lept_top.1LMET30.root"
+      },
+      {
+        "checksum": "adler32:daaf92af",
+        "size": 379939303,
+        "uri": "root://eospublic.cern.ch//eos/opendata/atlas/rucio/opendata/ODEO_FEB2025_v0_1LMET30_mc_410659.PhPy8EG_A14_tchan_BW50_lept_antitop.1LMET30.root"
+      },
+      {
+        "checksum": "adler32:086e188c",
+        "size": 1637320981,
+        "uri": "root://eospublic.cern.ch//eos/opendata/atlas/rucio/opendata/ODEO_FEB2025_v0_1LMET30_mc_411233.PowhegHerwig7EvtGen_tt_hdamp258p75_713_SingleLep.1LMET30.root"
+      },
+      {
+        "checksum": "adler32:0c9d5ec6",
+        "size": 1192663840,
+        "uri": "root://eospublic.cern.ch//eos/opendata/atlas/rucio/opendata/ODEO_FEB2025_v0_1LMET30_mc_411234.PowhegHerwig7EvtGen_tt_hdamp258p75_713_dil.1LMET30.root"
+      },
+      {
+        "checksum": "adler32:cdb428f5",
+        "size": 342174081,
+        "uri": "root://eospublic.cern.ch//eos/opendata/atlas/rucio/opendata/ODEO_FEB2025_v0_1LMET30_mc_411316.PowhegHerwig7EvtGen_tt_hdamp258p75_713_allhad.1LMET30.root"
+      },
+      {
+        "checksum": "adler32:e180721b",
+        "size": 62487325,
+        "uri": "root://eospublic.cern.ch//eos/opendata/atlas/rucio/opendata/ODEO_FEB2025_v0_1LMET30_mc_412043.aMcAtNloPythia8EvtGen_A14NNPDF31_SM4topsNLO.1LMET30.root"
+      },
+      {
+        "checksum": "adler32:bccde75a",
+        "size": 61041456,
+        "uri": "root://eospublic.cern.ch//eos/opendata/atlas/rucio/opendata/ODEO_FEB2025_v0_1LMET30_mc_412044.aMcAtNloHerwig7EvtGen_H7UE_SM4topsNLO.1LMET30.root"
+      },
+      {
+        "checksum": "adler32:6a3c58c9",
+        "size": 1598460,
+        "uri": "root://eospublic.cern.ch//eos/opendata/atlas/rucio/opendata/ODEO_FEB2025_v0_1LMET30_mc_423099.Pythia8EvtGen_A14NNPDF23LO_gammajet_DP8_17.1LMET30.root"
+      },
+      {
+        "checksum": "adler32:c921559a",
+        "size": 2814419,
+        "uri": "root://eospublic.cern.ch//eos/opendata/atlas/rucio/opendata/ODEO_FEB2025_v0_1LMET30_mc_423100.Pythia8EvtGen_A14NNPDF23LO_gammajet_DP17_35.1LMET30.root"
+      },
+      {
+        "checksum": "adler32:64d0b8c5",
+        "size": 5616733,
+        "uri": "root://eospublic.cern.ch//eos/opendata/atlas/rucio/opendata/ODEO_FEB2025_v0_1LMET30_mc_423101.Pythia8EvtGen_A14NNPDF23LO_gammajet_DP35_50.1LMET30.root"
+      },
+      {
+        "checksum": "adler32:1b0631f3",
+        "size": 9255108,
+        "uri": "root://eospublic.cern.ch//eos/opendata/atlas/rucio/opendata/ODEO_FEB2025_v0_1LMET30_mc_423102.Pythia8EvtGen_A14NNPDF23LO_gammajet_DP50_70.1LMET30.root"
+      },
+      {
+        "checksum": "adler32:3d5e44c8",
+        "size": 6895803,
+        "uri": "root://eospublic.cern.ch//eos/opendata/atlas/rucio/opendata/ODEO_FEB2025_v0_1LMET30_mc_423103.Pythia8EvtGen_A14NNPDF23LO_gammajet_DP70_140.1LMET30.root"
+      },
+      {
+        "checksum": "adler32:2152e470",
+        "size": 9509691,
+        "uri": "root://eospublic.cern.ch//eos/opendata/atlas/rucio/opendata/ODEO_FEB2025_v0_1LMET30_mc_423104.Pythia8EvtGen_A14NNPDF23LO_gammajet_DP140_280.1LMET30.root"
+      },
+      {
+        "checksum": "adler32:09747afd",
+        "size": 9557463,
+        "uri": "root://eospublic.cern.ch//eos/opendata/atlas/rucio/opendata/ODEO_FEB2025_v0_1LMET30_mc_423105.Pythia8EvtGen_A14NNPDF23LO_gammajet_DP280_500.1LMET30.root"
+      },
+      {
+        "checksum": "adler32:20c4fcf9",
+        "size": 1459610,
+        "uri": "root://eospublic.cern.ch//eos/opendata/atlas/rucio/opendata/ODEO_FEB2025_v0_1LMET30_mc_423106.Pythia8EvtGen_A14NNPDF23LO_gammajet_DP500_800.1LMET30.root"
+      },
+      {
+        "checksum": "adler32:eb02ab54",
+        "size": 959588,
+        "uri": "root://eospublic.cern.ch//eos/opendata/atlas/rucio/opendata/ODEO_FEB2025_v0_1LMET30_mc_423107.Pythia8EvtGen_A14NNPDF23LO_gammajet_DP800_1000.1LMET30.root"
+      },
+      {
+        "checksum": "adler32:be8bedd1",
+        "size": 1492289,
+        "uri": "root://eospublic.cern.ch//eos/opendata/atlas/rucio/opendata/ODEO_FEB2025_v0_1LMET30_mc_423108.Pythia8EvtGen_A14NNPDF23LO_gammajet_DP1000_1500.1LMET30.root"
+      },
+      {
+        "checksum": "adler32:dc4380ad",
+        "size": 592921,
+        "uri": "root://eospublic.cern.ch//eos/opendata/atlas/rucio/opendata/ODEO_FEB2025_v0_1LMET30_mc_423109.Pythia8EvtGen_A14NNPDF23LO_gammajet_DP1500_2000.1LMET30.root"
+      },
+      {
+        "checksum": "adler32:f3b5c874",
+        "size": 468098,
+        "uri": "root://eospublic.cern.ch//eos/opendata/atlas/rucio/opendata/ODEO_FEB2025_v0_1LMET30_mc_423110.Pythia8EvtGen_A14NNPDF23LO_gammajet_DP2000_2500.1LMET30.root"
+      },
+      {
+        "checksum": "adler32:cc9134c8",
+        "size": 794797,
+        "uri": "root://eospublic.cern.ch//eos/opendata/atlas/rucio/opendata/ODEO_FEB2025_v0_1LMET30_mc_423111.Pythia8EvtGen_A14NNPDF23LO_gammajet_DP2500_3000.1LMET30.root"
+      },
+      {
+        "checksum": "adler32:986ff1de",
+        "size": 580988,
+        "uri": "root://eospublic.cern.ch//eos/opendata/atlas/rucio/opendata/ODEO_FEB2025_v0_1LMET30_mc_423112.Pythia8EvtGen_A14NNPDF23LO_gammajet_DP3000_inf.1LMET30.root"
+      },
+      {
+        "checksum": "adler32:f236998d",
+        "size": 2498218,
+        "uri": "root://eospublic.cern.ch//eos/opendata/atlas/rucio/opendata/ODEO_FEB2025_v0_1LMET30_mc_448624.MGPy8EG_A14N23LO_TT_higgsinoRPV_1075_700.1LMET30.root"
+      },
+      {
+        "checksum": "adler32:d750a16b",
+        "size": 5463371,
+        "uri": "root://eospublic.cern.ch//eos/opendata/atlas/rucio/opendata/ODEO_FEB2025_v0_1LMET30_mc_449595.MGPy8EG_A14N23LO_TT_RPVdirectBL_1400.1LMET30.root"
+      },
+      {
+        "checksum": "adler32:94e21eda",
+        "size": 8500202,
+        "uri": "root://eospublic.cern.ch//eos/opendata/atlas/rucio/opendata/ODEO_FEB2025_v0_1LMET30_mc_450576.PowhegPythia8EvtGen_NNLOPS_nnlo_30_VBFH125_ZZllbb.1LMET30.root"
+      },
+      {
+        "checksum": "adler32:7b007abf",
+        "size": 45076530,
+        "uri": "root://eospublic.cern.ch//eos/opendata/atlas/rucio/opendata/ODEO_FEB2025_v0_1LMET30_mc_500335.MGH7EG_VBFHWWlvlv.1LMET30.root"
+      },
+      {
+        "checksum": "adler32:265c2fef",
+        "size": 3626507,
+        "uri": "root://eospublic.cern.ch//eos/opendata/atlas/rucio/opendata/ODEO_FEB2025_v0_1LMET30_mc_500553.aMCPy8EG_ZH_FxFx_Hyy.1LMET30.root"
+      },
+      {
+        "checksum": "adler32:5afefe7a",
+        "size": 8234767,
+        "uri": "root://eospublic.cern.ch//eos/opendata/atlas/rucio/opendata/ODEO_FEB2025_v0_1LMET30_mc_500554.aMCPy8EG_WH_FxFx_Hyy.1LMET30.root"
+      },
+      {
+        "checksum": "adler32:3910a934",
+        "size": 3911548,
+        "uri": "root://eospublic.cern.ch//eos/opendata/atlas/rucio/opendata/ODEO_FEB2025_v0_1LMET30_mc_500555.aMCPy8EG_ggZH_Hyy.1LMET30.root"
+      },
+      {
+        "checksum": "adler32:e80bb8af",
+        "size": 7912144,
+        "uri": "root://eospublic.cern.ch//eos/opendata/atlas/rucio/opendata/ODEO_FEB2025_v0_1LMET30_mc_501058.MGPy8EG_StauStauDirect_200p0_1p0_TFilt.1LMET30.root"
+      },
+      {
+        "checksum": "adler32:a52617de",
+        "size": 11370711,
+        "uri": "root://eospublic.cern.ch//eos/opendata/atlas/rucio/opendata/ODEO_FEB2025_v0_1LMET30_mc_506098.aMCPy8EG_WpH_FxFx_Htautau.1LMET30.root"
+      },
+      {
+        "checksum": "adler32:1c276c7f",
+        "size": 7120969,
+        "uri": "root://eospublic.cern.ch//eos/opendata/atlas/rucio/opendata/ODEO_FEB2025_v0_1LMET30_mc_506099.aMCPy8EG_ZH_FxFx_Htautau.1LMET30.root"
+      },
+      {
+        "checksum": "adler32:74069ee5",
+        "size": 1391137,
+        "uri": "root://eospublic.cern.ch//eos/opendata/atlas/rucio/opendata/ODEO_FEB2025_v0_1LMET30_mc_506101.aMCH7EG_VBF_Htautauh30h20.1LMET30.root"
+      },
+      {
+        "checksum": "adler32:fb5df243",
+        "size": 46917633,
+        "uri": "root://eospublic.cern.ch//eos/opendata/atlas/rucio/opendata/ODEO_FEB2025_v0_1LMET30_mc_506102.aMCH7EG_VBF_Htautaul13l7.1LMET30.root"
+      },
+      {
+        "checksum": "adler32:58c70b67",
+        "size": 25288787,
+        "uri": "root://eospublic.cern.ch//eos/opendata/atlas/rucio/opendata/ODEO_FEB2025_v0_1LMET30_mc_506103.aMCH7EG_VBF_Htautaulp15hm20.1LMET30.root"
+      },
+      {
+        "checksum": "adler32:1a9b4da2",
+        "size": 41978242,
+        "uri": "root://eospublic.cern.ch//eos/opendata/atlas/rucio/opendata/ODEO_FEB2025_v0_1LMET30_mc_506104.aMCH7EG_VBF_Htautaulm15hp20.1LMET30.root"
+      },
+      {
+        "checksum": "adler32:1a295e9d",
+        "size": 771951,
+        "uri": "root://eospublic.cern.ch//eos/opendata/atlas/rucio/opendata/ODEO_FEB2025_v0_1LMET30_mc_506811.aMCH7EG_VBF_HC_Hyy.1LMET30.root"
+      },
+      {
+        "checksum": "adler32:5fcf4cb8",
+        "size": 492255,
+        "uri": "root://eospublic.cern.ch//eos/opendata/atlas/rucio/opendata/ODEO_FEB2025_v0_1LMET30_mc_506813.aMCPy8EG_ZH_had_FxFx_Hyy.1LMET30.root"
+      },
+      {
+        "checksum": "adler32:7593ea81",
+        "size": 625457,
+        "uri": "root://eospublic.cern.ch//eos/opendata/atlas/rucio/opendata/ODEO_FEB2025_v0_1LMET30_mc_506814.aMCPy8EG_ggZH_Zhad_Hyy.1LMET30.root"
+      },
+      {
+        "checksum": "adler32:66aee6de",
+        "size": 883244,
+        "uri": "root://eospublic.cern.ch//eos/opendata/atlas/rucio/opendata/ODEO_FEB2025_v0_1LMET30_mc_507366.MGPy8EG_A14NNPDF23LO_GGM_N1N2C1_950.1LMET30.root"
+      },
+      {
+        "checksum": "adler32:cc92237c",
+        "size": 9822787,
+        "uri": "root://eospublic.cern.ch//eos/opendata/atlas/rucio/opendata/ODEO_FEB2025_v0_1LMET30_mc_510097.MGPy8EG_A14N23LO_DM_4topscalar_p1000_c1_nonallhad.1LMET30.root"
+      },
+      {
+        "checksum": "adler32:7dda24ea",
+        "size": 1783987,
+        "uri": "root://eospublic.cern.ch//eos/opendata/atlas/rucio/opendata/ODEO_FEB2025_v0_1LMET30_mc_523692.MGPy8EG_A14N23LO_TT_tN1_1200_200_MS.1LMET30.root"
+      },
+      {
+        "checksum": "adler32:f77c89cc",
+        "size": 304704361,
+        "uri": "root://eospublic.cern.ch//eos/opendata/atlas/rucio/opendata/ODEO_FEB2025_v0_1LMET30_mc_600017.PhH7EG_H7UE_716_tchan_lept_antitop.1LMET30.root"
+      },
+      {
+        "checksum": "adler32:73fa4724",
+        "size": 513116243,
+        "uri": "root://eospublic.cern.ch//eos/opendata/atlas/rucio/opendata/ODEO_FEB2025_v0_1LMET30_mc_600018.PhH7EG_H7UE_716_tchan_lept_top.1LMET30.root"
+      },
+      {
+        "checksum": "adler32:7c381e42",
+        "size": 24702507,
+        "uri": "root://eospublic.cern.ch//eos/opendata/atlas/rucio/opendata/ODEO_FEB2025_v0_1LMET30_mc_600019.PhH7EG_H7UE_716_schan_lept_antitop.1LMET30.root"
+      },
+      {
+        "checksum": "adler32:295c1c82",
+        "size": 28382807,
+        "uri": "root://eospublic.cern.ch//eos/opendata/atlas/rucio/opendata/ODEO_FEB2025_v0_1LMET30_mc_600020.PhH7EG_H7UE_716_schan_lept_top.1LMET30.root"
+      },
+      {
+        "checksum": "adler32:989c8413",
+        "size": 3810429,
+        "uri": "root://eospublic.cern.ch//eos/opendata/atlas/rucio/opendata/ODEO_FEB2025_v0_1LMET30_mc_600565.PhH7EG_ggH125_tautauh30h20_ShowerSys_fix.1LMET30.root"
+      },
+      {
+        "checksum": "adler32:9b91bfa1",
+        "size": 124850762,
+        "uri": "root://eospublic.cern.ch//eos/opendata/atlas/rucio/opendata/ODEO_FEB2025_v0_1LMET30_mc_600566.PhH7EG_ggH125_tautaul13l7_ShowerSys_fix.1LMET30.root"
+      },
+      {
+        "checksum": "adler32:e9ecb9be",
+        "size": 46517998,
+        "uri": "root://eospublic.cern.ch//eos/opendata/atlas/rucio/opendata/ODEO_FEB2025_v0_1LMET30_mc_600567.PhH7EG_ggH125_ttlp15hm20_ShowerSys_fix.1LMET30.root"
+      },
+      {
+        "checksum": "adler32:9107f8de",
+        "size": 52904683,
+        "uri": "root://eospublic.cern.ch//eos/opendata/atlas/rucio/opendata/ODEO_FEB2025_v0_1LMET30_mc_600568.PhH7EG_ggH125_ttlm15hp20_ShowerSys_fix.1LMET30.root"
+      },
+      {
+        "checksum": "adler32:b4600832",
+        "size": 1705337,
+        "uri": "root://eospublic.cern.ch//eos/opendata/atlas/rucio/opendata/ODEO_FEB2025_v0_1LMET30_mc_600569.PhH7EG_VBFH125_tautauh30h20_ShowerSys_fix.1LMET30.root"
+      },
+      {
+        "checksum": "adler32:79428524",
+        "size": 45148760,
+        "uri": "root://eospublic.cern.ch//eos/opendata/atlas/rucio/opendata/ODEO_FEB2025_v0_1LMET30_mc_600570.PhH7EG_VBFH125_tautaul13l7_ShowerSys_fix.1LMET30.root"
+      },
+      {
+        "checksum": "adler32:690866f8",
+        "size": 16608111,
+        "uri": "root://eospublic.cern.ch//eos/opendata/atlas/rucio/opendata/ODEO_FEB2025_v0_1LMET30_mc_600571.PhH7EG_VBFH125_tautaulp15hm20_ShowerSys_fix.1LMET30.root"
+      },
+      {
+        "checksum": "adler32:c5911268",
+        "size": 16653760,
+        "uri": "root://eospublic.cern.ch//eos/opendata/atlas/rucio/opendata/ODEO_FEB2025_v0_1LMET30_mc_600572.PhH7EG_VBFH125_tautaulm15hp20_ShowerSys_fix.1LMET30.root"
+      },
+      {
+        "checksum": "adler32:0d1f0383",
+        "size": 6841859,
+        "uri": "root://eospublic.cern.ch//eos/opendata/atlas/rucio/opendata/ODEO_FEB2025_v0_1LMET30_mc_600573.PhH7EG_WmH125J_Winc_MINLO_tt_ShowerSys_fix.1LMET30.root"
+      },
+      {
+        "checksum": "adler32:db37b13e",
+        "size": 11140326,
+        "uri": "root://eospublic.cern.ch//eos/opendata/atlas/rucio/opendata/ODEO_FEB2025_v0_1LMET30_mc_600574.PhH7EG_WpH125J_Winc_MINLO_tt_ShowerSys_fix.1LMET30.root"
+      },
+      {
+        "checksum": "adler32:d3952e9b",
+        "size": 10208650,
+        "uri": "root://eospublic.cern.ch//eos/opendata/atlas/rucio/opendata/ODEO_FEB2025_v0_1LMET30_mc_600575.PhH7EG_ZH125J_Zinc_MINLO_tautau_ShowerSys_fix.1LMET30.root"
+      },
+      {
+        "checksum": "adler32:62ba90aa",
+        "size": 6442317,
+        "uri": "root://eospublic.cern.ch//eos/opendata/atlas/rucio/opendata/ODEO_FEB2025_v0_1LMET30_mc_600686.PhPy8EG_NNPDF3_AZNLO_ggZH125_Htautau_Zinc.1LMET30.root"
+      },
+      {
+        "checksum": "adler32:ca03ee64",
+        "size": 373346065,
+        "uri": "root://eospublic.cern.ch//eos/opendata/atlas/rucio/opendata/ODEO_FEB2025_v0_1LMET30_mc_601352.PhPy8EG_tW_dyn_DR_incl_antitop.1LMET30.root"
+      },
+      {
+        "checksum": "adler32:2103c66f",
+        "size": 367350859,
+        "uri": "root://eospublic.cern.ch//eos/opendata/atlas/rucio/opendata/ODEO_FEB2025_v0_1LMET30_mc_601355.PhPy8EG_tW_dyn_DR_incl_top.1LMET30.root"
+      },
+      {
+        "checksum": "adler32:5a3e4543",
+        "size": 320302729,
+        "uri": "root://eospublic.cern.ch//eos/opendata/atlas/rucio/opendata/ODEO_FEB2025_v0_1LMET30_mc_601487.PhPy8EG_A14_tchan_pThard1_lep_antitop.1LMET30.root"
+      },
+      {
+        "checksum": "adler32:dbb32eff",
+        "size": 509922543,
+        "uri": "root://eospublic.cern.ch//eos/opendata/atlas/rucio/opendata/ODEO_FEB2025_v0_1LMET30_mc_601489.PhPy8EG_A14_tchan_pThard1_lep_top.1LMET30.root"
+      },
+      {
+        "checksum": "adler32:46992076",
+        "size": 2037677510,
+        "uri": "root://eospublic.cern.ch//eos/opendata/atlas/rucio/opendata/ODEO_FEB2025_v0_1LMET30_mc_601491.PhPy8EG_A14_ttbar_pThard1_dil.1LMET30.root"
+      },
+      {
+        "checksum": "adler32:5f8ea7d7",
+        "size": 2632108,
+        "uri": "root://eospublic.cern.ch//eos/opendata/atlas/rucio/opendata/ODEO_FEB2025_v0_1LMET30_mc_601495.PhPy8EG_A14_ttbar_pThard1_allhad.1LMET30.root"
+      },
+      {
+        "checksum": "adler32:5ffe9ce0",
+        "size": 5826620674,
+        "uri": "root://eospublic.cern.ch//eos/opendata/atlas/rucio/opendata/ODEO_FEB2025_v0_1LMET30_mc_601497.PhPy8EG_A14_ttbar_pThard1_singlelep.1LMET30.root"
+      },
+      {
+        "checksum": "adler32:980bb301",
+        "size": 101013883,
+        "uri": "root://eospublic.cern.ch//eos/opendata/atlas/rucio/opendata/ODEO_FEB2025_v0_1LMET30_mc_601624.PhPy8EG_tW_DS_dyn_dil_antitop.1LMET30.root"
+      },
+      {
+        "checksum": "adler32:b249db8a",
+        "size": 363122801,
+        "uri": "root://eospublic.cern.ch//eos/opendata/atlas/rucio/opendata/ODEO_FEB2025_v0_1LMET30_mc_601627.PhPy8EG_tW_DS_dyn_incl_antitop.1LMET30.root"
+      },
+      {
+        "checksum": "adler32:8be47d92",
+        "size": 127228801,
+        "uri": "root://eospublic.cern.ch//eos/opendata/atlas/rucio/opendata/ODEO_FEB2025_v0_1LMET30_mc_601628.PhPy8EG_tW_DS_dyn_dil_top.1LMET30.root"
+      },
+      {
+        "checksum": "adler32:45a16c99",
+        "size": 352721352,
+        "uri": "root://eospublic.cern.ch//eos/opendata/atlas/rucio/opendata/ODEO_FEB2025_v0_1LMET30_mc_601631.PhPy8EG_tW_DS_dyn_incl_top.1LMET30.root"
+      },
+      {
+        "checksum": "adler32:72825a77",
+        "size": 374161938,
+        "uri": "root://eospublic.cern.ch//eos/opendata/atlas/rucio/opendata/ODEO_FEB2025_v0_1LMET30_mc_601761.PhPy8EG_tW_dyn_DR_pThard1_incl_top.1LMET30.root"
+      },
+      {
+        "checksum": "adler32:3a1e1ee3",
+        "size": 368124434,
+        "uri": "root://eospublic.cern.ch//eos/opendata/atlas/rucio/opendata/ODEO_FEB2025_v0_1LMET30_mc_601762.PhPy8EG_tW_dyn_DR_pThard1_incl_antitop.1LMET30.root"
+      },
+      {
+        "checksum": "adler32:2b834932",
+        "size": 129137264,
+        "uri": "root://eospublic.cern.ch//eos/opendata/atlas/rucio/opendata/ODEO_FEB2025_v0_1LMET30_mc_601763.PhPy8EG_tW_dyn_DR_pThard1_dil_top.1LMET30.root"
+      },
+      {
+        "checksum": "adler32:bcc18f65",
+        "size": 129144764,
+        "uri": "root://eospublic.cern.ch//eos/opendata/atlas/rucio/opendata/ODEO_FEB2025_v0_1LMET30_mc_601764.PhPy8EG_tW_dyn_DR_pThard1_dil_antitop.1LMET30.root"
+      },
+      {
+        "checksum": "adler32:e9ff5760",
+        "size": 40054244,
+        "uri": "root://eospublic.cern.ch//eos/opendata/atlas/rucio/opendata/ODEO_FEB2025_v0_1LMET30_mc_700000.Sh_228_ttW.1LMET30.root"
+      },
+      {
+        "checksum": "adler32:2db3690c",
+        "size": 341397,
+        "uri": "root://eospublic.cern.ch//eos/opendata/atlas/rucio/opendata/ODEO_FEB2025_v0_1LMET30_mc_700007.Sh_228_yyy_01NLO.1LMET30.root"
+      },
+      {
+        "checksum": "adler32:2cd581b9",
+        "size": 11341221,
+        "uri": "root://eospublic.cern.ch//eos/opendata/atlas/rucio/opendata/ODEO_FEB2025_v0_1LMET30_mc_700195.Sh_2210_eegammagamma.1LMET30.root"
+      },
+      {
+        "checksum": "adler32:ae967cbd",
+        "size": 35157246,
+        "uri": "root://eospublic.cern.ch//eos/opendata/atlas/rucio/opendata/ODEO_FEB2025_v0_1LMET30_mc_700196.Sh_2210_mumugammagamma.1LMET30.root"
+      },
+      {
+        "checksum": "adler32:491a5615",
+        "size": 3505320,
+        "uri": "root://eospublic.cern.ch//eos/opendata/atlas/rucio/opendata/ODEO_FEB2025_v0_1LMET30_mc_700197.Sh_2210_tautaugammagamma.1LMET30.root"
+      },
+      {
+        "checksum": "adler32:775d3e12",
+        "size": 276494,
+        "uri": "root://eospublic.cern.ch//eos/opendata/atlas/rucio/opendata/ODEO_FEB2025_v0_1LMET30_mc_700198.Sh_2210_nunugammagamma.1LMET30.root"
+      },
+      {
+        "checksum": "adler32:09f5f60c",
+        "size": 14977067,
+        "uri": "root://eospublic.cern.ch//eos/opendata/atlas/rucio/opendata/ODEO_FEB2025_v0_1LMET30_mc_700199.Sh_2210_enugammagamma.1LMET30.root"
+      },
+      {
+        "checksum": "adler32:f93ca7e5",
+        "size": 15303191,
+        "uri": "root://eospublic.cern.ch//eos/opendata/atlas/rucio/opendata/ODEO_FEB2025_v0_1LMET30_mc_700200.Sh_2210_munugammagamma.1LMET30.root"
+      },
+      {
+        "checksum": "adler32:9cea3c58",
+        "size": 3102127,
+        "uri": "root://eospublic.cern.ch//eos/opendata/atlas/rucio/opendata/ODEO_FEB2025_v0_1LMET30_mc_700201.Sh_2210_taunugammagamma.1LMET30.root"
+      },
+      {
+        "checksum": "adler32:73420c0a",
+        "size": 769203230,
+        "uri": "root://eospublic.cern.ch//eos/opendata/atlas/rucio/opendata/ODEO_FEB2025_v0_1LMET30_mc_700320.Sh_2211_Zee_maxHTpTV2_BFilter.1LMET30.root"
+      },
+      {
+        "checksum": "adler32:def7a23b",
+        "size": 3115372844,
+        "uri": "root://eospublic.cern.ch//eos/opendata/atlas/rucio/opendata/ODEO_FEB2025_v0_1LMET30_mc_700321.Sh_2211_Zee_maxHTpTV2_CFilterBVeto.1LMET30.root"
+      },
+      {
+        "checksum": "adler32:3bd9e1be",
+        "size": 9281283601,
+        "uri": "root://eospublic.cern.ch//eos/opendata/atlas/rucio/opendata/ODEO_FEB2025_v0_1LMET30_mc_700322.Sh_2211_Zee_maxHTpTV2_CVetoBVeto.1LMET30.root"
+      },
+      {
+        "checksum": "adler32:b0f209ae",
+        "size": 1209193231,
+        "uri": "root://eospublic.cern.ch//eos/opendata/atlas/rucio/opendata/ODEO_FEB2025_v0_1LMET30_mc_700323.Sh_2211_Zmumu_maxHTpTV2_BFilter.1LMET30.root"
+      },
+      {
+        "checksum": "adler32:806459bd",
+        "size": 5607803908,
+        "uri": "root://eospublic.cern.ch//eos/opendata/atlas/rucio/opendata/ODEO_FEB2025_v0_1LMET30_mc_700324.Sh_2211_Zmumu_maxHTpTV2_CFilterBVeto.1LMET30.root"
+      },
+      {
+        "checksum": "adler32:ecc7325c",
+        "size": 19079147843,
+        "uri": "root://eospublic.cern.ch//eos/opendata/atlas/rucio/opendata/ODEO_FEB2025_v0_1LMET30_mc_700325.Sh_2211_Zmumu_maxHTpTV2_CVetoBVeto.1LMET30.root"
+      },
+      {
+        "checksum": "adler32:e7f6d4ff",
+        "size": 25289898,
+        "uri": "root://eospublic.cern.ch//eos/opendata/atlas/rucio/opendata/ODEO_FEB2025_v0_1LMET30_mc_700335.Sh_2211_Znunu_pTV2_BFilter.1LMET30.root"
+      },
+      {
+        "checksum": "adler32:f753154e",
+        "size": 25098846,
+        "uri": "root://eospublic.cern.ch//eos/opendata/atlas/rucio/opendata/ODEO_FEB2025_v0_1LMET30_mc_700336.Sh_2211_Znunu_pTV2_CFilterBVeto.1LMET30.root"
+      },
+      {
+        "checksum": "adler32:6cb0fb56",
+        "size": 55616816,
+        "uri": "root://eospublic.cern.ch//eos/opendata/atlas/rucio/opendata/ODEO_FEB2025_v0_1LMET30_mc_700337.Sh_2211_Znunu_pTV2_CVetoBVeto.1LMET30.root"
+      },
+      {
+        "checksum": "adler32:43fe0d2a",
+        "size": 3406470632,
+        "uri": "root://eospublic.cern.ch//eos/opendata/atlas/rucio/opendata/ODEO_FEB2025_v0_1LMET30_mc_700338.Sh_2211_Wenu_maxHTpTV2_BFilter.1LMET30.root"
+      },
+      {
+        "checksum": "adler32:e5330702",
+        "size": 26394781811,
+        "uri": "root://eospublic.cern.ch//eos/opendata/atlas/rucio/opendata/ODEO_FEB2025_v0_1LMET30_mc_700339.Sh_2211_Wenu_maxHTpTV2_CFilterBVeto.1LMET30.root"
+      },
+      {
+        "checksum": "adler32:6649fa46",
+        "size": 28902374557,
+        "uri": "root://eospublic.cern.ch//eos/opendata/atlas/rucio/opendata/ODEO_FEB2025_v0_1LMET30_mc_700340.Sh_2211_Wenu_maxHTpTV2_CVetoBVeto.1LMET30.root"
+      },
+      {
+        "checksum": "adler32:4c241221",
+        "size": 4021230584,
+        "uri": "root://eospublic.cern.ch//eos/opendata/atlas/rucio/opendata/ODEO_FEB2025_v0_1LMET30_mc_700341.Sh_2211_Wmunu_maxHTpTV2_BFilter.1LMET30.root"
+      },
+      {
+        "checksum": "adler32:426b58ef",
+        "size": 28639720675,
+        "uri": "root://eospublic.cern.ch//eos/opendata/atlas/rucio/opendata/ODEO_FEB2025_v0_1LMET30_mc_700342.Sh_2211_Wmunu_maxHTpTV2_CFilterBVeto.1LMET30.root"
+      },
+      {
+        "checksum": "adler32:8f11520a",
+        "size": 30568268205,
+        "uri": "root://eospublic.cern.ch//eos/opendata/atlas/rucio/opendata/ODEO_FEB2025_v0_1LMET30_mc_700343.Sh_2211_Wmunu_maxHTpTV2_CVetoBVeto.1LMET30.root"
+      },
+      {
+        "checksum": "adler32:5a9098f2",
+        "size": 772241216,
+        "uri": "root://eospublic.cern.ch//eos/opendata/atlas/rucio/opendata/ODEO_FEB2025_v0_1LMET30_mc_700344.Sh_2211_Wtaunu_L_maxHTpTV2_BFilter.1LMET30.root"
+      },
+      {
+        "checksum": "adler32:20fc78c0",
+        "size": 3175940281,
+        "uri": "root://eospublic.cern.ch//eos/opendata/atlas/rucio/opendata/ODEO_FEB2025_v0_1LMET30_mc_700345.Sh_2211_Wtaunu_L_maxHTpTV2_CFilterBVeto.1LMET30.root"
+      },
+      {
+        "checksum": "adler32:30db89a3",
+        "size": 5846443019,
+        "uri": "root://eospublic.cern.ch//eos/opendata/atlas/rucio/opendata/ODEO_FEB2025_v0_1LMET30_mc_700346.Sh_2211_Wtaunu_L_maxHTpTV2_CVetoBVeto.1LMET30.root"
+      },
+      {
+        "checksum": "adler32:1541e675",
+        "size": 112402076,
+        "uri": "root://eospublic.cern.ch//eos/opendata/atlas/rucio/opendata/ODEO_FEB2025_v0_1LMET30_mc_700347.Sh_2211_Wtaunu_H_maxHTpTV2_BFilter.1LMET30.root"
+      },
+      {
+        "checksum": "adler32:061bf53e",
+        "size": 57787626,
+        "uri": "root://eospublic.cern.ch//eos/opendata/atlas/rucio/opendata/ODEO_FEB2025_v0_1LMET30_mc_700348.Sh_2211_Wtaunu_H_maxHTpTV2_CFilterBVeto.1LMET30.root"
+      },
+      {
+        "checksum": "adler32:b2c02a7f",
+        "size": 296417875,
+        "uri": "root://eospublic.cern.ch//eos/opendata/atlas/rucio/opendata/ODEO_FEB2025_v0_1LMET30_mc_700349.Sh_2211_Wtaunu_H_maxHTpTV2_CVetoBVeto.1LMET30.root"
+      },
+      {
+        "checksum": "adler32:aa1f4ecc",
+        "size": 2074096,
+        "uri": "root://eospublic.cern.ch//eos/opendata/atlas/rucio/opendata/ODEO_FEB2025_v0_1LMET30_mc_700352.Sh_2211_pTZ100_Zqqgamma.1LMET30.root"
+      },
+      {
+        "checksum": "adler32:22c529d2",
+        "size": 1700196,
+        "uri": "root://eospublic.cern.ch//eos/opendata/atlas/rucio/opendata/ODEO_FEB2025_v0_1LMET30_mc_700353.Sh_2211_pTZ100_Zbbgamma.1LMET30.root"
+      },
+      {
+        "checksum": "adler32:c07ac39e",
+        "size": 20077042,
+        "uri": "root://eospublic.cern.ch//eos/opendata/atlas/rucio/opendata/ODEO_FEB2025_v0_1LMET30_mc_700358.Sh_2211_Zee2jets_Min_N_TChannel.1LMET30.root"
+      },
+      {
+        "checksum": "adler32:8d712510",
+        "size": 35565439,
+        "uri": "root://eospublic.cern.ch//eos/opendata/atlas/rucio/opendata/ODEO_FEB2025_v0_1LMET30_mc_700359.Sh_2211_Zmm2jets_Min_N_TChannel.1LMET30.root"
+      },
+      {
+        "checksum": "adler32:20cc6028",
+        "size": 11994613,
+        "uri": "root://eospublic.cern.ch//eos/opendata/atlas/rucio/opendata/ODEO_FEB2025_v0_1LMET30_mc_700360.Sh_2211_Ztt2jets_Min_N_TChannel.1LMET30.root"
+      },
+      {
+        "checksum": "adler32:81e68c9b",
+        "size": 831891,
+        "uri": "root://eospublic.cern.ch//eos/opendata/atlas/rucio/opendata/ODEO_FEB2025_v0_1LMET30_mc_700361.Sh_2211_Znunu2jets_Min_N_TChannel.1LMET30.root"
+      },
+      {
+        "checksum": "adler32:a761d634",
+        "size": 156888014,
+        "uri": "root://eospublic.cern.ch//eos/opendata/atlas/rucio/opendata/ODEO_FEB2025_v0_1LMET30_mc_700362.Sh_2211_Wenu2jets_Min_N_TChannel.1LMET30.root"
+      },
+      {
+        "checksum": "adler32:9191f449",
+        "size": 210156704,
+        "uri": "root://eospublic.cern.ch//eos/opendata/atlas/rucio/opendata/ODEO_FEB2025_v0_1LMET30_mc_700363.Sh_2211_Wmunu2jets_Min_N_TChannel.1LMET30.root"
+      },
+      {
+        "checksum": "adler32:249f0966",
+        "size": 34002149,
+        "uri": "root://eospublic.cern.ch//eos/opendata/atlas/rucio/opendata/ODEO_FEB2025_v0_1LMET30_mc_700364.Sh_2211_Wtaunu2jets_Min_N_TChannel.1LMET30.root"
+      },
+      {
+        "checksum": "adler32:6ac30fe8",
+        "size": 1515216144,
+        "uri": "root://eospublic.cern.ch//eos/opendata/atlas/rucio/opendata/ODEO_FEB2025_v0_1LMET30_mc_700398.Sh_2211_mumugamma.1LMET30.root"
+      },
+      {
+        "checksum": "adler32:40c00a3c",
+        "size": 755213790,
+        "uri": "root://eospublic.cern.ch//eos/opendata/atlas/rucio/opendata/ODEO_FEB2025_v0_1LMET30_mc_700399.Sh_2211_eegamma.1LMET30.root"
+      },
+      {
+        "checksum": "adler32:2c33cf35",
+        "size": 473866261,
+        "uri": "root://eospublic.cern.ch//eos/opendata/atlas/rucio/opendata/ODEO_FEB2025_v0_1LMET30_mc_700400.Sh_2211_tautaugamma.1LMET30.root"
+      },
+      {
+        "checksum": "adler32:62eb56f5",
+        "size": 22965306,
+        "uri": "root://eospublic.cern.ch//eos/opendata/atlas/rucio/opendata/ODEO_FEB2025_v0_1LMET30_mc_700401.Sh_2211_nunugamma.1LMET30.root"
+      },
+      {
+        "checksum": "adler32:8c70b8be",
+        "size": 4729837010,
+        "uri": "root://eospublic.cern.ch//eos/opendata/atlas/rucio/opendata/ODEO_FEB2025_v0_1LMET30_mc_700402.Sh_2211_munugamma.1LMET30.root"
+      },
+      {
+        "checksum": "adler32:9f00d997",
+        "size": 4447616793,
+        "uri": "root://eospublic.cern.ch//eos/opendata/atlas/rucio/opendata/ODEO_FEB2025_v0_1LMET30_mc_700403.Sh_2211_enugamma.1LMET30.root"
+      },
+      {
+        "checksum": "adler32:0cb20623",
+        "size": 1140111998,
+        "uri": "root://eospublic.cern.ch//eos/opendata/atlas/rucio/opendata/ODEO_FEB2025_v0_1LMET30_mc_700404.Sh_2211_taunugamma.1LMET30.root"
+      },
+      {
+        "checksum": "adler32:c6b8c9f2",
+        "size": 495317,
+        "uri": "root://eospublic.cern.ch//eos/opendata/atlas/rucio/opendata/ODEO_FEB2025_v0_1LMET30_mc_700442.Sh_2211_gamma2jets_pTy140_Min_N_TChannel.1LMET30.root"
+      },
+      {
+        "checksum": "adler32:e27c943e",
+        "size": 71527714,
+        "uri": "root://eospublic.cern.ch//eos/opendata/atlas/rucio/opendata/ODEO_FEB2025_v0_1LMET30_mc_700467.Sh_2211_Zee_maxHTpTV2_m10_40_pT5_BFilter.1LMET30.root"
+      },
+      {
+        "checksum": "adler32:1e47fd2d",
+        "size": 289514998,
+        "uri": "root://eospublic.cern.ch//eos/opendata/atlas/rucio/opendata/ODEO_FEB2025_v0_1LMET30_mc_700468.Sh_2211_Zee_maxHTpTV2_m10_40_pT5_CFilterBVeto.1LMET30.root"
+      },
+      {
+        "checksum": "adler32:aef3e187",
+        "size": 1476769475,
+        "uri": "root://eospublic.cern.ch//eos/opendata/atlas/rucio/opendata/ODEO_FEB2025_v0_1LMET30_mc_700469.Sh_2211_Zee_maxHTpTV2_m10_40_pT5_CVetoBVeto.1LMET30.root"
+      },
+      {
+        "checksum": "adler32:bd1056e3",
+        "size": 100340003,
+        "uri": "root://eospublic.cern.ch//eos/opendata/atlas/rucio/opendata/ODEO_FEB2025_v0_1LMET30_mc_700470.Sh_2211_Zmumu_maxHTpTV2_m10_40_pT5_BFilter.1LMET30.root"
+      },
+      {
+        "checksum": "adler32:5927724c",
+        "size": 409280716,
+        "uri": "root://eospublic.cern.ch//eos/opendata/atlas/rucio/opendata/ODEO_FEB2025_v0_1LMET30_mc_700471.Sh_2211_Zmumu_maxHTpTV2_m10_40_pT5_CFilterBVeto.1LMET30.root"
+      },
+      {
+        "checksum": "adler32:d102451a",
+        "size": 2131282894,
+        "uri": "root://eospublic.cern.ch//eos/opendata/atlas/rucio/opendata/ODEO_FEB2025_v0_1LMET30_mc_700472.Sh_2211_Zmumu_maxHTpTV2_m10_40_pT5_CVetoBVeto.1LMET30.root"
+      },
+      {
+        "checksum": "adler32:4fe3ae56",
+        "size": 615602907,
+        "uri": "root://eospublic.cern.ch//eos/opendata/atlas/rucio/opendata/ODEO_FEB2025_v0_1LMET30_mc_700488.Sh_2211_WlvWqq.1LMET30.root"
+      },
+      {
+        "checksum": "adler32:dd7aa858",
+        "size": 125165505,
+        "uri": "root://eospublic.cern.ch//eos/opendata/atlas/rucio/opendata/ODEO_FEB2025_v0_1LMET30_mc_700489.Sh_2211_WlvZqq.1LMET30.root"
+      },
+      {
+        "checksum": "adler32:42b08e80",
+        "size": 38916824,
+        "uri": "root://eospublic.cern.ch//eos/opendata/atlas/rucio/opendata/ODEO_FEB2025_v0_1LMET30_mc_700490.Sh_2211_WlvZbb.1LMET30.root"
+      },
+      {
+        "checksum": "adler32:69e10226",
+        "size": 2252702,
+        "uri": "root://eospublic.cern.ch//eos/opendata/atlas/rucio/opendata/ODEO_FEB2025_v0_1LMET30_mc_700491.Sh_2211_WqqZvv.1LMET30.root"
+      },
+      {
+        "checksum": "adler32:0d8b4ea1",
+        "size": 43648489,
+        "uri": "root://eospublic.cern.ch//eos/opendata/atlas/rucio/opendata/ODEO_FEB2025_v0_1LMET30_mc_700492.Sh_2211_WqqZll.1LMET30.root"
+      },
+      {
+        "checksum": "adler32:70961174",
+        "size": 33555558,
+        "uri": "root://eospublic.cern.ch//eos/opendata/atlas/rucio/opendata/ODEO_FEB2025_v0_1LMET30_mc_700493.Sh_2211_ZqqZll.1LMET30.root"
+      },
+      {
+        "checksum": "adler32:4822122d",
+        "size": 30958646,
+        "uri": "root://eospublic.cern.ch//eos/opendata/atlas/rucio/opendata/ODEO_FEB2025_v0_1LMET30_mc_700494.Sh_2211_ZbbZll.1LMET30.root"
+      },
+      {
+        "checksum": "adler32:a305d657",
+        "size": 1111234,
+        "uri": "root://eospublic.cern.ch//eos/opendata/atlas/rucio/opendata/ODEO_FEB2025_v0_1LMET30_mc_700495.Sh_2211_ZqqZvv.1LMET30.root"
+      },
+      {
+        "checksum": "adler32:3c98c1c1",
+        "size": 1061351,
+        "uri": "root://eospublic.cern.ch//eos/opendata/atlas/rucio/opendata/ODEO_FEB2025_v0_1LMET30_mc_700496.Sh_2211_ZbbZvv.1LMET30.root"
+      },
+      {
+        "checksum": "adler32:250cabec",
+        "size": 1033734,
+        "uri": "root://eospublic.cern.ch//eos/opendata/atlas/rucio/opendata/ODEO_FEB2025_v0_1LMET30_mc_700507.Sh_2211_pTW140_Wqqgamma.1LMET30.root"
+      },
+      {
+        "checksum": "adler32:92c6a28e",
+        "size": 19039079,
+        "uri": "root://eospublic.cern.ch//eos/opendata/atlas/rucio/opendata/ODEO_FEB2025_v0_1LMET30_mc_700587.Sh_2212_lllljj.1LMET30.root"
+      },
+      {
+        "checksum": "adler32:e5963c64",
+        "size": 12418203,
+        "uri": "root://eospublic.cern.ch//eos/opendata/atlas/rucio/opendata/ODEO_FEB2025_v0_1LMET30_mc_700588.Sh_2212_lllvjj.1LMET30.root"
+      },
+      {
+        "checksum": "adler32:ea1df1e2",
+        "size": 14705925,
+        "uri": "root://eospublic.cern.ch//eos/opendata/atlas/rucio/opendata/ODEO_FEB2025_v0_1LMET30_mc_700589.Sh_2212_llvvjj_os.1LMET30.root"
+      },
+      {
+        "checksum": "adler32:8ea203cb",
+        "size": 31792325,
+        "uri": "root://eospublic.cern.ch//eos/opendata/atlas/rucio/opendata/ODEO_FEB2025_v0_1LMET30_mc_700590.Sh_2212_llvvjj_ss.1LMET30.root"
+      },
+      {
+        "checksum": "adler32:a5739810",
+        "size": 2394339,
+        "uri": "root://eospublic.cern.ch//eos/opendata/atlas/rucio/opendata/ODEO_FEB2025_v0_1LMET30_mc_700591.Sh_2212_lllljj_Int.1LMET30.root"
+      },
+      {
+        "checksum": "adler32:455f95cb",
+        "size": 5430415,
+        "uri": "root://eospublic.cern.ch//eos/opendata/atlas/rucio/opendata/ODEO_FEB2025_v0_1LMET30_mc_700592.Sh_2212_lllvjj_Int.1LMET30.root"
+      },
+      {
+        "checksum": "adler32:9e513f37",
+        "size": 6660771,
+        "uri": "root://eospublic.cern.ch//eos/opendata/atlas/rucio/opendata/ODEO_FEB2025_v0_1LMET30_mc_700593.Sh_2212_llvvjj_os_Int.1LMET30.root"
+      },
+      {
+        "checksum": "adler32:1764ef59",
+        "size": 7055663,
+        "uri": "root://eospublic.cern.ch//eos/opendata/atlas/rucio/opendata/ODEO_FEB2025_v0_1LMET30_mc_700594.Sh_2212_llvvjj_ss_Int.1LMET30.root"
+      },
+      {
+        "checksum": "adler32:659107e0",
+        "size": 34436885,
+        "uri": "root://eospublic.cern.ch//eos/opendata/atlas/rucio/opendata/ODEO_FEB2025_v0_1LMET30_mc_700600.Sh_2212_llll.1LMET30.root"
+      },
+      {
+        "checksum": "adler32:e526f92b",
+        "size": 107547353,
+        "uri": "root://eospublic.cern.ch//eos/opendata/atlas/rucio/opendata/ODEO_FEB2025_v0_1LMET30_mc_700601.Sh_2212_lllv.1LMET30.root"
+      },
+      {
+        "checksum": "adler32:b8909ed9",
+        "size": 239915514,
+        "uri": "root://eospublic.cern.ch//eos/opendata/atlas/rucio/opendata/ODEO_FEB2025_v0_1LMET30_mc_700602.Sh_2212_llvv_os.1LMET30.root"
+      },
+      {
+        "checksum": "adler32:ef89d532",
+        "size": 40837950,
+        "uri": "root://eospublic.cern.ch//eos/opendata/atlas/rucio/opendata/ODEO_FEB2025_v0_1LMET30_mc_700603.Sh_2212_llvv_ss.1LMET30.root"
+      },
+      {
+        "checksum": "adler32:b100a9eb",
+        "size": 53934178,
+        "uri": "root://eospublic.cern.ch//eos/opendata/atlas/rucio/opendata/ODEO_FEB2025_v0_1LMET30_mc_700604.Sh_2212_lvvv.1LMET30.root"
+      },
+      {
+        "checksum": "adler32:74f411a7",
+        "size": 311030,
+        "uri": "root://eospublic.cern.ch//eos/opendata/atlas/rucio/opendata/ODEO_FEB2025_v0_1LMET30_mc_700605.Sh_2212_vvvv.1LMET30.root"
+      },
+      {
+        "checksum": "adler32:ad2d2d4b",
+        "size": 23999739,
+        "uri": "root://eospublic.cern.ch//eos/opendata/atlas/rucio/opendata/ODEO_FEB2025_v0_1LMET30_mc_700709.Sh_2212_lvgammajj.1LMET30.root"
+      },
+      {
+        "checksum": "adler32:9c0c025e",
+        "size": 33069661,
+        "uri": "root://eospublic.cern.ch//eos/opendata/atlas/rucio/opendata/ODEO_FEB2025_v0_1LMET30_mc_700710.Sh_2212_llgammajj.1LMET30.root"
+      },
+      {
+        "checksum": "adler32:070cea0e",
+        "size": 411982361,
+        "uri": "root://eospublic.cern.ch//eos/opendata/atlas/rucio/opendata/ODEO_FEB2025_v0_1LMET30_mc_700792.Sh_2214_Ztautau_maxHTpTV2_BFilter.1LMET30.root"
+      },
+      {
+        "checksum": "adler32:4c4a1c97",
+        "size": 1801362659,
+        "uri": "root://eospublic.cern.ch//eos/opendata/atlas/rucio/opendata/ODEO_FEB2025_v0_1LMET30_mc_700793.Sh_2214_Ztautau_maxHTpTV2_CFilterBVeto.1LMET30.root"
+      },
+      {
+        "checksum": "adler32:22b46fc5",
+        "size": 3491375295,
+        "uri": "root://eospublic.cern.ch//eos/opendata/atlas/rucio/opendata/ODEO_FEB2025_v0_1LMET30_mc_700794.Sh_2214_Ztautau_maxHTpTV2_CVetoBVeto.1LMET30.root"
+      },
+      {
+        "checksum": "adler32:8c44589b",
+        "size": 41148284,
+        "uri": "root://eospublic.cern.ch//eos/opendata/atlas/rucio/opendata/ODEO_FEB2025_v0_1LMET30_mc_700843.Sh_2214_Wqq_ptW_200_ECMS.1LMET30.root"
+      },
+      {
+        "checksum": "adler32:dbff8176",
+        "size": 14800864,
+        "uri": "root://eospublic.cern.ch//eos/opendata/atlas/rucio/opendata/ODEO_FEB2025_v0_1LMET30_mc_700849.Sh_2214_Zqq_ptZ_200_ECMS.1LMET30.root"
+      },
+      {
+        "checksum": "adler32:68083c32",
+        "size": 7903051,
+        "uri": "root://eospublic.cern.ch//eos/opendata/atlas/rucio/opendata/ODEO_FEB2025_v0_1LMET30_mc_700855.Sh_2214_Zbb_ptZ_200_ECMS.1LMET30.root"
+      },
+      {
+        "checksum": "adler32:c20558cd",
+        "size": 45849810,
+        "uri": "root://eospublic.cern.ch//eos/opendata/atlas/rucio/opendata/ODEO_FEB2025_v0_1LMET30_mc_700901.Sh_2214_Ztt_maxHTpTV2_Mll10_40_BFilter.1LMET30.root"
+      },
+      {
+        "checksum": "adler32:05dcdd53",
+        "size": 231792216,
+        "uri": "root://eospublic.cern.ch//eos/opendata/atlas/rucio/opendata/ODEO_FEB2025_v0_1LMET30_mc_700902.Sh_2214_Ztt_maxHTpTV2_Mll10_40_CFilterBVeto.1LMET30.root"
+      },
+      {
+        "checksum": "adler32:98cdbcfc",
+        "size": 390488453,
+        "uri": "root://eospublic.cern.ch//eos/opendata/atlas/rucio/opendata/ODEO_FEB2025_v0_1LMET30_mc_700903.Sh_2214_Ztt_maxHTpTV2_Mll10_40_CVetoBVeto.1LMET30.root"
+      },
+      {
+        "checksum": "adler32:de77f2b8",
+        "size": 10436627,
+        "uri": "root://eospublic.cern.ch//eos/opendata/atlas/rucio/opendata/ODEO_FEB2025_v0_1LMET30_mc_801976.Py8EG_A14NNPDF23LO_Zprime_NoInt_tautau_SSM3000.1LMET30.root"
+      },
+      {
+        "checksum": "adler32:0e223820",
+        "size": 2382447,
+        "uri": "root://eospublic.cern.ch//eos/opendata/atlas/rucio/opendata/ODEO_FEB2025_v0_1LMET30_mc_801978.Py8EG_A14NNPDF23LO_Wprime_taunu_SSM3000.1LMET30.root"
+      }
+    ],
+    "license": {
+      "attribution": "CC0-1.0"
+    },
+    "methodology": {
+      "description": "<p>These data were created during LS2 as part of a major reprocessing campaign of the Run 2 data. All data were reprocessed using Athena Release 22, and new corresponding MC simulation samples were produced. These data and MC simulation datasets were processed into ROOT ntuple files from the DAOD_PHYSLITE format that is released as open data for research. For the files in this record, the following skimming selection was applied: At least one lepton with at least 7 GeV of p<sub>T</sub> and 30 GeV of missing transverse momentum (i.e. a leptonically-decaying W-boson enhanced selection)"
+    },
+    "publisher": "CERN Open Data Portal",
+    "recid": "93931",
+    "relations": [
+      {
+        "description": "For citing all the Open Data for Education and Outreach from this release, and to find other related datasets, please see",
+        "doi": "10.7483/OPENDATA.ATLAS.B5M9.44TN",
+        "recid": "93910",
+        "title": "ROOT ntuple format 2015-2016 proton-proton Open Data for Education and Outreach from the ATLAS experiment",
+        "type": "isChildOf"
+      }
+    ],
+    "run_period": [
+      "2015",
+      "2016"
+    ],
+    "title": "ATLAS ROOT ntuple format MC simulation, 2015+2016 proton-proton collisions beta release, 1LMET30 skim",
+    "type": {
+      "primary": "Dataset",
+      "secondary": [
+        "Simulated"
+      ]
+    },
+    "usage": {
+      "description": "<p> The data and MC simulation provided by the ATLAS experiment in root ntuple format is released under a CC0 license; citation of the data and acknowledgement of the collaboration is requested. This format can be used directly using ROOT or uproot for simple studies and is primarily intended for educational and outreach purposes. <p>Extensive instructions for interacting with the data, as well as documentation of the dataset naming conventions and their contents, are provided on the ATLAS Open Data website linked below. For those interested in implementing a research-quality data analysis, the open data designed for research (also linked below) may be a better starting point. Please be sure to cite the Open Data that you use, in line with the policy below.",
+      "links": [
+        {
+          "description": "ATLAS Open Data Website",
+          "url": "http://opendata.atlas.cern"
+        },
+        {
+          "description": "Resources to understand and use the open data for education and outreach",
+          "url": "https://opendata.atlas.cern/docs/category/13-tev-tutorials-for-education"
+        },
+        {
+          "description": "More about this ntuple format",
+          "url": "https://opendata.atlas.cern/docs/data/for_education/13TeV25_details"
+        },
+        {
+          "description": "Ntuple making framework",
+          "url": "http://gitlab.cern.ch/atlas-outreach-data-tools/physlitetoopendata"
+        },
+        {
+          "description": "Citation policy",
+          "url": "https://opendata.atlas.cern/docs/documentation/ethical_legal/citation_policy"
+        }
+      ]
+    }
+  }
+]

--- a/data/records/atlas-odeo-FEB2025-2bjets-data.json
+++ b/data/records/atlas-odeo-FEB2025-2bjets-data.json
@@ -27,9 +27,9 @@
       "formats": [
         "root"
       ],
-      "number_events": 16796044,
+      "number_events": 141259550,
       "number_files": 16,
-      "size": 4739804251
+      "size": 38827451723
     },
     "doi": "10.7483/OPENDATA.ATLAS.1P1H.J3QK",
     "experiment": [
@@ -37,84 +37,84 @@
     ],
     "files": [
       {
-        "checksum": "adler32:fcb6c916",
-        "size": 21398403,
-        "uri": "root://eospublic.cern.ch//eos/opendata/atlas/rucio/opendata/ODEO_FEB2025_v0_2bjets_data15_periodD.2bjets.root"
+        "checksum": "adler32:47c20649",
+        "size": 112003429,
+        "uri": "root://eospublic.cern.ch//eos/opendata/atlas/rucio/user/egramsta/data15_periodD.2bjets70.root"
       },
       {
-        "checksum": "adler32:ec613344",
-        "size": 132711939,
-        "uri": "root://eospublic.cern.ch//eos/opendata/atlas/rucio/opendata/ODEO_FEB2025_v0_2bjets_data15_periodE.2bjets.root"
+        "checksum": "adler32:ef37f1f3",
+        "size": 803627848,
+        "uri": "root://eospublic.cern.ch//eos/opendata/atlas/rucio/user/egramsta/data15_periodE.2bjets70.root"
       },
       {
-        "checksum": "adler32:d33a3051",
-        "size": 81172596,
-        "uri": "root://eospublic.cern.ch//eos/opendata/atlas/rucio/opendata/ODEO_FEB2025_v0_2bjets_data15_periodF.2bjets.root"
+        "checksum": "adler32:eb5ae4cf",
+        "size": 508004152,
+        "uri": "root://eospublic.cern.ch//eos/opendata/atlas/rucio/user/egramsta/data15_periodF.2bjets70.root"
       },
       {
-        "checksum": "adler32:f6977ccd",
-        "size": 182682617,
-        "uri": "root://eospublic.cern.ch//eos/opendata/atlas/rucio/opendata/ODEO_FEB2025_v0_2bjets_data15_periodG.2bjets.root"
+        "checksum": "adler32:71fd9b6b",
+        "size": 1176737694,
+        "uri": "root://eospublic.cern.ch//eos/opendata/atlas/rucio/user/egramsta/data15_periodG.2bjets70.root"
       },
       {
-        "checksum": "adler32:6f649697",
-        "size": 59214591,
-        "uri": "root://eospublic.cern.ch//eos/opendata/atlas/rucio/opendata/ODEO_FEB2025_v0_2bjets_data15_periodH.2bjets.root"
+        "checksum": "adler32:f63fea7e",
+        "size": 395091060,
+        "uri": "root://eospublic.cern.ch//eos/opendata/atlas/rucio/user/egramsta/data15_periodH.2bjets70.root"
       },
       {
-        "checksum": "adler32:b3f9818a",
-        "size": 323456464,
-        "uri": "root://eospublic.cern.ch//eos/opendata/atlas/rucio/opendata/ODEO_FEB2025_v0_2bjets_data15_periodJ.2bjets.root"
+        "checksum": "adler32:b0fd55c2",
+        "size": 2188004082,
+        "uri": "root://eospublic.cern.ch//eos/opendata/atlas/rucio/user/egramsta/data15_periodJ.2bjets70.root"
       },
       {
-        "checksum": "adler32:a8b63208",
-        "size": 139608770,
-        "uri": "root://eospublic.cern.ch//eos/opendata/atlas/rucio/opendata/ODEO_FEB2025_v0_2bjets_data16_periodA.2bjets.root"
+        "checksum": "adler32:510d98b0",
+        "size": 867636130,
+        "uri": "root://eospublic.cern.ch//eos/opendata/atlas/rucio/user/egramsta/data16_periodA.2bjets70.root"
       },
       {
-        "checksum": "adler32:e3ae8658",
-        "size": 269333987,
-        "uri": "root://eospublic.cern.ch//eos/opendata/atlas/rucio/opendata/ODEO_FEB2025_v0_2bjets_data16_periodB.2bjets.root"
+        "checksum": "adler32:d499b59b",
+        "size": 2162092725,
+        "uri": "root://eospublic.cern.ch//eos/opendata/atlas/rucio/user/egramsta/data16_periodB.2bjets70.root"
       },
       {
-        "checksum": "adler32:e279dc95",
-        "size": 362036133,
-        "uri": "root://eospublic.cern.ch//eos/opendata/atlas/rucio/opendata/ODEO_FEB2025_v0_2bjets_data16_periodC.2bjets.root"
+        "checksum": "adler32:4e56e426",
+        "size": 2776082332,
+        "uri": "root://eospublic.cern.ch//eos/opendata/atlas/rucio/user/egramsta/data16_periodC.2bjets70.root"
       },
       {
-        "checksum": "adler32:e82b5469",
-        "size": 663464719,
-        "uri": "root://eospublic.cern.ch//eos/opendata/atlas/rucio/opendata/ODEO_FEB2025_v0_2bjets_data16_periodD.2bjets.root"
+        "checksum": "adler32:0229b0fd",
+        "size": 5173086340,
+        "uri": "root://eospublic.cern.ch//eos/opendata/atlas/rucio/user/egramsta/data16_periodD.2bjets70.root"
       },
       {
-        "checksum": "adler32:36f330b6",
-        "size": 189278194,
-        "uri": "root://eospublic.cern.ch//eos/opendata/atlas/rucio/opendata/ODEO_FEB2025_v0_2bjets_data16_periodE.2bjets.root"
+        "checksum": "adler32:5cf45cbe",
+        "size": 1610503033,
+        "uri": "root://eospublic.cern.ch//eos/opendata/atlas/rucio/user/egramsta/data16_periodE.2bjets70.root"
       },
       {
-        "checksum": "adler32:4ed395f7",
-        "size": 363689682,
-        "uri": "root://eospublic.cern.ch//eos/opendata/atlas/rucio/opendata/ODEO_FEB2025_v0_2bjets_data16_periodF.2bjets.root"
+        "checksum": "adler32:53ab0ece",
+        "size": 3160136532,
+        "uri": "root://eospublic.cern.ch//eos/opendata/atlas/rucio/user/egramsta/data16_periodF.2bjets70.root"
       },
       {
-        "checksum": "adler32:7e122918",
-        "size": 410717839,
-        "uri": "root://eospublic.cern.ch//eos/opendata/atlas/rucio/opendata/ODEO_FEB2025_v0_2bjets_data16_periodG.2bjets.root"
+        "checksum": "adler32:61930ecc",
+        "size": 3564196221,
+        "uri": "root://eospublic.cern.ch//eos/opendata/atlas/rucio/user/egramsta/data16_periodG.2bjets70.root"
       },
       {
-        "checksum": "adler32:4d26ef23",
-        "size": 623895361,
-        "uri": "root://eospublic.cern.ch//eos/opendata/atlas/rucio/opendata/ODEO_FEB2025_v0_2bjets_data16_periodI.2bjets.root"
+        "checksum": "adler32:aa47c39b",
+        "size": 5471362259,
+        "uri": "root://eospublic.cern.ch//eos/opendata/atlas/rucio/user/egramsta/data16_periodI.2bjets70.root"
       },
       {
-        "checksum": "adler32:edd1439d",
-        "size": 233322761,
-        "uri": "root://eospublic.cern.ch//eos/opendata/atlas/rucio/opendata/ODEO_FEB2025_v0_2bjets_data16_periodK.2bjets.root"
+        "checksum": "adler32:edab3220",
+        "size": 2272804263,
+        "uri": "root://eospublic.cern.ch//eos/opendata/atlas/rucio/user/egramsta/data16_periodK.2bjets70.root"
       },
       {
-        "checksum": "adler32:4ba80e93",
-        "size": 683820195,
-        "uri": "root://eospublic.cern.ch//eos/opendata/atlas/rucio/opendata/ODEO_FEB2025_v0_2bjets_data16_periodL.2bjets.root"
+        "checksum": "adler32:b56ac437",
+        "size": 6586083623,
+        "uri": "root://eospublic.cern.ch//eos/opendata/atlas/rucio/user/egramsta/data16_periodL.2bjets70.root"
       }
     ],
     "license": {
@@ -154,15 +154,15 @@
         },
         {
           "description": "Resources to understand and use the open data for education and outreach",
-          "url": "https://opendata.atlas.cern/docs/category/13-tev-tutorials-for-education"
+          "url": "https://opendata.atlas.cern/docs/category/13-tev-2025-beta-release"
         },
         {
           "description": "More about this ntuple format",
-          "url": "https://opendata.atlas.cern/docs/data/for_education/13TeV25_details"
+          "url": "https://opendata.atlas.cern/docs/data/for_education/13TeV25_details#variable-list"
         },
         {
-          "description": "Ntuple making framework",
-          "url": "http://gitlab.cern.ch/atlas-outreach-data-tools/physlitetoopendata"
+          "description": "Ntuple making framework (PhysLiteToOpenData)",
+          "url": "https://doi.org/10.5281/zenodo.15791091"
         },
         {
           "description": "Citation policy",

--- a/data/records/atlas-odeo-FEB2025-2bjets-data.json
+++ b/data/records/atlas-odeo-FEB2025-2bjets-data.json
@@ -1,0 +1,174 @@
+[
+  {
+    "abstract": {
+      "description": "Run 2 2015+2016 proton-proton collision data beta release, 2bjets skim from the ATLAS experiment"
+    },
+    "accelerator": "CERN-LHC",
+    "categories": {
+      "source": "ATLAS Collaboration"
+    },
+    "collaboration": {
+      "name": "ATLAS collaboration"
+    },
+    "collections": [
+      "ATLAS-Primary-Datasets"
+    ],
+    "collision_information": {
+      "energy": "13TeV",
+      "type": "pp"
+    },
+    "date_created": [
+      "2015",
+      "2016"
+    ],
+    "date_published": "2025",
+    "date_reprocessed": "2020",
+    "distribution": {
+      "formats": [
+        "root"
+      ],
+      "number_events": 16796044,
+      "number_files": 16,
+      "size": 4739804251
+    },
+    "doi": "10.7483/OPENDATA.ATLAS.1P1H.J3QK",
+    "experiment": [
+      "ATLAS"
+    ],
+    "files": [
+      {
+        "checksum": "adler32:fcb6c916",
+        "size": 21398403,
+        "uri": "root://eospublic.cern.ch//eos/opendata/atlas/rucio/opendata/ODEO_FEB2025_v0_2bjets_data15_periodD.2bjets.root"
+      },
+      {
+        "checksum": "adler32:ec613344",
+        "size": 132711939,
+        "uri": "root://eospublic.cern.ch//eos/opendata/atlas/rucio/opendata/ODEO_FEB2025_v0_2bjets_data15_periodE.2bjets.root"
+      },
+      {
+        "checksum": "adler32:d33a3051",
+        "size": 81172596,
+        "uri": "root://eospublic.cern.ch//eos/opendata/atlas/rucio/opendata/ODEO_FEB2025_v0_2bjets_data15_periodF.2bjets.root"
+      },
+      {
+        "checksum": "adler32:f6977ccd",
+        "size": 182682617,
+        "uri": "root://eospublic.cern.ch//eos/opendata/atlas/rucio/opendata/ODEO_FEB2025_v0_2bjets_data15_periodG.2bjets.root"
+      },
+      {
+        "checksum": "adler32:6f649697",
+        "size": 59214591,
+        "uri": "root://eospublic.cern.ch//eos/opendata/atlas/rucio/opendata/ODEO_FEB2025_v0_2bjets_data15_periodH.2bjets.root"
+      },
+      {
+        "checksum": "adler32:b3f9818a",
+        "size": 323456464,
+        "uri": "root://eospublic.cern.ch//eos/opendata/atlas/rucio/opendata/ODEO_FEB2025_v0_2bjets_data15_periodJ.2bjets.root"
+      },
+      {
+        "checksum": "adler32:a8b63208",
+        "size": 139608770,
+        "uri": "root://eospublic.cern.ch//eos/opendata/atlas/rucio/opendata/ODEO_FEB2025_v0_2bjets_data16_periodA.2bjets.root"
+      },
+      {
+        "checksum": "adler32:e3ae8658",
+        "size": 269333987,
+        "uri": "root://eospublic.cern.ch//eos/opendata/atlas/rucio/opendata/ODEO_FEB2025_v0_2bjets_data16_periodB.2bjets.root"
+      },
+      {
+        "checksum": "adler32:e279dc95",
+        "size": 362036133,
+        "uri": "root://eospublic.cern.ch//eos/opendata/atlas/rucio/opendata/ODEO_FEB2025_v0_2bjets_data16_periodC.2bjets.root"
+      },
+      {
+        "checksum": "adler32:e82b5469",
+        "size": 663464719,
+        "uri": "root://eospublic.cern.ch//eos/opendata/atlas/rucio/opendata/ODEO_FEB2025_v0_2bjets_data16_periodD.2bjets.root"
+      },
+      {
+        "checksum": "adler32:36f330b6",
+        "size": 189278194,
+        "uri": "root://eospublic.cern.ch//eos/opendata/atlas/rucio/opendata/ODEO_FEB2025_v0_2bjets_data16_periodE.2bjets.root"
+      },
+      {
+        "checksum": "adler32:4ed395f7",
+        "size": 363689682,
+        "uri": "root://eospublic.cern.ch//eos/opendata/atlas/rucio/opendata/ODEO_FEB2025_v0_2bjets_data16_periodF.2bjets.root"
+      },
+      {
+        "checksum": "adler32:7e122918",
+        "size": 410717839,
+        "uri": "root://eospublic.cern.ch//eos/opendata/atlas/rucio/opendata/ODEO_FEB2025_v0_2bjets_data16_periodG.2bjets.root"
+      },
+      {
+        "checksum": "adler32:4d26ef23",
+        "size": 623895361,
+        "uri": "root://eospublic.cern.ch//eos/opendata/atlas/rucio/opendata/ODEO_FEB2025_v0_2bjets_data16_periodI.2bjets.root"
+      },
+      {
+        "checksum": "adler32:edd1439d",
+        "size": 233322761,
+        "uri": "root://eospublic.cern.ch//eos/opendata/atlas/rucio/opendata/ODEO_FEB2025_v0_2bjets_data16_periodK.2bjets.root"
+      },
+      {
+        "checksum": "adler32:4ba80e93",
+        "size": 683820195,
+        "uri": "root://eospublic.cern.ch//eos/opendata/atlas/rucio/opendata/ODEO_FEB2025_v0_2bjets_data16_periodL.2bjets.root"
+      }
+    ],
+    "license": {
+      "attribution": "CC0-1.0"
+    },
+    "methodology": {
+      "description": "<p>These data were created during LS2 as part of a major reprocessing campaign of the Run 2 data. All data were reprocessed using Athena Release 22, and new corresponding MC simulation samples were produced. These data and MC simulation datasets were processed into ROOT ntuple files from the DAOD_PHYSLITE format that is released as open data for research. For the files in this record, the following skimming selection was applied: At least two jets with at least 20 GeV of p<sub>T</sub> identified as containing at least one heavy flavor hadron using the 85% working point (i.e. a Higgs boson decaying to b-quarks enhanced selection)"
+    },
+    "publisher": "CERN Open Data Portal",
+    "recid": "93927",
+    "relations": [
+      {
+        "description": "For citing all the Open Data for Education and Outreach from this release, and to find other related datasets, please see",
+        "doi": "10.7483/OPENDATA.ATLAS.B5M9.44TN",
+        "recid": "93910",
+        "title": "ROOT ntuple format 2015-2016 proton-proton Open Data for Education and Outreach from the ATLAS experiment",
+        "type": "isChildOf"
+      }
+    ],
+    "run_period": [
+      "2015",
+      "2016"
+    ],
+    "title": "ATLAS ROOT ntuple format Run 2 2015+2016 proton-proton collision data beta release, 2bjets skim",
+    "type": {
+      "primary": "Dataset",
+      "secondary": [
+        "Collision"
+      ]
+    },
+    "usage": {
+      "description": "<p> The data and MC simulation provided by the ATLAS experiment in root ntuple format is released under a CC0 license; citation of the data and acknowledgement of the collaboration is requested. This format can be used directly using ROOT or uproot for simple studies and is primarily intended for educational and outreach purposes. <p>Extensive instructions for interacting with the data, as well as documentation of the dataset naming conventions and their contents, are provided on the ATLAS Open Data website linked below. For those interested in implementing a research-quality data analysis, the open data designed for research (also linked below) may be a better starting point. Please be sure to cite the Open Data that you use, in line with the policy below.",
+      "links": [
+        {
+          "description": "ATLAS Open Data Website",
+          "url": "http://opendata.atlas.cern"
+        },
+        {
+          "description": "Resources to understand and use the open data for education and outreach",
+          "url": "https://opendata.atlas.cern/docs/category/13-tev-tutorials-for-education"
+        },
+        {
+          "description": "More about this ntuple format",
+          "url": "https://opendata.atlas.cern/docs/data/for_education/13TeV25_details"
+        },
+        {
+          "description": "Ntuple making framework",
+          "url": "http://gitlab.cern.ch/atlas-outreach-data-tools/physlitetoopendata"
+        },
+        {
+          "description": "Citation policy",
+          "url": "https://opendata.atlas.cern/docs/documentation/ethical_legal/citation_policy"
+        }
+      ]
+    }
+  }
+]

--- a/data/records/atlas-odeo-FEB2025-2bjets-mc.json
+++ b/data/records/atlas-odeo-FEB2025-2bjets-mc.json
@@ -1,0 +1,1959 @@
+[
+  {
+    "abstract": {
+      "description": "MC simulation, 2015+2016 proton-proton collisions beta release, 2bjets skim from the ATLAS experiment"
+    },
+    "accelerator": "CERN-LHC",
+    "categories": {
+      "source": "ATLAS Collaboration"
+    },
+    "collaboration": {
+      "name": "ATLAS collaboration"
+    },
+    "collections": [
+      "ATLAS-Primary-Datasets"
+    ],
+    "collision_information": {
+      "energy": "13TeV",
+      "type": "pp"
+    },
+    "date_created": [
+      "2015",
+      "2016"
+    ],
+    "date_published": "2025",
+    "date_reprocessed": "2020",
+    "distribution": {
+      "formats": [
+        "root"
+      ],
+      "number_events": 4304665,
+      "number_files": 373,
+      "size": 2406812407
+    },
+    "doi": "10.7483/OPENDATA.ATLAS.71IP.L3OC",
+    "experiment": [
+      "ATLAS"
+    ],
+    "files": [
+      {
+        "checksum": "adler32:28588336",
+        "size": 34483,
+        "uri": "root://eospublic.cern.ch//eos/opendata/atlas/rucio/opendata/ODEO_FEB2025_v0_2bjets_mc_301204.Pythia8EvtGen_A14MSTW2008LO_Zprime_NoInt_ee_SSM3000.2bjets.root"
+      },
+      {
+        "checksum": "adler32:e000fb43",
+        "size": 31739,
+        "uri": "root://eospublic.cern.ch//eos/opendata/atlas/rucio/opendata/ODEO_FEB2025_v0_2bjets_mc_301209.Pythia8EvtGen_A14MSTW2008LO_Zprime_NoInt_mumu_SSM3000.2bjets.root"
+      },
+      {
+        "checksum": "adler32:d275e28b",
+        "size": 28031,
+        "uri": "root://eospublic.cern.ch//eos/opendata/atlas/rucio/opendata/ODEO_FEB2025_v0_2bjets_mc_301243.Pythia8EvtGen_A14NNPDF23LO_Wprime_enu_SSM3000.2bjets.root"
+      },
+      {
+        "checksum": "adler32:dc21a648",
+        "size": 31972,
+        "uri": "root://eospublic.cern.ch//eos/opendata/atlas/rucio/opendata/ODEO_FEB2025_v0_2bjets_mc_301247.Pythia8EvtGen_A14NNPDF23LO_Wprime_munu_SSM3000.2bjets.root"
+      },
+      {
+        "checksum": "adler32:fc194550",
+        "size": 100198,
+        "uri": "root://eospublic.cern.ch//eos/opendata/atlas/rucio/opendata/ODEO_FEB2025_v0_2bjets_mc_301333.Pythia8EvtGen_A14NNPDF23LO_zprime3000_tt.2bjets.root"
+      },
+      {
+        "checksum": "adler32:d057ce4d",
+        "size": 57687,
+        "uri": "root://eospublic.cern.ch//eos/opendata/atlas/rucio/opendata/ODEO_FEB2025_v0_2bjets_mc_301826.Pythia8EvtGen_A14NNPDF23LO_Wprime_qq_3000.2bjets.root"
+      },
+      {
+        "checksum": "adler32:61b91be4",
+        "size": 79715,
+        "uri": "root://eospublic.cern.ch//eos/opendata/atlas/rucio/opendata/ODEO_FEB2025_v0_2bjets_mc_301928.Pythia8EvtGen_A14NNPDF23LO_Zprimebb3000.2bjets.root"
+      },
+      {
+        "checksum": "adler32:f5f7f010",
+        "size": 423104,
+        "uri": "root://eospublic.cern.ch//eos/opendata/atlas/rucio/opendata/ODEO_FEB2025_v0_2bjets_mc_302520.Pythia8EvtGen_A14NNPDF23LO_2DP20_Mass_55_100.2bjets.root"
+      },
+      {
+        "checksum": "adler32:dbfccc68",
+        "size": 125467,
+        "uri": "root://eospublic.cern.ch//eos/opendata/atlas/rucio/opendata/ODEO_FEB2025_v0_2bjets_mc_302521.Pythia8EvtGen_A14NNPDF23LO_2DP20_Mass_100_160.2bjets.root"
+      },
+      {
+        "checksum": "adler32:70334a78",
+        "size": 63185,
+        "uri": "root://eospublic.cern.ch//eos/opendata/atlas/rucio/opendata/ODEO_FEB2025_v0_2bjets_mc_302522.Pythia8EvtGen_A14NNPDF23LO_2DP20_Mass_160_250.2bjets.root"
+      },
+      {
+        "checksum": "adler32:da573fb6",
+        "size": 46227,
+        "uri": "root://eospublic.cern.ch//eos/opendata/atlas/rucio/opendata/ODEO_FEB2025_v0_2bjets_mc_302523.Pythia8EvtGen_A14NNPDF23LO_2DP20_Mass_250_400.2bjets.root"
+      },
+      {
+        "checksum": "adler32:cf62d229",
+        "size": 72601,
+        "uri": "root://eospublic.cern.ch//eos/opendata/atlas/rucio/opendata/ODEO_FEB2025_v0_2bjets_mc_302524.Pythia8EvtGen_A14NNPDF23LO_2DP20_Mass_400_650.2bjets.root"
+      },
+      {
+        "checksum": "adler32:cc14ff24",
+        "size": 35471,
+        "uri": "root://eospublic.cern.ch//eos/opendata/atlas/rucio/opendata/ODEO_FEB2025_v0_2bjets_mc_302525.Pythia8EvtGen_A14NNPDF23LO_2DP20_Mass_650_1000.2bjets.root"
+      },
+      {
+        "checksum": "adler32:2e4d5453",
+        "size": 61131,
+        "uri": "root://eospublic.cern.ch//eos/opendata/atlas/rucio/opendata/ODEO_FEB2025_v0_2bjets_mc_302526.Pythia8EvtGen_A14NNPDF23LO_2DP20_Mass_1000_1500.2bjets.root"
+      },
+      {
+        "checksum": "adler32:c7a09d96",
+        "size": 66484,
+        "uri": "root://eospublic.cern.ch//eos/opendata/atlas/rucio/opendata/ODEO_FEB2025_v0_2bjets_mc_302527.Pythia8EvtGen_A14NNPDF23LO_2DP20_Mass_1500_2000.2bjets.root"
+      },
+      {
+        "checksum": "adler32:5b38c9c5",
+        "size": 88783,
+        "uri": "root://eospublic.cern.ch//eos/opendata/atlas/rucio/opendata/ODEO_FEB2025_v0_2bjets_mc_302528.Pythia8EvtGen_A14NNPDF23LO_2DP20_Mass_2000_2500.2bjets.root"
+      },
+      {
+        "checksum": "adler32:7abc778f",
+        "size": 64893,
+        "uri": "root://eospublic.cern.ch//eos/opendata/atlas/rucio/opendata/ODEO_FEB2025_v0_2bjets_mc_302529.Pythia8EvtGen_A14NNPDF23LO_2DP20_Mass_2500_3000.2bjets.root"
+      },
+      {
+        "checksum": "adler32:ce508354",
+        "size": 87935,
+        "uri": "root://eospublic.cern.ch//eos/opendata/atlas/rucio/opendata/ODEO_FEB2025_v0_2bjets_mc_302530.Pythia8EvtGen_A14NNPDF23LO_2DP20_Mass_3000_3500.2bjets.root"
+      },
+      {
+        "checksum": "adler32:c767766e",
+        "size": 58040,
+        "uri": "root://eospublic.cern.ch//eos/opendata/atlas/rucio/opendata/ODEO_FEB2025_v0_2bjets_mc_302531.Pythia8EvtGen_A14NNPDF23LO_2DP20_Mass_3500_4000.2bjets.root"
+      },
+      {
+        "checksum": "adler32:039c173a",
+        "size": 85091,
+        "uri": "root://eospublic.cern.ch//eos/opendata/atlas/rucio/opendata/ODEO_FEB2025_v0_2bjets_mc_302532.Pythia8EvtGen_A14NNPDF23LO_2DP20_Mass_4000_4500.2bjets.root"
+      },
+      {
+        "checksum": "adler32:df6e089a",
+        "size": 41636,
+        "uri": "root://eospublic.cern.ch//eos/opendata/atlas/rucio/opendata/ODEO_FEB2025_v0_2bjets_mc_302533.Pythia8EvtGen_A14NNPDF23LO_2DP20_Mass_4500_5000.2bjets.root"
+      },
+      {
+        "checksum": "adler32:4363d7d9",
+        "size": 69520,
+        "uri": "root://eospublic.cern.ch//eos/opendata/atlas/rucio/opendata/ODEO_FEB2025_v0_2bjets_mc_302534.Pythia8EvtGen_A14NNPDF23LO_2DP20_Mass_5000_inf.2bjets.root"
+      },
+      {
+        "checksum": "adler32:637def89",
+        "size": 186116,
+        "uri": "root://eospublic.cern.ch//eos/opendata/atlas/rucio/opendata/ODEO_FEB2025_v0_2bjets_mc_302733.MadGraphPythia8EvtGen_A14NNPDF23LO_WpL_tblep_M3000.2bjets.root"
+      },
+      {
+        "checksum": "adler32:5d04ffcc",
+        "size": 766236,
+        "uri": "root://eospublic.cern.ch//eos/opendata/atlas/rucio/opendata/ODEO_FEB2025_v0_2bjets_mc_304014.MadGraphPythia8EvtGen_A14NNPDF23_3top_SM.2bjets.root"
+      },
+      {
+        "checksum": "adler32:e117fb1e",
+        "size": 122255,
+        "uri": "root://eospublic.cern.ch//eos/opendata/atlas/rucio/opendata/ODEO_FEB2025_v0_2bjets_mc_306149.MadGraphPythia8EvtGen_A14NNPDF23LO_WpL_tbhad_M3000.2bjets.root"
+      },
+      {
+        "checksum": "adler32:9eb79553",
+        "size": 42191,
+        "uri": "root://eospublic.cern.ch//eos/opendata/atlas/rucio/opendata/ODEO_FEB2025_v0_2bjets_mc_311490.PowhegPy8EG_A14N23LO_DMA_500_700_gq0p25.2bjets.root"
+      },
+      {
+        "checksum": "adler32:f7f76fc3",
+        "size": 225403,
+        "uri": "root://eospublic.cern.ch//eos/opendata/atlas/rucio/opendata/ODEO_FEB2025_v0_2bjets_mc_312613.aMcAtNloPy8EG_A14N30NLO_LQd_gstML_0p3_nonallhad_M1000.2bjets.root"
+      },
+      {
+        "checksum": "adler32:c76a4589",
+        "size": 50398,
+        "uri": "root://eospublic.cern.ch//eos/opendata/atlas/rucio/opendata/ODEO_FEB2025_v0_2bjets_mc_341456.PowhegPythia8EvtGen_CT10_AZNLO_ZH125J_MINLO_veveWWlvqq_VpT.2bjets.root"
+      },
+      {
+        "checksum": "adler32:a1bf9b59",
+        "size": 63855,
+        "uri": "root://eospublic.cern.ch//eos/opendata/atlas/rucio/opendata/ODEO_FEB2025_v0_2bjets_mc_341458.PowhegPythia8EvtGen_CT10_AZNLO_ZH125J_MINLO_vmuvmuWWlvqq_VpT.2bjets.root"
+      },
+      {
+        "checksum": "adler32:c419e669",
+        "size": 59710,
+        "uri": "root://eospublic.cern.ch//eos/opendata/atlas/rucio/opendata/ODEO_FEB2025_v0_2bjets_mc_341460.PowhegPy8EG_CT10_AZNLO_ZH125J_MINLO_vtauvtauWWlvqq_VpT.2bjets.root"
+      },
+      {
+        "checksum": "adler32:d360baed",
+        "size": 81296,
+        "uri": "root://eospublic.cern.ch//eos/opendata/atlas/rucio/opendata/ODEO_FEB2025_v0_2bjets_mc_343981.PowhegPythia8EvtGen_NNLOPS_nnlo_30_ggH125_gamgam.2bjets.root"
+      },
+      {
+        "checksum": "adler32:707138dc",
+        "size": 81623,
+        "uri": "root://eospublic.cern.ch//eos/opendata/atlas/rucio/opendata/ODEO_FEB2025_v0_2bjets_mc_344158.aMcAtNloPythia8EvtGen_A14NNPDF23LO_ppx0_FxFx_Np012_SM.2bjets.root"
+      },
+      {
+        "checksum": "adler32:cd0ff361",
+        "size": 214797,
+        "uri": "root://eospublic.cern.ch//eos/opendata/atlas/rucio/opendata/ODEO_FEB2025_v0_2bjets_mc_345056.PowhegPythia8EvtGen_NNPDF3_AZNLO_ZH125J_MINLO_vvbb_VpT.2bjets.root"
+      },
+      {
+        "checksum": "adler32:0777f63b",
+        "size": 235911,
+        "uri": "root://eospublic.cern.ch//eos/opendata/atlas/rucio/opendata/ODEO_FEB2025_v0_2bjets_mc_345058.PowhegPythia8EvtGen_NNPDF3_AZNLO_ggZH125_vvbb.2bjets.root"
+      },
+      {
+        "checksum": "adler32:088b6d62",
+        "size": 787649,
+        "uri": "root://eospublic.cern.ch//eos/opendata/atlas/rucio/opendata/ODEO_FEB2025_v0_2bjets_mc_345060.PowhegPythia8EvtGen_NNLOPS_nnlo_30_ggH125_ZZ4l.2bjets.root"
+      },
+      {
+        "checksum": "adler32:97947c27",
+        "size": 82134,
+        "uri": "root://eospublic.cern.ch//eos/opendata/atlas/rucio/opendata/ODEO_FEB2025_v0_2bjets_mc_345061.PowhegPythia8EvtGen_NNPDF3_AZNLO_ggZH125_HgamgamZinc.2bjets.root"
+      },
+      {
+        "checksum": "adler32:ce2a970e",
+        "size": 152598,
+        "uri": "root://eospublic.cern.ch//eos/opendata/atlas/rucio/opendata/ODEO_FEB2025_v0_2bjets_mc_345066.PowhegPythia8EvtGen_NNPDF3_AZNLO_ggZH125_ZZ4lepZinc.2bjets.root"
+      },
+      {
+        "checksum": "adler32:99ec0985",
+        "size": 65205,
+        "uri": "root://eospublic.cern.ch//eos/opendata/atlas/rucio/opendata/ODEO_FEB2025_v0_2bjets_mc_345097.PowhegPythia8EvtGen_NNLOPS_nnlo_30_ggH125_mumu.2bjets.root"
+      },
+      {
+        "checksum": "adler32:a907d032",
+        "size": 84818,
+        "uri": "root://eospublic.cern.ch//eos/opendata/atlas/rucio/opendata/ODEO_FEB2025_v0_2bjets_mc_345098.PowhegPythia8EvtGen_NNPDF3_AZNLO_ggZH125_Hmumu_Zinc.2bjets.root"
+      },
+      {
+        "checksum": "adler32:40b42397",
+        "size": 75214,
+        "uri": "root://eospublic.cern.ch//eos/opendata/atlas/rucio/opendata/ODEO_FEB2025_v0_2bjets_mc_345103.PowhegPythia8EvtGen_NNPDF30_AZNLO_ZH125J_Hmumu_Zincl_MINLO.2bjets.root"
+      },
+      {
+        "checksum": "adler32:5ad02ca2",
+        "size": 57998,
+        "uri": "root://eospublic.cern.ch//eos/opendata/atlas/rucio/opendata/ODEO_FEB2025_v0_2bjets_mc_345104.PowhegPythia8EvtGen_NNPDF30_AZNLO_WpH125J_Hmumu_Wincl_MINLO.2bjets.root"
+      },
+      {
+        "checksum": "adler32:c782b6c0",
+        "size": 51653,
+        "uri": "root://eospublic.cern.ch//eos/opendata/atlas/rucio/opendata/ODEO_FEB2025_v0_2bjets_mc_345105.PowhegPythia8EvtGen_NNPDF30_AZNLO_WmH125J_Hmumu_Wincl_MINLO.2bjets.root"
+      },
+      {
+        "checksum": "adler32:388149b9",
+        "size": 67428,
+        "uri": "root://eospublic.cern.ch//eos/opendata/atlas/rucio/opendata/ODEO_FEB2025_v0_2bjets_mc_345106.PowhegPythia8EvtGen_NNPDF30_AZNLOCTEQ6L1_VBFH125_mumu.2bjets.root"
+      },
+      {
+        "checksum": "adler32:fcd86ab5",
+        "size": 518082,
+        "uri": "root://eospublic.cern.ch//eos/opendata/atlas/rucio/opendata/ODEO_FEB2025_v0_2bjets_mc_345112.PowhegPythia8EvtGen_NNPDF3_AZNLO_ZH125J_MINLO_vvcc_VpT.2bjets.root"
+      },
+      {
+        "checksum": "adler32:8755e05e",
+        "size": 552303,
+        "uri": "root://eospublic.cern.ch//eos/opendata/atlas/rucio/opendata/ODEO_FEB2025_v0_2bjets_mc_345114.PowhegPythia8EvtGen_NNPDF3_AZNLO_ggZH125_vvcc.2bjets.root"
+      },
+      {
+        "checksum": "adler32:0b201ade",
+        "size": 102447,
+        "uri": "root://eospublic.cern.ch//eos/opendata/atlas/rucio/opendata/ODEO_FEB2025_v0_2bjets_mc_345120.PowhegPy8EG_NNLOPS_nnlo_30_ggH125_tautaul13l7.2bjets.root"
+      },
+      {
+        "checksum": "adler32:ac93d480",
+        "size": 100601,
+        "uri": "root://eospublic.cern.ch//eos/opendata/atlas/rucio/opendata/ODEO_FEB2025_v0_2bjets_mc_345121.PowhegPy8EG_NNLOPS_nnlo_30_ggH125_tautaulm15hp20.2bjets.root"
+      },
+      {
+        "checksum": "adler32:3e9a52af",
+        "size": 146009,
+        "uri": "root://eospublic.cern.ch//eos/opendata/atlas/rucio/opendata/ODEO_FEB2025_v0_2bjets_mc_345122.PowhegPy8EG_NNLOPS_nnlo_30_ggH125_tautaulp15hm20.2bjets.root"
+      },
+      {
+        "checksum": "adler32:46f2f21f",
+        "size": 247448,
+        "uri": "root://eospublic.cern.ch//eos/opendata/atlas/rucio/opendata/ODEO_FEB2025_v0_2bjets_mc_345123.PowhegPy8EG_NNLOPS_nnlo_30_ggH125_tautauh30h20.2bjets.root"
+      },
+      {
+        "checksum": "adler32:779c4490",
+        "size": 623509,
+        "uri": "root://eospublic.cern.ch//eos/opendata/atlas/rucio/opendata/ODEO_FEB2025_v0_2bjets_mc_345124.PowhegPy8EG_NNLOPS_nnlo_30_ggH125_etau_filt.2bjets.root"
+      },
+      {
+        "checksum": "adler32:44e826f2",
+        "size": 720755,
+        "uri": "root://eospublic.cern.ch//eos/opendata/atlas/rucio/opendata/ODEO_FEB2025_v0_2bjets_mc_345125.PowhegPy8EG_NNLOPS_nnlo_30_ggH125_mutau_filt.2bjets.root"
+      },
+      {
+        "checksum": "adler32:437bfa2f",
+        "size": 96500,
+        "uri": "root://eospublic.cern.ch//eos/opendata/atlas/rucio/opendata/ODEO_FEB2025_v0_2bjets_mc_345211.PowhegPy8EG_NNPDF30_AZNLO_WmH125J_Winc_MINLO_tautau.2bjets.root"
+      },
+      {
+        "checksum": "adler32:2e4533ea",
+        "size": 97926,
+        "uri": "root://eospublic.cern.ch//eos/opendata/atlas/rucio/opendata/ODEO_FEB2025_v0_2bjets_mc_345212.PowhegPy8EG_NNPDF30_AZNLO_WpH125J_Winc_MINLO_tautau.2bjets.root"
+      },
+      {
+        "checksum": "adler32:756ff182",
+        "size": 70723,
+        "uri": "root://eospublic.cern.ch//eos/opendata/atlas/rucio/opendata/ODEO_FEB2025_v0_2bjets_mc_345213.PowhegPy8EG_NNPDF30_AZNLO_WmH125J_Winc_MINLO_etau.2bjets.root"
+      },
+      {
+        "checksum": "adler32:23642f91",
+        "size": 131647,
+        "uri": "root://eospublic.cern.ch//eos/opendata/atlas/rucio/opendata/ODEO_FEB2025_v0_2bjets_mc_345214.PowhegPy8EG_NNPDF30_AZNLO_WpH125J_Winc_MINLO_etau.2bjets.root"
+      },
+      {
+        "checksum": "adler32:f8a77726",
+        "size": 90442,
+        "uri": "root://eospublic.cern.ch//eos/opendata/atlas/rucio/opendata/ODEO_FEB2025_v0_2bjets_mc_345215.PowhegPy8EG_NNPDF30_AZNLO_WmH125J_Winc_MINLO_mutau.2bjets.root"
+      },
+      {
+        "checksum": "adler32:d7bedd8f",
+        "size": 142360,
+        "uri": "root://eospublic.cern.ch//eos/opendata/atlas/rucio/opendata/ODEO_FEB2025_v0_2bjets_mc_345216.PowhegPy8EG_NNPDF30_AZNLO_WpH125J_Winc_MINLO_mutau.2bjets.root"
+      },
+      {
+        "checksum": "adler32:d8b4e205",
+        "size": 188184,
+        "uri": "root://eospublic.cern.ch//eos/opendata/atlas/rucio/opendata/ODEO_FEB2025_v0_2bjets_mc_345217.PowhegPy8EG_NNPDF30_AZNLO_ZH125J_Zinc_MINLO_tautau.2bjets.root"
+      },
+      {
+        "checksum": "adler32:6250bc4d",
+        "size": 142858,
+        "uri": "root://eospublic.cern.ch//eos/opendata/atlas/rucio/opendata/ODEO_FEB2025_v0_2bjets_mc_345218.PowhegPy8EG_NNPDF30_AZNLO_ZH125J_Zinc_MINLO_etau.2bjets.root"
+      },
+      {
+        "checksum": "adler32:b446474e",
+        "size": 132399,
+        "uri": "root://eospublic.cern.ch//eos/opendata/atlas/rucio/opendata/ODEO_FEB2025_v0_2bjets_mc_345219.PowhegPy8EG_NNPDF30_AZNLO_ZH125J_Zinc_MINLO_mutau.2bjets.root"
+      },
+      {
+        "checksum": "adler32:9d45c91d",
+        "size": 377298,
+        "uri": "root://eospublic.cern.ch//eos/opendata/atlas/rucio/opendata/ODEO_FEB2025_v0_2bjets_mc_345316.PowhegPythia8EvtGen_NNLOPS_nnlo_30_ggH125_Zy_Zll.2bjets.root"
+      },
+      {
+        "checksum": "adler32:df5feb6d",
+        "size": 186670,
+        "uri": "root://eospublic.cern.ch//eos/opendata/atlas/rucio/opendata/ODEO_FEB2025_v0_2bjets_mc_345317.PowhegPythia8EvtGen_NNPDF30_AZNLO_WmH125J_Hyy_Wincl_MINLO.2bjets.root"
+      },
+      {
+        "checksum": "adler32:d1ce683a",
+        "size": 102509,
+        "uri": "root://eospublic.cern.ch//eos/opendata/atlas/rucio/opendata/ODEO_FEB2025_v0_2bjets_mc_345318.PowhegPythia8EvtGen_NNPDF30_AZNLO_WpH125J_Hyy_Wincl_MINLO.2bjets.root"
+      },
+      {
+        "checksum": "adler32:7b0bb3b3",
+        "size": 102393,
+        "uri": "root://eospublic.cern.ch//eos/opendata/atlas/rucio/opendata/ODEO_FEB2025_v0_2bjets_mc_345319.PowhegPythia8EvtGen_NNPDF30_AZNLO_ZH125J_Hyy_Zincl_MINLO.2bjets.root"
+      },
+      {
+        "checksum": "adler32:c3c475d7",
+        "size": 48509,
+        "uri": "root://eospublic.cern.ch//eos/opendata/atlas/rucio/opendata/ODEO_FEB2025_v0_2bjets_mc_345320.PowhegPythia8EvtGen_NNPDF30_AZNLO_WmH125J_HZy_Wincl_MINLO.2bjets.root"
+      },
+      {
+        "checksum": "adler32:e50c9cf2",
+        "size": 48564,
+        "uri": "root://eospublic.cern.ch//eos/opendata/atlas/rucio/opendata/ODEO_FEB2025_v0_2bjets_mc_345321.PowhegPythia8EvtGen_NNPDF30_AZNLO_WpH125J_HZy_Wincl_MINLO.2bjets.root"
+      },
+      {
+        "checksum": "adler32:15337c87",
+        "size": 88292,
+        "uri": "root://eospublic.cern.ch//eos/opendata/atlas/rucio/opendata/ODEO_FEB2025_v0_2bjets_mc_345322.PowhegPythia8EvtGen_NNPDF30_AZNLO_ZH125J_HZy_Zincl_MINLO.2bjets.root"
+      },
+      {
+        "checksum": "adler32:a8002ab2",
+        "size": 78054,
+        "uri": "root://eospublic.cern.ch//eos/opendata/atlas/rucio/opendata/ODEO_FEB2025_v0_2bjets_mc_345324.PowhegPythia8EvtGen_NNLOPS_NN30_ggH125_WWlvlv_EF_15_5.2bjets.root"
+      },
+      {
+        "checksum": "adler32:37ee7f71",
+        "size": 132027,
+        "uri": "root://eospublic.cern.ch//eos/opendata/atlas/rucio/opendata/ODEO_FEB2025_v0_2bjets_mc_345325.PowhegPythia8EvtGen_NNPDF3_AZNLO_WpH125J_MINLO_qqWWlvlv.2bjets.root"
+      },
+      {
+        "checksum": "adler32:bf072510",
+        "size": 158908,
+        "uri": "root://eospublic.cern.ch//eos/opendata/atlas/rucio/opendata/ODEO_FEB2025_v0_2bjets_mc_345433.PowhegPythia8EvtGen_NNPDF3_AZNLO_WmH125J_MINLO_qqWWlvlv.2bjets.root"
+      },
+      {
+        "checksum": "adler32:50699871",
+        "size": 47614,
+        "uri": "root://eospublic.cern.ch//eos/opendata/atlas/rucio/opendata/ODEO_FEB2025_v0_2bjets_mc_345445.PowhegPythia8EvtGen_NNPDF3_AZNLO_ZH125J_MINLO_vvWWlvlv.2bjets.root"
+      },
+      {
+        "checksum": "adler32:4b77d02a",
+        "size": 73679,
+        "uri": "root://eospublic.cern.ch//eos/opendata/atlas/rucio/opendata/ODEO_FEB2025_v0_2bjets_mc_345596.PowhegPythia8EvtGen_NNPDF3_AZNLO_ggZH125_Zinc_HZZinv.2bjets.root"
+      },
+      {
+        "checksum": "adler32:5873b701",
+        "size": 149019,
+        "uri": "root://eospublic.cern.ch//eos/opendata/atlas/rucio/opendata/ODEO_FEB2025_v0_2bjets_mc_345697.MadGraphPythia8EvtGen_AZNLOCTEQ6L1_ggfhtautaullNp2.2bjets.root"
+      },
+      {
+        "checksum": "adler32:8ef56708",
+        "size": 319229,
+        "uri": "root://eospublic.cern.ch//eos/opendata/atlas/rucio/opendata/ODEO_FEB2025_v0_2bjets_mc_345698.MadGraphPythia8EvtGen_AZNLOCTEQ6L1_ggfhtautaulhNp2.2bjets.root"
+      },
+      {
+        "checksum": "adler32:d4a1c068",
+        "size": 480506,
+        "uri": "root://eospublic.cern.ch//eos/opendata/atlas/rucio/opendata/ODEO_FEB2025_v0_2bjets_mc_345699.MadGraphPythia8EvtGen_AZNLOCTEQ6L1_ggfhtautauhhNp2.2bjets.root"
+      },
+      {
+        "checksum": "adler32:a35775c5",
+        "size": 253750,
+        "uri": "root://eospublic.cern.ch//eos/opendata/atlas/rucio/opendata/ODEO_FEB2025_v0_2bjets_mc_345833.PowhegPythia8EvtGen_NNPDF30_AZNLOCTEQ6L1_VBFH125_Zllgam.2bjets.root"
+      },
+      {
+        "checksum": "adler32:2a5a5228",
+        "size": 38135,
+        "uri": "root://eospublic.cern.ch//eos/opendata/atlas/rucio/opendata/ODEO_FEB2025_v0_2bjets_mc_345834.PowhegPythia8EvtGen_NNPDF30_AZNLOCTEQ6L1_VBFH125_gamstargam.2bjets.root"
+      },
+      {
+        "checksum": "adler32:d31614ec",
+        "size": 71200,
+        "uri": "root://eospublic.cern.ch//eos/opendata/atlas/rucio/opendata/ODEO_FEB2025_v0_2bjets_mc_345876.PowhegPythia8EvtGen_NNPDF30_AZNLO_ZH125J_Hee__Zincl_MINLO.2bjets.root"
+      },
+      {
+        "checksum": "adler32:074207b0",
+        "size": 41316,
+        "uri": "root://eospublic.cern.ch//eos/opendata/atlas/rucio/opendata/ODEO_FEB2025_v0_2bjets_mc_345877.PowhegPythia8EvtGen_NNPDF30_AZNLO_WpH125J_Hee_Wincl_MINLO.2bjets.root"
+      },
+      {
+        "checksum": "adler32:aaa8ee2b",
+        "size": 45076,
+        "uri": "root://eospublic.cern.ch//eos/opendata/atlas/rucio/opendata/ODEO_FEB2025_v0_2bjets_mc_345878.PowhegPythia8EvtGen_NNPDF30_AZNLO_WmH125J_Hee_Wincl_MINLO.2bjets.root"
+      },
+      {
+        "checksum": "adler32:a0885926",
+        "size": 100884,
+        "uri": "root://eospublic.cern.ch//eos/opendata/atlas/rucio/opendata/ODEO_FEB2025_v0_2bjets_mc_345944.aMcAtNloPy8EG_A14NNPDF23LO_ppx0yy_FxFx_Np012_SM.2bjets.root"
+      },
+      {
+        "checksum": "adler32:e6db4928",
+        "size": 107936,
+        "uri": "root://eospublic.cern.ch//eos/opendata/atlas/rucio/opendata/ODEO_FEB2025_v0_2bjets_mc_345948.PowhegPy8EG_NNPDF30_AZNLOCTEQ6L1_VBFH125_WWlvlv.2bjets.root"
+      },
+      {
+        "checksum": "adler32:34b1fb6c",
+        "size": 341790,
+        "uri": "root://eospublic.cern.ch//eos/opendata/atlas/rucio/opendata/ODEO_FEB2025_v0_2bjets_mc_345949.PowhegPythia8EvtGen_NNPDF30_AZNLOCTEQ6L1_VBFH125_bb.2bjets.root"
+      },
+      {
+        "checksum": "adler32:a2718729",
+        "size": 55768,
+        "uri": "root://eospublic.cern.ch//eos/opendata/atlas/rucio/opendata/ODEO_FEB2025_v0_2bjets_mc_345961.PowhegPythia8EvtGen_NNLOPS_nnlo_30_ggH125_gamstargam.2bjets.root"
+      },
+      {
+        "checksum": "adler32:cd5a8bcb",
+        "size": 45194,
+        "uri": "root://eospublic.cern.ch//eos/opendata/atlas/rucio/opendata/ODEO_FEB2025_v0_2bjets_mc_345963.PowhegPythia8EvtGen_NNPDF30_AZNLO_WmH125J_Hgamstargam_MINLO.2bjets.root"
+      },
+      {
+        "checksum": "adler32:2e774858",
+        "size": 44993,
+        "uri": "root://eospublic.cern.ch//eos/opendata/atlas/rucio/opendata/ODEO_FEB2025_v0_2bjets_mc_345964.PowhegPythia8EvtGen_NNPDF30_AZNLO_WpH125J_Hgamstargam_MINLO.2bjets.root"
+      },
+      {
+        "checksum": "adler32:c1552ea7",
+        "size": 65462,
+        "uri": "root://eospublic.cern.ch//eos/opendata/atlas/rucio/opendata/ODEO_FEB2025_v0_2bjets_mc_345965.PowhegPythia8EvtGen_NNPDF30_AZNLO_ZH125J_Hgamstargam_MINLO.2bjets.root"
+      },
+      {
+        "checksum": "adler32:9e7ccd14",
+        "size": 188941,
+        "uri": "root://eospublic.cern.ch//eos/opendata/atlas/rucio/opendata/ODEO_FEB2025_v0_2bjets_mc_346188.aMcAtNloPythia8EvtGen_tHjb125_4fl_gamgam.2bjets.root"
+      },
+      {
+        "checksum": "adler32:f7e041b2",
+        "size": 526706,
+        "uri": "root://eospublic.cern.ch//eos/opendata/atlas/rucio/opendata/ODEO_FEB2025_v0_2bjets_mc_346189.aMcAtNloPythia8EvtGen_ttH_gamgam.2bjets.root"
+      },
+      {
+        "checksum": "adler32:6214f259",
+        "size": 103749,
+        "uri": "root://eospublic.cern.ch//eos/opendata/atlas/rucio/opendata/ODEO_FEB2025_v0_2bjets_mc_346190.PowhegPy8EG_NNPDF30_AZNLOCTEQ6L1_VBFH125_tautaul13l7.2bjets.root"
+      },
+      {
+        "checksum": "adler32:ff8a0cbd",
+        "size": 94662,
+        "uri": "root://eospublic.cern.ch//eos/opendata/atlas/rucio/opendata/ODEO_FEB2025_v0_2bjets_mc_346191.PowhegPy8EG_NNPDF30_AZNLOCTEQ6L1_VBFH125_tautaulm15hp20.2bjets.root"
+      },
+      {
+        "checksum": "adler32:b2f5ad77",
+        "size": 86576,
+        "uri": "root://eospublic.cern.ch//eos/opendata/atlas/rucio/opendata/ODEO_FEB2025_v0_2bjets_mc_346192.PowhegPy8EG_NNPDF30_AZNLOCTEQ6L1_VBFH125_tautaulp15hm20.2bjets.root"
+      },
+      {
+        "checksum": "adler32:a208c659",
+        "size": 140860,
+        "uri": "root://eospublic.cern.ch//eos/opendata/atlas/rucio/opendata/ODEO_FEB2025_v0_2bjets_mc_346193.PowhegPy8EG_NNPDF30_AZNLOCTEQ6L1_VBFH125_tautauh30h20.2bjets.root"
+      },
+      {
+        "checksum": "adler32:bd9d93a3",
+        "size": 185006,
+        "uri": "root://eospublic.cern.ch//eos/opendata/atlas/rucio/opendata/ODEO_FEB2025_v0_2bjets_mc_346194.PowhegPy8EG_NNPDF30_AZNLOCTEQ6L1_VBFH125_etau_filt.2bjets.root"
+      },
+      {
+        "checksum": "adler32:3dcf37e1",
+        "size": 173844,
+        "uri": "root://eospublic.cern.ch//eos/opendata/atlas/rucio/opendata/ODEO_FEB2025_v0_2bjets_mc_346195.PowhegPy8EG_NNPDF30_AZNLOCTEQ6L1_VBFH125_mutau_filt.2bjets.root"
+      },
+      {
+        "checksum": "adler32:85e94a4c",
+        "size": 1175128,
+        "uri": "root://eospublic.cern.ch//eos/opendata/atlas/rucio/opendata/ODEO_FEB2025_v0_2bjets_mc_346198.PhPy8EG_A14NNPDF23_NNPDF30ME_ttH125_Zgam.2bjets.root"
+      },
+      {
+        "checksum": "adler32:c6cfddc2",
+        "size": 41340,
+        "uri": "root://eospublic.cern.ch//eos/opendata/atlas/rucio/opendata/ODEO_FEB2025_v0_2bjets_mc_346214.PowhegPy8EG_NNPDF30_AZNLOCTEQ6L1_VBFH125_gamgam.2bjets.root"
+      },
+      {
+        "checksum": "adler32:2a7f5849",
+        "size": 197916,
+        "uri": "root://eospublic.cern.ch//eos/opendata/atlas/rucio/opendata/ODEO_FEB2025_v0_2bjets_mc_346228.PowhegPy8EG_NNPDF30_AZNLOCTEQ6L1_VBFH125_ZZ4lep_notau.2bjets.root"
+      },
+      {
+        "checksum": "adler32:45f0e5cf",
+        "size": 298260,
+        "uri": "root://eospublic.cern.ch//eos/opendata/atlas/rucio/opendata/ODEO_FEB2025_v0_2bjets_mc_346310.PowhegPythia8EvtGen_NNPDF30_AZNLO_ZH125J_Zincl_H_incl_MINLO.2bjets.root"
+      },
+      {
+        "checksum": "adler32:8032f2a3",
+        "size": 158617,
+        "uri": "root://eospublic.cern.ch//eos/opendata/atlas/rucio/opendata/ODEO_FEB2025_v0_2bjets_mc_346311.PowhegPythia8EvtGen_NNPDF30_AZNLO_WpH125J_Wincl_H_incl_MINLO.2bjets.root"
+      },
+      {
+        "checksum": "adler32:d53e6f87",
+        "size": 136219,
+        "uri": "root://eospublic.cern.ch//eos/opendata/atlas/rucio/opendata/ODEO_FEB2025_v0_2bjets_mc_346312.PowhegPythia8EvtGen_NNPDF30_AZNLO_WmH125J_Wincl_H_incl_MINLO.2bjets.root"
+      },
+      {
+        "checksum": "adler32:46efed41",
+        "size": 564449,
+        "uri": "root://eospublic.cern.ch//eos/opendata/atlas/rucio/opendata/ODEO_FEB2025_v0_2bjets_mc_346317.PowhegPy8EG_NNPDF30_AZNLOCTEQ6L1_VBFH125_incl.2bjets.root"
+      },
+      {
+        "checksum": "adler32:834d2f3c",
+        "size": 466325,
+        "uri": "root://eospublic.cern.ch//eos/opendata/atlas/rucio/opendata/ODEO_FEB2025_v0_2bjets_mc_346340.PowhegPy8EG_A14NNPDF23_NNPDF30ME_ttH125_ZZ4l_allhad.2bjets.root"
+      },
+      {
+        "checksum": "adler32:d387d8ae",
+        "size": 333025,
+        "uri": "root://eospublic.cern.ch//eos/opendata/atlas/rucio/opendata/ODEO_FEB2025_v0_2bjets_mc_346341.PowhegPy8EG_A14NNPDF23_NNPDF30ME_ttH125_ZZ4l_semilep.2bjets.root"
+      },
+      {
+        "checksum": "adler32:b6f194fd",
+        "size": 204400,
+        "uri": "root://eospublic.cern.ch//eos/opendata/atlas/rucio/opendata/ODEO_FEB2025_v0_2bjets_mc_346342.PowhegPy8EG_A14NNPDF23_NNPDF30ME_ttH125_ZZ4l_dilep.2bjets.root"
+      },
+      {
+        "checksum": "adler32:0bbcc1d5",
+        "size": 2506967,
+        "uri": "root://eospublic.cern.ch//eos/opendata/atlas/rucio/opendata/ODEO_FEB2025_v0_2bjets_mc_346343.PhPy8EG_A14NNPDF23_NNPDF30ME_ttH125_allhad.2bjets.root"
+      },
+      {
+        "checksum": "adler32:c1856693",
+        "size": 1388339,
+        "uri": "root://eospublic.cern.ch//eos/opendata/atlas/rucio/opendata/ODEO_FEB2025_v0_2bjets_mc_346344.PhPy8EG_A14NNPDF23_NNPDF30ME_ttH125_semilep.2bjets.root"
+      },
+      {
+        "checksum": "adler32:a846a6f8",
+        "size": 1945265,
+        "uri": "root://eospublic.cern.ch//eos/opendata/atlas/rucio/opendata/ODEO_FEB2025_v0_2bjets_mc_346345.PhPy8EG_A14NNPDF23_NNPDF30ME_ttH125_dilep.2bjets.root"
+      },
+      {
+        "checksum": "adler32:e8b5654d",
+        "size": 150087,
+        "uri": "root://eospublic.cern.ch//eos/opendata/atlas/rucio/opendata/ODEO_FEB2025_v0_2bjets_mc_346398.PowhegHerwig7EvtGen_NNPDF3_AZNLO_ZH125J_MINLO_vvbb_VpT.2bjets.root"
+      },
+      {
+        "checksum": "adler32:c3e5e553",
+        "size": 240689,
+        "uri": "root://eospublic.cern.ch//eos/opendata/atlas/rucio/opendata/ODEO_FEB2025_v0_2bjets_mc_346400.PowhegHerwig7EvtGen_NNPDF3_AZNLO_ggZH125J_vvbb.2bjets.root"
+      },
+      {
+        "checksum": "adler32:a425a33e",
+        "size": 245558,
+        "uri": "root://eospublic.cern.ch//eos/opendata/atlas/rucio/opendata/ODEO_FEB2025_v0_2bjets_mc_346414.aMcAtNloPythia8EvtGen_tHjb125_4fl_ZZ4l.2bjets.root"
+      },
+      {
+        "checksum": "adler32:80f65a40",
+        "size": 519900,
+        "uri": "root://eospublic.cern.ch//eos/opendata/atlas/rucio/opendata/ODEO_FEB2025_v0_2bjets_mc_346446.PhH7EG_H7UE_NNLOPS_nnlo_30_ggH125_ZZ4l_noTau.2bjets.root"
+      },
+      {
+        "checksum": "adler32:dc28cd0d",
+        "size": 189213,
+        "uri": "root://eospublic.cern.ch//eos/opendata/atlas/rucio/opendata/ODEO_FEB2025_v0_2bjets_mc_346447.PhH7EG_H7UE_NNPDF30_VBFH125_ZZ4lep_noTau.2bjets.root"
+      },
+      {
+        "checksum": "adler32:2aba6dfa",
+        "size": 254592,
+        "uri": "root://eospublic.cern.ch//eos/opendata/atlas/rucio/opendata/ODEO_FEB2025_v0_2bjets_mc_346448.PhH7EG_H7UE_NNPDF30_ZH125J_Zincl_MINLO.2bjets.root"
+      },
+      {
+        "checksum": "adler32:1b36a344",
+        "size": 184065,
+        "uri": "root://eospublic.cern.ch//eos/opendata/atlas/rucio/opendata/ODEO_FEB2025_v0_2bjets_mc_346449.PhH7EG_H7UE_NNPDF30_WpH125J_Wincl_MINLO.2bjets.root"
+      },
+      {
+        "checksum": "adler32:b9fa8756",
+        "size": 106094,
+        "uri": "root://eospublic.cern.ch//eos/opendata/atlas/rucio/opendata/ODEO_FEB2025_v0_2bjets_mc_346450.PhH7EG_H7UE_NNPDF30_WmH125J_Wincl_MINLO.2bjets.root"
+      },
+      {
+        "checksum": "adler32:29952602",
+        "size": 167424,
+        "uri": "root://eospublic.cern.ch//eos/opendata/atlas/rucio/opendata/ODEO_FEB2025_v0_2bjets_mc_346451.PhH7EG_H7UE_NNPDF3_ggZH125_ZZ4lepZinc.2bjets.root"
+      },
+      {
+        "checksum": "adler32:1badeebc",
+        "size": 458316,
+        "uri": "root://eospublic.cern.ch//eos/opendata/atlas/rucio/opendata/ODEO_FEB2025_v0_2bjets_mc_346452.PhH7EG_H7UE_NNPDF30ME_ttH125_ZZ4l_allhad_noTau.2bjets.root"
+      },
+      {
+        "checksum": "adler32:e1a9c5e5",
+        "size": 347717,
+        "uri": "root://eospublic.cern.ch//eos/opendata/atlas/rucio/opendata/ODEO_FEB2025_v0_2bjets_mc_346453.PhH7EG_H7UE_NNPDF30ME_ttH125_ZZ4l_semilep_noTau.2bjets.root"
+      },
+      {
+        "checksum": "adler32:f268e528",
+        "size": 225893,
+        "uri": "root://eospublic.cern.ch//eos/opendata/atlas/rucio/opendata/ODEO_FEB2025_v0_2bjets_mc_346454.PhH7EG_H7UE_NNPDF30ME_ttH125_ZZ4l_dilep_noTau.2bjets.root"
+      },
+      {
+        "checksum": "adler32:d8cd5d98",
+        "size": 219821,
+        "uri": "root://eospublic.cern.ch//eos/opendata/atlas/rucio/opendata/ODEO_FEB2025_v0_2bjets_mc_346486.aMcAtNloPythia8EvtGen_tWH125_yy.2bjets.root"
+      },
+      {
+        "checksum": "adler32:8bfed01e",
+        "size": 380761,
+        "uri": "root://eospublic.cern.ch//eos/opendata/atlas/rucio/opendata/ODEO_FEB2025_v0_2bjets_mc_346511.aMcAtNloPythia8EvtGen_tWH125_ZZ4l.2bjets.root"
+      },
+      {
+        "checksum": "adler32:f8cc12d5",
+        "size": 109069,
+        "uri": "root://eospublic.cern.ch//eos/opendata/atlas/rucio/opendata/ODEO_FEB2025_v0_2bjets_mc_346524.PowhegPythia8EvtGen_NNPDF3_AZNLO_ggZH125J_MINLO_ZinclWWlvlv.2bjets.root"
+      },
+      {
+        "checksum": "adler32:bff22499",
+        "size": 1089893,
+        "uri": "root://eospublic.cern.ch//eos/opendata/atlas/rucio/opendata/ODEO_FEB2025_v0_2bjets_mc_346525.PowhegPythia8EvtGen_A14NNPDF23_NNPDF30ME_ttH125_gamgam.2bjets.root"
+      },
+      {
+        "checksum": "adler32:eb4e601a",
+        "size": 1240119,
+        "uri": "root://eospublic.cern.ch//eos/opendata/atlas/rucio/opendata/ODEO_FEB2025_v0_2bjets_mc_346526.PowhegHerwig7EvtGen_H7UE_NNPDF30ME_ttH125_gamgam.2bjets.root"
+      },
+      {
+        "checksum": "adler32:720ecee9",
+        "size": 98737,
+        "uri": "root://eospublic.cern.ch//eos/opendata/atlas/rucio/opendata/ODEO_FEB2025_v0_2bjets_mc_346588.PowhegPythia8EvtGen_NNLOPS_nnlo_30_ggH125_ZZ4nu_MET75.2bjets.root"
+      },
+      {
+        "checksum": "adler32:554165d3",
+        "size": 780537,
+        "uri": "root://eospublic.cern.ch//eos/opendata/atlas/rucio/opendata/ODEO_FEB2025_v0_2bjets_mc_346601.aMcAtNloHerwig7EvtGen_MEN30NLO_ttH125_gamgam.2bjets.root"
+      },
+      {
+        "checksum": "adler32:236569b9",
+        "size": 155635,
+        "uri": "root://eospublic.cern.ch//eos/opendata/atlas/rucio/opendata/ODEO_FEB2025_v0_2bjets_mc_346602.aMcAtNloHerwig7EvtGen_MEN30NLO_tHjb125_gamgam.2bjets.root"
+      },
+      {
+        "checksum": "adler32:e1642a67",
+        "size": 90928,
+        "uri": "root://eospublic.cern.ch//eos/opendata/atlas/rucio/opendata/ODEO_FEB2025_v0_2bjets_mc_346605.PowhegPythia8EvtGen_NNPDF30_AZNLO_WpH125J_WinclHinv_MET75.2bjets.root"
+      },
+      {
+        "checksum": "adler32:c2586a2d",
+        "size": 108044,
+        "uri": "root://eospublic.cern.ch//eos/opendata/atlas/rucio/opendata/ODEO_FEB2025_v0_2bjets_mc_346606.PowhegPythia8EvtGen_NNPDF30_AZNLO_WmH125J_WinclHinv_MET75.2bjets.root"
+      },
+      {
+        "checksum": "adler32:8f6befe8",
+        "size": 167426,
+        "uri": "root://eospublic.cern.ch//eos/opendata/atlas/rucio/opendata/ODEO_FEB2025_v0_2bjets_mc_346607.PowhegPythia8EvtGen_NNPDF30_AZNLO_ZH125J_ZinclHinv_MET75.2bjets.root"
+      },
+      {
+        "checksum": "adler32:b885d8a5",
+        "size": 1089972,
+        "uri": "root://eospublic.cern.ch//eos/opendata/atlas/rucio/opendata/ODEO_FEB2025_v0_2bjets_mc_346632.PowhegPy8EG_A14NNPDF23_NNPDF30ME_ttH125_ZZ4nu_semilep.2bjets.root"
+      },
+      {
+        "checksum": "adler32:866809a9",
+        "size": 1185438,
+        "uri": "root://eospublic.cern.ch//eos/opendata/atlas/rucio/opendata/ODEO_FEB2025_v0_2bjets_mc_346633.PowhegPy8EG_A14NNPDF23_NNPDF30ME_ttH125_ZZ4nu_allhad.2bjets.root"
+      },
+      {
+        "checksum": "adler32:7a98ad42",
+        "size": 183288,
+        "uri": "root://eospublic.cern.ch//eos/opendata/atlas/rucio/opendata/ODEO_FEB2025_v0_2bjets_mc_346634.PowhegPy8EG_A14NNPDF23_NNPDF30ME_ttH125_ZZ4nu_dilep.2bjets.root"
+      },
+      {
+        "checksum": "adler32:7527cd80",
+        "size": 360032,
+        "uri": "root://eospublic.cern.ch//eos/opendata/atlas/rucio/opendata/ODEO_FEB2025_v0_2bjets_mc_346645.PowhegPythia8EvtGen_NNPDF30_AZNLO_ZH125J_Zincl_MINLO_shw.2bjets.root"
+      },
+      {
+        "checksum": "adler32:78611c51",
+        "size": 183186,
+        "uri": "root://eospublic.cern.ch//eos/opendata/atlas/rucio/opendata/ODEO_FEB2025_v0_2bjets_mc_346646.PowhegPythia8EvtGen_NNPDF30_AZNLO_WpH125J_Wincl_MINLO_shw.2bjets.root"
+      },
+      {
+        "checksum": "adler32:0cbbfdaa",
+        "size": 105796,
+        "uri": "root://eospublic.cern.ch//eos/opendata/atlas/rucio/opendata/ODEO_FEB2025_v0_2bjets_mc_346647.PowhegPythia8EvtGen_NNPDF30_AZNLO_WmH125J_Wincl_MINLO_shw.2bjets.root"
+      },
+      {
+        "checksum": "adler32:2dc70247",
+        "size": 783587,
+        "uri": "root://eospublic.cern.ch//eos/opendata/atlas/rucio/opendata/ODEO_FEB2025_v0_2bjets_mc_346726.PowhegHerwig7EvtGen_NNPDF3_AZNLO_ZH125J_MINLO_vvcc_VpT.2bjets.root"
+      },
+      {
+        "checksum": "adler32:556d0ead",
+        "size": 240844,
+        "uri": "root://eospublic.cern.ch//eos/opendata/atlas/rucio/opendata/ODEO_FEB2025_v0_2bjets_mc_346728.PowhegHerwig7EvtGen_NNPDF3_AZNLO_ggZH125J_vvcc.2bjets.root"
+      },
+      {
+        "checksum": "adler32:a89a399a",
+        "size": 672716,
+        "uri": "root://eospublic.cern.ch//eos/opendata/atlas/rucio/opendata/ODEO_FEB2025_v0_2bjets_mc_346797.PhH7EG_H7UE_NNLOPS_nnlo_30_ggH125_gamgam.2bjets.root"
+      },
+      {
+        "checksum": "adler32:01e5fdff",
+        "size": 443213,
+        "uri": "root://eospublic.cern.ch//eos/opendata/atlas/rucio/opendata/ODEO_FEB2025_v0_2bjets_mc_346802.PhH7EG_NNLOPS_nnlo_30_ggH125_WWlvlv_noTau.2bjets.root"
+      },
+      {
+        "checksum": "adler32:e984c261",
+        "size": 77677,
+        "uri": "root://eospublic.cern.ch//eos/opendata/atlas/rucio/opendata/ODEO_FEB2025_v0_2bjets_mc_346877.PhH7EG_NNPDF30_VBFH125_WWlvlv.2bjets.root"
+      },
+      {
+        "checksum": "adler32:d13d7e7e",
+        "size": 144363,
+        "uri": "root://eospublic.cern.ch//eos/opendata/atlas/rucio/opendata/ODEO_FEB2025_v0_2bjets_mc_346878.PhH7EG_H7UE_NNPDF30_VBF125_gammagamma.2bjets.root"
+      },
+      {
+        "checksum": "adler32:2b6cb109",
+        "size": 137440,
+        "uri": "root://eospublic.cern.ch//eos/opendata/atlas/rucio/opendata/ODEO_FEB2025_v0_2bjets_mc_346879.PhH7EG_H7UE_NNPDF30_ZH125J_Zincl_MINLO_gammagamma.2bjets.root"
+      },
+      {
+        "checksum": "adler32:dbad3806",
+        "size": 57962,
+        "uri": "root://eospublic.cern.ch//eos/opendata/atlas/rucio/opendata/ODEO_FEB2025_v0_2bjets_mc_346880.PhH7EG_H7UE_NNPDF30_WmH125J_Wincl_MINLO_gammagamma.2bjets.root"
+      },
+      {
+        "checksum": "adler32:91aadd25",
+        "size": 92523,
+        "uri": "root://eospublic.cern.ch//eos/opendata/atlas/rucio/opendata/ODEO_FEB2025_v0_2bjets_mc_346881.PhH7EG_H7UE_NNPDF30_WpH125J_Wincl_MINLO_gammagamma.2bjets.root"
+      },
+      {
+        "checksum": "adler32:6e2d3cf5",
+        "size": 81141,
+        "uri": "root://eospublic.cern.ch//eos/opendata/atlas/rucio/opendata/ODEO_FEB2025_v0_2bjets_mc_346882.PhH7EG_H7UE_NNPDF30_ggZH125_gammagamma.2bjets.root"
+      },
+      {
+        "checksum": "adler32:70857595",
+        "size": 2609036,
+        "uri": "root://eospublic.cern.ch//eos/opendata/atlas/rucio/opendata/ODEO_FEB2025_v0_2bjets_mc_346919.PhPy8EG_A14NNPDF23_NNPDF30ME_ttH125_allhad_tautau_unpol.2bjets.root"
+      },
+      {
+        "checksum": "adler32:9ea5f32c",
+        "size": 1504687,
+        "uri": "root://eospublic.cern.ch//eos/opendata/atlas/rucio/opendata/ODEO_FEB2025_v0_2bjets_mc_346923.PhPy8EG_A14NNPDF23_NNPDF30ME_ttH125_semilep_tautau_unpol.2bjets.root"
+      },
+      {
+        "checksum": "adler32:e99ed236",
+        "size": 695587,
+        "uri": "root://eospublic.cern.ch//eos/opendata/atlas/rucio/opendata/ODEO_FEB2025_v0_2bjets_mc_346927.PhPy8EG_A14NNPDF23_NNPDF30ME_ttH125_dilep_tautau_unpol.2bjets.root"
+      },
+      {
+        "checksum": "adler32:dda9fbfc",
+        "size": 165269,
+        "uri": "root://eospublic.cern.ch//eos/opendata/atlas/rucio/opendata/ODEO_FEB2025_v0_2bjets_mc_364242.Sherpa_222_NNPDF30NNLO_WWW_3l3v_EW6.2bjets.root"
+      },
+      {
+        "checksum": "adler32:6727512d",
+        "size": 79241,
+        "uri": "root://eospublic.cern.ch//eos/opendata/atlas/rucio/opendata/ODEO_FEB2025_v0_2bjets_mc_364243.Sherpa_222_NNPDF30NNLO_WWZ_4l2v_EW6.2bjets.root"
+      },
+      {
+        "checksum": "adler32:2206213f",
+        "size": 52859,
+        "uri": "root://eospublic.cern.ch//eos/opendata/atlas/rucio/opendata/ODEO_FEB2025_v0_2bjets_mc_364244.Sherpa_222_NNPDF30NNLO_WWZ_2l4v_EW6.2bjets.root"
+      },
+      {
+        "checksum": "adler32:1f15556d",
+        "size": 89107,
+        "uri": "root://eospublic.cern.ch//eos/opendata/atlas/rucio/opendata/ODEO_FEB2025_v0_2bjets_mc_364245.Sherpa_222_NNPDF30NNLO_WZZ_5l1v_EW6.2bjets.root"
+      },
+      {
+        "checksum": "adler32:9ffe30ab",
+        "size": 58427,
+        "uri": "root://eospublic.cern.ch//eos/opendata/atlas/rucio/opendata/ODEO_FEB2025_v0_2bjets_mc_364246.Sherpa_222_NNPDF30NNLO_WZZ_3l3v_EW6.2bjets.root"
+      },
+      {
+        "checksum": "adler32:84da2cbe",
+        "size": 76469,
+        "uri": "root://eospublic.cern.ch//eos/opendata/atlas/rucio/opendata/ODEO_FEB2025_v0_2bjets_mc_364247.Sherpa_222_NNPDF30NNLO_ZZZ_6l0v_EW6.2bjets.root"
+      },
+      {
+        "checksum": "adler32:0b34260d",
+        "size": 33074,
+        "uri": "root://eospublic.cern.ch//eos/opendata/atlas/rucio/opendata/ODEO_FEB2025_v0_2bjets_mc_364248.Sherpa_222_NNPDF30NNLO_ZZZ_4l2v_EW6.2bjets.root"
+      },
+      {
+        "checksum": "adler32:ca7efbc5",
+        "size": 37585,
+        "uri": "root://eospublic.cern.ch//eos/opendata/atlas/rucio/opendata/ODEO_FEB2025_v0_2bjets_mc_364249.Sherpa_222_NNPDF30NNLO_ZZZ_2l4v_EW6.2bjets.root"
+      },
+      {
+        "checksum": "adler32:b7f70ef8",
+        "size": 81440,
+        "uri": "root://eospublic.cern.ch//eos/opendata/atlas/rucio/opendata/ODEO_FEB2025_v0_2bjets_mc_364336.Sherpa_222_NNPDF30NNLO_WpWpWn_sslvlvjj_EW6.2bjets.root"
+      },
+      {
+        "checksum": "adler32:a31fa3f4",
+        "size": 79061,
+        "uri": "root://eospublic.cern.ch//eos/opendata/atlas/rucio/opendata/ODEO_FEB2025_v0_2bjets_mc_364337.Sherpa_222_NNPDF30NNLO_WnWnWp_sslvlvjj_EW6.2bjets.root"
+      },
+      {
+        "checksum": "adler32:d31a882b",
+        "size": 52183,
+        "uri": "root://eospublic.cern.ch//eos/opendata/atlas/rucio/opendata/ODEO_FEB2025_v0_2bjets_mc_364338.Sherpa_222_NNPDF30NNLO_WpWpWn_oslvlvjj_EW6.2bjets.root"
+      },
+      {
+        "checksum": "adler32:1cfc54ac",
+        "size": 36628,
+        "uri": "root://eospublic.cern.ch//eos/opendata/atlas/rucio/opendata/ODEO_FEB2025_v0_2bjets_mc_364339.Sherpa_222_NNPDF30NNLO_WnWnWp_oslvlvjj_EW6.2bjets.root"
+      },
+      {
+        "checksum": "adler32:58d7fab3",
+        "size": 433771,
+        "uri": "root://eospublic.cern.ch//eos/opendata/atlas/rucio/opendata/ODEO_FEB2025_v0_2bjets_mc_364350.Sherpa_224_NNPDF30NNLO_Diphoton_myy_0_50.2bjets.root"
+      },
+      {
+        "checksum": "adler32:97ce5f8e",
+        "size": 3281697,
+        "uri": "root://eospublic.cern.ch//eos/opendata/atlas/rucio/opendata/ODEO_FEB2025_v0_2bjets_mc_364351.Sherpa_224_NNPDF30NNLO_Diphoton_myy_50_90.2bjets.root"
+      },
+      {
+        "checksum": "adler32:d8714fd2",
+        "size": 1575062,
+        "uri": "root://eospublic.cern.ch//eos/opendata/atlas/rucio/opendata/ODEO_FEB2025_v0_2bjets_mc_364352.Sherpa_224_NNPDF30NNLO_Diphoton_myy_90_175.2bjets.root"
+      },
+      {
+        "checksum": "adler32:c5999684",
+        "size": 497723,
+        "uri": "root://eospublic.cern.ch//eos/opendata/atlas/rucio/opendata/ODEO_FEB2025_v0_2bjets_mc_364353.Sherpa_224_NNPDF30NNLO_Diphoton_myy_175_2000.2bjets.root"
+      },
+      {
+        "checksum": "adler32:840cfe95",
+        "size": 45453,
+        "uri": "root://eospublic.cern.ch//eos/opendata/atlas/rucio/opendata/ODEO_FEB2025_v0_2bjets_mc_364354.Sherpa_224_NNPDF30NNLO_Diphoton_myy_2000_E_CMS.2bjets.root"
+      },
+      {
+        "checksum": "adler32:c3355f74",
+        "size": 2284445,
+        "uri": "root://eospublic.cern.ch//eos/opendata/atlas/rucio/opendata/ODEO_FEB2025_v0_2bjets_mc_364541.Sherpa_222_NNPDF30NNLO_SinglePhoton_pty_17_35.2bjets.root"
+      },
+      {
+        "checksum": "adler32:e05fbdb9",
+        "size": 3379157,
+        "uri": "root://eospublic.cern.ch//eos/opendata/atlas/rucio/opendata/ODEO_FEB2025_v0_2bjets_mc_364542.Sherpa_222_NNPDF30NNLO_SinglePhoton_pty_35_70.2bjets.root"
+      },
+      {
+        "checksum": "adler32:d92b9f70",
+        "size": 5135705,
+        "uri": "root://eospublic.cern.ch//eos/opendata/atlas/rucio/opendata/ODEO_FEB2025_v0_2bjets_mc_364543.Sherpa_222_NNPDF30NNLO_SinglePhoton_pty_70_140.2bjets.root"
+      },
+      {
+        "checksum": "adler32:c434beff",
+        "size": 6724455,
+        "uri": "root://eospublic.cern.ch//eos/opendata/atlas/rucio/opendata/ODEO_FEB2025_v0_2bjets_mc_364544.Sherpa_222_NNPDF30NNLO_SinglePhoton_pty_140_280.2bjets.root"
+      },
+      {
+        "checksum": "adler32:c0d7761d",
+        "size": 1280296,
+        "uri": "root://eospublic.cern.ch//eos/opendata/atlas/rucio/opendata/ODEO_FEB2025_v0_2bjets_mc_364545.Sherpa_222_NNPDF30NNLO_SinglePhoton_pty_280_500.2bjets.root"
+      },
+      {
+        "checksum": "adler32:fea783e7",
+        "size": 115153,
+        "uri": "root://eospublic.cern.ch//eos/opendata/atlas/rucio/opendata/ODEO_FEB2025_v0_2bjets_mc_364546.Sherpa_222_NNPDF30NNLO_SinglePhoton_pty_500_1000.2bjets.root"
+      },
+      {
+        "checksum": "adler32:bf442164",
+        "size": 135828,
+        "uri": "root://eospublic.cern.ch//eos/opendata/atlas/rucio/opendata/ODEO_FEB2025_v0_2bjets_mc_364547.Sherpa_222_NNPDF30NNLO_SinglePhoton_pty_1000_E_CMS.2bjets.root"
+      },
+      {
+        "checksum": "adler32:73af3fe1",
+        "size": 3933193,
+        "uri": "root://eospublic.cern.ch//eos/opendata/atlas/rucio/opendata/ODEO_FEB2025_v0_2bjets_mc_364700.Pythia8EvtGen_A14NNPDF23LO_jetjet_JZ0WithSW.2bjets.root"
+      },
+      {
+        "checksum": "adler32:ec754a5b",
+        "size": 6476428,
+        "uri": "root://eospublic.cern.ch//eos/opendata/atlas/rucio/opendata/ODEO_FEB2025_v0_2bjets_mc_364701.Pythia8EvtGen_A14NNPDF23LO_jetjet_JZ1WithSW.2bjets.root"
+      },
+      {
+        "checksum": "adler32:68dab965",
+        "size": 33816904,
+        "uri": "root://eospublic.cern.ch//eos/opendata/atlas/rucio/opendata/ODEO_FEB2025_v0_2bjets_mc_364702.Pythia8EvtGen_A14NNPDF23LO_jetjet_JZ2WithSW.2bjets.root"
+      },
+      {
+        "checksum": "adler32:3bade9a9",
+        "size": 61615283,
+        "uri": "root://eospublic.cern.ch//eos/opendata/atlas/rucio/opendata/ODEO_FEB2025_v0_2bjets_mc_364703.Pythia8EvtGen_A14NNPDF23LO_jetjet_JZ3WithSW.2bjets.root"
+      },
+      {
+        "checksum": "adler32:fbc112b5",
+        "size": 73783881,
+        "uri": "root://eospublic.cern.ch//eos/opendata/atlas/rucio/opendata/ODEO_FEB2025_v0_2bjets_mc_364704.Pythia8EvtGen_A14NNPDF23LO_jetjet_JZ4WithSW.2bjets.root"
+      },
+      {
+        "checksum": "adler32:0f0f2dd5",
+        "size": 8904787,
+        "uri": "root://eospublic.cern.ch//eos/opendata/atlas/rucio/opendata/ODEO_FEB2025_v0_2bjets_mc_364705.Pythia8EvtGen_A14NNPDF23LO_jetjet_JZ5WithSW.2bjets.root"
+      },
+      {
+        "checksum": "adler32:02a771b3",
+        "size": 388719,
+        "uri": "root://eospublic.cern.ch//eos/opendata/atlas/rucio/opendata/ODEO_FEB2025_v0_2bjets_mc_364706.Pythia8EvtGen_A14NNPDF23LO_jetjet_JZ6WithSW.2bjets.root"
+      },
+      {
+        "checksum": "adler32:177f3ff2",
+        "size": 214084,
+        "uri": "root://eospublic.cern.ch//eos/opendata/atlas/rucio/opendata/ODEO_FEB2025_v0_2bjets_mc_364707.Pythia8EvtGen_A14NNPDF23LO_jetjet_JZ7WithSW.2bjets.root"
+      },
+      {
+        "checksum": "adler32:d6f1ce98",
+        "size": 432387,
+        "uri": "root://eospublic.cern.ch//eos/opendata/atlas/rucio/opendata/ODEO_FEB2025_v0_2bjets_mc_364708.Pythia8EvtGen_A14NNPDF23LO_jetjet_JZ8WithSW.2bjets.root"
+      },
+      {
+        "checksum": "adler32:595c6202",
+        "size": 386343,
+        "uri": "root://eospublic.cern.ch//eos/opendata/atlas/rucio/opendata/ODEO_FEB2025_v0_2bjets_mc_364709.Pythia8EvtGen_A14NNPDF23LO_jetjet_JZ9WithSW.2bjets.root"
+      },
+      {
+        "checksum": "adler32:e4db8f14",
+        "size": 1087516,
+        "uri": "root://eospublic.cern.ch//eos/opendata/atlas/rucio/opendata/ODEO_FEB2025_v0_2bjets_mc_364710.Pythia8EvtGen_A14NNPDF23LO_jetjet_JZ10WithSW.2bjets.root"
+      },
+      {
+        "checksum": "adler32:7e2f220a",
+        "size": 506585,
+        "uri": "root://eospublic.cern.ch//eos/opendata/atlas/rucio/opendata/ODEO_FEB2025_v0_2bjets_mc_364711.Pythia8EvtGen_A14NNPDF23LO_jetjet_JZ11WithSW.2bjets.root"
+      },
+      {
+        "checksum": "adler32:55c1c41f",
+        "size": 986399,
+        "uri": "root://eospublic.cern.ch//eos/opendata/atlas/rucio/opendata/ODEO_FEB2025_v0_2bjets_mc_364712.Pythia8EvtGen_A14NNPDF23LO_jetjet_JZ12WithSW.2bjets.root"
+      },
+      {
+        "checksum": "adler32:41ed25b9",
+        "size": 153463,
+        "uri": "root://eospublic.cern.ch//eos/opendata/atlas/rucio/opendata/ODEO_FEB2025_v0_2bjets_mc_375884.MGPy8EG_A14N_GG_ttn1_2000_5000_200.2bjets.root"
+      },
+      {
+        "checksum": "adler32:e1f2e074",
+        "size": 38734,
+        "uri": "root://eospublic.cern.ch//eos/opendata/atlas/rucio/opendata/ODEO_FEB2025_v0_2bjets_mc_376359.MGPy8EG_A14N23LO_SS_onestepCC_1600_900_200.2bjets.root"
+      },
+      {
+        "checksum": "adler32:ac15b11d",
+        "size": 43636,
+        "uri": "root://eospublic.cern.ch//eos/opendata/atlas/rucio/opendata/ODEO_FEB2025_v0_2bjets_mc_376518.MadGraphPythia8EvtGen_A14NNPDF23LO_GG_direct_2400_200.2bjets.root"
+      },
+      {
+        "checksum": "adler32:1e11780c",
+        "size": 28694,
+        "uri": "root://eospublic.cern.ch//eos/opendata/atlas/rucio/opendata/ODEO_FEB2025_v0_2bjets_mc_392202.MGPy8EG_A14N23LO_C1N2_WZ_500p0_100p0_3L_2L7.2bjets.root"
+      },
+      {
+        "checksum": "adler32:e73c2724",
+        "size": 33568,
+        "uri": "root://eospublic.cern.ch//eos/opendata/atlas/rucio/opendata/ODEO_FEB2025_v0_2bjets_mc_394997.MGPy8EG_A14N23LO_SM_N2C1p_105_100_2L2MET75_MadSpin.2bjets.root"
+      },
+      {
+        "checksum": "adler32:1e000e45",
+        "size": 124488,
+        "uri": "root://eospublic.cern.ch//eos/opendata/atlas/rucio/opendata/ODEO_FEB2025_v0_2bjets_mc_398384.MGPy8EG_A14N23LO_C1N2N1_GGMHinoZh50_800_noFilter.2bjets.root"
+      },
+      {
+        "checksum": "adler32:82d1892c",
+        "size": 498248,
+        "uri": "root://eospublic.cern.ch//eos/opendata/atlas/rucio/opendata/ODEO_FEB2025_v0_2bjets_mc_410081.MadGraphPythia8EvtGen_A14NNPDF23_ttbarWW.2bjets.root"
+      },
+      {
+        "checksum": "adler32:4253bd72",
+        "size": 2195433,
+        "uri": "root://eospublic.cern.ch//eos/opendata/atlas/rucio/opendata/ODEO_FEB2025_v0_2bjets_mc_410082.MadGraphPythia8EvtGen_A14NNPDF23LO_ttgamma_noallhad.2bjets.root"
+      },
+      {
+        "checksum": "adler32:ffcbc566",
+        "size": 2025024,
+        "uri": "root://eospublic.cern.ch//eos/opendata/atlas/rucio/opendata/ODEO_FEB2025_v0_2bjets_mc_410087.MadGraphPythia8EvtGen_A14NNPDF23LO_ttgamma_allhad.2bjets.root"
+      },
+      {
+        "checksum": "adler32:d190eba4",
+        "size": 1197403,
+        "uri": "root://eospublic.cern.ch//eos/opendata/atlas/rucio/opendata/ODEO_FEB2025_v0_2bjets_mc_410155.aMcAtNloPythia8EvtGen_MEN30NLO_A14N23LO_ttW.2bjets.root"
+      },
+      {
+        "checksum": "adler32:8dfe88ea",
+        "size": 1009976,
+        "uri": "root://eospublic.cern.ch//eos/opendata/atlas/rucio/opendata/ODEO_FEB2025_v0_2bjets_mc_410156.aMcAtNloPythia8EvtGen_MEN30NLO_A14N23LO_ttZnunu.2bjets.root"
+      },
+      {
+        "checksum": "adler32:9b3be938",
+        "size": 2426979,
+        "uri": "root://eospublic.cern.ch//eos/opendata/atlas/rucio/opendata/ODEO_FEB2025_v0_2bjets_mc_410157.aMcAtNloPythia8EvtGen_MEN30NLO_A14N23LO_ttZqq.2bjets.root"
+      },
+      {
+        "checksum": "adler32:dda19710",
+        "size": 793041,
+        "uri": "root://eospublic.cern.ch//eos/opendata/atlas/rucio/opendata/ODEO_FEB2025_v0_2bjets_mc_410218.aMcAtNloPythia8EvtGen_MEN30NLO_A14N23LO_ttee.2bjets.root"
+      },
+      {
+        "checksum": "adler32:f3bb1343",
+        "size": 1338031,
+        "uri": "root://eospublic.cern.ch//eos/opendata/atlas/rucio/opendata/ODEO_FEB2025_v0_2bjets_mc_410219.aMcAtNloPythia8EvtGen_MEN30NLO_A14N23LO_ttmumu.2bjets.root"
+      },
+      {
+        "checksum": "adler32:7aeb17b2",
+        "size": 2254767,
+        "uri": "root://eospublic.cern.ch//eos/opendata/atlas/rucio/opendata/ODEO_FEB2025_v0_2bjets_mc_410220.aMcAtNloPythia8EvtGen_MEN30NLO_A14N23LO_tttautau.2bjets.root"
+      },
+      {
+        "checksum": "adler32:4649ddfb",
+        "size": 2869593,
+        "uri": "root://eospublic.cern.ch//eos/opendata/atlas/rucio/opendata/ODEO_FEB2025_v0_2bjets_mc_410389.MadGraphPythia8EvtGen_A14NNPDF23_ttgamma_nonallhadronic.2bjets.root"
+      },
+      {
+        "checksum": "adler32:c994a8c0",
+        "size": 2730846,
+        "uri": "root://eospublic.cern.ch//eos/opendata/atlas/rucio/opendata/ODEO_FEB2025_v0_2bjets_mc_410395.MGH7EG_H7UE_ttgamma_nonallhadronic.2bjets.root"
+      },
+      {
+        "checksum": "adler32:9e6085a9",
+        "size": 2972054,
+        "uri": "root://eospublic.cern.ch//eos/opendata/atlas/rucio/opendata/ODEO_FEB2025_v0_2bjets_mc_410396.MGH7EG_H7UE_ttgamma_allhadronic.2bjets.root"
+      },
+      {
+        "checksum": "adler32:80f6d121",
+        "size": 260455,
+        "uri": "root://eospublic.cern.ch//eos/opendata/atlas/rucio/opendata/ODEO_FEB2025_v0_2bjets_mc_410408.aMcAtNloPythia8EvtGen_tWZ_Ztoll_minDR1.2bjets.root"
+      },
+      {
+        "checksum": "adler32:3b567b1a",
+        "size": 195682136,
+        "uri": "root://eospublic.cern.ch//eos/opendata/atlas/rucio/opendata/ODEO_FEB2025_v0_2bjets_mc_410470.PhPy8EG_A14_ttbar_hdamp258p75_nonallhad.2bjets.root"
+      },
+      {
+        "checksum": "adler32:d2cdc3f2",
+        "size": 176548563,
+        "uri": "root://eospublic.cern.ch//eos/opendata/atlas/rucio/opendata/ODEO_FEB2025_v0_2bjets_mc_410471.PhPy8EG_A14_ttbar_hdamp258p75_allhad.2bjets.root"
+      },
+      {
+        "checksum": "adler32:9b3b3fa1",
+        "size": 619309,
+        "uri": "root://eospublic.cern.ch//eos/opendata/atlas/rucio/opendata/ODEO_FEB2025_v0_2bjets_mc_410560.MadGraphPythia8EvtGen_A14_tZ_4fl_tchan_noAllHad.2bjets.root"
+      },
+      {
+        "checksum": "adler32:61eb766f",
+        "size": 360526,
+        "uri": "root://eospublic.cern.ch//eos/opendata/atlas/rucio/opendata/ODEO_FEB2025_v0_2bjets_mc_410644.PowhegPythia8EvtGen_A14_singletop_schan_lept_top.2bjets.root"
+      },
+      {
+        "checksum": "adler32:97442d11",
+        "size": 272786,
+        "uri": "root://eospublic.cern.ch//eos/opendata/atlas/rucio/opendata/ODEO_FEB2025_v0_2bjets_mc_410645.PowhegPythia8EvtGen_A14_singletop_schan_lept_antitop.2bjets.root"
+      },
+      {
+        "checksum": "adler32:d9005bca",
+        "size": 5404117,
+        "uri": "root://eospublic.cern.ch//eos/opendata/atlas/rucio/opendata/ODEO_FEB2025_v0_2bjets_mc_410658.PhPy8EG_A14_tchan_BW50_lept_top.2bjets.root"
+      },
+      {
+        "checksum": "adler32:baee591a",
+        "size": 3360683,
+        "uri": "root://eospublic.cern.ch//eos/opendata/atlas/rucio/opendata/ODEO_FEB2025_v0_2bjets_mc_410659.PhPy8EG_A14_tchan_BW50_lept_antitop.2bjets.root"
+      },
+      {
+        "checksum": "adler32:c60b5d18",
+        "size": 44762966,
+        "uri": "root://eospublic.cern.ch//eos/opendata/atlas/rucio/opendata/ODEO_FEB2025_v0_2bjets_mc_411233.PowhegHerwig7EvtGen_tt_hdamp258p75_713_SingleLep.2bjets.root"
+      },
+      {
+        "checksum": "adler32:d2b6b11f",
+        "size": 12754827,
+        "uri": "root://eospublic.cern.ch//eos/opendata/atlas/rucio/opendata/ODEO_FEB2025_v0_2bjets_mc_411234.PowhegHerwig7EvtGen_tt_hdamp258p75_713_dil.2bjets.root"
+      },
+      {
+        "checksum": "adler32:3429c1fd",
+        "size": 251740986,
+        "uri": "root://eospublic.cern.ch//eos/opendata/atlas/rucio/opendata/ODEO_FEB2025_v0_2bjets_mc_411316.PowhegHerwig7EvtGen_tt_hdamp258p75_713_allhad.2bjets.root"
+      },
+      {
+        "checksum": "adler32:3c782c77",
+        "size": 4894377,
+        "uri": "root://eospublic.cern.ch//eos/opendata/atlas/rucio/opendata/ODEO_FEB2025_v0_2bjets_mc_412043.aMcAtNloPythia8EvtGen_A14NNPDF31_SM4topsNLO.2bjets.root"
+      },
+      {
+        "checksum": "adler32:8ada48bb",
+        "size": 4738951,
+        "uri": "root://eospublic.cern.ch//eos/opendata/atlas/rucio/opendata/ODEO_FEB2025_v0_2bjets_mc_412044.aMcAtNloHerwig7EvtGen_H7UE_SM4topsNLO.2bjets.root"
+      },
+      {
+        "checksum": "adler32:1fa824f3",
+        "size": 450118,
+        "uri": "root://eospublic.cern.ch//eos/opendata/atlas/rucio/opendata/ODEO_FEB2025_v0_2bjets_mc_423099.Pythia8EvtGen_A14NNPDF23LO_gammajet_DP8_17.2bjets.root"
+      },
+      {
+        "checksum": "adler32:46889277",
+        "size": 613105,
+        "uri": "root://eospublic.cern.ch//eos/opendata/atlas/rucio/opendata/ODEO_FEB2025_v0_2bjets_mc_423100.Pythia8EvtGen_A14NNPDF23LO_gammajet_DP17_35.2bjets.root"
+      },
+      {
+        "checksum": "adler32:f95bceda",
+        "size": 877471,
+        "uri": "root://eospublic.cern.ch//eos/opendata/atlas/rucio/opendata/ODEO_FEB2025_v0_2bjets_mc_423101.Pythia8EvtGen_A14NNPDF23LO_gammajet_DP35_50.2bjets.root"
+      },
+      {
+        "checksum": "adler32:84ff0a81",
+        "size": 1540673,
+        "uri": "root://eospublic.cern.ch//eos/opendata/atlas/rucio/opendata/ODEO_FEB2025_v0_2bjets_mc_423102.Pythia8EvtGen_A14NNPDF23LO_gammajet_DP50_70.2bjets.root"
+      },
+      {
+        "checksum": "adler32:fd4993f3",
+        "size": 1306641,
+        "uri": "root://eospublic.cern.ch//eos/opendata/atlas/rucio/opendata/ODEO_FEB2025_v0_2bjets_mc_423103.Pythia8EvtGen_A14NNPDF23LO_gammajet_DP70_140.2bjets.root"
+      },
+      {
+        "checksum": "adler32:d9707882",
+        "size": 1667577,
+        "uri": "root://eospublic.cern.ch//eos/opendata/atlas/rucio/opendata/ODEO_FEB2025_v0_2bjets_mc_423104.Pythia8EvtGen_A14NNPDF23LO_gammajet_DP140_280.2bjets.root"
+      },
+      {
+        "checksum": "adler32:cefb8176",
+        "size": 1322492,
+        "uri": "root://eospublic.cern.ch//eos/opendata/atlas/rucio/opendata/ODEO_FEB2025_v0_2bjets_mc_423105.Pythia8EvtGen_A14NNPDF23LO_gammajet_DP280_500.2bjets.root"
+      },
+      {
+        "checksum": "adler32:3c4a9913",
+        "size": 180969,
+        "uri": "root://eospublic.cern.ch//eos/opendata/atlas/rucio/opendata/ODEO_FEB2025_v0_2bjets_mc_423106.Pythia8EvtGen_A14NNPDF23LO_gammajet_DP500_800.2bjets.root"
+      },
+      {
+        "checksum": "adler32:75217495",
+        "size": 110137,
+        "uri": "root://eospublic.cern.ch//eos/opendata/atlas/rucio/opendata/ODEO_FEB2025_v0_2bjets_mc_423107.Pythia8EvtGen_A14NNPDF23LO_gammajet_DP800_1000.2bjets.root"
+      },
+      {
+        "checksum": "adler32:9f68e488",
+        "size": 146914,
+        "uri": "root://eospublic.cern.ch//eos/opendata/atlas/rucio/opendata/ODEO_FEB2025_v0_2bjets_mc_423108.Pythia8EvtGen_A14NNPDF23LO_gammajet_DP1000_1500.2bjets.root"
+      },
+      {
+        "checksum": "adler32:2a9bc5d7",
+        "size": 63749,
+        "uri": "root://eospublic.cern.ch//eos/opendata/atlas/rucio/opendata/ODEO_FEB2025_v0_2bjets_mc_423109.Pythia8EvtGen_A14NNPDF23LO_gammajet_DP1500_2000.2bjets.root"
+      },
+      {
+        "checksum": "adler32:09fdd6d1",
+        "size": 44668,
+        "uri": "root://eospublic.cern.ch//eos/opendata/atlas/rucio/opendata/ODEO_FEB2025_v0_2bjets_mc_423110.Pythia8EvtGen_A14NNPDF23LO_gammajet_DP2000_2500.2bjets.root"
+      },
+      {
+        "checksum": "adler32:4f23ef9b",
+        "size": 65939,
+        "uri": "root://eospublic.cern.ch//eos/opendata/atlas/rucio/opendata/ODEO_FEB2025_v0_2bjets_mc_423111.Pythia8EvtGen_A14NNPDF23LO_gammajet_DP2500_3000.2bjets.root"
+      },
+      {
+        "checksum": "adler32:a4b33c40",
+        "size": 73751,
+        "uri": "root://eospublic.cern.ch//eos/opendata/atlas/rucio/opendata/ODEO_FEB2025_v0_2bjets_mc_423112.Pythia8EvtGen_A14NNPDF23LO_gammajet_DP3000_inf.2bjets.root"
+      },
+      {
+        "checksum": "adler32:a461c237",
+        "size": 231194,
+        "uri": "root://eospublic.cern.ch//eos/opendata/atlas/rucio/opendata/ODEO_FEB2025_v0_2bjets_mc_448624.MGPy8EG_A14N23LO_TT_higgsinoRPV_1075_700.2bjets.root"
+      },
+      {
+        "checksum": "adler32:4ffc6f9e",
+        "size": 90134,
+        "uri": "root://eospublic.cern.ch//eos/opendata/atlas/rucio/opendata/ODEO_FEB2025_v0_2bjets_mc_449595.MGPy8EG_A14N23LO_TT_RPVdirectBL_1400.2bjets.root"
+      },
+      {
+        "checksum": "adler32:b8fdedf9",
+        "size": 118725,
+        "uri": "root://eospublic.cern.ch//eos/opendata/atlas/rucio/opendata/ODEO_FEB2025_v0_2bjets_mc_450576.PowhegPythia8EvtGen_NNLOPS_nnlo_30_VBFH125_ZZllbb.2bjets.root"
+      },
+      {
+        "checksum": "adler32:7b7a1026",
+        "size": 79694,
+        "uri": "root://eospublic.cern.ch//eos/opendata/atlas/rucio/opendata/ODEO_FEB2025_v0_2bjets_mc_500335.MGH7EG_VBFHWWlvlv.2bjets.root"
+      },
+      {
+        "checksum": "adler32:c776fefd",
+        "size": 41863,
+        "uri": "root://eospublic.cern.ch//eos/opendata/atlas/rucio/opendata/ODEO_FEB2025_v0_2bjets_mc_500553.aMCPy8EG_ZH_FxFx_Hyy.2bjets.root"
+      },
+      {
+        "checksum": "adler32:99095fd7",
+        "size": 37351,
+        "uri": "root://eospublic.cern.ch//eos/opendata/atlas/rucio/opendata/ODEO_FEB2025_v0_2bjets_mc_500554.aMCPy8EG_WH_FxFx_Hyy.2bjets.root"
+      },
+      {
+        "checksum": "adler32:4b57aa8a",
+        "size": 41790,
+        "uri": "root://eospublic.cern.ch//eos/opendata/atlas/rucio/opendata/ODEO_FEB2025_v0_2bjets_mc_500555.aMCPy8EG_ggZH_Hyy.2bjets.root"
+      },
+      {
+        "checksum": "adler32:cb0a4251",
+        "size": 49381,
+        "uri": "root://eospublic.cern.ch//eos/opendata/atlas/rucio/opendata/ODEO_FEB2025_v0_2bjets_mc_501058.MGPy8EG_StauStauDirect_200p0_1p0_TFilt.2bjets.root"
+      },
+      {
+        "checksum": "adler32:5021d368",
+        "size": 167889,
+        "uri": "root://eospublic.cern.ch//eos/opendata/atlas/rucio/opendata/ODEO_FEB2025_v0_2bjets_mc_506098.aMCPy8EG_WpH_FxFx_Htautau.2bjets.root"
+      },
+      {
+        "checksum": "adler32:10c113c7",
+        "size": 157108,
+        "uri": "root://eospublic.cern.ch//eos/opendata/atlas/rucio/opendata/ODEO_FEB2025_v0_2bjets_mc_506099.aMCPy8EG_ZH_FxFx_Htautau.2bjets.root"
+      },
+      {
+        "checksum": "adler32:0cf03797",
+        "size": 240956,
+        "uri": "root://eospublic.cern.ch//eos/opendata/atlas/rucio/opendata/ODEO_FEB2025_v0_2bjets_mc_506101.aMCH7EG_VBF_Htautauh30h20.2bjets.root"
+      },
+      {
+        "checksum": "adler32:a794632e",
+        "size": 119971,
+        "uri": "root://eospublic.cern.ch//eos/opendata/atlas/rucio/opendata/ODEO_FEB2025_v0_2bjets_mc_506102.aMCH7EG_VBF_Htautaul13l7.2bjets.root"
+      },
+      {
+        "checksum": "adler32:e1f3d951",
+        "size": 115099,
+        "uri": "root://eospublic.cern.ch//eos/opendata/atlas/rucio/opendata/ODEO_FEB2025_v0_2bjets_mc_506103.aMCH7EG_VBF_Htautaulp15hm20.2bjets.root"
+      },
+      {
+        "checksum": "adler32:81fdbde0",
+        "size": 158679,
+        "uri": "root://eospublic.cern.ch//eos/opendata/atlas/rucio/opendata/ODEO_FEB2025_v0_2bjets_mc_506104.aMCH7EG_VBF_Htautaulm15hp20.2bjets.root"
+      },
+      {
+        "checksum": "adler32:0d635907",
+        "size": 69778,
+        "uri": "root://eospublic.cern.ch//eos/opendata/atlas/rucio/opendata/ODEO_FEB2025_v0_2bjets_mc_506811.aMCH7EG_VBF_HC_Hyy.2bjets.root"
+      },
+      {
+        "checksum": "adler32:342121a2",
+        "size": 78407,
+        "uri": "root://eospublic.cern.ch//eos/opendata/atlas/rucio/opendata/ODEO_FEB2025_v0_2bjets_mc_506813.aMCPy8EG_ZH_had_FxFx_Hyy.2bjets.root"
+      },
+      {
+        "checksum": "adler32:0247ec84",
+        "size": 110337,
+        "uri": "root://eospublic.cern.ch//eos/opendata/atlas/rucio/opendata/ODEO_FEB2025_v0_2bjets_mc_506814.aMCPy8EG_ggZH_Zhad_Hyy.2bjets.root"
+      },
+      {
+        "checksum": "adler32:fced4726",
+        "size": 40699,
+        "uri": "root://eospublic.cern.ch//eos/opendata/atlas/rucio/opendata/ODEO_FEB2025_v0_2bjets_mc_507366.MGPy8EG_A14NNPDF23LO_GGM_N1N2C1_950.2bjets.root"
+      },
+      {
+        "checksum": "adler32:31c63110",
+        "size": 431854,
+        "uri": "root://eospublic.cern.ch//eos/opendata/atlas/rucio/opendata/ODEO_FEB2025_v0_2bjets_mc_510097.MGPy8EG_A14N23LO_DM_4topscalar_p1000_c1_nonallhad.2bjets.root"
+      },
+      {
+        "checksum": "adler32:e9df4328",
+        "size": 56792,
+        "uri": "root://eospublic.cern.ch//eos/opendata/atlas/rucio/opendata/ODEO_FEB2025_v0_2bjets_mc_523692.MGPy8EG_A14N23LO_TT_tN1_1200_200_MS.2bjets.root"
+      },
+      {
+        "checksum": "adler32:1c686e88",
+        "size": 2696032,
+        "uri": "root://eospublic.cern.ch//eos/opendata/atlas/rucio/opendata/ODEO_FEB2025_v0_2bjets_mc_600017.PhH7EG_H7UE_716_tchan_lept_antitop.2bjets.root"
+      },
+      {
+        "checksum": "adler32:90b9bddd",
+        "size": 4419624,
+        "uri": "root://eospublic.cern.ch//eos/opendata/atlas/rucio/opendata/ODEO_FEB2025_v0_2bjets_mc_600018.PhH7EG_H7UE_716_tchan_lept_top.2bjets.root"
+      },
+      {
+        "checksum": "adler32:1ede4970",
+        "size": 338036,
+        "uri": "root://eospublic.cern.ch//eos/opendata/atlas/rucio/opendata/ODEO_FEB2025_v0_2bjets_mc_600019.PhH7EG_H7UE_716_schan_lept_antitop.2bjets.root"
+      },
+      {
+        "checksum": "adler32:30cb8bf8",
+        "size": 345416,
+        "uri": "root://eospublic.cern.ch//eos/opendata/atlas/rucio/opendata/ODEO_FEB2025_v0_2bjets_mc_600020.PhH7EG_H7UE_716_schan_lept_top.2bjets.root"
+      },
+      {
+        "checksum": "adler32:437ba205",
+        "size": 827162,
+        "uri": "root://eospublic.cern.ch//eos/opendata/atlas/rucio/opendata/ODEO_FEB2025_v0_2bjets_mc_600565.PhH7EG_ggH125_tautauh30h20_ShowerSys_fix.2bjets.root"
+      },
+      {
+        "checksum": "adler32:8c56c131",
+        "size": 410411,
+        "uri": "root://eospublic.cern.ch//eos/opendata/atlas/rucio/opendata/ODEO_FEB2025_v0_2bjets_mc_600566.PhH7EG_ggH125_tautaul13l7_ShowerSys_fix.2bjets.root"
+      },
+      {
+        "checksum": "adler32:a411df3c",
+        "size": 234046,
+        "uri": "root://eospublic.cern.ch//eos/opendata/atlas/rucio/opendata/ODEO_FEB2025_v0_2bjets_mc_600567.PhH7EG_ggH125_ttlp15hm20_ShowerSys_fix.2bjets.root"
+      },
+      {
+        "checksum": "adler32:d8718eb2",
+        "size": 291168,
+        "uri": "root://eospublic.cern.ch//eos/opendata/atlas/rucio/opendata/ODEO_FEB2025_v0_2bjets_mc_600568.PhH7EG_ggH125_ttlm15hp20_ShowerSys_fix.2bjets.root"
+      },
+      {
+        "checksum": "adler32:bd5c9a15",
+        "size": 271467,
+        "uri": "root://eospublic.cern.ch//eos/opendata/atlas/rucio/opendata/ODEO_FEB2025_v0_2bjets_mc_600569.PhH7EG_VBFH125_tautauh30h20_ShowerSys_fix.2bjets.root"
+      },
+      {
+        "checksum": "adler32:1f7f4254",
+        "size": 115816,
+        "uri": "root://eospublic.cern.ch//eos/opendata/atlas/rucio/opendata/ODEO_FEB2025_v0_2bjets_mc_600570.PhH7EG_VBFH125_tautaul13l7_ShowerSys_fix.2bjets.root"
+      },
+      {
+        "checksum": "adler32:370ed4b4",
+        "size": 90402,
+        "uri": "root://eospublic.cern.ch//eos/opendata/atlas/rucio/opendata/ODEO_FEB2025_v0_2bjets_mc_600571.PhH7EG_VBFH125_tautaulp15hm20_ShowerSys_fix.2bjets.root"
+      },
+      {
+        "checksum": "adler32:f5397bbf",
+        "size": 92941,
+        "uri": "root://eospublic.cern.ch//eos/opendata/atlas/rucio/opendata/ODEO_FEB2025_v0_2bjets_mc_600572.PhH7EG_VBFH125_tautaulm15hp20_ShowerSys_fix.2bjets.root"
+      },
+      {
+        "checksum": "adler32:74b07a93",
+        "size": 115517,
+        "uri": "root://eospublic.cern.ch//eos/opendata/atlas/rucio/opendata/ODEO_FEB2025_v0_2bjets_mc_600573.PhH7EG_WmH125J_Winc_MINLO_tt_ShowerSys_fix.2bjets.root"
+      },
+      {
+        "checksum": "adler32:c87dd06e",
+        "size": 167336,
+        "uri": "root://eospublic.cern.ch//eos/opendata/atlas/rucio/opendata/ODEO_FEB2025_v0_2bjets_mc_600574.PhH7EG_WpH125J_Winc_MINLO_tt_ShowerSys_fix.2bjets.root"
+      },
+      {
+        "checksum": "adler32:d94b86a2",
+        "size": 221102,
+        "uri": "root://eospublic.cern.ch//eos/opendata/atlas/rucio/opendata/ODEO_FEB2025_v0_2bjets_mc_600575.PhH7EG_ZH125J_Zinc_MINLO_tautau_ShowerSys_fix.2bjets.root"
+      },
+      {
+        "checksum": "adler32:841e9fe3",
+        "size": 146916,
+        "uri": "root://eospublic.cern.ch//eos/opendata/atlas/rucio/opendata/ODEO_FEB2025_v0_2bjets_mc_600686.PhPy8EG_NNPDF3_AZNLO_ggZH125_Htautau_Zinc.2bjets.root"
+      },
+      {
+        "checksum": "adler32:3fe72314",
+        "size": 13446263,
+        "uri": "root://eospublic.cern.ch//eos/opendata/atlas/rucio/opendata/ODEO_FEB2025_v0_2bjets_mc_601352.PhPy8EG_tW_dyn_DR_incl_antitop.2bjets.root"
+      },
+      {
+        "checksum": "adler32:d9b2ce0c",
+        "size": 13336796,
+        "uri": "root://eospublic.cern.ch//eos/opendata/atlas/rucio/opendata/ODEO_FEB2025_v0_2bjets_mc_601355.PhPy8EG_tW_dyn_DR_incl_top.2bjets.root"
+      },
+      {
+        "checksum": "adler32:9f41dfa3",
+        "size": 2707135,
+        "uri": "root://eospublic.cern.ch//eos/opendata/atlas/rucio/opendata/ODEO_FEB2025_v0_2bjets_mc_601487.PhPy8EG_A14_tchan_pThard1_lep_antitop.2bjets.root"
+      },
+      {
+        "checksum": "adler32:5fe31173",
+        "size": 4040421,
+        "uri": "root://eospublic.cern.ch//eos/opendata/atlas/rucio/opendata/ODEO_FEB2025_v0_2bjets_mc_601489.PhPy8EG_A14_tchan_pThard1_lep_top.2bjets.root"
+      },
+      {
+        "checksum": "adler32:37ee0c76",
+        "size": 20210137,
+        "uri": "root://eospublic.cern.ch//eos/opendata/atlas/rucio/opendata/ODEO_FEB2025_v0_2bjets_mc_601491.PhPy8EG_A14_ttbar_pThard1_dil.2bjets.root"
+      },
+      {
+        "checksum": "adler32:495079dd",
+        "size": 1831271,
+        "uri": "root://eospublic.cern.ch//eos/opendata/atlas/rucio/opendata/ODEO_FEB2025_v0_2bjets_mc_601495.PhPy8EG_A14_ttbar_pThard1_allhad.2bjets.root"
+      },
+      {
+        "checksum": "adler32:7e42fa43",
+        "size": 151310143,
+        "uri": "root://eospublic.cern.ch//eos/opendata/atlas/rucio/opendata/ODEO_FEB2025_v0_2bjets_mc_601497.PhPy8EG_A14_ttbar_pThard1_singlelep.2bjets.root"
+      },
+      {
+        "checksum": "adler32:af305c7b",
+        "size": 582351,
+        "uri": "root://eospublic.cern.ch//eos/opendata/atlas/rucio/opendata/ODEO_FEB2025_v0_2bjets_mc_601624.PhPy8EG_tW_DS_dyn_dil_antitop.2bjets.root"
+      },
+      {
+        "checksum": "adler32:1190a824",
+        "size": 12913272,
+        "uri": "root://eospublic.cern.ch//eos/opendata/atlas/rucio/opendata/ODEO_FEB2025_v0_2bjets_mc_601627.PhPy8EG_tW_DS_dyn_incl_antitop.2bjets.root"
+      },
+      {
+        "checksum": "adler32:d2e248ec",
+        "size": 716919,
+        "uri": "root://eospublic.cern.ch//eos/opendata/atlas/rucio/opendata/ODEO_FEB2025_v0_2bjets_mc_601628.PhPy8EG_tW_DS_dyn_dil_top.2bjets.root"
+      },
+      {
+        "checksum": "adler32:dae64062",
+        "size": 12738992,
+        "uri": "root://eospublic.cern.ch//eos/opendata/atlas/rucio/opendata/ODEO_FEB2025_v0_2bjets_mc_601631.PhPy8EG_tW_DS_dyn_incl_top.2bjets.root"
+      },
+      {
+        "checksum": "adler32:e23481df",
+        "size": 13558676,
+        "uri": "root://eospublic.cern.ch//eos/opendata/atlas/rucio/opendata/ODEO_FEB2025_v0_2bjets_mc_601761.PhPy8EG_tW_dyn_DR_pThard1_incl_top.2bjets.root"
+      },
+      {
+        "checksum": "adler32:4484e22e",
+        "size": 13410128,
+        "uri": "root://eospublic.cern.ch//eos/opendata/atlas/rucio/opendata/ODEO_FEB2025_v0_2bjets_mc_601762.PhPy8EG_tW_dyn_DR_pThard1_incl_antitop.2bjets.root"
+      },
+      {
+        "checksum": "adler32:fd73b71a",
+        "size": 758632,
+        "uri": "root://eospublic.cern.ch//eos/opendata/atlas/rucio/opendata/ODEO_FEB2025_v0_2bjets_mc_601763.PhPy8EG_tW_dyn_DR_pThard1_dil_top.2bjets.root"
+      },
+      {
+        "checksum": "adler32:17adad71",
+        "size": 783488,
+        "uri": "root://eospublic.cern.ch//eos/opendata/atlas/rucio/opendata/ODEO_FEB2025_v0_2bjets_mc_601764.PhPy8EG_tW_dyn_DR_pThard1_dil_antitop.2bjets.root"
+      },
+      {
+        "checksum": "adler32:15adc87b",
+        "size": 1924968,
+        "uri": "root://eospublic.cern.ch//eos/opendata/atlas/rucio/opendata/ODEO_FEB2025_v0_2bjets_mc_700000.Sh_228_ttW.2bjets.root"
+      },
+      {
+        "checksum": "adler32:92502189",
+        "size": 50536,
+        "uri": "root://eospublic.cern.ch//eos/opendata/atlas/rucio/opendata/ODEO_FEB2025_v0_2bjets_mc_700007.Sh_228_yyy_01NLO.2bjets.root"
+      },
+      {
+        "checksum": "adler32:e0714498",
+        "size": 58012,
+        "uri": "root://eospublic.cern.ch//eos/opendata/atlas/rucio/opendata/ODEO_FEB2025_v0_2bjets_mc_700195.Sh_2210_eegammagamma.2bjets.root"
+      },
+      {
+        "checksum": "adler32:d4da000d",
+        "size": 111344,
+        "uri": "root://eospublic.cern.ch//eos/opendata/atlas/rucio/opendata/ODEO_FEB2025_v0_2bjets_mc_700196.Sh_2210_mumugammagamma.2bjets.root"
+      },
+      {
+        "checksum": "adler32:38afe205",
+        "size": 87636,
+        "uri": "root://eospublic.cern.ch//eos/opendata/atlas/rucio/opendata/ODEO_FEB2025_v0_2bjets_mc_700197.Sh_2210_tautaugammagamma.2bjets.root"
+      },
+      {
+        "checksum": "adler32:98a5d5ae",
+        "size": 33664,
+        "uri": "root://eospublic.cern.ch//eos/opendata/atlas/rucio/opendata/ODEO_FEB2025_v0_2bjets_mc_700198.Sh_2210_nunugammagamma.2bjets.root"
+      },
+      {
+        "checksum": "adler32:0727f0a0",
+        "size": 72246,
+        "uri": "root://eospublic.cern.ch//eos/opendata/atlas/rucio/opendata/ODEO_FEB2025_v0_2bjets_mc_700199.Sh_2210_enugammagamma.2bjets.root"
+      },
+      {
+        "checksum": "adler32:e29ba8d0",
+        "size": 63683,
+        "uri": "root://eospublic.cern.ch//eos/opendata/atlas/rucio/opendata/ODEO_FEB2025_v0_2bjets_mc_700200.Sh_2210_munugammagamma.2bjets.root"
+      },
+      {
+        "checksum": "adler32:2b9139d0",
+        "size": 74610,
+        "uri": "root://eospublic.cern.ch//eos/opendata/atlas/rucio/opendata/ODEO_FEB2025_v0_2bjets_mc_700201.Sh_2210_taunugammagamma.2bjets.root"
+      },
+      {
+        "checksum": "adler32:801d6747",
+        "size": 9153818,
+        "uri": "root://eospublic.cern.ch//eos/opendata/atlas/rucio/opendata/ODEO_FEB2025_v0_2bjets_mc_700320.Sh_2211_Zee_maxHTpTV2_BFilter.2bjets.root"
+      },
+      {
+        "checksum": "adler32:5945ec05",
+        "size": 43248812,
+        "uri": "root://eospublic.cern.ch//eos/opendata/atlas/rucio/opendata/ODEO_FEB2025_v0_2bjets_mc_700321.Sh_2211_Zee_maxHTpTV2_CFilterBVeto.2bjets.root"
+      },
+      {
+        "checksum": "adler32:30460ad3",
+        "size": 25281103,
+        "uri": "root://eospublic.cern.ch//eos/opendata/atlas/rucio/opendata/ODEO_FEB2025_v0_2bjets_mc_700322.Sh_2211_Zee_maxHTpTV2_CVetoBVeto.2bjets.root"
+      },
+      {
+        "checksum": "adler32:71db3078",
+        "size": 8605015,
+        "uri": "root://eospublic.cern.ch//eos/opendata/atlas/rucio/opendata/ODEO_FEB2025_v0_2bjets_mc_700323.Sh_2211_Zmumu_maxHTpTV2_BFilter.2bjets.root"
+      },
+      {
+        "checksum": "adler32:3b812e4d",
+        "size": 43029329,
+        "uri": "root://eospublic.cern.ch//eos/opendata/atlas/rucio/opendata/ODEO_FEB2025_v0_2bjets_mc_700324.Sh_2211_Zmumu_maxHTpTV2_CFilterBVeto.2bjets.root"
+      },
+      {
+        "checksum": "adler32:62a5f212",
+        "size": 25871069,
+        "uri": "root://eospublic.cern.ch//eos/opendata/atlas/rucio/opendata/ODEO_FEB2025_v0_2bjets_mc_700325.Sh_2211_Zmumu_maxHTpTV2_CVetoBVeto.2bjets.root"
+      },
+      {
+        "checksum": "adler32:8be7318d",
+        "size": 3116979,
+        "uri": "root://eospublic.cern.ch//eos/opendata/atlas/rucio/opendata/ODEO_FEB2025_v0_2bjets_mc_700335.Sh_2211_Znunu_pTV2_BFilter.2bjets.root"
+      },
+      {
+        "checksum": "adler32:2f7bcb1d",
+        "size": 6997663,
+        "uri": "root://eospublic.cern.ch//eos/opendata/atlas/rucio/opendata/ODEO_FEB2025_v0_2bjets_mc_700336.Sh_2211_Znunu_pTV2_CFilterBVeto.2bjets.root"
+      },
+      {
+        "checksum": "adler32:65be29c5",
+        "size": 5344772,
+        "uri": "root://eospublic.cern.ch//eos/opendata/atlas/rucio/opendata/ODEO_FEB2025_v0_2bjets_mc_700337.Sh_2211_Znunu_pTV2_CVetoBVeto.2bjets.root"
+      },
+      {
+        "checksum": "adler32:c41599cd",
+        "size": 35741803,
+        "uri": "root://eospublic.cern.ch//eos/opendata/atlas/rucio/opendata/ODEO_FEB2025_v0_2bjets_mc_700338.Sh_2211_Wenu_maxHTpTV2_BFilter.2bjets.root"
+      },
+      {
+        "checksum": "adler32:66aeeac2",
+        "size": 187813289,
+        "uri": "root://eospublic.cern.ch//eos/opendata/atlas/rucio/opendata/ODEO_FEB2025_v0_2bjets_mc_700339.Sh_2211_Wenu_maxHTpTV2_CFilterBVeto.2bjets.root"
+      },
+      {
+        "checksum": "adler32:46e5af00",
+        "size": 37304229,
+        "uri": "root://eospublic.cern.ch//eos/opendata/atlas/rucio/opendata/ODEO_FEB2025_v0_2bjets_mc_700340.Sh_2211_Wenu_maxHTpTV2_CVetoBVeto.2bjets.root"
+      },
+      {
+        "checksum": "adler32:97e7e41d",
+        "size": 37094706,
+        "uri": "root://eospublic.cern.ch//eos/opendata/atlas/rucio/opendata/ODEO_FEB2025_v0_2bjets_mc_700341.Sh_2211_Wmunu_maxHTpTV2_BFilter.2bjets.root"
+      },
+      {
+        "checksum": "adler32:38bd6802",
+        "size": 172766270,
+        "uri": "root://eospublic.cern.ch//eos/opendata/atlas/rucio/opendata/ODEO_FEB2025_v0_2bjets_mc_700342.Sh_2211_Wmunu_maxHTpTV2_CFilterBVeto.2bjets.root"
+      },
+      {
+        "checksum": "adler32:c47db955",
+        "size": 33067019,
+        "uri": "root://eospublic.cern.ch//eos/opendata/atlas/rucio/opendata/ODEO_FEB2025_v0_2bjets_mc_700343.Sh_2211_Wmunu_maxHTpTV2_CVetoBVeto.2bjets.root"
+      },
+      {
+        "checksum": "adler32:364cd6eb",
+        "size": 13338050,
+        "uri": "root://eospublic.cern.ch//eos/opendata/atlas/rucio/opendata/ODEO_FEB2025_v0_2bjets_mc_700344.Sh_2211_Wtaunu_L_maxHTpTV2_BFilter.2bjets.root"
+      },
+      {
+        "checksum": "adler32:27e570b5",
+        "size": 42197396,
+        "uri": "root://eospublic.cern.ch//eos/opendata/atlas/rucio/opendata/ODEO_FEB2025_v0_2bjets_mc_700345.Sh_2211_Wtaunu_L_maxHTpTV2_CFilterBVeto.2bjets.root"
+      },
+      {
+        "checksum": "adler32:9a0466af",
+        "size": 18789688,
+        "uri": "root://eospublic.cern.ch//eos/opendata/atlas/rucio/opendata/ODEO_FEB2025_v0_2bjets_mc_700346.Sh_2211_Wtaunu_L_maxHTpTV2_CVetoBVeto.2bjets.root"
+      },
+      {
+        "checksum": "adler32:e5bc7cc5",
+        "size": 23456489,
+        "uri": "root://eospublic.cern.ch//eos/opendata/atlas/rucio/opendata/ODEO_FEB2025_v0_2bjets_mc_700347.Sh_2211_Wtaunu_H_maxHTpTV2_BFilter.2bjets.root"
+      },
+      {
+        "checksum": "adler32:20043235",
+        "size": 18471616,
+        "uri": "root://eospublic.cern.ch//eos/opendata/atlas/rucio/opendata/ODEO_FEB2025_v0_2bjets_mc_700348.Sh_2211_Wtaunu_H_maxHTpTV2_CFilterBVeto.2bjets.root"
+      },
+      {
+        "checksum": "adler32:ff5bc0e9",
+        "size": 27263950,
+        "uri": "root://eospublic.cern.ch//eos/opendata/atlas/rucio/opendata/ODEO_FEB2025_v0_2bjets_mc_700349.Sh_2211_Wtaunu_H_maxHTpTV2_CVetoBVeto.2bjets.root"
+      },
+      {
+        "checksum": "adler32:c4573848",
+        "size": 777248,
+        "uri": "root://eospublic.cern.ch//eos/opendata/atlas/rucio/opendata/ODEO_FEB2025_v0_2bjets_mc_700352.Sh_2211_pTZ100_Zqqgamma.2bjets.root"
+      },
+      {
+        "checksum": "adler32:f98b6414",
+        "size": 430577,
+        "uri": "root://eospublic.cern.ch//eos/opendata/atlas/rucio/opendata/ODEO_FEB2025_v0_2bjets_mc_700353.Sh_2211_pTZ100_Zbbgamma.2bjets.root"
+      },
+      {
+        "checksum": "adler32:933e9260",
+        "size": 128210,
+        "uri": "root://eospublic.cern.ch//eos/opendata/atlas/rucio/opendata/ODEO_FEB2025_v0_2bjets_mc_700358.Sh_2211_Zee2jets_Min_N_TChannel.2bjets.root"
+      },
+      {
+        "checksum": "adler32:ec1e7736",
+        "size": 103676,
+        "uri": "root://eospublic.cern.ch//eos/opendata/atlas/rucio/opendata/ODEO_FEB2025_v0_2bjets_mc_700359.Sh_2211_Zmm2jets_Min_N_TChannel.2bjets.root"
+      },
+      {
+        "checksum": "adler32:397aa05f",
+        "size": 230238,
+        "uri": "root://eospublic.cern.ch//eos/opendata/atlas/rucio/opendata/ODEO_FEB2025_v0_2bjets_mc_700360.Sh_2211_Ztt2jets_Min_N_TChannel.2bjets.root"
+      },
+      {
+        "checksum": "adler32:133e3623",
+        "size": 148192,
+        "uri": "root://eospublic.cern.ch//eos/opendata/atlas/rucio/opendata/ODEO_FEB2025_v0_2bjets_mc_700361.Sh_2211_Znunu2jets_Min_N_TChannel.2bjets.root"
+      },
+      {
+        "checksum": "adler32:be52f412",
+        "size": 438588,
+        "uri": "root://eospublic.cern.ch//eos/opendata/atlas/rucio/opendata/ODEO_FEB2025_v0_2bjets_mc_700362.Sh_2211_Wenu2jets_Min_N_TChannel.2bjets.root"
+      },
+      {
+        "checksum": "adler32:ef4cab76",
+        "size": 481211,
+        "uri": "root://eospublic.cern.ch//eos/opendata/atlas/rucio/opendata/ODEO_FEB2025_v0_2bjets_mc_700363.Sh_2211_Wmunu2jets_Min_N_TChannel.2bjets.root"
+      },
+      {
+        "checksum": "adler32:0c52b7ca",
+        "size": 554498,
+        "uri": "root://eospublic.cern.ch//eos/opendata/atlas/rucio/opendata/ODEO_FEB2025_v0_2bjets_mc_700364.Sh_2211_Wtaunu2jets_Min_N_TChannel.2bjets.root"
+      },
+      {
+        "checksum": "adler32:fe5b4fa5",
+        "size": 4420802,
+        "uri": "root://eospublic.cern.ch//eos/opendata/atlas/rucio/opendata/ODEO_FEB2025_v0_2bjets_mc_700398.Sh_2211_mumugamma.2bjets.root"
+      },
+      {
+        "checksum": "adler32:7f3847d0",
+        "size": 4207433,
+        "uri": "root://eospublic.cern.ch//eos/opendata/atlas/rucio/opendata/ODEO_FEB2025_v0_2bjets_mc_700399.Sh_2211_eegamma.2bjets.root"
+      },
+      {
+        "checksum": "adler32:e0517d0c",
+        "size": 7842696,
+        "uri": "root://eospublic.cern.ch//eos/opendata/atlas/rucio/opendata/ODEO_FEB2025_v0_2bjets_mc_700400.Sh_2211_tautaugamma.2bjets.root"
+      },
+      {
+        "checksum": "adler32:5cf54a24",
+        "size": 2027400,
+        "uri": "root://eospublic.cern.ch//eos/opendata/atlas/rucio/opendata/ODEO_FEB2025_v0_2bjets_mc_700401.Sh_2211_nunugamma.2bjets.root"
+      },
+      {
+        "checksum": "adler32:36fe0a62",
+        "size": 14338775,
+        "uri": "root://eospublic.cern.ch//eos/opendata/atlas/rucio/opendata/ODEO_FEB2025_v0_2bjets_mc_700402.Sh_2211_munugamma.2bjets.root"
+      },
+      {
+        "checksum": "adler32:f2a57c58",
+        "size": 13620200,
+        "uri": "root://eospublic.cern.ch//eos/opendata/atlas/rucio/opendata/ODEO_FEB2025_v0_2bjets_mc_700403.Sh_2211_enugamma.2bjets.root"
+      },
+      {
+        "checksum": "adler32:81b1724e",
+        "size": 18917942,
+        "uri": "root://eospublic.cern.ch//eos/opendata/atlas/rucio/opendata/ODEO_FEB2025_v0_2bjets_mc_700404.Sh_2211_taunugamma.2bjets.root"
+      },
+      {
+        "checksum": "adler32:e162dc8d",
+        "size": 94395,
+        "uri": "root://eospublic.cern.ch//eos/opendata/atlas/rucio/opendata/ODEO_FEB2025_v0_2bjets_mc_700442.Sh_2211_gamma2jets_pTy140_Min_N_TChannel.2bjets.root"
+      },
+      {
+        "checksum": "adler32:152b93e9",
+        "size": 1484942,
+        "uri": "root://eospublic.cern.ch//eos/opendata/atlas/rucio/opendata/ODEO_FEB2025_v0_2bjets_mc_700467.Sh_2211_Zee_maxHTpTV2_m10_40_pT5_BFilter.2bjets.root"
+      },
+      {
+        "checksum": "adler32:6b7da527",
+        "size": 7049110,
+        "uri": "root://eospublic.cern.ch//eos/opendata/atlas/rucio/opendata/ODEO_FEB2025_v0_2bjets_mc_700468.Sh_2211_Zee_maxHTpTV2_m10_40_pT5_CFilterBVeto.2bjets.root"
+      },
+      {
+        "checksum": "adler32:3359f727",
+        "size": 10548898,
+        "uri": "root://eospublic.cern.ch//eos/opendata/atlas/rucio/opendata/ODEO_FEB2025_v0_2bjets_mc_700469.Sh_2211_Zee_maxHTpTV2_m10_40_pT5_CVetoBVeto.2bjets.root"
+      },
+      {
+        "checksum": "adler32:c45011d9",
+        "size": 1478870,
+        "uri": "root://eospublic.cern.ch//eos/opendata/atlas/rucio/opendata/ODEO_FEB2025_v0_2bjets_mc_700470.Sh_2211_Zmumu_maxHTpTV2_m10_40_pT5_BFilter.2bjets.root"
+      },
+      {
+        "checksum": "adler32:87cc6c83",
+        "size": 6221467,
+        "uri": "root://eospublic.cern.ch//eos/opendata/atlas/rucio/opendata/ODEO_FEB2025_v0_2bjets_mc_700471.Sh_2211_Zmumu_maxHTpTV2_m10_40_pT5_CFilterBVeto.2bjets.root"
+      },
+      {
+        "checksum": "adler32:dc215854",
+        "size": 9490916,
+        "uri": "root://eospublic.cern.ch//eos/opendata/atlas/rucio/opendata/ODEO_FEB2025_v0_2bjets_mc_700472.Sh_2211_Zmumu_maxHTpTV2_m10_40_pT5_CVetoBVeto.2bjets.root"
+      },
+      {
+        "checksum": "adler32:c15821a8",
+        "size": 4122768,
+        "uri": "root://eospublic.cern.ch//eos/opendata/atlas/rucio/opendata/ODEO_FEB2025_v0_2bjets_mc_700488.Sh_2211_WlvWqq.2bjets.root"
+      },
+      {
+        "checksum": "adler32:a50805de",
+        "size": 1315496,
+        "uri": "root://eospublic.cern.ch//eos/opendata/atlas/rucio/opendata/ODEO_FEB2025_v0_2bjets_mc_700489.Sh_2211_WlvZqq.2bjets.root"
+      },
+      {
+        "checksum": "adler32:cf4fe932",
+        "size": 491912,
+        "uri": "root://eospublic.cern.ch//eos/opendata/atlas/rucio/opendata/ODEO_FEB2025_v0_2bjets_mc_700490.Sh_2211_WlvZbb.2bjets.root"
+      },
+      {
+        "checksum": "adler32:b04c8c7a",
+        "size": 536550,
+        "uri": "root://eospublic.cern.ch//eos/opendata/atlas/rucio/opendata/ODEO_FEB2025_v0_2bjets_mc_700491.Sh_2211_WqqZvv.2bjets.root"
+      },
+      {
+        "checksum": "adler32:cc236eb2",
+        "size": 491976,
+        "uri": "root://eospublic.cern.ch//eos/opendata/atlas/rucio/opendata/ODEO_FEB2025_v0_2bjets_mc_700492.Sh_2211_WqqZll.2bjets.root"
+      },
+      {
+        "checksum": "adler32:d48daa8c",
+        "size": 382779,
+        "uri": "root://eospublic.cern.ch//eos/opendata/atlas/rucio/opendata/ODEO_FEB2025_v0_2bjets_mc_700493.Sh_2211_ZqqZll.2bjets.root"
+      },
+      {
+        "checksum": "adler32:4d9f33d3",
+        "size": 443903,
+        "uri": "root://eospublic.cern.ch//eos/opendata/atlas/rucio/opendata/ODEO_FEB2025_v0_2bjets_mc_700494.Sh_2211_ZbbZll.2bjets.root"
+      },
+      {
+        "checksum": "adler32:93929ba3",
+        "size": 318424,
+        "uri": "root://eospublic.cern.ch//eos/opendata/atlas/rucio/opendata/ODEO_FEB2025_v0_2bjets_mc_700495.Sh_2211_ZqqZvv.2bjets.root"
+      },
+      {
+        "checksum": "adler32:a021eefc",
+        "size": 157611,
+        "uri": "root://eospublic.cern.ch//eos/opendata/atlas/rucio/opendata/ODEO_FEB2025_v0_2bjets_mc_700496.Sh_2211_ZbbZvv.2bjets.root"
+      },
+      {
+        "checksum": "adler32:62c7b1eb",
+        "size": 184636,
+        "uri": "root://eospublic.cern.ch//eos/opendata/atlas/rucio/opendata/ODEO_FEB2025_v0_2bjets_mc_700507.Sh_2211_pTW140_Wqqgamma.2bjets.root"
+      },
+      {
+        "checksum": "adler32:73490cde",
+        "size": 170297,
+        "uri": "root://eospublic.cern.ch//eos/opendata/atlas/rucio/opendata/ODEO_FEB2025_v0_2bjets_mc_700587.Sh_2212_lllljj.2bjets.root"
+      },
+      {
+        "checksum": "adler32:8ff0bf95",
+        "size": 78478,
+        "uri": "root://eospublic.cern.ch//eos/opendata/atlas/rucio/opendata/ODEO_FEB2025_v0_2bjets_mc_700588.Sh_2212_lllvjj.2bjets.root"
+      },
+      {
+        "checksum": "adler32:38036be1",
+        "size": 65913,
+        "uri": "root://eospublic.cern.ch//eos/opendata/atlas/rucio/opendata/ODEO_FEB2025_v0_2bjets_mc_700589.Sh_2212_llvvjj_os.2bjets.root"
+      },
+      {
+        "checksum": "adler32:72c77853",
+        "size": 149430,
+        "uri": "root://eospublic.cern.ch//eos/opendata/atlas/rucio/opendata/ODEO_FEB2025_v0_2bjets_mc_700590.Sh_2212_llvvjj_ss.2bjets.root"
+      },
+      {
+        "checksum": "adler32:54c31912",
+        "size": 43181,
+        "uri": "root://eospublic.cern.ch//eos/opendata/atlas/rucio/opendata/ODEO_FEB2025_v0_2bjets_mc_700591.Sh_2212_lllljj_Int.2bjets.root"
+      },
+      {
+        "checksum": "adler32:76a803db",
+        "size": 50305,
+        "uri": "root://eospublic.cern.ch//eos/opendata/atlas/rucio/opendata/ODEO_FEB2025_v0_2bjets_mc_700592.Sh_2212_lllvjj_Int.2bjets.root"
+      },
+      {
+        "checksum": "adler32:53f37462",
+        "size": 54357,
+        "uri": "root://eospublic.cern.ch//eos/opendata/atlas/rucio/opendata/ODEO_FEB2025_v0_2bjets_mc_700593.Sh_2212_llvvjj_os_Int.2bjets.root"
+      },
+      {
+        "checksum": "adler32:bb275c00",
+        "size": 53740,
+        "uri": "root://eospublic.cern.ch//eos/opendata/atlas/rucio/opendata/ODEO_FEB2025_v0_2bjets_mc_700594.Sh_2212_llvvjj_ss_Int.2bjets.root"
+      },
+      {
+        "checksum": "adler32:b2c1f452",
+        "size": 236203,
+        "uri": "root://eospublic.cern.ch//eos/opendata/atlas/rucio/opendata/ODEO_FEB2025_v0_2bjets_mc_700600.Sh_2212_llll.2bjets.root"
+      },
+      {
+        "checksum": "adler32:4fa4e445",
+        "size": 442427,
+        "uri": "root://eospublic.cern.ch//eos/opendata/atlas/rucio/opendata/ODEO_FEB2025_v0_2bjets_mc_700601.Sh_2212_lllv.2bjets.root"
+      },
+      {
+        "checksum": "adler32:76e79657",
+        "size": 718239,
+        "uri": "root://eospublic.cern.ch//eos/opendata/atlas/rucio/opendata/ODEO_FEB2025_v0_2bjets_mc_700602.Sh_2212_llvv_os.2bjets.root"
+      },
+      {
+        "checksum": "adler32:35e49297",
+        "size": 203264,
+        "uri": "root://eospublic.cern.ch//eos/opendata/atlas/rucio/opendata/ODEO_FEB2025_v0_2bjets_mc_700603.Sh_2212_llvv_ss.2bjets.root"
+      },
+      {
+        "checksum": "adler32:de004fe7",
+        "size": 210106,
+        "uri": "root://eospublic.cern.ch//eos/opendata/atlas/rucio/opendata/ODEO_FEB2025_v0_2bjets_mc_700604.Sh_2212_lvvv.2bjets.root"
+      },
+      {
+        "checksum": "adler32:cad08f9d",
+        "size": 71906,
+        "uri": "root://eospublic.cern.ch//eos/opendata/atlas/rucio/opendata/ODEO_FEB2025_v0_2bjets_mc_700605.Sh_2212_vvvv.2bjets.root"
+      },
+      {
+        "checksum": "adler32:a552e6cd",
+        "size": 172614,
+        "uri": "root://eospublic.cern.ch//eos/opendata/atlas/rucio/opendata/ODEO_FEB2025_v0_2bjets_mc_700709.Sh_2212_lvgammajj.2bjets.root"
+      },
+      {
+        "checksum": "adler32:fde4f0a2",
+        "size": 340438,
+        "uri": "root://eospublic.cern.ch//eos/opendata/atlas/rucio/opendata/ODEO_FEB2025_v0_2bjets_mc_700710.Sh_2212_llgammajj.2bjets.root"
+      },
+      {
+        "checksum": "adler32:d84bce5a",
+        "size": 15907572,
+        "uri": "root://eospublic.cern.ch//eos/opendata/atlas/rucio/opendata/ODEO_FEB2025_v0_2bjets_mc_700792.Sh_2214_Ztautau_maxHTpTV2_BFilter.2bjets.root"
+      },
+      {
+        "checksum": "adler32:8a0bda1f",
+        "size": 76867952,
+        "uri": "root://eospublic.cern.ch//eos/opendata/atlas/rucio/opendata/ODEO_FEB2025_v0_2bjets_mc_700793.Sh_2214_Ztautau_maxHTpTV2_CFilterBVeto.2bjets.root"
+      },
+      {
+        "checksum": "adler32:0bc4fdfe",
+        "size": 43444944,
+        "uri": "root://eospublic.cern.ch//eos/opendata/atlas/rucio/opendata/ODEO_FEB2025_v0_2bjets_mc_700794.Sh_2214_Ztautau_maxHTpTV2_CVetoBVeto.2bjets.root"
+      },
+      {
+        "checksum": "adler32:d8d60caf",
+        "size": 15682377,
+        "uri": "root://eospublic.cern.ch//eos/opendata/atlas/rucio/opendata/ODEO_FEB2025_v0_2bjets_mc_700843.Sh_2214_Wqq_ptW_200_ECMS.2bjets.root"
+      },
+      {
+        "checksum": "adler32:a119c84b",
+        "size": 6724367,
+        "uri": "root://eospublic.cern.ch//eos/opendata/atlas/rucio/opendata/ODEO_FEB2025_v0_2bjets_mc_700849.Sh_2214_Zqq_ptZ_200_ECMS.2bjets.root"
+      },
+      {
+        "checksum": "adler32:df9cb4d4",
+        "size": 2592570,
+        "uri": "root://eospublic.cern.ch//eos/opendata/atlas/rucio/opendata/ODEO_FEB2025_v0_2bjets_mc_700855.Sh_2214_Zbb_ptZ_200_ECMS.2bjets.root"
+      },
+      {
+        "checksum": "adler32:c960c585",
+        "size": 3847169,
+        "uri": "root://eospublic.cern.ch//eos/opendata/atlas/rucio/opendata/ODEO_FEB2025_v0_2bjets_mc_700901.Sh_2214_Ztt_maxHTpTV2_Mll10_40_BFilter.2bjets.root"
+      },
+      {
+        "checksum": "adler32:d3c63a7d",
+        "size": 23255368,
+        "uri": "root://eospublic.cern.ch//eos/opendata/atlas/rucio/opendata/ODEO_FEB2025_v0_2bjets_mc_700902.Sh_2214_Ztt_maxHTpTV2_Mll10_40_CFilterBVeto.2bjets.root"
+      },
+      {
+        "checksum": "adler32:0b9325d5",
+        "size": 12893728,
+        "uri": "root://eospublic.cern.ch//eos/opendata/atlas/rucio/opendata/ODEO_FEB2025_v0_2bjets_mc_700903.Sh_2214_Ztt_maxHTpTV2_Mll10_40_CVetoBVeto.2bjets.root"
+      },
+      {
+        "checksum": "adler32:1e4366c6",
+        "size": 50769,
+        "uri": "root://eospublic.cern.ch//eos/opendata/atlas/rucio/opendata/ODEO_FEB2025_v0_2bjets_mc_801976.Py8EG_A14NNPDF23LO_Zprime_NoInt_tautau_SSM3000.2bjets.root"
+      },
+      {
+        "checksum": "adler32:d8653f1b",
+        "size": 32963,
+        "uri": "root://eospublic.cern.ch//eos/opendata/atlas/rucio/opendata/ODEO_FEB2025_v0_2bjets_mc_801978.Py8EG_A14NNPDF23LO_Wprime_taunu_SSM3000.2bjets.root"
+      }
+    ],
+    "license": {
+      "attribution": "CC0-1.0"
+    },
+    "methodology": {
+      "description": "<p>These data were created during LS2 as part of a major reprocessing campaign of the Run 2 data. All data were reprocessed using Athena Release 22, and new corresponding MC simulation samples were produced. These data and MC simulation datasets were processed into ROOT ntuple files from the DAOD_PHYSLITE format that is released as open data for research. For the files in this record, the following skimming selection was applied: At least two jets with at least 20 GeV of p<sub>T</sub> identified as containing at least one heavy flavor hadron using the 85% working point (i.e. a Higgs boson decaying to b-quarks enhanced selection)"
+    },
+    "publisher": "CERN Open Data Portal",
+    "recid": "93920",
+    "relations": [
+      {
+        "description": "For citing all the Open Data for Education and Outreach from this release, and to find other related datasets, please see",
+        "doi": "10.7483/OPENDATA.ATLAS.B5M9.44TN",
+        "recid": "93910",
+        "title": "ROOT ntuple format 2015-2016 proton-proton Open Data for Education and Outreach from the ATLAS experiment",
+        "type": "isChildOf"
+      }
+    ],
+    "run_period": [
+      "2015",
+      "2016"
+    ],
+    "title": "ATLAS ROOT ntuple format MC simulation, 2015+2016 proton-proton collisions beta release, 2bjets skim",
+    "type": {
+      "primary": "Dataset",
+      "secondary": [
+        "Simulated"
+      ]
+    },
+    "usage": {
+      "description": "<p> The data and MC simulation provided by the ATLAS experiment in root ntuple format is released under a CC0 license; citation of the data and acknowledgement of the collaboration is requested. This format can be used directly using ROOT or uproot for simple studies and is primarily intended for educational and outreach purposes. <p>Extensive instructions for interacting with the data, as well as documentation of the dataset naming conventions and their contents, are provided on the ATLAS Open Data website linked below. For those interested in implementing a research-quality data analysis, the open data designed for research (also linked below) may be a better starting point. Please be sure to cite the Open Data that you use, in line with the policy below.",
+      "links": [
+        {
+          "description": "ATLAS Open Data Website",
+          "url": "http://opendata.atlas.cern"
+        },
+        {
+          "description": "Resources to understand and use the open data for education and outreach",
+          "url": "https://opendata.atlas.cern/docs/category/13-tev-tutorials-for-education"
+        },
+        {
+          "description": "More about this ntuple format",
+          "url": "https://opendata.atlas.cern/docs/data/for_education/13TeV25_details"
+        },
+        {
+          "description": "Ntuple making framework",
+          "url": "http://gitlab.cern.ch/atlas-outreach-data-tools/physlitetoopendata"
+        },
+        {
+          "description": "Citation policy",
+          "url": "https://opendata.atlas.cern/docs/documentation/ethical_legal/citation_policy"
+        }
+      ]
+    }
+  }
+]

--- a/data/records/atlas-odeo-FEB2025-2bjets-mc.json
+++ b/data/records/atlas-odeo-FEB2025-2bjets-mc.json
@@ -11,7 +11,7 @@
       "name": "ATLAS collaboration"
     },
     "collections": [
-      "ATLAS-Primary-Datasets"
+      "ATLAS-Simulated-Datasets"
     ],
     "collision_information": {
       "energy": "13TeV",
@@ -27,9 +27,9 @@
       "formats": [
         "root"
       ],
-      "number_events": 4304665,
+      "number_events": 32354002,
       "number_files": 373,
-      "size": 2406812407
+      "size": 16978883159
     },
     "doi": "10.7483/OPENDATA.ATLAS.71IP.L3OC",
     "experiment": [
@@ -37,1869 +37,1869 @@
     ],
     "files": [
       {
-        "checksum": "adler32:28588336",
-        "size": 34483,
-        "uri": "root://eospublic.cern.ch//eos/opendata/atlas/rucio/opendata/ODEO_FEB2025_v0_2bjets_mc_301204.Pythia8EvtGen_A14MSTW2008LO_Zprime_NoInt_ee_SSM3000.2bjets.root"
+        "checksum": "adler32:2a92f3eb",
+        "size": 42467,
+        "uri": "root://eospublic.cern.ch//eos/opendata/atlas/rucio/user/egramsta/mc_301204.Pythia8EvtGen_A14MSTW2008LO_Zprime_NoInt_ee_SSM3000.2bjets70.root"
       },
       {
-        "checksum": "adler32:e000fb43",
-        "size": 31739,
-        "uri": "root://eospublic.cern.ch//eos/opendata/atlas/rucio/opendata/ODEO_FEB2025_v0_2bjets_mc_301209.Pythia8EvtGen_A14MSTW2008LO_Zprime_NoInt_mumu_SSM3000.2bjets.root"
+        "checksum": "adler32:14d54355",
+        "size": 46207,
+        "uri": "root://eospublic.cern.ch//eos/opendata/atlas/rucio/user/egramsta/mc_301209.Pythia8EvtGen_A14MSTW2008LO_Zprime_NoInt_mumu_SSM3000.2bjets70.root"
       },
       {
-        "checksum": "adler32:d275e28b",
-        "size": 28031,
-        "uri": "root://eospublic.cern.ch//eos/opendata/atlas/rucio/opendata/ODEO_FEB2025_v0_2bjets_mc_301243.Pythia8EvtGen_A14NNPDF23LO_Wprime_enu_SSM3000.2bjets.root"
+        "checksum": "adler32:a28f7686",
+        "size": 33048,
+        "uri": "root://eospublic.cern.ch//eos/opendata/atlas/rucio/user/egramsta/mc_301243.Pythia8EvtGen_A14NNPDF23LO_Wprime_enu_SSM3000.2bjets70.root"
       },
       {
-        "checksum": "adler32:dc21a648",
-        "size": 31972,
-        "uri": "root://eospublic.cern.ch//eos/opendata/atlas/rucio/opendata/ODEO_FEB2025_v0_2bjets_mc_301247.Pythia8EvtGen_A14NNPDF23LO_Wprime_munu_SSM3000.2bjets.root"
+        "checksum": "adler32:9959f951",
+        "size": 40986,
+        "uri": "root://eospublic.cern.ch//eos/opendata/atlas/rucio/user/egramsta/mc_301247.Pythia8EvtGen_A14NNPDF23LO_Wprime_munu_SSM3000.2bjets70.root"
       },
       {
-        "checksum": "adler32:fc194550",
-        "size": 100198,
-        "uri": "root://eospublic.cern.ch//eos/opendata/atlas/rucio/opendata/ODEO_FEB2025_v0_2bjets_mc_301333.Pythia8EvtGen_A14NNPDF23LO_zprime3000_tt.2bjets.root"
+        "checksum": "adler32:953c96ca",
+        "size": 617711,
+        "uri": "root://eospublic.cern.ch//eos/opendata/atlas/rucio/user/egramsta/mc_301333.Pythia8EvtGen_A14NNPDF23LO_zprime3000_tt.2bjets70.root"
       },
       {
-        "checksum": "adler32:d057ce4d",
-        "size": 57687,
-        "uri": "root://eospublic.cern.ch//eos/opendata/atlas/rucio/opendata/ODEO_FEB2025_v0_2bjets_mc_301826.Pythia8EvtGen_A14NNPDF23LO_Wprime_qq_3000.2bjets.root"
+        "checksum": "adler32:8b007909",
+        "size": 120360,
+        "uri": "root://eospublic.cern.ch//eos/opendata/atlas/rucio/user/egramsta/mc_301826.Pythia8EvtGen_A14NNPDF23LO_Wprime_qq_3000.2bjets70.root"
       },
       {
-        "checksum": "adler32:61b91be4",
-        "size": 79715,
-        "uri": "root://eospublic.cern.ch//eos/opendata/atlas/rucio/opendata/ODEO_FEB2025_v0_2bjets_mc_301928.Pythia8EvtGen_A14NNPDF23LO_Zprimebb3000.2bjets.root"
+        "checksum": "adler32:654cf17b",
+        "size": 312845,
+        "uri": "root://eospublic.cern.ch//eos/opendata/atlas/rucio/user/egramsta/mc_301928.Pythia8EvtGen_A14NNPDF23LO_Zprimebb3000.2bjets70.root"
       },
       {
-        "checksum": "adler32:f5f7f010",
-        "size": 423104,
-        "uri": "root://eospublic.cern.ch//eos/opendata/atlas/rucio/opendata/ODEO_FEB2025_v0_2bjets_mc_302520.Pythia8EvtGen_A14NNPDF23LO_2DP20_Mass_55_100.2bjets.root"
+        "checksum": "adler32:29c645d1",
+        "size": 447119,
+        "uri": "root://eospublic.cern.ch//eos/opendata/atlas/rucio/user/egramsta/mc_302520.Pythia8EvtGen_A14NNPDF23LO_2DP20_Mass_55_100.2bjets70.root"
       },
       {
-        "checksum": "adler32:dbfccc68",
-        "size": 125467,
-        "uri": "root://eospublic.cern.ch//eos/opendata/atlas/rucio/opendata/ODEO_FEB2025_v0_2bjets_mc_302521.Pythia8EvtGen_A14NNPDF23LO_2DP20_Mass_100_160.2bjets.root"
+        "checksum": "adler32:627ce7c0",
+        "size": 129871,
+        "uri": "root://eospublic.cern.ch//eos/opendata/atlas/rucio/user/egramsta/mc_302521.Pythia8EvtGen_A14NNPDF23LO_2DP20_Mass_100_160.2bjets70.root"
       },
       {
-        "checksum": "adler32:70334a78",
-        "size": 63185,
-        "uri": "root://eospublic.cern.ch//eos/opendata/atlas/rucio/opendata/ODEO_FEB2025_v0_2bjets_mc_302522.Pythia8EvtGen_A14NNPDF23LO_2DP20_Mass_160_250.2bjets.root"
+        "checksum": "adler32:2b661fcf",
+        "size": 53496,
+        "uri": "root://eospublic.cern.ch//eos/opendata/atlas/rucio/user/egramsta/mc_302522.Pythia8EvtGen_A14NNPDF23LO_2DP20_Mass_160_250.2bjets70.root"
       },
       {
-        "checksum": "adler32:da573fb6",
-        "size": 46227,
-        "uri": "root://eospublic.cern.ch//eos/opendata/atlas/rucio/opendata/ODEO_FEB2025_v0_2bjets_mc_302523.Pythia8EvtGen_A14NNPDF23LO_2DP20_Mass_250_400.2bjets.root"
+        "checksum": "adler32:434b6f59",
+        "size": 36420,
+        "uri": "root://eospublic.cern.ch//eos/opendata/atlas/rucio/user/egramsta/mc_302523.Pythia8EvtGen_A14NNPDF23LO_2DP20_Mass_250_400.2bjets70.root"
       },
       {
-        "checksum": "adler32:cf62d229",
-        "size": 72601,
-        "uri": "root://eospublic.cern.ch//eos/opendata/atlas/rucio/opendata/ODEO_FEB2025_v0_2bjets_mc_302524.Pythia8EvtGen_A14NNPDF23LO_2DP20_Mass_400_650.2bjets.root"
+        "checksum": "adler32:1edf712c",
+        "size": 88491,
+        "uri": "root://eospublic.cern.ch//eos/opendata/atlas/rucio/user/egramsta/mc_302524.Pythia8EvtGen_A14NNPDF23LO_2DP20_Mass_400_650.2bjets70.root"
       },
       {
-        "checksum": "adler32:cc14ff24",
-        "size": 35471,
-        "uri": "root://eospublic.cern.ch//eos/opendata/atlas/rucio/opendata/ODEO_FEB2025_v0_2bjets_mc_302525.Pythia8EvtGen_A14NNPDF23LO_2DP20_Mass_650_1000.2bjets.root"
+        "checksum": "adler32:58cbd730",
+        "size": 42625,
+        "uri": "root://eospublic.cern.ch//eos/opendata/atlas/rucio/user/egramsta/mc_302525.Pythia8EvtGen_A14NNPDF23LO_2DP20_Mass_650_1000.2bjets70.root"
       },
       {
-        "checksum": "adler32:2e4d5453",
-        "size": 61131,
-        "uri": "root://eospublic.cern.ch//eos/opendata/atlas/rucio/opendata/ODEO_FEB2025_v0_2bjets_mc_302526.Pythia8EvtGen_A14NNPDF23LO_2DP20_Mass_1000_1500.2bjets.root"
+        "checksum": "adler32:824a62e3",
+        "size": 92747,
+        "uri": "root://eospublic.cern.ch//eos/opendata/atlas/rucio/user/egramsta/mc_302526.Pythia8EvtGen_A14NNPDF23LO_2DP20_Mass_1000_1500.2bjets70.root"
       },
       {
-        "checksum": "adler32:c7a09d96",
-        "size": 66484,
-        "uri": "root://eospublic.cern.ch//eos/opendata/atlas/rucio/opendata/ODEO_FEB2025_v0_2bjets_mc_302527.Pythia8EvtGen_A14NNPDF23LO_2DP20_Mass_1500_2000.2bjets.root"
+        "checksum": "adler32:6eea2fcd",
+        "size": 110702,
+        "uri": "root://eospublic.cern.ch//eos/opendata/atlas/rucio/user/egramsta/mc_302527.Pythia8EvtGen_A14NNPDF23LO_2DP20_Mass_1500_2000.2bjets70.root"
       },
       {
-        "checksum": "adler32:5b38c9c5",
-        "size": 88783,
-        "uri": "root://eospublic.cern.ch//eos/opendata/atlas/rucio/opendata/ODEO_FEB2025_v0_2bjets_mc_302528.Pythia8EvtGen_A14NNPDF23LO_2DP20_Mass_2000_2500.2bjets.root"
+        "checksum": "adler32:7a5f1a1f",
+        "size": 157732,
+        "uri": "root://eospublic.cern.ch//eos/opendata/atlas/rucio/user/egramsta/mc_302528.Pythia8EvtGen_A14NNPDF23LO_2DP20_Mass_2000_2500.2bjets70.root"
       },
       {
-        "checksum": "adler32:7abc778f",
-        "size": 64893,
-        "uri": "root://eospublic.cern.ch//eos/opendata/atlas/rucio/opendata/ODEO_FEB2025_v0_2bjets_mc_302529.Pythia8EvtGen_A14NNPDF23LO_2DP20_Mass_2500_3000.2bjets.root"
+        "checksum": "adler32:92b55d00",
+        "size": 117017,
+        "uri": "root://eospublic.cern.ch//eos/opendata/atlas/rucio/user/egramsta/mc_302529.Pythia8EvtGen_A14NNPDF23LO_2DP20_Mass_2500_3000.2bjets70.root"
       },
       {
-        "checksum": "adler32:ce508354",
-        "size": 87935,
-        "uri": "root://eospublic.cern.ch//eos/opendata/atlas/rucio/opendata/ODEO_FEB2025_v0_2bjets_mc_302530.Pythia8EvtGen_A14NNPDF23LO_2DP20_Mass_3000_3500.2bjets.root"
+        "checksum": "adler32:5bf0f45f",
+        "size": 176750,
+        "uri": "root://eospublic.cern.ch//eos/opendata/atlas/rucio/user/egramsta/mc_302530.Pythia8EvtGen_A14NNPDF23LO_2DP20_Mass_3000_3500.2bjets70.root"
       },
       {
-        "checksum": "adler32:c767766e",
-        "size": 58040,
-        "uri": "root://eospublic.cern.ch//eos/opendata/atlas/rucio/opendata/ODEO_FEB2025_v0_2bjets_mc_302531.Pythia8EvtGen_A14NNPDF23LO_2DP20_Mass_3500_4000.2bjets.root"
+        "checksum": "adler32:214e4856",
+        "size": 97491,
+        "uri": "root://eospublic.cern.ch//eos/opendata/atlas/rucio/user/egramsta/mc_302531.Pythia8EvtGen_A14NNPDF23LO_2DP20_Mass_3500_4000.2bjets70.root"
       },
       {
-        "checksum": "adler32:039c173a",
-        "size": 85091,
-        "uri": "root://eospublic.cern.ch//eos/opendata/atlas/rucio/opendata/ODEO_FEB2025_v0_2bjets_mc_302532.Pythia8EvtGen_A14NNPDF23LO_2DP20_Mass_4000_4500.2bjets.root"
+        "checksum": "adler32:9684c329",
+        "size": 156112,
+        "uri": "root://eospublic.cern.ch//eos/opendata/atlas/rucio/user/egramsta/mc_302532.Pythia8EvtGen_A14NNPDF23LO_2DP20_Mass_4000_4500.2bjets70.root"
       },
       {
-        "checksum": "adler32:df6e089a",
-        "size": 41636,
-        "uri": "root://eospublic.cern.ch//eos/opendata/atlas/rucio/opendata/ODEO_FEB2025_v0_2bjets_mc_302533.Pythia8EvtGen_A14NNPDF23LO_2DP20_Mass_4500_5000.2bjets.root"
+        "checksum": "adler32:e23e5869",
+        "size": 73390,
+        "uri": "root://eospublic.cern.ch//eos/opendata/atlas/rucio/user/egramsta/mc_302533.Pythia8EvtGen_A14NNPDF23LO_2DP20_Mass_4500_5000.2bjets70.root"
       },
       {
-        "checksum": "adler32:4363d7d9",
-        "size": 69520,
-        "uri": "root://eospublic.cern.ch//eos/opendata/atlas/rucio/opendata/ODEO_FEB2025_v0_2bjets_mc_302534.Pythia8EvtGen_A14NNPDF23LO_2DP20_Mass_5000_inf.2bjets.root"
+        "checksum": "adler32:8b44a4e4",
+        "size": 173475,
+        "uri": "root://eospublic.cern.ch//eos/opendata/atlas/rucio/user/egramsta/mc_302534.Pythia8EvtGen_A14NNPDF23LO_2DP20_Mass_5000_inf.2bjets70.root"
       },
       {
-        "checksum": "adler32:637def89",
-        "size": 186116,
-        "uri": "root://eospublic.cern.ch//eos/opendata/atlas/rucio/opendata/ODEO_FEB2025_v0_2bjets_mc_302733.MadGraphPythia8EvtGen_A14NNPDF23LO_WpL_tblep_M3000.2bjets.root"
+        "checksum": "adler32:f073873e",
+        "size": 1147604,
+        "uri": "root://eospublic.cern.ch//eos/opendata/atlas/rucio/user/egramsta/mc_302733.MadGraphPythia8EvtGen_A14NNPDF23LO_WpL_tblep_M3000.2bjets70.root"
       },
       {
-        "checksum": "adler32:5d04ffcc",
-        "size": 766236,
-        "uri": "root://eospublic.cern.ch//eos/opendata/atlas/rucio/opendata/ODEO_FEB2025_v0_2bjets_mc_304014.MadGraphPythia8EvtGen_A14NNPDF23_3top_SM.2bjets.root"
+        "checksum": "adler32:717600f0",
+        "size": 8587641,
+        "uri": "root://eospublic.cern.ch//eos/opendata/atlas/rucio/user/egramsta/mc_304014.MadGraphPythia8EvtGen_A14NNPDF23_3top_SM.2bjets70.root"
       },
       {
-        "checksum": "adler32:e117fb1e",
-        "size": 122255,
-        "uri": "root://eospublic.cern.ch//eos/opendata/atlas/rucio/opendata/ODEO_FEB2025_v0_2bjets_mc_306149.MadGraphPythia8EvtGen_A14NNPDF23LO_WpL_tbhad_M3000.2bjets.root"
+        "checksum": "adler32:2f7392ad",
+        "size": 535058,
+        "uri": "root://eospublic.cern.ch//eos/opendata/atlas/rucio/user/egramsta/mc_306149.MadGraphPythia8EvtGen_A14NNPDF23LO_WpL_tbhad_M3000.2bjets70.root"
       },
       {
-        "checksum": "adler32:9eb79553",
-        "size": 42191,
-        "uri": "root://eospublic.cern.ch//eos/opendata/atlas/rucio/opendata/ODEO_FEB2025_v0_2bjets_mc_311490.PowhegPy8EG_A14N23LO_DMA_500_700_gq0p25.2bjets.root"
+        "checksum": "adler32:01d0d52f",
+        "size": 74817,
+        "uri": "root://eospublic.cern.ch//eos/opendata/atlas/rucio/user/egramsta/mc_311490.PowhegPy8EG_A14N23LO_DMA_500_700_gq0p25.2bjets70.root"
       },
       {
-        "checksum": "adler32:f7f76fc3",
-        "size": 225403,
-        "uri": "root://eospublic.cern.ch//eos/opendata/atlas/rucio/opendata/ODEO_FEB2025_v0_2bjets_mc_312613.aMcAtNloPy8EG_A14N30NLO_LQd_gstML_0p3_nonallhad_M1000.2bjets.root"
+        "checksum": "adler32:58c503a5",
+        "size": 1896172,
+        "uri": "root://eospublic.cern.ch//eos/opendata/atlas/rucio/user/egramsta/mc_312613.aMcAtNloPy8EG_A14N30NLO_LQd_gstML_0p3_nonallhad_M1000.2bjets70.root"
       },
       {
-        "checksum": "adler32:c76a4589",
-        "size": 50398,
-        "uri": "root://eospublic.cern.ch//eos/opendata/atlas/rucio/opendata/ODEO_FEB2025_v0_2bjets_mc_341456.PowhegPythia8EvtGen_CT10_AZNLO_ZH125J_MINLO_veveWWlvqq_VpT.2bjets.root"
+        "checksum": "adler32:11c02eab",
+        "size": 44629,
+        "uri": "root://eospublic.cern.ch//eos/opendata/atlas/rucio/user/egramsta/mc_341456.PowhegPythia8EvtGen_CT10_AZNLO_ZH125J_MINLO_veveWWlvqq_VpT.2bjets70.root"
       },
       {
-        "checksum": "adler32:a1bf9b59",
-        "size": 63855,
-        "uri": "root://eospublic.cern.ch//eos/opendata/atlas/rucio/opendata/ODEO_FEB2025_v0_2bjets_mc_341458.PowhegPythia8EvtGen_CT10_AZNLO_ZH125J_MINLO_vmuvmuWWlvqq_VpT.2bjets.root"
+        "checksum": "adler32:f8577181",
+        "size": 62267,
+        "uri": "root://eospublic.cern.ch//eos/opendata/atlas/rucio/user/egramsta/mc_341458.PowhegPythia8EvtGen_CT10_AZNLO_ZH125J_MINLO_vmuvmuWWlvqq_VpT.2bjets70.root"
       },
       {
-        "checksum": "adler32:c419e669",
-        "size": 59710,
-        "uri": "root://eospublic.cern.ch//eos/opendata/atlas/rucio/opendata/ODEO_FEB2025_v0_2bjets_mc_341460.PowhegPy8EG_CT10_AZNLO_ZH125J_MINLO_vtauvtauWWlvqq_VpT.2bjets.root"
+        "checksum": "adler32:74c0565d",
+        "size": 64022,
+        "uri": "root://eospublic.cern.ch//eos/opendata/atlas/rucio/user/egramsta/mc_341460.PowhegPy8EG_CT10_AZNLO_ZH125J_MINLO_vtauvtauWWlvqq_VpT.2bjets70.root"
       },
       {
-        "checksum": "adler32:d360baed",
-        "size": 81296,
-        "uri": "root://eospublic.cern.ch//eos/opendata/atlas/rucio/opendata/ODEO_FEB2025_v0_2bjets_mc_343981.PowhegPythia8EvtGen_NNLOPS_nnlo_30_ggH125_gamgam.2bjets.root"
+        "checksum": "adler32:46ceb458",
+        "size": 134129,
+        "uri": "root://eospublic.cern.ch//eos/opendata/atlas/rucio/user/egramsta/mc_343981.PowhegPythia8EvtGen_NNLOPS_nnlo_30_ggH125_gamgam.2bjets70.root"
       },
       {
-        "checksum": "adler32:707138dc",
-        "size": 81623,
-        "uri": "root://eospublic.cern.ch//eos/opendata/atlas/rucio/opendata/ODEO_FEB2025_v0_2bjets_mc_344158.aMcAtNloPythia8EvtGen_A14NNPDF23LO_ppx0_FxFx_Np012_SM.2bjets.root"
+        "checksum": "adler32:be87bde5",
+        "size": 115712,
+        "uri": "root://eospublic.cern.ch//eos/opendata/atlas/rucio/user/egramsta/mc_344158.aMcAtNloPythia8EvtGen_A14NNPDF23LO_ppx0_FxFx_Np012_SM.2bjets70.root"
       },
       {
-        "checksum": "adler32:cd0ff361",
-        "size": 214797,
-        "uri": "root://eospublic.cern.ch//eos/opendata/atlas/rucio/opendata/ODEO_FEB2025_v0_2bjets_mc_345056.PowhegPythia8EvtGen_NNPDF3_AZNLO_ZH125J_MINLO_vvbb_VpT.2bjets.root"
+        "checksum": "adler32:55402e7a",
+        "size": 6175207,
+        "uri": "root://eospublic.cern.ch//eos/opendata/atlas/rucio/user/egramsta/mc_345056.PowhegPythia8EvtGen_NNPDF3_AZNLO_ZH125J_MINLO_vvbb_VpT.2bjets70.root"
       },
       {
-        "checksum": "adler32:0777f63b",
-        "size": 235911,
-        "uri": "root://eospublic.cern.ch//eos/opendata/atlas/rucio/opendata/ODEO_FEB2025_v0_2bjets_mc_345058.PowhegPythia8EvtGen_NNPDF3_AZNLO_ggZH125_vvbb.2bjets.root"
+        "checksum": "adler32:68c0480b",
+        "size": 6952179,
+        "uri": "root://eospublic.cern.ch//eos/opendata/atlas/rucio/user/egramsta/mc_345058.PowhegPythia8EvtGen_NNPDF3_AZNLO_ggZH125_vvbb.2bjets70.root"
       },
       {
-        "checksum": "adler32:088b6d62",
-        "size": 787649,
-        "uri": "root://eospublic.cern.ch//eos/opendata/atlas/rucio/opendata/ODEO_FEB2025_v0_2bjets_mc_345060.PowhegPythia8EvtGen_NNLOPS_nnlo_30_ggH125_ZZ4l.2bjets.root"
+        "checksum": "adler32:5277e73b",
+        "size": 1235253,
+        "uri": "root://eospublic.cern.ch//eos/opendata/atlas/rucio/user/egramsta/mc_345060.PowhegPythia8EvtGen_NNLOPS_nnlo_30_ggH125_ZZ4l.2bjets70.root"
       },
       {
-        "checksum": "adler32:97947c27",
-        "size": 82134,
-        "uri": "root://eospublic.cern.ch//eos/opendata/atlas/rucio/opendata/ODEO_FEB2025_v0_2bjets_mc_345061.PowhegPythia8EvtGen_NNPDF3_AZNLO_ggZH125_HgamgamZinc.2bjets.root"
+        "checksum": "adler32:c7f29fed",
+        "size": 568703,
+        "uri": "root://eospublic.cern.ch//eos/opendata/atlas/rucio/user/egramsta/mc_345061.PowhegPythia8EvtGen_NNPDF3_AZNLO_ggZH125_HgamgamZinc.2bjets70.root"
       },
       {
-        "checksum": "adler32:ce2a970e",
-        "size": 152598,
-        "uri": "root://eospublic.cern.ch//eos/opendata/atlas/rucio/opendata/ODEO_FEB2025_v0_2bjets_mc_345066.PowhegPythia8EvtGen_NNPDF3_AZNLO_ggZH125_ZZ4lepZinc.2bjets.root"
+        "checksum": "adler32:4e8254b1",
+        "size": 833331,
+        "uri": "root://eospublic.cern.ch//eos/opendata/atlas/rucio/user/egramsta/mc_345066.PowhegPythia8EvtGen_NNPDF3_AZNLO_ggZH125_ZZ4lepZinc.2bjets70.root"
       },
       {
-        "checksum": "adler32:99ec0985",
-        "size": 65205,
-        "uri": "root://eospublic.cern.ch//eos/opendata/atlas/rucio/opendata/ODEO_FEB2025_v0_2bjets_mc_345097.PowhegPythia8EvtGen_NNLOPS_nnlo_30_ggH125_mumu.2bjets.root"
+        "checksum": "adler32:7841eb88",
+        "size": 111858,
+        "uri": "root://eospublic.cern.ch//eos/opendata/atlas/rucio/user/egramsta/mc_345097.PowhegPythia8EvtGen_NNLOPS_nnlo_30_ggH125_mumu.2bjets70.root"
       },
       {
-        "checksum": "adler32:a907d032",
-        "size": 84818,
-        "uri": "root://eospublic.cern.ch//eos/opendata/atlas/rucio/opendata/ODEO_FEB2025_v0_2bjets_mc_345098.PowhegPythia8EvtGen_NNPDF3_AZNLO_ggZH125_Hmumu_Zinc.2bjets.root"
+        "checksum": "adler32:4606195b",
+        "size": 672934,
+        "uri": "root://eospublic.cern.ch//eos/opendata/atlas/rucio/user/egramsta/mc_345098.PowhegPythia8EvtGen_NNPDF3_AZNLO_ggZH125_Hmumu_Zinc.2bjets70.root"
       },
       {
-        "checksum": "adler32:40b42397",
-        "size": 75214,
-        "uri": "root://eospublic.cern.ch//eos/opendata/atlas/rucio/opendata/ODEO_FEB2025_v0_2bjets_mc_345103.PowhegPythia8EvtGen_NNPDF30_AZNLO_ZH125J_Hmumu_Zincl_MINLO.2bjets.root"
+        "checksum": "adler32:c1b66d47",
+        "size": 493366,
+        "uri": "root://eospublic.cern.ch//eos/opendata/atlas/rucio/user/egramsta/mc_345103.PowhegPythia8EvtGen_NNPDF30_AZNLO_ZH125J_Hmumu_Zincl_MINLO.2bjets70.root"
       },
       {
-        "checksum": "adler32:5ad02ca2",
-        "size": 57998,
-        "uri": "root://eospublic.cern.ch//eos/opendata/atlas/rucio/opendata/ODEO_FEB2025_v0_2bjets_mc_345104.PowhegPythia8EvtGen_NNPDF30_AZNLO_WpH125J_Hmumu_Wincl_MINLO.2bjets.root"
+        "checksum": "adler32:a858cdd1",
+        "size": 43886,
+        "uri": "root://eospublic.cern.ch//eos/opendata/atlas/rucio/user/egramsta/mc_345104.PowhegPythia8EvtGen_NNPDF30_AZNLO_WpH125J_Hmumu_Wincl_MINLO.2bjets70.root"
       },
       {
-        "checksum": "adler32:c782b6c0",
-        "size": 51653,
-        "uri": "root://eospublic.cern.ch//eos/opendata/atlas/rucio/opendata/ODEO_FEB2025_v0_2bjets_mc_345105.PowhegPythia8EvtGen_NNPDF30_AZNLO_WmH125J_Hmumu_Wincl_MINLO.2bjets.root"
+        "checksum": "adler32:9e49f526",
+        "size": 39864,
+        "uri": "root://eospublic.cern.ch//eos/opendata/atlas/rucio/user/egramsta/mc_345105.PowhegPythia8EvtGen_NNPDF30_AZNLO_WmH125J_Hmumu_Wincl_MINLO.2bjets70.root"
       },
       {
-        "checksum": "adler32:388149b9",
-        "size": 67428,
-        "uri": "root://eospublic.cern.ch//eos/opendata/atlas/rucio/opendata/ODEO_FEB2025_v0_2bjets_mc_345106.PowhegPythia8EvtGen_NNPDF30_AZNLOCTEQ6L1_VBFH125_mumu.2bjets.root"
+        "checksum": "adler32:328c817b",
+        "size": 113668,
+        "uri": "root://eospublic.cern.ch//eos/opendata/atlas/rucio/user/egramsta/mc_345106.PowhegPythia8EvtGen_NNPDF30_AZNLOCTEQ6L1_VBFH125_mumu.2bjets70.root"
       },
       {
-        "checksum": "adler32:fcd86ab5",
-        "size": 518082,
-        "uri": "root://eospublic.cern.ch//eos/opendata/atlas/rucio/opendata/ODEO_FEB2025_v0_2bjets_mc_345112.PowhegPythia8EvtGen_NNPDF3_AZNLO_ZH125J_MINLO_vvcc_VpT.2bjets.root"
+        "checksum": "adler32:c4fce84d",
+        "size": 211725,
+        "uri": "root://eospublic.cern.ch//eos/opendata/atlas/rucio/user/egramsta/mc_345112.PowhegPythia8EvtGen_NNPDF3_AZNLO_ZH125J_MINLO_vvcc_VpT.2bjets70.root"
       },
       {
-        "checksum": "adler32:8755e05e",
-        "size": 552303,
-        "uri": "root://eospublic.cern.ch//eos/opendata/atlas/rucio/opendata/ODEO_FEB2025_v0_2bjets_mc_345114.PowhegPythia8EvtGen_NNPDF3_AZNLO_ggZH125_vvcc.2bjets.root"
+        "checksum": "adler32:bdc617dc",
+        "size": 209243,
+        "uri": "root://eospublic.cern.ch//eos/opendata/atlas/rucio/user/egramsta/mc_345114.PowhegPythia8EvtGen_NNPDF3_AZNLO_ggZH125_vvcc.2bjets70.root"
       },
       {
-        "checksum": "adler32:0b201ade",
-        "size": 102447,
-        "uri": "root://eospublic.cern.ch//eos/opendata/atlas/rucio/opendata/ODEO_FEB2025_v0_2bjets_mc_345120.PowhegPy8EG_NNLOPS_nnlo_30_ggH125_tautaul13l7.2bjets.root"
+        "checksum": "adler32:0c82045a",
+        "size": 141994,
+        "uri": "root://eospublic.cern.ch//eos/opendata/atlas/rucio/user/egramsta/mc_345120.PowhegPy8EG_NNLOPS_nnlo_30_ggH125_tautaul13l7.2bjets70.root"
       },
       {
-        "checksum": "adler32:ac93d480",
-        "size": 100601,
-        "uri": "root://eospublic.cern.ch//eos/opendata/atlas/rucio/opendata/ODEO_FEB2025_v0_2bjets_mc_345121.PowhegPy8EG_NNLOPS_nnlo_30_ggH125_tautaulm15hp20.2bjets.root"
+        "checksum": "adler32:906012a3",
+        "size": 119887,
+        "uri": "root://eospublic.cern.ch//eos/opendata/atlas/rucio/user/egramsta/mc_345121.PowhegPy8EG_NNLOPS_nnlo_30_ggH125_tautaulm15hp20.2bjets70.root"
       },
       {
-        "checksum": "adler32:3e9a52af",
-        "size": 146009,
-        "uri": "root://eospublic.cern.ch//eos/opendata/atlas/rucio/opendata/ODEO_FEB2025_v0_2bjets_mc_345122.PowhegPy8EG_NNLOPS_nnlo_30_ggH125_tautaulp15hm20.2bjets.root"
+        "checksum": "adler32:079ec8a0",
+        "size": 177501,
+        "uri": "root://eospublic.cern.ch//eos/opendata/atlas/rucio/user/egramsta/mc_345122.PowhegPy8EG_NNLOPS_nnlo_30_ggH125_tautaulp15hm20.2bjets70.root"
       },
       {
-        "checksum": "adler32:46f2f21f",
-        "size": 247448,
-        "uri": "root://eospublic.cern.ch//eos/opendata/atlas/rucio/opendata/ODEO_FEB2025_v0_2bjets_mc_345123.PowhegPy8EG_NNLOPS_nnlo_30_ggH125_tautauh30h20.2bjets.root"
+        "checksum": "adler32:611355b0",
+        "size": 233626,
+        "uri": "root://eospublic.cern.ch//eos/opendata/atlas/rucio/user/egramsta/mc_345123.PowhegPy8EG_NNLOPS_nnlo_30_ggH125_tautauh30h20.2bjets70.root"
       },
       {
-        "checksum": "adler32:779c4490",
-        "size": 623509,
-        "uri": "root://eospublic.cern.ch//eos/opendata/atlas/rucio/opendata/ODEO_FEB2025_v0_2bjets_mc_345124.PowhegPy8EG_NNLOPS_nnlo_30_ggH125_etau_filt.2bjets.root"
+        "checksum": "adler32:809cd4d9",
+        "size": 883459,
+        "uri": "root://eospublic.cern.ch//eos/opendata/atlas/rucio/user/egramsta/mc_345124.PowhegPy8EG_NNLOPS_nnlo_30_ggH125_etau_filt.2bjets70.root"
       },
       {
-        "checksum": "adler32:44e826f2",
-        "size": 720755,
-        "uri": "root://eospublic.cern.ch//eos/opendata/atlas/rucio/opendata/ODEO_FEB2025_v0_2bjets_mc_345125.PowhegPy8EG_NNLOPS_nnlo_30_ggH125_mutau_filt.2bjets.root"
+        "checksum": "adler32:afa52be2",
+        "size": 992508,
+        "uri": "root://eospublic.cern.ch//eos/opendata/atlas/rucio/user/egramsta/mc_345125.PowhegPy8EG_NNLOPS_nnlo_30_ggH125_mutau_filt.2bjets70.root"
       },
       {
-        "checksum": "adler32:437bfa2f",
-        "size": 96500,
-        "uri": "root://eospublic.cern.ch//eos/opendata/atlas/rucio/opendata/ODEO_FEB2025_v0_2bjets_mc_345211.PowhegPy8EG_NNPDF30_AZNLO_WmH125J_Winc_MINLO_tautau.2bjets.root"
+        "checksum": "adler32:3ef0143b",
+        "size": 41842,
+        "uri": "root://eospublic.cern.ch//eos/opendata/atlas/rucio/user/egramsta/mc_345211.PowhegPy8EG_NNPDF30_AZNLO_WmH125J_Winc_MINLO_tautau.2bjets70.root"
       },
       {
-        "checksum": "adler32:2e4533ea",
-        "size": 97926,
-        "uri": "root://eospublic.cern.ch//eos/opendata/atlas/rucio/opendata/ODEO_FEB2025_v0_2bjets_mc_345212.PowhegPy8EG_NNPDF30_AZNLO_WpH125J_Winc_MINLO_tautau.2bjets.root"
+        "checksum": "adler32:d2cce8ef",
+        "size": 57734,
+        "uri": "root://eospublic.cern.ch//eos/opendata/atlas/rucio/user/egramsta/mc_345212.PowhegPy8EG_NNPDF30_AZNLO_WpH125J_Winc_MINLO_tautau.2bjets70.root"
       },
       {
-        "checksum": "adler32:756ff182",
-        "size": 70723,
-        "uri": "root://eospublic.cern.ch//eos/opendata/atlas/rucio/opendata/ODEO_FEB2025_v0_2bjets_mc_345213.PowhegPy8EG_NNPDF30_AZNLO_WmH125J_Winc_MINLO_etau.2bjets.root"
+        "checksum": "adler32:968d65ac",
+        "size": 50602,
+        "uri": "root://eospublic.cern.ch//eos/opendata/atlas/rucio/user/egramsta/mc_345213.PowhegPy8EG_NNPDF30_AZNLO_WmH125J_Winc_MINLO_etau.2bjets70.root"
       },
       {
-        "checksum": "adler32:23642f91",
-        "size": 131647,
-        "uri": "root://eospublic.cern.ch//eos/opendata/atlas/rucio/opendata/ODEO_FEB2025_v0_2bjets_mc_345214.PowhegPy8EG_NNPDF30_AZNLO_WpH125J_Winc_MINLO_etau.2bjets.root"
+        "checksum": "adler32:cb3535a0",
+        "size": 88116,
+        "uri": "root://eospublic.cern.ch//eos/opendata/atlas/rucio/user/egramsta/mc_345214.PowhegPy8EG_NNPDF30_AZNLO_WpH125J_Winc_MINLO_etau.2bjets70.root"
       },
       {
-        "checksum": "adler32:f8a77726",
-        "size": 90442,
-        "uri": "root://eospublic.cern.ch//eos/opendata/atlas/rucio/opendata/ODEO_FEB2025_v0_2bjets_mc_345215.PowhegPy8EG_NNPDF30_AZNLO_WmH125J_Winc_MINLO_mutau.2bjets.root"
+        "checksum": "adler32:c60b26c8",
+        "size": 50123,
+        "uri": "root://eospublic.cern.ch//eos/opendata/atlas/rucio/user/egramsta/mc_345215.PowhegPy8EG_NNPDF30_AZNLO_WmH125J_Winc_MINLO_mutau.2bjets70.root"
       },
       {
-        "checksum": "adler32:d7bedd8f",
-        "size": 142360,
-        "uri": "root://eospublic.cern.ch//eos/opendata/atlas/rucio/opendata/ODEO_FEB2025_v0_2bjets_mc_345216.PowhegPy8EG_NNPDF30_AZNLO_WpH125J_Winc_MINLO_mutau.2bjets.root"
+        "checksum": "adler32:49b707a3",
+        "size": 85182,
+        "uri": "root://eospublic.cern.ch//eos/opendata/atlas/rucio/user/egramsta/mc_345216.PowhegPy8EG_NNPDF30_AZNLO_WpH125J_Winc_MINLO_mutau.2bjets70.root"
       },
       {
-        "checksum": "adler32:d8b4e205",
-        "size": 188184,
-        "uri": "root://eospublic.cern.ch//eos/opendata/atlas/rucio/opendata/ODEO_FEB2025_v0_2bjets_mc_345217.PowhegPy8EG_NNPDF30_AZNLO_ZH125J_Zinc_MINLO_tautau.2bjets.root"
+        "checksum": "adler32:c25fba03",
+        "size": 765830,
+        "uri": "root://eospublic.cern.ch//eos/opendata/atlas/rucio/user/egramsta/mc_345217.PowhegPy8EG_NNPDF30_AZNLO_ZH125J_Zinc_MINLO_tautau.2bjets70.root"
       },
       {
-        "checksum": "adler32:6250bc4d",
-        "size": 142858,
-        "uri": "root://eospublic.cern.ch//eos/opendata/atlas/rucio/opendata/ODEO_FEB2025_v0_2bjets_mc_345218.PowhegPy8EG_NNPDF30_AZNLO_ZH125J_Zinc_MINLO_etau.2bjets.root"
+        "checksum": "adler32:4866b124",
+        "size": 795297,
+        "uri": "root://eospublic.cern.ch//eos/opendata/atlas/rucio/user/egramsta/mc_345218.PowhegPy8EG_NNPDF30_AZNLO_ZH125J_Zinc_MINLO_etau.2bjets70.root"
       },
       {
-        "checksum": "adler32:b446474e",
-        "size": 132399,
-        "uri": "root://eospublic.cern.ch//eos/opendata/atlas/rucio/opendata/ODEO_FEB2025_v0_2bjets_mc_345219.PowhegPy8EG_NNPDF30_AZNLO_ZH125J_Zinc_MINLO_mutau.2bjets.root"
+        "checksum": "adler32:6e536928",
+        "size": 716930,
+        "uri": "root://eospublic.cern.ch//eos/opendata/atlas/rucio/user/egramsta/mc_345219.PowhegPy8EG_NNPDF30_AZNLO_ZH125J_Zinc_MINLO_mutau.2bjets70.root"
       },
       {
-        "checksum": "adler32:9d45c91d",
-        "size": 377298,
-        "uri": "root://eospublic.cern.ch//eos/opendata/atlas/rucio/opendata/ODEO_FEB2025_v0_2bjets_mc_345316.PowhegPythia8EvtGen_NNLOPS_nnlo_30_ggH125_Zy_Zll.2bjets.root"
+        "checksum": "adler32:3199a48e",
+        "size": 435506,
+        "uri": "root://eospublic.cern.ch//eos/opendata/atlas/rucio/user/egramsta/mc_345316.PowhegPythia8EvtGen_NNLOPS_nnlo_30_ggH125_Zy_Zll.2bjets70.root"
       },
       {
-        "checksum": "adler32:df5feb6d",
-        "size": 186670,
-        "uri": "root://eospublic.cern.ch//eos/opendata/atlas/rucio/opendata/ODEO_FEB2025_v0_2bjets_mc_345317.PowhegPythia8EvtGen_NNPDF30_AZNLO_WmH125J_Hyy_Wincl_MINLO.2bjets.root"
+        "checksum": "adler32:af65ea8d",
+        "size": 156192,
+        "uri": "root://eospublic.cern.ch//eos/opendata/atlas/rucio/user/egramsta/mc_345317.PowhegPythia8EvtGen_NNPDF30_AZNLO_WmH125J_Hyy_Wincl_MINLO.2bjets70.root"
       },
       {
-        "checksum": "adler32:d1ce683a",
-        "size": 102509,
-        "uri": "root://eospublic.cern.ch//eos/opendata/atlas/rucio/opendata/ODEO_FEB2025_v0_2bjets_mc_345318.PowhegPythia8EvtGen_NNPDF30_AZNLO_WpH125J_Hyy_Wincl_MINLO.2bjets.root"
+        "checksum": "adler32:ca76aac2",
+        "size": 85852,
+        "uri": "root://eospublic.cern.ch//eos/opendata/atlas/rucio/user/egramsta/mc_345318.PowhegPythia8EvtGen_NNPDF30_AZNLO_WpH125J_Hyy_Wincl_MINLO.2bjets70.root"
       },
       {
-        "checksum": "adler32:7b0bb3b3",
-        "size": 102393,
-        "uri": "root://eospublic.cern.ch//eos/opendata/atlas/rucio/opendata/ODEO_FEB2025_v0_2bjets_mc_345319.PowhegPythia8EvtGen_NNPDF30_AZNLO_ZH125J_Hyy_Zincl_MINLO.2bjets.root"
+        "checksum": "adler32:abadbcc3",
+        "size": 689538,
+        "uri": "root://eospublic.cern.ch//eos/opendata/atlas/rucio/user/egramsta/mc_345319.PowhegPythia8EvtGen_NNPDF30_AZNLO_ZH125J_Hyy_Zincl_MINLO.2bjets70.root"
       },
       {
-        "checksum": "adler32:c3c475d7",
-        "size": 48509,
-        "uri": "root://eospublic.cern.ch//eos/opendata/atlas/rucio/opendata/ODEO_FEB2025_v0_2bjets_mc_345320.PowhegPythia8EvtGen_NNPDF30_AZNLO_WmH125J_HZy_Wincl_MINLO.2bjets.root"
+        "checksum": "adler32:08ca89c3",
+        "size": 35057,
+        "uri": "root://eospublic.cern.ch//eos/opendata/atlas/rucio/user/egramsta/mc_345320.PowhegPythia8EvtGen_NNPDF30_AZNLO_WmH125J_HZy_Wincl_MINLO.2bjets70.root"
       },
       {
-        "checksum": "adler32:e50c9cf2",
-        "size": 48564,
-        "uri": "root://eospublic.cern.ch//eos/opendata/atlas/rucio/opendata/ODEO_FEB2025_v0_2bjets_mc_345321.PowhegPythia8EvtGen_NNPDF30_AZNLO_WpH125J_HZy_Wincl_MINLO.2bjets.root"
+        "checksum": "adler32:da7afc30",
+        "size": 39283,
+        "uri": "root://eospublic.cern.ch//eos/opendata/atlas/rucio/user/egramsta/mc_345321.PowhegPythia8EvtGen_NNPDF30_AZNLO_WpH125J_HZy_Wincl_MINLO.2bjets70.root"
       },
       {
-        "checksum": "adler32:15337c87",
-        "size": 88292,
-        "uri": "root://eospublic.cern.ch//eos/opendata/atlas/rucio/opendata/ODEO_FEB2025_v0_2bjets_mc_345322.PowhegPythia8EvtGen_NNPDF30_AZNLO_ZH125J_HZy_Zincl_MINLO.2bjets.root"
+        "checksum": "adler32:3068f3bd",
+        "size": 463692,
+        "uri": "root://eospublic.cern.ch//eos/opendata/atlas/rucio/user/egramsta/mc_345322.PowhegPythia8EvtGen_NNPDF30_AZNLO_ZH125J_HZy_Zincl_MINLO.2bjets70.root"
       },
       {
-        "checksum": "adler32:a8002ab2",
-        "size": 78054,
-        "uri": "root://eospublic.cern.ch//eos/opendata/atlas/rucio/opendata/ODEO_FEB2025_v0_2bjets_mc_345324.PowhegPythia8EvtGen_NNLOPS_NN30_ggH125_WWlvlv_EF_15_5.2bjets.root"
+        "checksum": "adler32:4129d096",
+        "size": 139161,
+        "uri": "root://eospublic.cern.ch//eos/opendata/atlas/rucio/user/egramsta/mc_345324.PowhegPythia8EvtGen_NNLOPS_NN30_ggH125_WWlvlv_EF_15_5.2bjets70.root"
       },
       {
-        "checksum": "adler32:37ee7f71",
-        "size": 132027,
-        "uri": "root://eospublic.cern.ch//eos/opendata/atlas/rucio/opendata/ODEO_FEB2025_v0_2bjets_mc_345325.PowhegPythia8EvtGen_NNPDF3_AZNLO_WpH125J_MINLO_qqWWlvlv.2bjets.root"
+        "checksum": "adler32:abf4b0e8",
+        "size": 89500,
+        "uri": "root://eospublic.cern.ch//eos/opendata/atlas/rucio/user/egramsta/mc_345325.PowhegPythia8EvtGen_NNPDF3_AZNLO_WpH125J_MINLO_qqWWlvlv.2bjets70.root"
       },
       {
-        "checksum": "adler32:bf072510",
-        "size": 158908,
-        "uri": "root://eospublic.cern.ch//eos/opendata/atlas/rucio/opendata/ODEO_FEB2025_v0_2bjets_mc_345433.PowhegPythia8EvtGen_NNPDF3_AZNLO_WmH125J_MINLO_qqWWlvlv.2bjets.root"
+        "checksum": "adler32:4f905dec",
+        "size": 105343,
+        "uri": "root://eospublic.cern.ch//eos/opendata/atlas/rucio/user/egramsta/mc_345433.PowhegPythia8EvtGen_NNPDF3_AZNLO_WmH125J_MINLO_qqWWlvlv.2bjets70.root"
       },
       {
-        "checksum": "adler32:50699871",
-        "size": 47614,
-        "uri": "root://eospublic.cern.ch//eos/opendata/atlas/rucio/opendata/ODEO_FEB2025_v0_2bjets_mc_345445.PowhegPythia8EvtGen_NNPDF3_AZNLO_ZH125J_MINLO_vvWWlvlv.2bjets.root"
+        "checksum": "adler32:2be4b39d",
+        "size": 65224,
+        "uri": "root://eospublic.cern.ch//eos/opendata/atlas/rucio/user/egramsta/mc_345445.PowhegPythia8EvtGen_NNPDF3_AZNLO_ZH125J_MINLO_vvWWlvlv.2bjets70.root"
       },
       {
-        "checksum": "adler32:4b77d02a",
-        "size": 73679,
-        "uri": "root://eospublic.cern.ch//eos/opendata/atlas/rucio/opendata/ODEO_FEB2025_v0_2bjets_mc_345596.PowhegPythia8EvtGen_NNPDF3_AZNLO_ggZH125_Zinc_HZZinv.2bjets.root"
+        "checksum": "adler32:1c4d4144",
+        "size": 473298,
+        "uri": "root://eospublic.cern.ch//eos/opendata/atlas/rucio/user/egramsta/mc_345596.PowhegPythia8EvtGen_NNPDF3_AZNLO_ggZH125_Zinc_HZZinv.2bjets70.root"
       },
       {
-        "checksum": "adler32:5873b701",
-        "size": 149019,
-        "uri": "root://eospublic.cern.ch//eos/opendata/atlas/rucio/opendata/ODEO_FEB2025_v0_2bjets_mc_345697.MadGraphPythia8EvtGen_AZNLOCTEQ6L1_ggfhtautaullNp2.2bjets.root"
+        "checksum": "adler32:9d3bd5c8",
+        "size": 224972,
+        "uri": "root://eospublic.cern.ch//eos/opendata/atlas/rucio/user/egramsta/mc_345697.MadGraphPythia8EvtGen_AZNLOCTEQ6L1_ggfhtautaullNp2.2bjets70.root"
       },
       {
-        "checksum": "adler32:8ef56708",
-        "size": 319229,
-        "uri": "root://eospublic.cern.ch//eos/opendata/atlas/rucio/opendata/ODEO_FEB2025_v0_2bjets_mc_345698.MadGraphPythia8EvtGen_AZNLOCTEQ6L1_ggfhtautaulhNp2.2bjets.root"
+        "checksum": "adler32:f86eede4",
+        "size": 424977,
+        "uri": "root://eospublic.cern.ch//eos/opendata/atlas/rucio/user/egramsta/mc_345698.MadGraphPythia8EvtGen_AZNLOCTEQ6L1_ggfhtautaulhNp2.2bjets70.root"
       },
       {
-        "checksum": "adler32:d4a1c068",
-        "size": 480506,
-        "uri": "root://eospublic.cern.ch//eos/opendata/atlas/rucio/opendata/ODEO_FEB2025_v0_2bjets_mc_345699.MadGraphPythia8EvtGen_AZNLOCTEQ6L1_ggfhtautauhhNp2.2bjets.root"
+        "checksum": "adler32:ae6958bb",
+        "size": 507437,
+        "uri": "root://eospublic.cern.ch//eos/opendata/atlas/rucio/user/egramsta/mc_345699.MadGraphPythia8EvtGen_AZNLOCTEQ6L1_ggfhtautauhhNp2.2bjets70.root"
       },
       {
-        "checksum": "adler32:a35775c5",
-        "size": 253750,
-        "uri": "root://eospublic.cern.ch//eos/opendata/atlas/rucio/opendata/ODEO_FEB2025_v0_2bjets_mc_345833.PowhegPythia8EvtGen_NNPDF30_AZNLOCTEQ6L1_VBFH125_Zllgam.2bjets.root"
+        "checksum": "adler32:3ea22fae",
+        "size": 309161,
+        "uri": "root://eospublic.cern.ch//eos/opendata/atlas/rucio/user/egramsta/mc_345833.PowhegPythia8EvtGen_NNPDF30_AZNLOCTEQ6L1_VBFH125_Zllgam.2bjets70.root"
       },
       {
-        "checksum": "adler32:2a5a5228",
-        "size": 38135,
-        "uri": "root://eospublic.cern.ch//eos/opendata/atlas/rucio/opendata/ODEO_FEB2025_v0_2bjets_mc_345834.PowhegPythia8EvtGen_NNPDF30_AZNLOCTEQ6L1_VBFH125_gamstargam.2bjets.root"
+        "checksum": "adler32:41c153b5",
+        "size": 50249,
+        "uri": "root://eospublic.cern.ch//eos/opendata/atlas/rucio/user/egramsta/mc_345834.PowhegPythia8EvtGen_NNPDF30_AZNLOCTEQ6L1_VBFH125_gamstargam.2bjets70.root"
       },
       {
-        "checksum": "adler32:d31614ec",
-        "size": 71200,
-        "uri": "root://eospublic.cern.ch//eos/opendata/atlas/rucio/opendata/ODEO_FEB2025_v0_2bjets_mc_345876.PowhegPythia8EvtGen_NNPDF30_AZNLO_ZH125J_Hee__Zincl_MINLO.2bjets.root"
+        "checksum": "adler32:c0c79f5b",
+        "size": 494155,
+        "uri": "root://eospublic.cern.ch//eos/opendata/atlas/rucio/user/egramsta/mc_345876.PowhegPythia8EvtGen_NNPDF30_AZNLO_ZH125J_Hee__Zincl_MINLO.2bjets70.root"
       },
       {
-        "checksum": "adler32:074207b0",
-        "size": 41316,
-        "uri": "root://eospublic.cern.ch//eos/opendata/atlas/rucio/opendata/ODEO_FEB2025_v0_2bjets_mc_345877.PowhegPythia8EvtGen_NNPDF30_AZNLO_WpH125J_Hee_Wincl_MINLO.2bjets.root"
+        "checksum": "adler32:3978682d",
+        "size": 42134,
+        "uri": "root://eospublic.cern.ch//eos/opendata/atlas/rucio/user/egramsta/mc_345877.PowhegPythia8EvtGen_NNPDF30_AZNLO_WpH125J_Hee_Wincl_MINLO.2bjets70.root"
       },
       {
-        "checksum": "adler32:aaa8ee2b",
-        "size": 45076,
-        "uri": "root://eospublic.cern.ch//eos/opendata/atlas/rucio/opendata/ODEO_FEB2025_v0_2bjets_mc_345878.PowhegPythia8EvtGen_NNPDF30_AZNLO_WmH125J_Hee_Wincl_MINLO.2bjets.root"
+        "checksum": "adler32:df210e2a",
+        "size": 39175,
+        "uri": "root://eospublic.cern.ch//eos/opendata/atlas/rucio/user/egramsta/mc_345878.PowhegPythia8EvtGen_NNPDF30_AZNLO_WmH125J_Hee_Wincl_MINLO.2bjets70.root"
       },
       {
-        "checksum": "adler32:a0885926",
-        "size": 100884,
-        "uri": "root://eospublic.cern.ch//eos/opendata/atlas/rucio/opendata/ODEO_FEB2025_v0_2bjets_mc_345944.aMcAtNloPy8EG_A14NNPDF23LO_ppx0yy_FxFx_Np012_SM.2bjets.root"
+        "checksum": "adler32:587f4dec",
+        "size": 179722,
+        "uri": "root://eospublic.cern.ch//eos/opendata/atlas/rucio/user/egramsta/mc_345944.aMcAtNloPy8EG_A14NNPDF23LO_ppx0yy_FxFx_Np012_SM.2bjets70.root"
       },
       {
-        "checksum": "adler32:e6db4928",
-        "size": 107936,
-        "uri": "root://eospublic.cern.ch//eos/opendata/atlas/rucio/opendata/ODEO_FEB2025_v0_2bjets_mc_345948.PowhegPy8EG_NNPDF30_AZNLOCTEQ6L1_VBFH125_WWlvlv.2bjets.root"
+        "checksum": "adler32:2395f563",
+        "size": 175006,
+        "uri": "root://eospublic.cern.ch//eos/opendata/atlas/rucio/user/egramsta/mc_345948.PowhegPy8EG_NNPDF30_AZNLOCTEQ6L1_VBFH125_WWlvlv.2bjets70.root"
       },
       {
-        "checksum": "adler32:34b1fb6c",
-        "size": 341790,
-        "uri": "root://eospublic.cern.ch//eos/opendata/atlas/rucio/opendata/ODEO_FEB2025_v0_2bjets_mc_345949.PowhegPythia8EvtGen_NNPDF30_AZNLOCTEQ6L1_VBFH125_bb.2bjets.root"
+        "checksum": "adler32:65f7ba82",
+        "size": 9585421,
+        "uri": "root://eospublic.cern.ch//eos/opendata/atlas/rucio/user/egramsta/mc_345949.PowhegPythia8EvtGen_NNPDF30_AZNLOCTEQ6L1_VBFH125_bb.2bjets70.root"
       },
       {
-        "checksum": "adler32:a2718729",
-        "size": 55768,
-        "uri": "root://eospublic.cern.ch//eos/opendata/atlas/rucio/opendata/ODEO_FEB2025_v0_2bjets_mc_345961.PowhegPythia8EvtGen_NNLOPS_nnlo_30_ggH125_gamstargam.2bjets.root"
+        "checksum": "adler32:7ac0efa6",
+        "size": 94020,
+        "uri": "root://eospublic.cern.ch//eos/opendata/atlas/rucio/user/egramsta/mc_345961.PowhegPythia8EvtGen_NNLOPS_nnlo_30_ggH125_gamstargam.2bjets70.root"
       },
       {
-        "checksum": "adler32:cd5a8bcb",
-        "size": 45194,
-        "uri": "root://eospublic.cern.ch//eos/opendata/atlas/rucio/opendata/ODEO_FEB2025_v0_2bjets_mc_345963.PowhegPythia8EvtGen_NNPDF30_AZNLO_WmH125J_Hgamstargam_MINLO.2bjets.root"
+        "checksum": "adler32:7387e38e",
+        "size": 34673,
+        "uri": "root://eospublic.cern.ch//eos/opendata/atlas/rucio/user/egramsta/mc_345963.PowhegPythia8EvtGen_NNPDF30_AZNLO_WmH125J_Hgamstargam_MINLO.2bjets70.root"
       },
       {
-        "checksum": "adler32:2e774858",
-        "size": 44993,
-        "uri": "root://eospublic.cern.ch//eos/opendata/atlas/rucio/opendata/ODEO_FEB2025_v0_2bjets_mc_345964.PowhegPythia8EvtGen_NNPDF30_AZNLO_WpH125J_Hgamstargam_MINLO.2bjets.root"
+        "checksum": "adler32:e89bc602",
+        "size": 37229,
+        "uri": "root://eospublic.cern.ch//eos/opendata/atlas/rucio/user/egramsta/mc_345964.PowhegPythia8EvtGen_NNPDF30_AZNLO_WpH125J_Hgamstargam_MINLO.2bjets70.root"
       },
       {
-        "checksum": "adler32:c1552ea7",
-        "size": 65462,
-        "uri": "root://eospublic.cern.ch//eos/opendata/atlas/rucio/opendata/ODEO_FEB2025_v0_2bjets_mc_345965.PowhegPythia8EvtGen_NNPDF30_AZNLO_ZH125J_Hgamstargam_MINLO.2bjets.root"
+        "checksum": "adler32:1d3a4bf0",
+        "size": 408687,
+        "uri": "root://eospublic.cern.ch//eos/opendata/atlas/rucio/user/egramsta/mc_345965.PowhegPythia8EvtGen_NNPDF30_AZNLO_ZH125J_Hgamstargam_MINLO.2bjets70.root"
       },
       {
-        "checksum": "adler32:9e7ccd14",
-        "size": 188941,
-        "uri": "root://eospublic.cern.ch//eos/opendata/atlas/rucio/opendata/ODEO_FEB2025_v0_2bjets_mc_346188.aMcAtNloPythia8EvtGen_tHjb125_4fl_gamgam.2bjets.root"
+        "checksum": "adler32:8e3c8c23",
+        "size": 2164570,
+        "uri": "root://eospublic.cern.ch//eos/opendata/atlas/rucio/user/egramsta/mc_346188.aMcAtNloPythia8EvtGen_tHjb125_4fl_gamgam.2bjets70.root"
       },
       {
-        "checksum": "adler32:f7e041b2",
-        "size": 526706,
-        "uri": "root://eospublic.cern.ch//eos/opendata/atlas/rucio/opendata/ODEO_FEB2025_v0_2bjets_mc_346189.aMcAtNloPythia8EvtGen_ttH_gamgam.2bjets.root"
+        "checksum": "adler32:951235f5",
+        "size": 6546306,
+        "uri": "root://eospublic.cern.ch//eos/opendata/atlas/rucio/user/egramsta/mc_346189.aMcAtNloPythia8EvtGen_ttH_gamgam.2bjets70.root"
       },
       {
-        "checksum": "adler32:6214f259",
-        "size": 103749,
-        "uri": "root://eospublic.cern.ch//eos/opendata/atlas/rucio/opendata/ODEO_FEB2025_v0_2bjets_mc_346190.PowhegPy8EG_NNPDF30_AZNLOCTEQ6L1_VBFH125_tautaul13l7.2bjets.root"
+        "checksum": "adler32:c0942757",
+        "size": 129275,
+        "uri": "root://eospublic.cern.ch//eos/opendata/atlas/rucio/user/egramsta/mc_346190.PowhegPy8EG_NNPDF30_AZNLOCTEQ6L1_VBFH125_tautaul13l7.2bjets70.root"
       },
       {
-        "checksum": "adler32:ff8a0cbd",
-        "size": 94662,
-        "uri": "root://eospublic.cern.ch//eos/opendata/atlas/rucio/opendata/ODEO_FEB2025_v0_2bjets_mc_346191.PowhegPy8EG_NNPDF30_AZNLOCTEQ6L1_VBFH125_tautaulm15hp20.2bjets.root"
+        "checksum": "adler32:04f0797e",
+        "size": 93031,
+        "uri": "root://eospublic.cern.ch//eos/opendata/atlas/rucio/user/egramsta/mc_346191.PowhegPy8EG_NNPDF30_AZNLOCTEQ6L1_VBFH125_tautaulm15hp20.2bjets70.root"
       },
       {
-        "checksum": "adler32:b2f5ad77",
-        "size": 86576,
-        "uri": "root://eospublic.cern.ch//eos/opendata/atlas/rucio/opendata/ODEO_FEB2025_v0_2bjets_mc_346192.PowhegPy8EG_NNPDF30_AZNLOCTEQ6L1_VBFH125_tautaulp15hm20.2bjets.root"
+        "checksum": "adler32:84d6250d",
+        "size": 107519,
+        "uri": "root://eospublic.cern.ch//eos/opendata/atlas/rucio/user/egramsta/mc_346192.PowhegPy8EG_NNPDF30_AZNLOCTEQ6L1_VBFH125_tautaulp15hm20.2bjets70.root"
       },
       {
-        "checksum": "adler32:a208c659",
-        "size": 140860,
-        "uri": "root://eospublic.cern.ch//eos/opendata/atlas/rucio/opendata/ODEO_FEB2025_v0_2bjets_mc_346193.PowhegPy8EG_NNPDF30_AZNLOCTEQ6L1_VBFH125_tautauh30h20.2bjets.root"
+        "checksum": "adler32:58d627ce",
+        "size": 108832,
+        "uri": "root://eospublic.cern.ch//eos/opendata/atlas/rucio/user/egramsta/mc_346193.PowhegPy8EG_NNPDF30_AZNLOCTEQ6L1_VBFH125_tautauh30h20.2bjets70.root"
       },
       {
-        "checksum": "adler32:bd9d93a3",
-        "size": 185006,
-        "uri": "root://eospublic.cern.ch//eos/opendata/atlas/rucio/opendata/ODEO_FEB2025_v0_2bjets_mc_346194.PowhegPy8EG_NNPDF30_AZNLOCTEQ6L1_VBFH125_etau_filt.2bjets.root"
+        "checksum": "adler32:69d7ea07",
+        "size": 235251,
+        "uri": "root://eospublic.cern.ch//eos/opendata/atlas/rucio/user/egramsta/mc_346194.PowhegPy8EG_NNPDF30_AZNLOCTEQ6L1_VBFH125_etau_filt.2bjets70.root"
       },
       {
-        "checksum": "adler32:3dcf37e1",
-        "size": 173844,
-        "uri": "root://eospublic.cern.ch//eos/opendata/atlas/rucio/opendata/ODEO_FEB2025_v0_2bjets_mc_346195.PowhegPy8EG_NNPDF30_AZNLOCTEQ6L1_VBFH125_mutau_filt.2bjets.root"
+        "checksum": "adler32:4aa807f3",
+        "size": 211701,
+        "uri": "root://eospublic.cern.ch//eos/opendata/atlas/rucio/user/egramsta/mc_346195.PowhegPy8EG_NNPDF30_AZNLOCTEQ6L1_VBFH125_mutau_filt.2bjets70.root"
       },
       {
-        "checksum": "adler32:85e94a4c",
-        "size": 1175128,
-        "uri": "root://eospublic.cern.ch//eos/opendata/atlas/rucio/opendata/ODEO_FEB2025_v0_2bjets_mc_346198.PhPy8EG_A14NNPDF23_NNPDF30ME_ttH125_Zgam.2bjets.root"
+        "checksum": "adler32:202b5ce4",
+        "size": 13063825,
+        "uri": "root://eospublic.cern.ch//eos/opendata/atlas/rucio/user/egramsta/mc_346198.PhPy8EG_A14NNPDF23_NNPDF30ME_ttH125_Zgam.2bjets70.root"
       },
       {
-        "checksum": "adler32:c6cfddc2",
-        "size": 41340,
-        "uri": "root://eospublic.cern.ch//eos/opendata/atlas/rucio/opendata/ODEO_FEB2025_v0_2bjets_mc_346214.PowhegPy8EG_NNPDF30_AZNLOCTEQ6L1_VBFH125_gamgam.2bjets.root"
+        "checksum": "adler32:7ba00f00",
+        "size": 72900,
+        "uri": "root://eospublic.cern.ch//eos/opendata/atlas/rucio/user/egramsta/mc_346214.PowhegPy8EG_NNPDF30_AZNLOCTEQ6L1_VBFH125_gamgam.2bjets70.root"
       },
       {
-        "checksum": "adler32:2a7f5849",
-        "size": 197916,
-        "uri": "root://eospublic.cern.ch//eos/opendata/atlas/rucio/opendata/ODEO_FEB2025_v0_2bjets_mc_346228.PowhegPy8EG_NNPDF30_AZNLOCTEQ6L1_VBFH125_ZZ4lep_notau.2bjets.root"
+        "checksum": "adler32:e554ea15",
+        "size": 284494,
+        "uri": "root://eospublic.cern.ch//eos/opendata/atlas/rucio/user/egramsta/mc_346228.PowhegPy8EG_NNPDF30_AZNLOCTEQ6L1_VBFH125_ZZ4lep_notau.2bjets70.root"
       },
       {
-        "checksum": "adler32:45f0e5cf",
-        "size": 298260,
-        "uri": "root://eospublic.cern.ch//eos/opendata/atlas/rucio/opendata/ODEO_FEB2025_v0_2bjets_mc_346310.PowhegPythia8EvtGen_NNPDF30_AZNLO_ZH125J_Zincl_H_incl_MINLO.2bjets.root"
+        "checksum": "adler32:28d879ac",
+        "size": 4201813,
+        "uri": "root://eospublic.cern.ch//eos/opendata/atlas/rucio/user/egramsta/mc_346310.PowhegPythia8EvtGen_NNPDF30_AZNLO_ZH125J_Zincl_H_incl_MINLO.2bjets70.root"
       },
       {
-        "checksum": "adler32:8032f2a3",
-        "size": 158617,
-        "uri": "root://eospublic.cern.ch//eos/opendata/atlas/rucio/opendata/ODEO_FEB2025_v0_2bjets_mc_346311.PowhegPythia8EvtGen_NNPDF30_AZNLO_WpH125J_Wincl_H_incl_MINLO.2bjets.root"
+        "checksum": "adler32:5d0b0d3a",
+        "size": 1811998,
+        "uri": "root://eospublic.cern.ch//eos/opendata/atlas/rucio/user/egramsta/mc_346311.PowhegPythia8EvtGen_NNPDF30_AZNLO_WpH125J_Wincl_H_incl_MINLO.2bjets70.root"
       },
       {
-        "checksum": "adler32:d53e6f87",
-        "size": 136219,
-        "uri": "root://eospublic.cern.ch//eos/opendata/atlas/rucio/opendata/ODEO_FEB2025_v0_2bjets_mc_346312.PowhegPythia8EvtGen_NNPDF30_AZNLO_WmH125J_Wincl_H_incl_MINLO.2bjets.root"
+        "checksum": "adler32:b0722ebb",
+        "size": 1682652,
+        "uri": "root://eospublic.cern.ch//eos/opendata/atlas/rucio/user/egramsta/mc_346312.PowhegPythia8EvtGen_NNPDF30_AZNLO_WmH125J_Wincl_H_incl_MINLO.2bjets70.root"
       },
       {
-        "checksum": "adler32:46efed41",
-        "size": 564449,
-        "uri": "root://eospublic.cern.ch//eos/opendata/atlas/rucio/opendata/ODEO_FEB2025_v0_2bjets_mc_346317.PowhegPy8EG_NNPDF30_AZNLOCTEQ6L1_VBFH125_incl.2bjets.root"
+        "checksum": "adler32:cbb99774",
+        "size": 10514325,
+        "uri": "root://eospublic.cern.ch//eos/opendata/atlas/rucio/user/egramsta/mc_346317.PowhegPy8EG_NNPDF30_AZNLOCTEQ6L1_VBFH125_incl.2bjets70.root"
       },
       {
-        "checksum": "adler32:834d2f3c",
-        "size": 466325,
-        "uri": "root://eospublic.cern.ch//eos/opendata/atlas/rucio/opendata/ODEO_FEB2025_v0_2bjets_mc_346340.PowhegPy8EG_A14NNPDF23_NNPDF30ME_ttH125_ZZ4l_allhad.2bjets.root"
+        "checksum": "adler32:942b48e5",
+        "size": 4461356,
+        "uri": "root://eospublic.cern.ch//eos/opendata/atlas/rucio/user/egramsta/mc_346340.PowhegPy8EG_A14NNPDF23_NNPDF30ME_ttH125_ZZ4l_allhad.2bjets70.root"
       },
       {
-        "checksum": "adler32:d387d8ae",
-        "size": 333025,
-        "uri": "root://eospublic.cern.ch//eos/opendata/atlas/rucio/opendata/ODEO_FEB2025_v0_2bjets_mc_346341.PowhegPy8EG_A14NNPDF23_NNPDF30ME_ttH125_ZZ4l_semilep.2bjets.root"
+        "checksum": "adler32:d6f49e84",
+        "size": 4662051,
+        "uri": "root://eospublic.cern.ch//eos/opendata/atlas/rucio/user/egramsta/mc_346341.PowhegPy8EG_A14NNPDF23_NNPDF30ME_ttH125_ZZ4l_semilep.2bjets70.root"
       },
       {
-        "checksum": "adler32:b6f194fd",
-        "size": 204400,
-        "uri": "root://eospublic.cern.ch//eos/opendata/atlas/rucio/opendata/ODEO_FEB2025_v0_2bjets_mc_346342.PowhegPy8EG_A14NNPDF23_NNPDF30ME_ttH125_ZZ4l_dilep.2bjets.root"
+        "checksum": "adler32:f92d881d",
+        "size": 4764941,
+        "uri": "root://eospublic.cern.ch//eos/opendata/atlas/rucio/user/egramsta/mc_346342.PowhegPy8EG_A14NNPDF23_NNPDF30ME_ttH125_ZZ4l_dilep.2bjets70.root"
       },
       {
-        "checksum": "adler32:0bbcc1d5",
-        "size": 2506967,
-        "uri": "root://eospublic.cern.ch//eos/opendata/atlas/rucio/opendata/ODEO_FEB2025_v0_2bjets_mc_346343.PhPy8EG_A14NNPDF23_NNPDF30ME_ttH125_allhad.2bjets.root"
+        "checksum": "adler32:01ce4b98",
+        "size": 29086714,
+        "uri": "root://eospublic.cern.ch//eos/opendata/atlas/rucio/user/egramsta/mc_346343.PhPy8EG_A14NNPDF23_NNPDF30ME_ttH125_allhad.2bjets70.root"
       },
       {
-        "checksum": "adler32:c1856693",
-        "size": 1388339,
-        "uri": "root://eospublic.cern.ch//eos/opendata/atlas/rucio/opendata/ODEO_FEB2025_v0_2bjets_mc_346344.PhPy8EG_A14NNPDF23_NNPDF30ME_ttH125_semilep.2bjets.root"
+        "checksum": "adler32:53e09cc1",
+        "size": 23542306,
+        "uri": "root://eospublic.cern.ch//eos/opendata/atlas/rucio/user/egramsta/mc_346344.PhPy8EG_A14NNPDF23_NNPDF30ME_ttH125_semilep.2bjets70.root"
       },
       {
-        "checksum": "adler32:a846a6f8",
-        "size": 1945265,
-        "uri": "root://eospublic.cern.ch//eos/opendata/atlas/rucio/opendata/ODEO_FEB2025_v0_2bjets_mc_346345.PhPy8EG_A14NNPDF23_NNPDF30ME_ttH125_dilep.2bjets.root"
+        "checksum": "adler32:96698630",
+        "size": 47773037,
+        "uri": "root://eospublic.cern.ch//eos/opendata/atlas/rucio/user/egramsta/mc_346345.PhPy8EG_A14NNPDF23_NNPDF30ME_ttH125_dilep.2bjets70.root"
       },
       {
-        "checksum": "adler32:e8b5654d",
-        "size": 150087,
-        "uri": "root://eospublic.cern.ch//eos/opendata/atlas/rucio/opendata/ODEO_FEB2025_v0_2bjets_mc_346398.PowhegHerwig7EvtGen_NNPDF3_AZNLO_ZH125J_MINLO_vvbb_VpT.2bjets.root"
+        "checksum": "adler32:e08c8c1e",
+        "size": 4300219,
+        "uri": "root://eospublic.cern.ch//eos/opendata/atlas/rucio/user/egramsta/mc_346398.PowhegHerwig7EvtGen_NNPDF3_AZNLO_ZH125J_MINLO_vvbb_VpT.2bjets70.root"
       },
       {
-        "checksum": "adler32:c3e5e553",
-        "size": 240689,
-        "uri": "root://eospublic.cern.ch//eos/opendata/atlas/rucio/opendata/ODEO_FEB2025_v0_2bjets_mc_346400.PowhegHerwig7EvtGen_NNPDF3_AZNLO_ggZH125J_vvbb.2bjets.root"
+        "checksum": "adler32:c3542eb3",
+        "size": 6763057,
+        "uri": "root://eospublic.cern.ch//eos/opendata/atlas/rucio/user/egramsta/mc_346400.PowhegHerwig7EvtGen_NNPDF3_AZNLO_ggZH125J_vvbb.2bjets70.root"
       },
       {
-        "checksum": "adler32:a425a33e",
-        "size": 245558,
-        "uri": "root://eospublic.cern.ch//eos/opendata/atlas/rucio/opendata/ODEO_FEB2025_v0_2bjets_mc_346414.aMcAtNloPythia8EvtGen_tHjb125_4fl_ZZ4l.2bjets.root"
+        "checksum": "adler32:64c7db8f",
+        "size": 2026790,
+        "uri": "root://eospublic.cern.ch//eos/opendata/atlas/rucio/user/egramsta/mc_346414.aMcAtNloPythia8EvtGen_tHjb125_4fl_ZZ4l.2bjets70.root"
       },
       {
-        "checksum": "adler32:80f65a40",
-        "size": 519900,
-        "uri": "root://eospublic.cern.ch//eos/opendata/atlas/rucio/opendata/ODEO_FEB2025_v0_2bjets_mc_346446.PhH7EG_H7UE_NNLOPS_nnlo_30_ggH125_ZZ4l_noTau.2bjets.root"
+        "checksum": "adler32:c865ff2a",
+        "size": 740325,
+        "uri": "root://eospublic.cern.ch//eos/opendata/atlas/rucio/user/egramsta/mc_346446.PhH7EG_H7UE_NNLOPS_nnlo_30_ggH125_ZZ4l_noTau.2bjets70.root"
       },
       {
-        "checksum": "adler32:dc28cd0d",
-        "size": 189213,
-        "uri": "root://eospublic.cern.ch//eos/opendata/atlas/rucio/opendata/ODEO_FEB2025_v0_2bjets_mc_346447.PhH7EG_H7UE_NNPDF30_VBFH125_ZZ4lep_noTau.2bjets.root"
+        "checksum": "adler32:172bce62",
+        "size": 234433,
+        "uri": "root://eospublic.cern.ch//eos/opendata/atlas/rucio/user/egramsta/mc_346447.PhH7EG_H7UE_NNPDF30_VBFH125_ZZ4lep_noTau.2bjets70.root"
       },
       {
-        "checksum": "adler32:2aba6dfa",
-        "size": 254592,
-        "uri": "root://eospublic.cern.ch//eos/opendata/atlas/rucio/opendata/ODEO_FEB2025_v0_2bjets_mc_346448.PhH7EG_H7UE_NNPDF30_ZH125J_Zincl_MINLO.2bjets.root"
+        "checksum": "adler32:b5d0a2df",
+        "size": 1194374,
+        "uri": "root://eospublic.cern.ch//eos/opendata/atlas/rucio/user/egramsta/mc_346448.PhH7EG_H7UE_NNPDF30_ZH125J_Zincl_MINLO.2bjets70.root"
       },
       {
-        "checksum": "adler32:1b36a344",
-        "size": 184065,
-        "uri": "root://eospublic.cern.ch//eos/opendata/atlas/rucio/opendata/ODEO_FEB2025_v0_2bjets_mc_346449.PhH7EG_H7UE_NNPDF30_WpH125J_Wincl_MINLO.2bjets.root"
+        "checksum": "adler32:aa7242e9",
+        "size": 82236,
+        "uri": "root://eospublic.cern.ch//eos/opendata/atlas/rucio/user/egramsta/mc_346449.PhH7EG_H7UE_NNPDF30_WpH125J_Wincl_MINLO.2bjets70.root"
       },
       {
-        "checksum": "adler32:b9fa8756",
-        "size": 106094,
-        "uri": "root://eospublic.cern.ch//eos/opendata/atlas/rucio/opendata/ODEO_FEB2025_v0_2bjets_mc_346450.PhH7EG_H7UE_NNPDF30_WmH125J_Wincl_MINLO.2bjets.root"
+        "checksum": "adler32:30a3b88f",
+        "size": 49360,
+        "uri": "root://eospublic.cern.ch//eos/opendata/atlas/rucio/user/egramsta/mc_346450.PhH7EG_H7UE_NNPDF30_WmH125J_Wincl_MINLO.2bjets70.root"
       },
       {
-        "checksum": "adler32:29952602",
-        "size": 167424,
-        "uri": "root://eospublic.cern.ch//eos/opendata/atlas/rucio/opendata/ODEO_FEB2025_v0_2bjets_mc_346451.PhH7EG_H7UE_NNPDF3_ggZH125_ZZ4lepZinc.2bjets.root"
+        "checksum": "adler32:64511b05",
+        "size": 813690,
+        "uri": "root://eospublic.cern.ch//eos/opendata/atlas/rucio/user/egramsta/mc_346451.PhH7EG_H7UE_NNPDF3_ggZH125_ZZ4lepZinc.2bjets70.root"
       },
       {
-        "checksum": "adler32:1badeebc",
-        "size": 458316,
-        "uri": "root://eospublic.cern.ch//eos/opendata/atlas/rucio/opendata/ODEO_FEB2025_v0_2bjets_mc_346452.PhH7EG_H7UE_NNPDF30ME_ttH125_ZZ4l_allhad_noTau.2bjets.root"
+        "checksum": "adler32:746a4c74",
+        "size": 4496916,
+        "uri": "root://eospublic.cern.ch//eos/opendata/atlas/rucio/user/egramsta/mc_346452.PhH7EG_H7UE_NNPDF30ME_ttH125_ZZ4l_allhad_noTau.2bjets70.root"
       },
       {
-        "checksum": "adler32:e1a9c5e5",
-        "size": 347717,
-        "uri": "root://eospublic.cern.ch//eos/opendata/atlas/rucio/opendata/ODEO_FEB2025_v0_2bjets_mc_346453.PhH7EG_H7UE_NNPDF30ME_ttH125_ZZ4l_semilep_noTau.2bjets.root"
+        "checksum": "adler32:c656e4a7",
+        "size": 4575144,
+        "uri": "root://eospublic.cern.ch//eos/opendata/atlas/rucio/user/egramsta/mc_346453.PhH7EG_H7UE_NNPDF30ME_ttH125_ZZ4l_semilep_noTau.2bjets70.root"
       },
       {
-        "checksum": "adler32:f268e528",
-        "size": 225893,
-        "uri": "root://eospublic.cern.ch//eos/opendata/atlas/rucio/opendata/ODEO_FEB2025_v0_2bjets_mc_346454.PhH7EG_H7UE_NNPDF30ME_ttH125_ZZ4l_dilep_noTau.2bjets.root"
+        "checksum": "adler32:10aadcb6",
+        "size": 4690784,
+        "uri": "root://eospublic.cern.ch//eos/opendata/atlas/rucio/user/egramsta/mc_346454.PhH7EG_H7UE_NNPDF30ME_ttH125_ZZ4l_dilep_noTau.2bjets70.root"
       },
       {
-        "checksum": "adler32:d8cd5d98",
-        "size": 219821,
-        "uri": "root://eospublic.cern.ch//eos/opendata/atlas/rucio/opendata/ODEO_FEB2025_v0_2bjets_mc_346486.aMcAtNloPythia8EvtGen_tWH125_yy.2bjets.root"
+        "checksum": "adler32:068a0573",
+        "size": 1829421,
+        "uri": "root://eospublic.cern.ch//eos/opendata/atlas/rucio/user/egramsta/mc_346486.aMcAtNloPythia8EvtGen_tWH125_yy.2bjets70.root"
       },
       {
-        "checksum": "adler32:8bfed01e",
-        "size": 380761,
-        "uri": "root://eospublic.cern.ch//eos/opendata/atlas/rucio/opendata/ODEO_FEB2025_v0_2bjets_mc_346511.aMcAtNloPythia8EvtGen_tWH125_ZZ4l.2bjets.root"
+        "checksum": "adler32:c52b04a9",
+        "size": 2318882,
+        "uri": "root://eospublic.cern.ch//eos/opendata/atlas/rucio/user/egramsta/mc_346511.aMcAtNloPythia8EvtGen_tWH125_ZZ4l.2bjets70.root"
       },
       {
-        "checksum": "adler32:f8cc12d5",
-        "size": 109069,
-        "uri": "root://eospublic.cern.ch//eos/opendata/atlas/rucio/opendata/ODEO_FEB2025_v0_2bjets_mc_346524.PowhegPythia8EvtGen_NNPDF3_AZNLO_ggZH125J_MINLO_ZinclWWlvlv.2bjets.root"
+        "checksum": "adler32:0f18e34e",
+        "size": 666904,
+        "uri": "root://eospublic.cern.ch//eos/opendata/atlas/rucio/user/egramsta/mc_346524.PowhegPythia8EvtGen_NNPDF3_AZNLO_ggZH125J_MINLO_ZinclWWlvlv.2bjets70.root"
       },
       {
-        "checksum": "adler32:bff22499",
-        "size": 1089893,
-        "uri": "root://eospublic.cern.ch//eos/opendata/atlas/rucio/opendata/ODEO_FEB2025_v0_2bjets_mc_346525.PowhegPythia8EvtGen_A14NNPDF23_NNPDF30ME_ttH125_gamgam.2bjets.root"
+        "checksum": "adler32:63de7370",
+        "size": 14622863,
+        "uri": "root://eospublic.cern.ch//eos/opendata/atlas/rucio/user/egramsta/mc_346525.PowhegPythia8EvtGen_A14NNPDF23_NNPDF30ME_ttH125_gamgam.2bjets70.root"
       },
       {
-        "checksum": "adler32:eb4e601a",
-        "size": 1240119,
-        "uri": "root://eospublic.cern.ch//eos/opendata/atlas/rucio/opendata/ODEO_FEB2025_v0_2bjets_mc_346526.PowhegHerwig7EvtGen_H7UE_NNPDF30ME_ttH125_gamgam.2bjets.root"
+        "checksum": "adler32:f76d3e21",
+        "size": 15125943,
+        "uri": "root://eospublic.cern.ch//eos/opendata/atlas/rucio/user/egramsta/mc_346526.PowhegHerwig7EvtGen_H7UE_NNPDF30ME_ttH125_gamgam.2bjets70.root"
       },
       {
-        "checksum": "adler32:720ecee9",
-        "size": 98737,
-        "uri": "root://eospublic.cern.ch//eos/opendata/atlas/rucio/opendata/ODEO_FEB2025_v0_2bjets_mc_346588.PowhegPythia8EvtGen_NNLOPS_nnlo_30_ggH125_ZZ4nu_MET75.2bjets.root"
+        "checksum": "adler32:6b2e8a31",
+        "size": 224694,
+        "uri": "root://eospublic.cern.ch//eos/opendata/atlas/rucio/user/egramsta/mc_346588.PowhegPythia8EvtGen_NNLOPS_nnlo_30_ggH125_ZZ4nu_MET75.2bjets70.root"
       },
       {
-        "checksum": "adler32:554165d3",
-        "size": 780537,
-        "uri": "root://eospublic.cern.ch//eos/opendata/atlas/rucio/opendata/ODEO_FEB2025_v0_2bjets_mc_346601.aMcAtNloHerwig7EvtGen_MEN30NLO_ttH125_gamgam.2bjets.root"
+        "checksum": "adler32:3808c1be",
+        "size": 10645634,
+        "uri": "root://eospublic.cern.ch//eos/opendata/atlas/rucio/user/egramsta/mc_346601.aMcAtNloHerwig7EvtGen_MEN30NLO_ttH125_gamgam.2bjets70.root"
       },
       {
-        "checksum": "adler32:236569b9",
-        "size": 155635,
-        "uri": "root://eospublic.cern.ch//eos/opendata/atlas/rucio/opendata/ODEO_FEB2025_v0_2bjets_mc_346602.aMcAtNloHerwig7EvtGen_MEN30NLO_tHjb125_gamgam.2bjets.root"
+        "checksum": "adler32:f1013c91",
+        "size": 1968693,
+        "uri": "root://eospublic.cern.ch//eos/opendata/atlas/rucio/user/egramsta/mc_346602.aMcAtNloHerwig7EvtGen_MEN30NLO_tHjb125_gamgam.2bjets70.root"
       },
       {
-        "checksum": "adler32:e1642a67",
-        "size": 90928,
-        "uri": "root://eospublic.cern.ch//eos/opendata/atlas/rucio/opendata/ODEO_FEB2025_v0_2bjets_mc_346605.PowhegPythia8EvtGen_NNPDF30_AZNLO_WpH125J_WinclHinv_MET75.2bjets.root"
+        "checksum": "adler32:698cdc83",
+        "size": 84606,
+        "uri": "root://eospublic.cern.ch//eos/opendata/atlas/rucio/user/egramsta/mc_346605.PowhegPythia8EvtGen_NNPDF30_AZNLO_WpH125J_WinclHinv_MET75.2bjets70.root"
       },
       {
-        "checksum": "adler32:c2586a2d",
-        "size": 108044,
-        "uri": "root://eospublic.cern.ch//eos/opendata/atlas/rucio/opendata/ODEO_FEB2025_v0_2bjets_mc_346606.PowhegPythia8EvtGen_NNPDF30_AZNLO_WmH125J_WinclHinv_MET75.2bjets.root"
+        "checksum": "adler32:ba0c4ddd",
+        "size": 81525,
+        "uri": "root://eospublic.cern.ch//eos/opendata/atlas/rucio/user/egramsta/mc_346606.PowhegPythia8EvtGen_NNPDF30_AZNLO_WmH125J_WinclHinv_MET75.2bjets70.root"
       },
       {
-        "checksum": "adler32:8f6befe8",
-        "size": 167426,
-        "uri": "root://eospublic.cern.ch//eos/opendata/atlas/rucio/opendata/ODEO_FEB2025_v0_2bjets_mc_346607.PowhegPythia8EvtGen_NNPDF30_AZNLO_ZH125J_ZinclHinv_MET75.2bjets.root"
+        "checksum": "adler32:d00c2577",
+        "size": 1325934,
+        "uri": "root://eospublic.cern.ch//eos/opendata/atlas/rucio/user/egramsta/mc_346607.PowhegPythia8EvtGen_NNPDF30_AZNLO_ZH125J_ZinclHinv_MET75.2bjets70.root"
       },
       {
-        "checksum": "adler32:b885d8a5",
-        "size": 1089972,
-        "uri": "root://eospublic.cern.ch//eos/opendata/atlas/rucio/opendata/ODEO_FEB2025_v0_2bjets_mc_346632.PowhegPy8EG_A14NNPDF23_NNPDF30ME_ttH125_ZZ4nu_semilep.2bjets.root"
+        "checksum": "adler32:5eb3aa72",
+        "size": 17798386,
+        "uri": "root://eospublic.cern.ch//eos/opendata/atlas/rucio/user/egramsta/mc_346632.PowhegPy8EG_A14NNPDF23_NNPDF30ME_ttH125_ZZ4nu_semilep.2bjets70.root"
       },
       {
-        "checksum": "adler32:866809a9",
-        "size": 1185438,
-        "uri": "root://eospublic.cern.ch//eos/opendata/atlas/rucio/opendata/ODEO_FEB2025_v0_2bjets_mc_346633.PowhegPy8EG_A14NNPDF23_NNPDF30ME_ttH125_ZZ4nu_allhad.2bjets.root"
+        "checksum": "adler32:815be1b0",
+        "size": 12222038,
+        "uri": "root://eospublic.cern.ch//eos/opendata/atlas/rucio/user/egramsta/mc_346633.PowhegPy8EG_A14NNPDF23_NNPDF30ME_ttH125_ZZ4nu_allhad.2bjets70.root"
       },
       {
-        "checksum": "adler32:7a98ad42",
-        "size": 183288,
-        "uri": "root://eospublic.cern.ch//eos/opendata/atlas/rucio/opendata/ODEO_FEB2025_v0_2bjets_mc_346634.PowhegPy8EG_A14NNPDF23_NNPDF30ME_ttH125_ZZ4nu_dilep.2bjets.root"
+        "checksum": "adler32:b28dcab7",
+        "size": 4740559,
+        "uri": "root://eospublic.cern.ch//eos/opendata/atlas/rucio/user/egramsta/mc_346634.PowhegPy8EG_A14NNPDF23_NNPDF30ME_ttH125_ZZ4nu_dilep.2bjets70.root"
       },
       {
-        "checksum": "adler32:7527cd80",
-        "size": 360032,
-        "uri": "root://eospublic.cern.ch//eos/opendata/atlas/rucio/opendata/ODEO_FEB2025_v0_2bjets_mc_346645.PowhegPythia8EvtGen_NNPDF30_AZNLO_ZH125J_Zincl_MINLO_shw.2bjets.root"
+        "checksum": "adler32:b3aa1241",
+        "size": 1731205,
+        "uri": "root://eospublic.cern.ch//eos/opendata/atlas/rucio/user/egramsta/mc_346645.PowhegPythia8EvtGen_NNPDF30_AZNLO_ZH125J_Zincl_MINLO_shw.2bjets70.root"
       },
       {
-        "checksum": "adler32:78611c51",
-        "size": 183186,
-        "uri": "root://eospublic.cern.ch//eos/opendata/atlas/rucio/opendata/ODEO_FEB2025_v0_2bjets_mc_346646.PowhegPythia8EvtGen_NNPDF30_AZNLO_WpH125J_Wincl_MINLO_shw.2bjets.root"
+        "checksum": "adler32:5b13ff3b",
+        "size": 88401,
+        "uri": "root://eospublic.cern.ch//eos/opendata/atlas/rucio/user/egramsta/mc_346646.PowhegPythia8EvtGen_NNPDF30_AZNLO_WpH125J_Wincl_MINLO_shw.2bjets70.root"
       },
       {
-        "checksum": "adler32:0cbbfdaa",
-        "size": 105796,
-        "uri": "root://eospublic.cern.ch//eos/opendata/atlas/rucio/opendata/ODEO_FEB2025_v0_2bjets_mc_346647.PowhegPythia8EvtGen_NNPDF30_AZNLO_WmH125J_Wincl_MINLO_shw.2bjets.root"
+        "checksum": "adler32:4fa2317f",
+        "size": 56589,
+        "uri": "root://eospublic.cern.ch//eos/opendata/atlas/rucio/user/egramsta/mc_346647.PowhegPythia8EvtGen_NNPDF30_AZNLO_WmH125J_Wincl_MINLO_shw.2bjets70.root"
       },
       {
-        "checksum": "adler32:2dc70247",
-        "size": 783587,
-        "uri": "root://eospublic.cern.ch//eos/opendata/atlas/rucio/opendata/ODEO_FEB2025_v0_2bjets_mc_346726.PowhegHerwig7EvtGen_NNPDF3_AZNLO_ZH125J_MINLO_vvcc_VpT.2bjets.root"
+        "checksum": "adler32:196b5366",
+        "size": 272251,
+        "uri": "root://eospublic.cern.ch//eos/opendata/atlas/rucio/user/egramsta/mc_346726.PowhegHerwig7EvtGen_NNPDF3_AZNLO_ZH125J_MINLO_vvcc_VpT.2bjets70.root"
       },
       {
-        "checksum": "adler32:556d0ead",
-        "size": 240844,
-        "uri": "root://eospublic.cern.ch//eos/opendata/atlas/rucio/opendata/ODEO_FEB2025_v0_2bjets_mc_346728.PowhegHerwig7EvtGen_NNPDF3_AZNLO_ggZH125J_vvcc.2bjets.root"
+        "checksum": "adler32:10f0643a",
+        "size": 88285,
+        "uri": "root://eospublic.cern.ch//eos/opendata/atlas/rucio/user/egramsta/mc_346728.PowhegHerwig7EvtGen_NNPDF3_AZNLO_ggZH125J_vvcc.2bjets70.root"
       },
       {
-        "checksum": "adler32:a89a399a",
-        "size": 672716,
-        "uri": "root://eospublic.cern.ch//eos/opendata/atlas/rucio/opendata/ODEO_FEB2025_v0_2bjets_mc_346797.PhH7EG_H7UE_NNLOPS_nnlo_30_ggH125_gamgam.2bjets.root"
+        "checksum": "adler32:01bfb292",
+        "size": 1189510,
+        "uri": "root://eospublic.cern.ch//eos/opendata/atlas/rucio/user/egramsta/mc_346797.PhH7EG_H7UE_NNLOPS_nnlo_30_ggH125_gamgam.2bjets70.root"
       },
       {
-        "checksum": "adler32:01e5fdff",
-        "size": 443213,
-        "uri": "root://eospublic.cern.ch//eos/opendata/atlas/rucio/opendata/ODEO_FEB2025_v0_2bjets_mc_346802.PhH7EG_NNLOPS_nnlo_30_ggH125_WWlvlv_noTau.2bjets.root"
+        "checksum": "adler32:f5599fca",
+        "size": 781634,
+        "uri": "root://eospublic.cern.ch//eos/opendata/atlas/rucio/user/egramsta/mc_346802.PhH7EG_NNLOPS_nnlo_30_ggH125_WWlvlv_noTau.2bjets70.root"
       },
       {
-        "checksum": "adler32:e984c261",
-        "size": 77677,
-        "uri": "root://eospublic.cern.ch//eos/opendata/atlas/rucio/opendata/ODEO_FEB2025_v0_2bjets_mc_346877.PhH7EG_NNPDF30_VBFH125_WWlvlv.2bjets.root"
+        "checksum": "adler32:aca46793",
+        "size": 123478,
+        "uri": "root://eospublic.cern.ch//eos/opendata/atlas/rucio/user/egramsta/mc_346877.PhH7EG_NNPDF30_VBFH125_WWlvlv.2bjets70.root"
       },
       {
-        "checksum": "adler32:d13d7e7e",
-        "size": 144363,
-        "uri": "root://eospublic.cern.ch//eos/opendata/atlas/rucio/opendata/ODEO_FEB2025_v0_2bjets_mc_346878.PhH7EG_H7UE_NNPDF30_VBF125_gammagamma.2bjets.root"
+        "checksum": "adler32:8973d7dd",
+        "size": 214228,
+        "uri": "root://eospublic.cern.ch//eos/opendata/atlas/rucio/user/egramsta/mc_346878.PhH7EG_H7UE_NNPDF30_VBF125_gammagamma.2bjets70.root"
       },
       {
-        "checksum": "adler32:2b6cb109",
-        "size": 137440,
-        "uri": "root://eospublic.cern.ch//eos/opendata/atlas/rucio/opendata/ODEO_FEB2025_v0_2bjets_mc_346879.PhH7EG_H7UE_NNPDF30_ZH125J_Zincl_MINLO_gammagamma.2bjets.root"
+        "checksum": "adler32:42b86bf9",
+        "size": 805707,
+        "uri": "root://eospublic.cern.ch//eos/opendata/atlas/rucio/user/egramsta/mc_346879.PhH7EG_H7UE_NNPDF30_ZH125J_Zincl_MINLO_gammagamma.2bjets70.root"
       },
       {
-        "checksum": "adler32:dbad3806",
-        "size": 57962,
-        "uri": "root://eospublic.cern.ch//eos/opendata/atlas/rucio/opendata/ODEO_FEB2025_v0_2bjets_mc_346880.PhH7EG_H7UE_NNPDF30_WmH125J_Wincl_MINLO_gammagamma.2bjets.root"
+        "checksum": "adler32:dcd7388c",
+        "size": 44220,
+        "uri": "root://eospublic.cern.ch//eos/opendata/atlas/rucio/user/egramsta/mc_346880.PhH7EG_H7UE_NNPDF30_WmH125J_Wincl_MINLO_gammagamma.2bjets70.root"
       },
       {
-        "checksum": "adler32:91aadd25",
-        "size": 92523,
-        "uri": "root://eospublic.cern.ch//eos/opendata/atlas/rucio/opendata/ODEO_FEB2025_v0_2bjets_mc_346881.PhH7EG_H7UE_NNPDF30_WpH125J_Wincl_MINLO_gammagamma.2bjets.root"
+        "checksum": "adler32:4ff42293",
+        "size": 76726,
+        "uri": "root://eospublic.cern.ch//eos/opendata/atlas/rucio/user/egramsta/mc_346881.PhH7EG_H7UE_NNPDF30_WpH125J_Wincl_MINLO_gammagamma.2bjets70.root"
       },
       {
-        "checksum": "adler32:6e2d3cf5",
-        "size": 81141,
-        "uri": "root://eospublic.cern.ch//eos/opendata/atlas/rucio/opendata/ODEO_FEB2025_v0_2bjets_mc_346882.PhH7EG_H7UE_NNPDF30_ggZH125_gammagamma.2bjets.root"
+        "checksum": "adler32:36457ee7",
+        "size": 615510,
+        "uri": "root://eospublic.cern.ch//eos/opendata/atlas/rucio/user/egramsta/mc_346882.PhH7EG_H7UE_NNPDF30_ggZH125_gammagamma.2bjets70.root"
       },
       {
-        "checksum": "adler32:70857595",
-        "size": 2609036,
-        "uri": "root://eospublic.cern.ch//eos/opendata/atlas/rucio/opendata/ODEO_FEB2025_v0_2bjets_mc_346919.PhPy8EG_A14NNPDF23_NNPDF30ME_ttH125_allhad_tautau_unpol.2bjets.root"
+        "checksum": "adler32:37afb339",
+        "size": 20076071,
+        "uri": "root://eospublic.cern.ch//eos/opendata/atlas/rucio/user/egramsta/mc_346919.PhPy8EG_A14NNPDF23_NNPDF30ME_ttH125_allhad_tautau_unpol.2bjets70.root"
       },
       {
-        "checksum": "adler32:9ea5f32c",
-        "size": 1504687,
-        "uri": "root://eospublic.cern.ch//eos/opendata/atlas/rucio/opendata/ODEO_FEB2025_v0_2bjets_mc_346923.PhPy8EG_A14NNPDF23_NNPDF30ME_ttH125_semilep_tautau_unpol.2bjets.root"
+        "checksum": "adler32:472fb293",
+        "size": 16497855,
+        "uri": "root://eospublic.cern.ch//eos/opendata/atlas/rucio/user/egramsta/mc_346923.PhPy8EG_A14NNPDF23_NNPDF30ME_ttH125_semilep_tautau_unpol.2bjets70.root"
       },
       {
-        "checksum": "adler32:e99ed236",
-        "size": 695587,
-        "uri": "root://eospublic.cern.ch//eos/opendata/atlas/rucio/opendata/ODEO_FEB2025_v0_2bjets_mc_346927.PhPy8EG_A14NNPDF23_NNPDF30ME_ttH125_dilep_tautau_unpol.2bjets.root"
+        "checksum": "adler32:60ee69c6",
+        "size": 11382264,
+        "uri": "root://eospublic.cern.ch//eos/opendata/atlas/rucio/user/egramsta/mc_346927.PhPy8EG_A14NNPDF23_NNPDF30ME_ttH125_dilep_tautau_unpol.2bjets70.root"
       },
       {
-        "checksum": "adler32:dda9fbfc",
-        "size": 165269,
-        "uri": "root://eospublic.cern.ch//eos/opendata/atlas/rucio/opendata/ODEO_FEB2025_v0_2bjets_mc_364242.Sherpa_222_NNPDF30NNLO_WWW_3l3v_EW6.2bjets.root"
+        "checksum": "adler32:d0aafd24",
+        "size": 133154,
+        "uri": "root://eospublic.cern.ch//eos/opendata/atlas/rucio/user/egramsta/mc_364242.Sherpa_222_NNPDF30NNLO_WWW_3l3v_EW6.2bjets70.root"
       },
       {
-        "checksum": "adler32:6727512d",
-        "size": 79241,
-        "uri": "root://eospublic.cern.ch//eos/opendata/atlas/rucio/opendata/ODEO_FEB2025_v0_2bjets_mc_364243.Sherpa_222_NNPDF30NNLO_WWZ_4l2v_EW6.2bjets.root"
+        "checksum": "adler32:62806635",
+        "size": 66771,
+        "uri": "root://eospublic.cern.ch//eos/opendata/atlas/rucio/user/egramsta/mc_364243.Sherpa_222_NNPDF30NNLO_WWZ_4l2v_EW6.2bjets70.root"
       },
       {
-        "checksum": "adler32:2206213f",
-        "size": 52859,
-        "uri": "root://eospublic.cern.ch//eos/opendata/atlas/rucio/opendata/ODEO_FEB2025_v0_2bjets_mc_364244.Sherpa_222_NNPDF30NNLO_WWZ_2l4v_EW6.2bjets.root"
+        "checksum": "adler32:ebc5f625",
+        "size": 62834,
+        "uri": "root://eospublic.cern.ch//eos/opendata/atlas/rucio/user/egramsta/mc_364244.Sherpa_222_NNPDF30NNLO_WWZ_2l4v_EW6.2bjets70.root"
       },
       {
-        "checksum": "adler32:1f15556d",
-        "size": 89107,
-        "uri": "root://eospublic.cern.ch//eos/opendata/atlas/rucio/opendata/ODEO_FEB2025_v0_2bjets_mc_364245.Sherpa_222_NNPDF30NNLO_WZZ_5l1v_EW6.2bjets.root"
+        "checksum": "adler32:57e29e24",
+        "size": 72353,
+        "uri": "root://eospublic.cern.ch//eos/opendata/atlas/rucio/user/egramsta/mc_364245.Sherpa_222_NNPDF30NNLO_WZZ_5l1v_EW6.2bjets70.root"
       },
       {
-        "checksum": "adler32:9ffe30ab",
-        "size": 58427,
-        "uri": "root://eospublic.cern.ch//eos/opendata/atlas/rucio/opendata/ODEO_FEB2025_v0_2bjets_mc_364246.Sherpa_222_NNPDF30NNLO_WZZ_3l3v_EW6.2bjets.root"
+        "checksum": "adler32:9bb21afc",
+        "size": 56998,
+        "uri": "root://eospublic.cern.ch//eos/opendata/atlas/rucio/user/egramsta/mc_364246.Sherpa_222_NNPDF30NNLO_WZZ_3l3v_EW6.2bjets70.root"
       },
       {
-        "checksum": "adler32:84da2cbe",
-        "size": 76469,
-        "uri": "root://eospublic.cern.ch//eos/opendata/atlas/rucio/opendata/ODEO_FEB2025_v0_2bjets_mc_364247.Sherpa_222_NNPDF30NNLO_ZZZ_6l0v_EW6.2bjets.root"
+        "checksum": "adler32:426c19a5",
+        "size": 46719,
+        "uri": "root://eospublic.cern.ch//eos/opendata/atlas/rucio/user/egramsta/mc_364247.Sherpa_222_NNPDF30NNLO_ZZZ_6l0v_EW6.2bjets70.root"
       },
       {
-        "checksum": "adler32:0b34260d",
-        "size": 33074,
-        "uri": "root://eospublic.cern.ch//eos/opendata/atlas/rucio/opendata/ODEO_FEB2025_v0_2bjets_mc_364248.Sherpa_222_NNPDF30NNLO_ZZZ_4l2v_EW6.2bjets.root"
+        "checksum": "adler32:a70e0c06",
+        "size": 33999,
+        "uri": "root://eospublic.cern.ch//eos/opendata/atlas/rucio/user/egramsta/mc_364248.Sherpa_222_NNPDF30NNLO_ZZZ_4l2v_EW6.2bjets70.root"
       },
       {
-        "checksum": "adler32:ca7efbc5",
-        "size": 37585,
-        "uri": "root://eospublic.cern.ch//eos/opendata/atlas/rucio/opendata/ODEO_FEB2025_v0_2bjets_mc_364249.Sherpa_222_NNPDF30NNLO_ZZZ_2l4v_EW6.2bjets.root"
+        "checksum": "adler32:3e150bae",
+        "size": 42967,
+        "uri": "root://eospublic.cern.ch//eos/opendata/atlas/rucio/user/egramsta/mc_364249.Sherpa_222_NNPDF30NNLO_ZZZ_2l4v_EW6.2bjets70.root"
       },
       {
-        "checksum": "adler32:b7f70ef8",
-        "size": 81440,
-        "uri": "root://eospublic.cern.ch//eos/opendata/atlas/rucio/opendata/ODEO_FEB2025_v0_2bjets_mc_364336.Sherpa_222_NNPDF30NNLO_WpWpWn_sslvlvjj_EW6.2bjets.root"
+        "checksum": "adler32:4b6d143a",
+        "size": 67739,
+        "uri": "root://eospublic.cern.ch//eos/opendata/atlas/rucio/user/egramsta/mc_364336.Sherpa_222_NNPDF30NNLO_WpWpWn_sslvlvjj_EW6.2bjets70.root"
       },
       {
-        "checksum": "adler32:a31fa3f4",
-        "size": 79061,
-        "uri": "root://eospublic.cern.ch//eos/opendata/atlas/rucio/opendata/ODEO_FEB2025_v0_2bjets_mc_364337.Sherpa_222_NNPDF30NNLO_WnWnWp_sslvlvjj_EW6.2bjets.root"
+        "checksum": "adler32:f1acbbf2",
+        "size": 55136,
+        "uri": "root://eospublic.cern.ch//eos/opendata/atlas/rucio/user/egramsta/mc_364337.Sherpa_222_NNPDF30NNLO_WnWnWp_sslvlvjj_EW6.2bjets70.root"
       },
       {
-        "checksum": "adler32:d31a882b",
-        "size": 52183,
-        "uri": "root://eospublic.cern.ch//eos/opendata/atlas/rucio/opendata/ODEO_FEB2025_v0_2bjets_mc_364338.Sherpa_222_NNPDF30NNLO_WpWpWn_oslvlvjj_EW6.2bjets.root"
+        "checksum": "adler32:2ecbd181",
+        "size": 46756,
+        "uri": "root://eospublic.cern.ch//eos/opendata/atlas/rucio/user/egramsta/mc_364338.Sherpa_222_NNPDF30NNLO_WpWpWn_oslvlvjj_EW6.2bjets70.root"
       },
       {
-        "checksum": "adler32:1cfc54ac",
-        "size": 36628,
-        "uri": "root://eospublic.cern.ch//eos/opendata/atlas/rucio/opendata/ODEO_FEB2025_v0_2bjets_mc_364339.Sherpa_222_NNPDF30NNLO_WnWnWp_oslvlvjj_EW6.2bjets.root"
+        "checksum": "adler32:3ffb5cf0",
+        "size": 32174,
+        "uri": "root://eospublic.cern.ch//eos/opendata/atlas/rucio/user/egramsta/mc_364339.Sherpa_222_NNPDF30NNLO_WnWnWp_oslvlvjj_EW6.2bjets70.root"
       },
       {
-        "checksum": "adler32:58d7fab3",
-        "size": 433771,
-        "uri": "root://eospublic.cern.ch//eos/opendata/atlas/rucio/opendata/ODEO_FEB2025_v0_2bjets_mc_364350.Sherpa_224_NNPDF30NNLO_Diphoton_myy_0_50.2bjets.root"
+        "checksum": "adler32:daf82b44",
+        "size": 561065,
+        "uri": "root://eospublic.cern.ch//eos/opendata/atlas/rucio/user/egramsta/mc_364350.Sherpa_224_NNPDF30NNLO_Diphoton_myy_0_50.2bjets70.root"
       },
       {
-        "checksum": "adler32:97ce5f8e",
-        "size": 3281697,
-        "uri": "root://eospublic.cern.ch//eos/opendata/atlas/rucio/opendata/ODEO_FEB2025_v0_2bjets_mc_364351.Sherpa_224_NNPDF30NNLO_Diphoton_myy_50_90.2bjets.root"
+        "checksum": "adler32:7446204c",
+        "size": 3753435,
+        "uri": "root://eospublic.cern.ch//eos/opendata/atlas/rucio/user/egramsta/mc_364351.Sherpa_224_NNPDF30NNLO_Diphoton_myy_50_90.2bjets70.root"
       },
       {
-        "checksum": "adler32:d8714fd2",
-        "size": 1575062,
-        "uri": "root://eospublic.cern.ch//eos/opendata/atlas/rucio/opendata/ODEO_FEB2025_v0_2bjets_mc_364352.Sherpa_224_NNPDF30NNLO_Diphoton_myy_90_175.2bjets.root"
+        "checksum": "adler32:e9426476",
+        "size": 2010405,
+        "uri": "root://eospublic.cern.ch//eos/opendata/atlas/rucio/user/egramsta/mc_364352.Sherpa_224_NNPDF30NNLO_Diphoton_myy_90_175.2bjets70.root"
       },
       {
-        "checksum": "adler32:c5999684",
-        "size": 497723,
-        "uri": "root://eospublic.cern.ch//eos/opendata/atlas/rucio/opendata/ODEO_FEB2025_v0_2bjets_mc_364353.Sherpa_224_NNPDF30NNLO_Diphoton_myy_175_2000.2bjets.root"
+        "checksum": "adler32:d13c12f2",
+        "size": 718433,
+        "uri": "root://eospublic.cern.ch//eos/opendata/atlas/rucio/user/egramsta/mc_364353.Sherpa_224_NNPDF30NNLO_Diphoton_myy_175_2000.2bjets70.root"
       },
       {
-        "checksum": "adler32:840cfe95",
-        "size": 45453,
-        "uri": "root://eospublic.cern.ch//eos/opendata/atlas/rucio/opendata/ODEO_FEB2025_v0_2bjets_mc_364354.Sherpa_224_NNPDF30NNLO_Diphoton_myy_2000_E_CMS.2bjets.root"
+        "checksum": "adler32:db18a928",
+        "size": 74845,
+        "uri": "root://eospublic.cern.ch//eos/opendata/atlas/rucio/user/egramsta/mc_364354.Sherpa_224_NNPDF30NNLO_Diphoton_myy_2000_E_CMS.2bjets70.root"
       },
       {
-        "checksum": "adler32:c3355f74",
-        "size": 2284445,
-        "uri": "root://eospublic.cern.ch//eos/opendata/atlas/rucio/opendata/ODEO_FEB2025_v0_2bjets_mc_364541.Sherpa_222_NNPDF30NNLO_SinglePhoton_pty_17_35.2bjets.root"
+        "checksum": "adler32:5415f7b2",
+        "size": 2581433,
+        "uri": "root://eospublic.cern.ch//eos/opendata/atlas/rucio/user/egramsta/mc_364541.Sherpa_222_NNPDF30NNLO_SinglePhoton_pty_17_35.2bjets70.root"
       },
       {
-        "checksum": "adler32:e05fbdb9",
-        "size": 3379157,
-        "uri": "root://eospublic.cern.ch//eos/opendata/atlas/rucio/opendata/ODEO_FEB2025_v0_2bjets_mc_364542.Sherpa_222_NNPDF30NNLO_SinglePhoton_pty_35_70.2bjets.root"
+        "checksum": "adler32:5e70df60",
+        "size": 4875783,
+        "uri": "root://eospublic.cern.ch//eos/opendata/atlas/rucio/user/egramsta/mc_364542.Sherpa_222_NNPDF30NNLO_SinglePhoton_pty_35_70.2bjets70.root"
       },
       {
-        "checksum": "adler32:d92b9f70",
-        "size": 5135705,
-        "uri": "root://eospublic.cern.ch//eos/opendata/atlas/rucio/opendata/ODEO_FEB2025_v0_2bjets_mc_364543.Sherpa_222_NNPDF30NNLO_SinglePhoton_pty_70_140.2bjets.root"
+        "checksum": "adler32:8fb484a7",
+        "size": 9580522,
+        "uri": "root://eospublic.cern.ch//eos/opendata/atlas/rucio/user/egramsta/mc_364543.Sherpa_222_NNPDF30NNLO_SinglePhoton_pty_70_140.2bjets70.root"
       },
       {
-        "checksum": "adler32:c434beff",
-        "size": 6724455,
-        "uri": "root://eospublic.cern.ch//eos/opendata/atlas/rucio/opendata/ODEO_FEB2025_v0_2bjets_mc_364544.Sherpa_222_NNPDF30NNLO_SinglePhoton_pty_140_280.2bjets.root"
+        "checksum": "adler32:b69b3d22",
+        "size": 14726497,
+        "uri": "root://eospublic.cern.ch//eos/opendata/atlas/rucio/user/egramsta/mc_364544.Sherpa_222_NNPDF30NNLO_SinglePhoton_pty_140_280.2bjets70.root"
       },
       {
-        "checksum": "adler32:c0d7761d",
-        "size": 1280296,
-        "uri": "root://eospublic.cern.ch//eos/opendata/atlas/rucio/opendata/ODEO_FEB2025_v0_2bjets_mc_364545.Sherpa_222_NNPDF30NNLO_SinglePhoton_pty_280_500.2bjets.root"
+        "checksum": "adler32:d9b95217",
+        "size": 2459308,
+        "uri": "root://eospublic.cern.ch//eos/opendata/atlas/rucio/user/egramsta/mc_364545.Sherpa_222_NNPDF30NNLO_SinglePhoton_pty_280_500.2bjets70.root"
       },
       {
-        "checksum": "adler32:fea783e7",
-        "size": 115153,
-        "uri": "root://eospublic.cern.ch//eos/opendata/atlas/rucio/opendata/ODEO_FEB2025_v0_2bjets_mc_364546.Sherpa_222_NNPDF30NNLO_SinglePhoton_pty_500_1000.2bjets.root"
+        "checksum": "adler32:505a6db3",
+        "size": 186513,
+        "uri": "root://eospublic.cern.ch//eos/opendata/atlas/rucio/user/egramsta/mc_364546.Sherpa_222_NNPDF30NNLO_SinglePhoton_pty_500_1000.2bjets70.root"
       },
       {
-        "checksum": "adler32:bf442164",
-        "size": 135828,
-        "uri": "root://eospublic.cern.ch//eos/opendata/atlas/rucio/opendata/ODEO_FEB2025_v0_2bjets_mc_364547.Sherpa_222_NNPDF30NNLO_SinglePhoton_pty_1000_E_CMS.2bjets.root"
+        "checksum": "adler32:11503b84",
+        "size": 178274,
+        "uri": "root://eospublic.cern.ch//eos/opendata/atlas/rucio/user/egramsta/mc_364547.Sherpa_222_NNPDF30NNLO_SinglePhoton_pty_1000_E_CMS.2bjets70.root"
       },
       {
-        "checksum": "adler32:73af3fe1",
-        "size": 3933193,
-        "uri": "root://eospublic.cern.ch//eos/opendata/atlas/rucio/opendata/ODEO_FEB2025_v0_2bjets_mc_364700.Pythia8EvtGen_A14NNPDF23LO_jetjet_JZ0WithSW.2bjets.root"
+        "checksum": "adler32:e83342c5",
+        "size": 4461270,
+        "uri": "root://eospublic.cern.ch//eos/opendata/atlas/rucio/user/egramsta/mc_364700.Pythia8EvtGen_A14NNPDF23LO_jetjet_JZ0WithSW.2bjets70.root"
       },
       {
-        "checksum": "adler32:ec754a5b",
-        "size": 6476428,
-        "uri": "root://eospublic.cern.ch//eos/opendata/atlas/rucio/opendata/ODEO_FEB2025_v0_2bjets_mc_364701.Pythia8EvtGen_A14NNPDF23LO_jetjet_JZ1WithSW.2bjets.root"
+        "checksum": "adler32:afd6ff3b",
+        "size": 7254544,
+        "uri": "root://eospublic.cern.ch//eos/opendata/atlas/rucio/user/egramsta/mc_364701.Pythia8EvtGen_A14NNPDF23LO_jetjet_JZ1WithSW.2bjets70.root"
       },
       {
-        "checksum": "adler32:68dab965",
-        "size": 33816904,
-        "uri": "root://eospublic.cern.ch//eos/opendata/atlas/rucio/opendata/ODEO_FEB2025_v0_2bjets_mc_364702.Pythia8EvtGen_A14NNPDF23LO_jetjet_JZ2WithSW.2bjets.root"
+        "checksum": "adler32:ad89c7ab",
+        "size": 110418368,
+        "uri": "root://eospublic.cern.ch//eos/opendata/atlas/rucio/user/egramsta/mc_364702.Pythia8EvtGen_A14NNPDF23LO_jetjet_JZ2WithSW.2bjets70.root"
       },
       {
-        "checksum": "adler32:3bade9a9",
-        "size": 61615283,
-        "uri": "root://eospublic.cern.ch//eos/opendata/atlas/rucio/opendata/ODEO_FEB2025_v0_2bjets_mc_364703.Pythia8EvtGen_A14NNPDF23LO_jetjet_JZ3WithSW.2bjets.root"
+        "checksum": "adler32:c4785ff9",
+        "size": 202712181,
+        "uri": "root://eospublic.cern.ch//eos/opendata/atlas/rucio/user/egramsta/mc_364703.Pythia8EvtGen_A14NNPDF23LO_jetjet_JZ3WithSW.2bjets70.root"
       },
       {
-        "checksum": "adler32:fbc112b5",
-        "size": 73783881,
-        "uri": "root://eospublic.cern.ch//eos/opendata/atlas/rucio/opendata/ODEO_FEB2025_v0_2bjets_mc_364704.Pythia8EvtGen_A14NNPDF23LO_jetjet_JZ4WithSW.2bjets.root"
+        "checksum": "adler32:d2e498af",
+        "size": 158147165,
+        "uri": "root://eospublic.cern.ch//eos/opendata/atlas/rucio/user/egramsta/mc_364704.Pythia8EvtGen_A14NNPDF23LO_jetjet_JZ4WithSW.2bjets70.root"
       },
       {
-        "checksum": "adler32:0f0f2dd5",
-        "size": 8904787,
-        "uri": "root://eospublic.cern.ch//eos/opendata/atlas/rucio/opendata/ODEO_FEB2025_v0_2bjets_mc_364705.Pythia8EvtGen_A14NNPDF23LO_jetjet_JZ5WithSW.2bjets.root"
+        "checksum": "adler32:bcb054d9",
+        "size": 12970763,
+        "uri": "root://eospublic.cern.ch//eos/opendata/atlas/rucio/user/egramsta/mc_364705.Pythia8EvtGen_A14NNPDF23LO_jetjet_JZ5WithSW.2bjets70.root"
       },
       {
-        "checksum": "adler32:02a771b3",
-        "size": 388719,
-        "uri": "root://eospublic.cern.ch//eos/opendata/atlas/rucio/opendata/ODEO_FEB2025_v0_2bjets_mc_364706.Pythia8EvtGen_A14NNPDF23LO_jetjet_JZ6WithSW.2bjets.root"
+        "checksum": "adler32:846f7691",
+        "size": 520121,
+        "uri": "root://eospublic.cern.ch//eos/opendata/atlas/rucio/user/egramsta/mc_364706.Pythia8EvtGen_A14NNPDF23LO_jetjet_JZ6WithSW.2bjets70.root"
       },
       {
-        "checksum": "adler32:177f3ff2",
-        "size": 214084,
-        "uri": "root://eospublic.cern.ch//eos/opendata/atlas/rucio/opendata/ODEO_FEB2025_v0_2bjets_mc_364707.Pythia8EvtGen_A14NNPDF23LO_jetjet_JZ7WithSW.2bjets.root"
+        "checksum": "adler32:c666deac",
+        "size": 297164,
+        "uri": "root://eospublic.cern.ch//eos/opendata/atlas/rucio/user/egramsta/mc_364707.Pythia8EvtGen_A14NNPDF23LO_jetjet_JZ7WithSW.2bjets70.root"
       },
       {
-        "checksum": "adler32:d6f1ce98",
-        "size": 432387,
-        "uri": "root://eospublic.cern.ch//eos/opendata/atlas/rucio/opendata/ODEO_FEB2025_v0_2bjets_mc_364708.Pythia8EvtGen_A14NNPDF23LO_jetjet_JZ8WithSW.2bjets.root"
+        "checksum": "adler32:971a11c6",
+        "size": 480276,
+        "uri": "root://eospublic.cern.ch//eos/opendata/atlas/rucio/user/egramsta/mc_364708.Pythia8EvtGen_A14NNPDF23LO_jetjet_JZ8WithSW.2bjets70.root"
       },
       {
-        "checksum": "adler32:595c6202",
-        "size": 386343,
-        "uri": "root://eospublic.cern.ch//eos/opendata/atlas/rucio/opendata/ODEO_FEB2025_v0_2bjets_mc_364709.Pythia8EvtGen_A14NNPDF23LO_jetjet_JZ9WithSW.2bjets.root"
+        "checksum": "adler32:02cd7fe9",
+        "size": 281424,
+        "uri": "root://eospublic.cern.ch//eos/opendata/atlas/rucio/user/egramsta/mc_364709.Pythia8EvtGen_A14NNPDF23LO_jetjet_JZ9WithSW.2bjets70.root"
       },
       {
-        "checksum": "adler32:e4db8f14",
-        "size": 1087516,
-        "uri": "root://eospublic.cern.ch//eos/opendata/atlas/rucio/opendata/ODEO_FEB2025_v0_2bjets_mc_364710.Pythia8EvtGen_A14NNPDF23LO_jetjet_JZ10WithSW.2bjets.root"
+        "checksum": "adler32:ed68fa1a",
+        "size": 758879,
+        "uri": "root://eospublic.cern.ch//eos/opendata/atlas/rucio/user/egramsta/mc_364710.Pythia8EvtGen_A14NNPDF23LO_jetjet_JZ10WithSW.2bjets70.root"
       },
       {
-        "checksum": "adler32:7e2f220a",
-        "size": 506585,
-        "uri": "root://eospublic.cern.ch//eos/opendata/atlas/rucio/opendata/ODEO_FEB2025_v0_2bjets_mc_364711.Pythia8EvtGen_A14NNPDF23LO_jetjet_JZ11WithSW.2bjets.root"
+        "checksum": "adler32:2abdc75e",
+        "size": 317259,
+        "uri": "root://eospublic.cern.ch//eos/opendata/atlas/rucio/user/egramsta/mc_364711.Pythia8EvtGen_A14NNPDF23LO_jetjet_JZ11WithSW.2bjets70.root"
       },
       {
-        "checksum": "adler32:55c1c41f",
-        "size": 986399,
-        "uri": "root://eospublic.cern.ch//eos/opendata/atlas/rucio/opendata/ODEO_FEB2025_v0_2bjets_mc_364712.Pythia8EvtGen_A14NNPDF23LO_jetjet_JZ12WithSW.2bjets.root"
+        "checksum": "adler32:6a4cf7f7",
+        "size": 306764,
+        "uri": "root://eospublic.cern.ch//eos/opendata/atlas/rucio/user/egramsta/mc_364712.Pythia8EvtGen_A14NNPDF23LO_jetjet_JZ12WithSW.2bjets70.root"
       },
       {
-        "checksum": "adler32:41ed25b9",
-        "size": 153463,
-        "uri": "root://eospublic.cern.ch//eos/opendata/atlas/rucio/opendata/ODEO_FEB2025_v0_2bjets_mc_375884.MGPy8EG_A14N_GG_ttn1_2000_5000_200.2bjets.root"
+        "checksum": "adler32:7ff4526a",
+        "size": 1673674,
+        "uri": "root://eospublic.cern.ch//eos/opendata/atlas/rucio/user/egramsta/mc_375884.MGPy8EG_A14N_GG_ttn1_2000_5000_200.2bjets70.root"
       },
       {
-        "checksum": "adler32:e1f2e074",
-        "size": 38734,
-        "uri": "root://eospublic.cern.ch//eos/opendata/atlas/rucio/opendata/ODEO_FEB2025_v0_2bjets_mc_376359.MGPy8EG_A14N23LO_SS_onestepCC_1600_900_200.2bjets.root"
+        "checksum": "adler32:b21366cc",
+        "size": 37301,
+        "uri": "root://eospublic.cern.ch//eos/opendata/atlas/rucio/user/egramsta/mc_376359.MGPy8EG_A14N23LO_SS_onestepCC_1600_900_200.2bjets70.root"
       },
       {
-        "checksum": "adler32:ac15b11d",
-        "size": 43636,
-        "uri": "root://eospublic.cern.ch//eos/opendata/atlas/rucio/opendata/ODEO_FEB2025_v0_2bjets_mc_376518.MadGraphPythia8EvtGen_A14NNPDF23LO_GG_direct_2400_200.2bjets.root"
+        "checksum": "adler32:0a7d89b3",
+        "size": 37121,
+        "uri": "root://eospublic.cern.ch//eos/opendata/atlas/rucio/user/egramsta/mc_376518.MadGraphPythia8EvtGen_A14NNPDF23LO_GG_direct_2400_200.2bjets70.root"
       },
       {
-        "checksum": "adler32:1e11780c",
-        "size": 28694,
-        "uri": "root://eospublic.cern.ch//eos/opendata/atlas/rucio/opendata/ODEO_FEB2025_v0_2bjets_mc_392202.MGPy8EG_A14N23LO_C1N2_WZ_500p0_100p0_3L_2L7.2bjets.root"
+        "checksum": "adler32:d5899b3b",
+        "size": 35348,
+        "uri": "root://eospublic.cern.ch//eos/opendata/atlas/rucio/user/egramsta/mc_392202.MGPy8EG_A14N23LO_C1N2_WZ_500p0_100p0_3L_2L7.2bjets70.root"
       },
       {
-        "checksum": "adler32:e73c2724",
-        "size": 33568,
-        "uri": "root://eospublic.cern.ch//eos/opendata/atlas/rucio/opendata/ODEO_FEB2025_v0_2bjets_mc_394997.MGPy8EG_A14N23LO_SM_N2C1p_105_100_2L2MET75_MadSpin.2bjets.root"
+        "checksum": "adler32:b9dc4864",
+        "size": 46028,
+        "uri": "root://eospublic.cern.ch//eos/opendata/atlas/rucio/user/egramsta/mc_394997.MGPy8EG_A14N23LO_SM_N2C1p_105_100_2L2MET75_MadSpin.2bjets70.root"
       },
       {
-        "checksum": "adler32:1e000e45",
-        "size": 124488,
-        "uri": "root://eospublic.cern.ch//eos/opendata/atlas/rucio/opendata/ODEO_FEB2025_v0_2bjets_mc_398384.MGPy8EG_A14N23LO_C1N2N1_GGMHinoZh50_800_noFilter.2bjets.root"
+        "checksum": "adler32:60ecac59",
+        "size": 1238614,
+        "uri": "root://eospublic.cern.ch//eos/opendata/atlas/rucio/user/egramsta/mc_398384.MGPy8EG_A14N23LO_C1N2N1_GGMHinoZh50_800_noFilter.2bjets70.root"
       },
       {
-        "checksum": "adler32:82d1892c",
-        "size": 498248,
-        "uri": "root://eospublic.cern.ch//eos/opendata/atlas/rucio/opendata/ODEO_FEB2025_v0_2bjets_mc_410081.MadGraphPythia8EvtGen_A14NNPDF23_ttbarWW.2bjets.root"
+        "checksum": "adler32:7e7b530f",
+        "size": 3635087,
+        "uri": "root://eospublic.cern.ch//eos/opendata/atlas/rucio/user/egramsta/mc_410081.MadGraphPythia8EvtGen_A14NNPDF23_ttbarWW.2bjets70.root"
       },
       {
-        "checksum": "adler32:4253bd72",
-        "size": 2195433,
-        "uri": "root://eospublic.cern.ch//eos/opendata/atlas/rucio/opendata/ODEO_FEB2025_v0_2bjets_mc_410082.MadGraphPythia8EvtGen_A14NNPDF23LO_ttgamma_noallhad.2bjets.root"
+        "checksum": "adler32:4c662120",
+        "size": 38840985,
+        "uri": "root://eospublic.cern.ch//eos/opendata/atlas/rucio/user/egramsta/mc_410082.MadGraphPythia8EvtGen_A14NNPDF23LO_ttgamma_noallhad.2bjets70.root"
       },
       {
-        "checksum": "adler32:ffcbc566",
-        "size": 2025024,
-        "uri": "root://eospublic.cern.ch//eos/opendata/atlas/rucio/opendata/ODEO_FEB2025_v0_2bjets_mc_410087.MadGraphPythia8EvtGen_A14NNPDF23LO_ttgamma_allhad.2bjets.root"
+        "checksum": "adler32:f38ac93d",
+        "size": 22155782,
+        "uri": "root://eospublic.cern.ch//eos/opendata/atlas/rucio/user/egramsta/mc_410087.MadGraphPythia8EvtGen_A14NNPDF23LO_ttgamma_allhad.2bjets70.root"
       },
       {
-        "checksum": "adler32:d190eba4",
-        "size": 1197403,
-        "uri": "root://eospublic.cern.ch//eos/opendata/atlas/rucio/opendata/ODEO_FEB2025_v0_2bjets_mc_410155.aMcAtNloPythia8EvtGen_MEN30NLO_A14N23LO_ttW.2bjets.root"
+        "checksum": "adler32:7fe4eb95",
+        "size": 11322310,
+        "uri": "root://eospublic.cern.ch//eos/opendata/atlas/rucio/user/egramsta/mc_410155.aMcAtNloPythia8EvtGen_MEN30NLO_A14N23LO_ttW.2bjets70.root"
       },
       {
-        "checksum": "adler32:8dfe88ea",
-        "size": 1009976,
-        "uri": "root://eospublic.cern.ch//eos/opendata/atlas/rucio/opendata/ODEO_FEB2025_v0_2bjets_mc_410156.aMcAtNloPythia8EvtGen_MEN30NLO_A14N23LO_ttZnunu.2bjets.root"
+        "checksum": "adler32:a7247d00",
+        "size": 12034930,
+        "uri": "root://eospublic.cern.ch//eos/opendata/atlas/rucio/user/egramsta/mc_410156.aMcAtNloPythia8EvtGen_MEN30NLO_A14N23LO_ttZnunu.2bjets70.root"
       },
       {
-        "checksum": "adler32:9b3be938",
-        "size": 2426979,
-        "uri": "root://eospublic.cern.ch//eos/opendata/atlas/rucio/opendata/ODEO_FEB2025_v0_2bjets_mc_410157.aMcAtNloPythia8EvtGen_MEN30NLO_A14N23LO_ttZqq.2bjets.root"
+        "checksum": "adler32:c1793261",
+        "size": 25011288,
+        "uri": "root://eospublic.cern.ch//eos/opendata/atlas/rucio/user/egramsta/mc_410157.aMcAtNloPythia8EvtGen_MEN30NLO_A14N23LO_ttZqq.2bjets70.root"
       },
       {
-        "checksum": "adler32:dda19710",
-        "size": 793041,
-        "uri": "root://eospublic.cern.ch//eos/opendata/atlas/rucio/opendata/ODEO_FEB2025_v0_2bjets_mc_410218.aMcAtNloPythia8EvtGen_MEN30NLO_A14N23LO_ttee.2bjets.root"
+        "checksum": "adler32:cc79ec34",
+        "size": 8811075,
+        "uri": "root://eospublic.cern.ch//eos/opendata/atlas/rucio/user/egramsta/mc_410218.aMcAtNloPythia8EvtGen_MEN30NLO_A14N23LO_ttee.2bjets70.root"
       },
       {
-        "checksum": "adler32:f3bb1343",
-        "size": 1338031,
-        "uri": "root://eospublic.cern.ch//eos/opendata/atlas/rucio/opendata/ODEO_FEB2025_v0_2bjets_mc_410219.aMcAtNloPythia8EvtGen_MEN30NLO_A14N23LO_ttmumu.2bjets.root"
+        "checksum": "adler32:e183969a",
+        "size": 15798034,
+        "uri": "root://eospublic.cern.ch//eos/opendata/atlas/rucio/user/egramsta/mc_410219.aMcAtNloPythia8EvtGen_MEN30NLO_A14N23LO_ttmumu.2bjets70.root"
       },
       {
-        "checksum": "adler32:7aeb17b2",
-        "size": 2254767,
-        "uri": "root://eospublic.cern.ch//eos/opendata/atlas/rucio/opendata/ODEO_FEB2025_v0_2bjets_mc_410220.aMcAtNloPythia8EvtGen_MEN30NLO_A14N23LO_tttautau.2bjets.root"
+        "checksum": "adler32:69cb944a",
+        "size": 19814106,
+        "uri": "root://eospublic.cern.ch//eos/opendata/atlas/rucio/user/egramsta/mc_410220.aMcAtNloPythia8EvtGen_MEN30NLO_A14N23LO_tttautau.2bjets70.root"
       },
       {
-        "checksum": "adler32:4649ddfb",
-        "size": 2869593,
-        "uri": "root://eospublic.cern.ch//eos/opendata/atlas/rucio/opendata/ODEO_FEB2025_v0_2bjets_mc_410389.MadGraphPythia8EvtGen_A14NNPDF23_ttgamma_nonallhadronic.2bjets.root"
+        "checksum": "adler32:9df5b601",
+        "size": 51977164,
+        "uri": "root://eospublic.cern.ch//eos/opendata/atlas/rucio/user/egramsta/mc_410389.MadGraphPythia8EvtGen_A14NNPDF23_ttgamma_nonallhadronic.2bjets70.root"
       },
       {
-        "checksum": "adler32:c994a8c0",
-        "size": 2730846,
-        "uri": "root://eospublic.cern.ch//eos/opendata/atlas/rucio/opendata/ODEO_FEB2025_v0_2bjets_mc_410395.MGH7EG_H7UE_ttgamma_nonallhadronic.2bjets.root"
+        "checksum": "adler32:3eca0e57",
+        "size": 45182105,
+        "uri": "root://eospublic.cern.ch//eos/opendata/atlas/rucio/user/egramsta/mc_410395.MGH7EG_H7UE_ttgamma_nonallhadronic.2bjets70.root"
       },
       {
-        "checksum": "adler32:9e6085a9",
-        "size": 2972054,
-        "uri": "root://eospublic.cern.ch//eos/opendata/atlas/rucio/opendata/ODEO_FEB2025_v0_2bjets_mc_410396.MGH7EG_H7UE_ttgamma_allhadronic.2bjets.root"
+        "checksum": "adler32:a46e87a9",
+        "size": 29782498,
+        "uri": "root://eospublic.cern.ch//eos/opendata/atlas/rucio/user/egramsta/mc_410396.MGH7EG_H7UE_ttgamma_allhadronic.2bjets70.root"
       },
       {
-        "checksum": "adler32:80f6d121",
-        "size": 260455,
-        "uri": "root://eospublic.cern.ch//eos/opendata/atlas/rucio/opendata/ODEO_FEB2025_v0_2bjets_mc_410408.aMcAtNloPythia8EvtGen_tWZ_Ztoll_minDR1.2bjets.root"
+        "checksum": "adler32:080f0d6b",
+        "size": 1792514,
+        "uri": "root://eospublic.cern.ch//eos/opendata/atlas/rucio/user/egramsta/mc_410408.aMcAtNloPythia8EvtGen_tWZ_Ztoll_minDR1.2bjets70.root"
       },
       {
-        "checksum": "adler32:3b567b1a",
-        "size": 195682136,
-        "uri": "root://eospublic.cern.ch//eos/opendata/atlas/rucio/opendata/ODEO_FEB2025_v0_2bjets_mc_410470.PhPy8EG_A14_ttbar_hdamp258p75_nonallhad.2bjets.root"
+        "checksum": "adler32:52f16f77",
+        "size": 3678127204,
+        "uri": "root://eospublic.cern.ch//eos/opendata/atlas/rucio/user/egramsta/mc_410470.PhPy8EG_A14_ttbar_hdamp258p75_nonallhad.2bjets70.root"
       },
       {
-        "checksum": "adler32:d2cdc3f2",
-        "size": 176548563,
-        "uri": "root://eospublic.cern.ch//eos/opendata/atlas/rucio/opendata/ODEO_FEB2025_v0_2bjets_mc_410471.PhPy8EG_A14_ttbar_hdamp258p75_allhad.2bjets.root"
+        "checksum": "adler32:373ac0f0",
+        "size": 1953671874,
+        "uri": "root://eospublic.cern.ch//eos/opendata/atlas/rucio/user/egramsta/mc_410471.PhPy8EG_A14_ttbar_hdamp258p75_allhad.2bjets70.root"
       },
       {
-        "checksum": "adler32:9b3b3fa1",
-        "size": 619309,
-        "uri": "root://eospublic.cern.ch//eos/opendata/atlas/rucio/opendata/ODEO_FEB2025_v0_2bjets_mc_410560.MadGraphPythia8EvtGen_A14_tZ_4fl_tchan_noAllHad.2bjets.root"
+        "checksum": "adler32:148791be",
+        "size": 8788355,
+        "uri": "root://eospublic.cern.ch//eos/opendata/atlas/rucio/user/egramsta/mc_410560.MadGraphPythia8EvtGen_A14_tZ_4fl_tchan_noAllHad.2bjets70.root"
       },
       {
-        "checksum": "adler32:61eb766f",
-        "size": 360526,
-        "uri": "root://eospublic.cern.ch//eos/opendata/atlas/rucio/opendata/ODEO_FEB2025_v0_2bjets_mc_410644.PowhegPythia8EvtGen_A14_singletop_schan_lept_top.2bjets.root"
+        "checksum": "adler32:ae525cc8",
+        "size": 11118415,
+        "uri": "root://eospublic.cern.ch//eos/opendata/atlas/rucio/user/egramsta/mc_410644.PowhegPythia8EvtGen_A14_singletop_schan_lept_top.2bjets70.root"
       },
       {
-        "checksum": "adler32:97442d11",
-        "size": 272786,
-        "uri": "root://eospublic.cern.ch//eos/opendata/atlas/rucio/opendata/ODEO_FEB2025_v0_2bjets_mc_410645.PowhegPythia8EvtGen_A14_singletop_schan_lept_antitop.2bjets.root"
+        "checksum": "adler32:03324e49",
+        "size": 7760350,
+        "uri": "root://eospublic.cern.ch//eos/opendata/atlas/rucio/user/egramsta/mc_410645.PowhegPythia8EvtGen_A14_singletop_schan_lept_antitop.2bjets70.root"
       },
       {
-        "checksum": "adler32:d9005bca",
-        "size": 5404117,
-        "uri": "root://eospublic.cern.ch//eos/opendata/atlas/rucio/opendata/ODEO_FEB2025_v0_2bjets_mc_410658.PhPy8EG_A14_tchan_BW50_lept_top.2bjets.root"
+        "checksum": "adler32:dfc502ff",
+        "size": 116387681,
+        "uri": "root://eospublic.cern.ch//eos/opendata/atlas/rucio/user/egramsta/mc_410658.PhPy8EG_A14_tchan_BW50_lept_top.2bjets70.root"
       },
       {
-        "checksum": "adler32:baee591a",
-        "size": 3360683,
-        "uri": "root://eospublic.cern.ch//eos/opendata/atlas/rucio/opendata/ODEO_FEB2025_v0_2bjets_mc_410659.PhPy8EG_A14_tchan_BW50_lept_antitop.2bjets.root"
+        "checksum": "adler32:6b39691a",
+        "size": 69088538,
+        "uri": "root://eospublic.cern.ch//eos/opendata/atlas/rucio/user/egramsta/mc_410659.PhPy8EG_A14_tchan_BW50_lept_antitop.2bjets70.root"
       },
       {
-        "checksum": "adler32:c60b5d18",
-        "size": 44762966,
-        "uri": "root://eospublic.cern.ch//eos/opendata/atlas/rucio/opendata/ODEO_FEB2025_v0_2bjets_mc_411233.PowhegHerwig7EvtGen_tt_hdamp258p75_713_SingleLep.2bjets.root"
+        "checksum": "adler32:86ee0885",
+        "size": 720929598,
+        "uri": "root://eospublic.cern.ch//eos/opendata/atlas/rucio/user/egramsta/mc_411233.PowhegHerwig7EvtGen_tt_hdamp258p75_713_SingleLep.2bjets70.root"
       },
       {
-        "checksum": "adler32:d2b6b11f",
-        "size": 12754827,
-        "uri": "root://eospublic.cern.ch//eos/opendata/atlas/rucio/opendata/ODEO_FEB2025_v0_2bjets_mc_411234.PowhegHerwig7EvtGen_tt_hdamp258p75_713_dil.2bjets.root"
+        "checksum": "adler32:4616c67d",
+        "size": 348283783,
+        "uri": "root://eospublic.cern.ch//eos/opendata/atlas/rucio/user/egramsta/mc_411234.PowhegHerwig7EvtGen_tt_hdamp258p75_713_dil.2bjets70.root"
       },
       {
-        "checksum": "adler32:3429c1fd",
-        "size": 251740986,
-        "uri": "root://eospublic.cern.ch//eos/opendata/atlas/rucio/opendata/ODEO_FEB2025_v0_2bjets_mc_411316.PowhegHerwig7EvtGen_tt_hdamp258p75_713_allhad.2bjets.root"
+        "checksum": "adler32:7254da6d",
+        "size": 2679835117,
+        "uri": "root://eospublic.cern.ch//eos/opendata/atlas/rucio/user/egramsta/mc_411316.PowhegHerwig7EvtGen_tt_hdamp258p75_713_allhad.2bjets70.root"
       },
       {
-        "checksum": "adler32:3c782c77",
-        "size": 4894377,
-        "uri": "root://eospublic.cern.ch//eos/opendata/atlas/rucio/opendata/ODEO_FEB2025_v0_2bjets_mc_412043.aMcAtNloPythia8EvtGen_A14NNPDF31_SM4topsNLO.2bjets.root"
+        "checksum": "adler32:a0a7bd99",
+        "size": 55848226,
+        "uri": "root://eospublic.cern.ch//eos/opendata/atlas/rucio/user/egramsta/mc_412043.aMcAtNloPythia8EvtGen_A14NNPDF31_SM4topsNLO.2bjets70.root"
       },
       {
-        "checksum": "adler32:8ada48bb",
-        "size": 4738951,
-        "uri": "root://eospublic.cern.ch//eos/opendata/atlas/rucio/opendata/ODEO_FEB2025_v0_2bjets_mc_412044.aMcAtNloHerwig7EvtGen_H7UE_SM4topsNLO.2bjets.root"
+        "checksum": "adler32:95665cec",
+        "size": 55031421,
+        "uri": "root://eospublic.cern.ch//eos/opendata/atlas/rucio/user/egramsta/mc_412044.aMcAtNloHerwig7EvtGen_H7UE_SM4topsNLO.2bjets70.root"
       },
       {
-        "checksum": "adler32:1fa824f3",
-        "size": 450118,
-        "uri": "root://eospublic.cern.ch//eos/opendata/atlas/rucio/opendata/ODEO_FEB2025_v0_2bjets_mc_423099.Pythia8EvtGen_A14NNPDF23LO_gammajet_DP8_17.2bjets.root"
+        "checksum": "adler32:34f3d930",
+        "size": 473589,
+        "uri": "root://eospublic.cern.ch//eos/opendata/atlas/rucio/user/egramsta/mc_423099.Pythia8EvtGen_A14NNPDF23LO_gammajet_DP8_17.2bjets70.root"
       },
       {
-        "checksum": "adler32:46889277",
-        "size": 613105,
-        "uri": "root://eospublic.cern.ch//eos/opendata/atlas/rucio/opendata/ODEO_FEB2025_v0_2bjets_mc_423100.Pythia8EvtGen_A14NNPDF23LO_gammajet_DP17_35.2bjets.root"
+        "checksum": "adler32:2454214a",
+        "size": 743158,
+        "uri": "root://eospublic.cern.ch//eos/opendata/atlas/rucio/user/egramsta/mc_423100.Pythia8EvtGen_A14NNPDF23LO_gammajet_DP17_35.2bjets70.root"
       },
       {
-        "checksum": "adler32:f95bceda",
-        "size": 877471,
-        "uri": "root://eospublic.cern.ch//eos/opendata/atlas/rucio/opendata/ODEO_FEB2025_v0_2bjets_mc_423101.Pythia8EvtGen_A14NNPDF23LO_gammajet_DP35_50.2bjets.root"
+        "checksum": "adler32:a88e5368",
+        "size": 1301595,
+        "uri": "root://eospublic.cern.ch//eos/opendata/atlas/rucio/user/egramsta/mc_423101.Pythia8EvtGen_A14NNPDF23LO_gammajet_DP35_50.2bjets70.root"
       },
       {
-        "checksum": "adler32:84ff0a81",
-        "size": 1540673,
-        "uri": "root://eospublic.cern.ch//eos/opendata/atlas/rucio/opendata/ODEO_FEB2025_v0_2bjets_mc_423102.Pythia8EvtGen_A14NNPDF23LO_gammajet_DP50_70.2bjets.root"
+        "checksum": "adler32:4dc7cd47",
+        "size": 2716493,
+        "uri": "root://eospublic.cern.ch//eos/opendata/atlas/rucio/user/egramsta/mc_423102.Pythia8EvtGen_A14NNPDF23LO_gammajet_DP50_70.2bjets70.root"
       },
       {
-        "checksum": "adler32:fd4993f3",
-        "size": 1306641,
-        "uri": "root://eospublic.cern.ch//eos/opendata/atlas/rucio/opendata/ODEO_FEB2025_v0_2bjets_mc_423103.Pythia8EvtGen_A14NNPDF23LO_gammajet_DP70_140.2bjets.root"
+        "checksum": "adler32:50155d19",
+        "size": 2758442,
+        "uri": "root://eospublic.cern.ch//eos/opendata/atlas/rucio/user/egramsta/mc_423103.Pythia8EvtGen_A14NNPDF23LO_gammajet_DP70_140.2bjets70.root"
       },
       {
-        "checksum": "adler32:d9707882",
-        "size": 1667577,
-        "uri": "root://eospublic.cern.ch//eos/opendata/atlas/rucio/opendata/ODEO_FEB2025_v0_2bjets_mc_423104.Pythia8EvtGen_A14NNPDF23LO_gammajet_DP140_280.2bjets.root"
+        "checksum": "adler32:c9252025",
+        "size": 3750180,
+        "uri": "root://eospublic.cern.ch//eos/opendata/atlas/rucio/user/egramsta/mc_423104.Pythia8EvtGen_A14NNPDF23LO_gammajet_DP140_280.2bjets70.root"
       },
       {
-        "checksum": "adler32:cefb8176",
-        "size": 1322492,
-        "uri": "root://eospublic.cern.ch//eos/opendata/atlas/rucio/opendata/ODEO_FEB2025_v0_2bjets_mc_423105.Pythia8EvtGen_A14NNPDF23LO_gammajet_DP280_500.2bjets.root"
+        "checksum": "adler32:f5938b4b",
+        "size": 2718367,
+        "uri": "root://eospublic.cern.ch//eos/opendata/atlas/rucio/user/egramsta/mc_423105.Pythia8EvtGen_A14NNPDF23LO_gammajet_DP280_500.2bjets70.root"
       },
       {
-        "checksum": "adler32:3c4a9913",
-        "size": 180969,
-        "uri": "root://eospublic.cern.ch//eos/opendata/atlas/rucio/opendata/ODEO_FEB2025_v0_2bjets_mc_423106.Pythia8EvtGen_A14NNPDF23LO_gammajet_DP500_800.2bjets.root"
+        "checksum": "adler32:7dc93f85",
+        "size": 286064,
+        "uri": "root://eospublic.cern.ch//eos/opendata/atlas/rucio/user/egramsta/mc_423106.Pythia8EvtGen_A14NNPDF23LO_gammajet_DP500_800.2bjets70.root"
       },
       {
-        "checksum": "adler32:75217495",
-        "size": 110137,
-        "uri": "root://eospublic.cern.ch//eos/opendata/atlas/rucio/opendata/ODEO_FEB2025_v0_2bjets_mc_423107.Pythia8EvtGen_A14NNPDF23LO_gammajet_DP800_1000.2bjets.root"
+        "checksum": "adler32:0582af4d",
+        "size": 153708,
+        "uri": "root://eospublic.cern.ch//eos/opendata/atlas/rucio/user/egramsta/mc_423107.Pythia8EvtGen_A14NNPDF23LO_gammajet_DP800_1000.2bjets70.root"
       },
       {
-        "checksum": "adler32:9f68e488",
-        "size": 146914,
-        "uri": "root://eospublic.cern.ch//eos/opendata/atlas/rucio/opendata/ODEO_FEB2025_v0_2bjets_mc_423108.Pythia8EvtGen_A14NNPDF23LO_gammajet_DP1000_1500.2bjets.root"
+        "checksum": "adler32:9044c527",
+        "size": 210740,
+        "uri": "root://eospublic.cern.ch//eos/opendata/atlas/rucio/user/egramsta/mc_423108.Pythia8EvtGen_A14NNPDF23LO_gammajet_DP1000_1500.2bjets70.root"
       },
       {
-        "checksum": "adler32:2a9bc5d7",
-        "size": 63749,
-        "uri": "root://eospublic.cern.ch//eos/opendata/atlas/rucio/opendata/ODEO_FEB2025_v0_2bjets_mc_423109.Pythia8EvtGen_A14NNPDF23LO_gammajet_DP1500_2000.2bjets.root"
+        "checksum": "adler32:8978d723",
+        "size": 86656,
+        "uri": "root://eospublic.cern.ch//eos/opendata/atlas/rucio/user/egramsta/mc_423109.Pythia8EvtGen_A14NNPDF23LO_gammajet_DP1500_2000.2bjets70.root"
       },
       {
-        "checksum": "adler32:09fdd6d1",
-        "size": 44668,
-        "uri": "root://eospublic.cern.ch//eos/opendata/atlas/rucio/opendata/ODEO_FEB2025_v0_2bjets_mc_423110.Pythia8EvtGen_A14NNPDF23LO_gammajet_DP2000_2500.2bjets.root"
+        "checksum": "adler32:5ea1d8bb",
+        "size": 72112,
+        "uri": "root://eospublic.cern.ch//eos/opendata/atlas/rucio/user/egramsta/mc_423110.Pythia8EvtGen_A14NNPDF23LO_gammajet_DP2000_2500.2bjets70.root"
       },
       {
-        "checksum": "adler32:4f23ef9b",
-        "size": 65939,
-        "uri": "root://eospublic.cern.ch//eos/opendata/atlas/rucio/opendata/ODEO_FEB2025_v0_2bjets_mc_423111.Pythia8EvtGen_A14NNPDF23LO_gammajet_DP2500_3000.2bjets.root"
+        "checksum": "adler32:eddeec7f",
+        "size": 93227,
+        "uri": "root://eospublic.cern.ch//eos/opendata/atlas/rucio/user/egramsta/mc_423111.Pythia8EvtGen_A14NNPDF23LO_gammajet_DP2500_3000.2bjets70.root"
       },
       {
-        "checksum": "adler32:a4b33c40",
-        "size": 73751,
-        "uri": "root://eospublic.cern.ch//eos/opendata/atlas/rucio/opendata/ODEO_FEB2025_v0_2bjets_mc_423112.Pythia8EvtGen_A14NNPDF23LO_gammajet_DP3000_inf.2bjets.root"
+        "checksum": "adler32:e529ecf2",
+        "size": 72529,
+        "uri": "root://eospublic.cern.ch//eos/opendata/atlas/rucio/user/egramsta/mc_423112.Pythia8EvtGen_A14NNPDF23LO_gammajet_DP3000_inf.2bjets70.root"
       },
       {
-        "checksum": "adler32:a461c237",
-        "size": 231194,
-        "uri": "root://eospublic.cern.ch//eos/opendata/atlas/rucio/opendata/ODEO_FEB2025_v0_2bjets_mc_448624.MGPy8EG_A14N23LO_TT_higgsinoRPV_1075_700.2bjets.root"
+        "checksum": "adler32:e1ef8c3b",
+        "size": 3840743,
+        "uri": "root://eospublic.cern.ch//eos/opendata/atlas/rucio/user/egramsta/mc_448624.MGPy8EG_A14N23LO_TT_higgsinoRPV_1075_700.2bjets70.root"
       },
       {
-        "checksum": "adler32:4ffc6f9e",
-        "size": 90134,
-        "uri": "root://eospublic.cern.ch//eos/opendata/atlas/rucio/opendata/ODEO_FEB2025_v0_2bjets_mc_449595.MGPy8EG_A14N23LO_TT_RPVdirectBL_1400.2bjets.root"
+        "checksum": "adler32:9c8bdb86",
+        "size": 532385,
+        "uri": "root://eospublic.cern.ch//eos/opendata/atlas/rucio/user/egramsta/mc_449595.MGPy8EG_A14N23LO_TT_RPVdirectBL_1400.2bjets70.root"
       },
       {
-        "checksum": "adler32:b8fdedf9",
-        "size": 118725,
-        "uri": "root://eospublic.cern.ch//eos/opendata/atlas/rucio/opendata/ODEO_FEB2025_v0_2bjets_mc_450576.PowhegPythia8EvtGen_NNLOPS_nnlo_30_VBFH125_ZZllbb.2bjets.root"
+        "checksum": "adler32:b995250d",
+        "size": 1988535,
+        "uri": "root://eospublic.cern.ch//eos/opendata/atlas/rucio/user/egramsta/mc_450576.PowhegPythia8EvtGen_NNLOPS_nnlo_30_VBFH125_ZZllbb.2bjets70.root"
       },
       {
-        "checksum": "adler32:7b7a1026",
-        "size": 79694,
-        "uri": "root://eospublic.cern.ch//eos/opendata/atlas/rucio/opendata/ODEO_FEB2025_v0_2bjets_mc_500335.MGH7EG_VBFHWWlvlv.2bjets.root"
+        "checksum": "adler32:064dc3b7",
+        "size": 111568,
+        "uri": "root://eospublic.cern.ch//eos/opendata/atlas/rucio/user/egramsta/mc_500335.MGH7EG_VBFHWWlvlv.2bjets70.root"
       },
       {
-        "checksum": "adler32:c776fefd",
-        "size": 41863,
-        "uri": "root://eospublic.cern.ch//eos/opendata/atlas/rucio/opendata/ODEO_FEB2025_v0_2bjets_mc_500553.aMCPy8EG_ZH_FxFx_Hyy.2bjets.root"
+        "checksum": "adler32:69b11d9c",
+        "size": 58670,
+        "uri": "root://eospublic.cern.ch//eos/opendata/atlas/rucio/user/egramsta/mc_500553.aMCPy8EG_ZH_FxFx_Hyy.2bjets70.root"
       },
       {
-        "checksum": "adler32:99095fd7",
-        "size": 37351,
-        "uri": "root://eospublic.cern.ch//eos/opendata/atlas/rucio/opendata/ODEO_FEB2025_v0_2bjets_mc_500554.aMCPy8EG_WH_FxFx_Hyy.2bjets.root"
+        "checksum": "adler32:c78a39b5",
+        "size": 38420,
+        "uri": "root://eospublic.cern.ch//eos/opendata/atlas/rucio/user/egramsta/mc_500554.aMCPy8EG_WH_FxFx_Hyy.2bjets70.root"
       },
       {
-        "checksum": "adler32:4b57aa8a",
-        "size": 41790,
-        "uri": "root://eospublic.cern.ch//eos/opendata/atlas/rucio/opendata/ODEO_FEB2025_v0_2bjets_mc_500555.aMCPy8EG_ggZH_Hyy.2bjets.root"
+        "checksum": "adler32:4a69e1e4",
+        "size": 53492,
+        "uri": "root://eospublic.cern.ch//eos/opendata/atlas/rucio/user/egramsta/mc_500555.aMCPy8EG_ggZH_Hyy.2bjets70.root"
       },
       {
-        "checksum": "adler32:cb0a4251",
-        "size": 49381,
-        "uri": "root://eospublic.cern.ch//eos/opendata/atlas/rucio/opendata/ODEO_FEB2025_v0_2bjets_mc_501058.MGPy8EG_StauStauDirect_200p0_1p0_TFilt.2bjets.root"
+        "checksum": "adler32:fe057cd8",
+        "size": 43334,
+        "uri": "root://eospublic.cern.ch//eos/opendata/atlas/rucio/user/egramsta/mc_501058.MGPy8EG_StauStauDirect_200p0_1p0_TFilt.2bjets70.root"
       },
       {
-        "checksum": "adler32:5021d368",
-        "size": 167889,
-        "uri": "root://eospublic.cern.ch//eos/opendata/atlas/rucio/opendata/ODEO_FEB2025_v0_2bjets_mc_506098.aMCPy8EG_WpH_FxFx_Htautau.2bjets.root"
+        "checksum": "adler32:746819b0",
+        "size": 76259,
+        "uri": "root://eospublic.cern.ch//eos/opendata/atlas/rucio/user/egramsta/mc_506098.aMCPy8EG_WpH_FxFx_Htautau.2bjets70.root"
       },
       {
-        "checksum": "adler32:10c113c7",
-        "size": 157108,
-        "uri": "root://eospublic.cern.ch//eos/opendata/atlas/rucio/opendata/ODEO_FEB2025_v0_2bjets_mc_506099.aMCPy8EG_ZH_FxFx_Htautau.2bjets.root"
+        "checksum": "adler32:b341e44d",
+        "size": 591373,
+        "uri": "root://eospublic.cern.ch//eos/opendata/atlas/rucio/user/egramsta/mc_506099.aMCPy8EG_ZH_FxFx_Htautau.2bjets70.root"
       },
       {
-        "checksum": "adler32:0cf03797",
-        "size": 240956,
-        "uri": "root://eospublic.cern.ch//eos/opendata/atlas/rucio/opendata/ODEO_FEB2025_v0_2bjets_mc_506101.aMCH7EG_VBF_Htautauh30h20.2bjets.root"
+        "checksum": "adler32:792f28ed",
+        "size": 131228,
+        "uri": "root://eospublic.cern.ch//eos/opendata/atlas/rucio/user/egramsta/mc_506101.aMCH7EG_VBF_Htautauh30h20.2bjets70.root"
       },
       {
-        "checksum": "adler32:a794632e",
-        "size": 119971,
-        "uri": "root://eospublic.cern.ch//eos/opendata/atlas/rucio/opendata/ODEO_FEB2025_v0_2bjets_mc_506102.aMCH7EG_VBF_Htautaul13l7.2bjets.root"
+        "checksum": "adler32:9f2d23f7",
+        "size": 117173,
+        "uri": "root://eospublic.cern.ch//eos/opendata/atlas/rucio/user/egramsta/mc_506102.aMCH7EG_VBF_Htautaul13l7.2bjets70.root"
       },
       {
-        "checksum": "adler32:e1f3d951",
-        "size": 115099,
-        "uri": "root://eospublic.cern.ch//eos/opendata/atlas/rucio/opendata/ODEO_FEB2025_v0_2bjets_mc_506103.aMCH7EG_VBF_Htautaulp15hm20.2bjets.root"
+        "checksum": "adler32:ec951554",
+        "size": 90754,
+        "uri": "root://eospublic.cern.ch//eos/opendata/atlas/rucio/user/egramsta/mc_506103.aMCH7EG_VBF_Htautaulp15hm20.2bjets70.root"
       },
       {
-        "checksum": "adler32:81fdbde0",
-        "size": 158679,
-        "uri": "root://eospublic.cern.ch//eos/opendata/atlas/rucio/opendata/ODEO_FEB2025_v0_2bjets_mc_506104.aMCH7EG_VBF_Htautaulm15hp20.2bjets.root"
+        "checksum": "adler32:5ee513d6",
+        "size": 135011,
+        "uri": "root://eospublic.cern.ch//eos/opendata/atlas/rucio/user/egramsta/mc_506104.aMCH7EG_VBF_Htautaulm15hp20.2bjets70.root"
       },
       {
-        "checksum": "adler32:0d635907",
-        "size": 69778,
-        "uri": "root://eospublic.cern.ch//eos/opendata/atlas/rucio/opendata/ODEO_FEB2025_v0_2bjets_mc_506811.aMCH7EG_VBF_HC_Hyy.2bjets.root"
+        "checksum": "adler32:ffc9176b",
+        "size": 80694,
+        "uri": "root://eospublic.cern.ch//eos/opendata/atlas/rucio/user/egramsta/mc_506811.aMCH7EG_VBF_HC_Hyy.2bjets70.root"
       },
       {
-        "checksum": "adler32:342121a2",
-        "size": 78407,
-        "uri": "root://eospublic.cern.ch//eos/opendata/atlas/rucio/opendata/ODEO_FEB2025_v0_2bjets_mc_506813.aMCPy8EG_ZH_had_FxFx_Hyy.2bjets.root"
+        "checksum": "adler32:51db86dd",
+        "size": 515016,
+        "uri": "root://eospublic.cern.ch//eos/opendata/atlas/rucio/user/egramsta/mc_506813.aMCPy8EG_ZH_had_FxFx_Hyy.2bjets70.root"
       },
       {
-        "checksum": "adler32:0247ec84",
-        "size": 110337,
-        "uri": "root://eospublic.cern.ch//eos/opendata/atlas/rucio/opendata/ODEO_FEB2025_v0_2bjets_mc_506814.aMCPy8EG_ggZH_Zhad_Hyy.2bjets.root"
+        "checksum": "adler32:e3bc80dd",
+        "size": 888700,
+        "uri": "root://eospublic.cern.ch//eos/opendata/atlas/rucio/user/egramsta/mc_506814.aMCPy8EG_ggZH_Zhad_Hyy.2bjets70.root"
       },
       {
-        "checksum": "adler32:fced4726",
-        "size": 40699,
-        "uri": "root://eospublic.cern.ch//eos/opendata/atlas/rucio/opendata/ODEO_FEB2025_v0_2bjets_mc_507366.MGPy8EG_A14NNPDF23LO_GGM_N1N2C1_950.2bjets.root"
+        "checksum": "adler32:164a3668",
+        "size": 176475,
+        "uri": "root://eospublic.cern.ch//eos/opendata/atlas/rucio/user/egramsta/mc_507366.MGPy8EG_A14NNPDF23LO_GGM_N1N2C1_950.2bjets70.root"
       },
       {
-        "checksum": "adler32:31c63110",
-        "size": 431854,
-        "uri": "root://eospublic.cern.ch//eos/opendata/atlas/rucio/opendata/ODEO_FEB2025_v0_2bjets_mc_510097.MGPy8EG_A14N23LO_DM_4topscalar_p1000_c1_nonallhad.2bjets.root"
+        "checksum": "adler32:a599e747",
+        "size": 5909728,
+        "uri": "root://eospublic.cern.ch//eos/opendata/atlas/rucio/user/egramsta/mc_510097.MGPy8EG_A14N23LO_DM_4topscalar_p1000_c1_nonallhad.2bjets70.root"
       },
       {
-        "checksum": "adler32:e9df4328",
-        "size": 56792,
-        "uri": "root://eospublic.cern.ch//eos/opendata/atlas/rucio/opendata/ODEO_FEB2025_v0_2bjets_mc_523692.MGPy8EG_A14N23LO_TT_tN1_1200_200_MS.2bjets.root"
+        "checksum": "adler32:e4e41745",
+        "size": 336828,
+        "uri": "root://eospublic.cern.ch//eos/opendata/atlas/rucio/user/egramsta/mc_523692.MGPy8EG_A14N23LO_TT_tN1_1200_200_MS.2bjets70.root"
       },
       {
-        "checksum": "adler32:1c686e88",
-        "size": 2696032,
-        "uri": "root://eospublic.cern.ch//eos/opendata/atlas/rucio/opendata/ODEO_FEB2025_v0_2bjets_mc_600017.PhH7EG_H7UE_716_tchan_lept_antitop.2bjets.root"
+        "checksum": "adler32:ebf64fec",
+        "size": 51453431,
+        "uri": "root://eospublic.cern.ch//eos/opendata/atlas/rucio/user/egramsta/mc_600017.PhH7EG_H7UE_716_tchan_lept_antitop.2bjets70.root"
       },
       {
-        "checksum": "adler32:90b9bddd",
-        "size": 4419624,
-        "uri": "root://eospublic.cern.ch//eos/opendata/atlas/rucio/opendata/ODEO_FEB2025_v0_2bjets_mc_600018.PhH7EG_H7UE_716_tchan_lept_top.2bjets.root"
+        "checksum": "adler32:62beb57c",
+        "size": 89408089,
+        "uri": "root://eospublic.cern.ch//eos/opendata/atlas/rucio/user/egramsta/mc_600018.PhH7EG_H7UE_716_tchan_lept_top.2bjets70.root"
       },
       {
-        "checksum": "adler32:1ede4970",
-        "size": 338036,
-        "uri": "root://eospublic.cern.ch//eos/opendata/atlas/rucio/opendata/ODEO_FEB2025_v0_2bjets_mc_600019.PhH7EG_H7UE_716_schan_lept_antitop.2bjets.root"
+        "checksum": "adler32:f6807c63",
+        "size": 8892608,
+        "uri": "root://eospublic.cern.ch//eos/opendata/atlas/rucio/user/egramsta/mc_600019.PhH7EG_H7UE_716_schan_lept_antitop.2bjets70.root"
       },
       {
-        "checksum": "adler32:30cb8bf8",
-        "size": 345416,
-        "uri": "root://eospublic.cern.ch//eos/opendata/atlas/rucio/opendata/ODEO_FEB2025_v0_2bjets_mc_600020.PhH7EG_H7UE_716_schan_lept_top.2bjets.root"
+        "checksum": "adler32:95d95519",
+        "size": 9695080,
+        "uri": "root://eospublic.cern.ch//eos/opendata/atlas/rucio/user/egramsta/mc_600020.PhH7EG_H7UE_716_schan_lept_top.2bjets70.root"
       },
       {
-        "checksum": "adler32:437ba205",
-        "size": 827162,
-        "uri": "root://eospublic.cern.ch//eos/opendata/atlas/rucio/opendata/ODEO_FEB2025_v0_2bjets_mc_600565.PhH7EG_ggH125_tautauh30h20_ShowerSys_fix.2bjets.root"
+        "checksum": "adler32:7d810ab6",
+        "size": 705810,
+        "uri": "root://eospublic.cern.ch//eos/opendata/atlas/rucio/user/egramsta/mc_600565.PhH7EG_ggH125_tautauh30h20_ShowerSys_fix.2bjets70.root"
       },
       {
-        "checksum": "adler32:8c56c131",
-        "size": 410411,
-        "uri": "root://eospublic.cern.ch//eos/opendata/atlas/rucio/opendata/ODEO_FEB2025_v0_2bjets_mc_600566.PhH7EG_ggH125_tautaul13l7_ShowerSys_fix.2bjets.root"
+        "checksum": "adler32:2dc3d43a",
+        "size": 512117,
+        "uri": "root://eospublic.cern.ch//eos/opendata/atlas/rucio/user/egramsta/mc_600566.PhH7EG_ggH125_tautaul13l7_ShowerSys_fix.2bjets70.root"
       },
       {
-        "checksum": "adler32:a411df3c",
-        "size": 234046,
-        "uri": "root://eospublic.cern.ch//eos/opendata/atlas/rucio/opendata/ODEO_FEB2025_v0_2bjets_mc_600567.PhH7EG_ggH125_ttlp15hm20_ShowerSys_fix.2bjets.root"
+        "checksum": "adler32:20557916",
+        "size": 275055,
+        "uri": "root://eospublic.cern.ch//eos/opendata/atlas/rucio/user/egramsta/mc_600567.PhH7EG_ggH125_ttlp15hm20_ShowerSys_fix.2bjets70.root"
       },
       {
-        "checksum": "adler32:d8718eb2",
-        "size": 291168,
-        "uri": "root://eospublic.cern.ch//eos/opendata/atlas/rucio/opendata/ODEO_FEB2025_v0_2bjets_mc_600568.PhH7EG_ggH125_ttlm15hp20_ShowerSys_fix.2bjets.root"
+        "checksum": "adler32:1a78fb00",
+        "size": 313775,
+        "uri": "root://eospublic.cern.ch//eos/opendata/atlas/rucio/user/egramsta/mc_600568.PhH7EG_ggH125_ttlm15hp20_ShowerSys_fix.2bjets70.root"
       },
       {
-        "checksum": "adler32:bd5c9a15",
-        "size": 271467,
-        "uri": "root://eospublic.cern.ch//eos/opendata/atlas/rucio/opendata/ODEO_FEB2025_v0_2bjets_mc_600569.PhH7EG_VBFH125_tautauh30h20_ShowerSys_fix.2bjets.root"
+        "checksum": "adler32:d624930a",
+        "size": 190631,
+        "uri": "root://eospublic.cern.ch//eos/opendata/atlas/rucio/user/egramsta/mc_600569.PhH7EG_VBFH125_tautauh30h20_ShowerSys_fix.2bjets70.root"
       },
       {
-        "checksum": "adler32:1f7f4254",
-        "size": 115816,
-        "uri": "root://eospublic.cern.ch//eos/opendata/atlas/rucio/opendata/ODEO_FEB2025_v0_2bjets_mc_600570.PhH7EG_VBFH125_tautaul13l7_ShowerSys_fix.2bjets.root"
+        "checksum": "adler32:66626975",
+        "size": 135849,
+        "uri": "root://eospublic.cern.ch//eos/opendata/atlas/rucio/user/egramsta/mc_600570.PhH7EG_VBFH125_tautaul13l7_ShowerSys_fix.2bjets70.root"
       },
       {
-        "checksum": "adler32:370ed4b4",
-        "size": 90402,
-        "uri": "root://eospublic.cern.ch//eos/opendata/atlas/rucio/opendata/ODEO_FEB2025_v0_2bjets_mc_600571.PhH7EG_VBFH125_tautaulp15hm20_ShowerSys_fix.2bjets.root"
+        "checksum": "adler32:73b9d13d",
+        "size": 81761,
+        "uri": "root://eospublic.cern.ch//eos/opendata/atlas/rucio/user/egramsta/mc_600571.PhH7EG_VBFH125_tautaulp15hm20_ShowerSys_fix.2bjets70.root"
       },
       {
-        "checksum": "adler32:f5397bbf",
-        "size": 92941,
-        "uri": "root://eospublic.cern.ch//eos/opendata/atlas/rucio/opendata/ODEO_FEB2025_v0_2bjets_mc_600572.PhH7EG_VBFH125_tautaulm15hp20_ShowerSys_fix.2bjets.root"
+        "checksum": "adler32:7b2e7f39",
+        "size": 86721,
+        "uri": "root://eospublic.cern.ch//eos/opendata/atlas/rucio/user/egramsta/mc_600572.PhH7EG_VBFH125_tautaulm15hp20_ShowerSys_fix.2bjets70.root"
       },
       {
-        "checksum": "adler32:74b07a93",
-        "size": 115517,
-        "uri": "root://eospublic.cern.ch//eos/opendata/atlas/rucio/opendata/ODEO_FEB2025_v0_2bjets_mc_600573.PhH7EG_WmH125J_Winc_MINLO_tt_ShowerSys_fix.2bjets.root"
+        "checksum": "adler32:e82c15c6",
+        "size": 50513,
+        "uri": "root://eospublic.cern.ch//eos/opendata/atlas/rucio/user/egramsta/mc_600573.PhH7EG_WmH125J_Winc_MINLO_tt_ShowerSys_fix.2bjets70.root"
       },
       {
-        "checksum": "adler32:c87dd06e",
-        "size": 167336,
-        "uri": "root://eospublic.cern.ch//eos/opendata/atlas/rucio/opendata/ODEO_FEB2025_v0_2bjets_mc_600574.PhH7EG_WpH125J_Winc_MINLO_tt_ShowerSys_fix.2bjets.root"
+        "checksum": "adler32:f0e61151",
+        "size": 77094,
+        "uri": "root://eospublic.cern.ch//eos/opendata/atlas/rucio/user/egramsta/mc_600574.PhH7EG_WpH125J_Winc_MINLO_tt_ShowerSys_fix.2bjets70.root"
       },
       {
-        "checksum": "adler32:d94b86a2",
-        "size": 221102,
-        "uri": "root://eospublic.cern.ch//eos/opendata/atlas/rucio/opendata/ODEO_FEB2025_v0_2bjets_mc_600575.PhH7EG_ZH125J_Zinc_MINLO_tautau_ShowerSys_fix.2bjets.root"
+        "checksum": "adler32:f60492f8",
+        "size": 893451,
+        "uri": "root://eospublic.cern.ch//eos/opendata/atlas/rucio/user/egramsta/mc_600575.PhH7EG_ZH125J_Zinc_MINLO_tautau_ShowerSys_fix.2bjets70.root"
       },
       {
-        "checksum": "adler32:841e9fe3",
-        "size": 146916,
-        "uri": "root://eospublic.cern.ch//eos/opendata/atlas/rucio/opendata/ODEO_FEB2025_v0_2bjets_mc_600686.PhPy8EG_NNPDF3_AZNLO_ggZH125_Htautau_Zinc.2bjets.root"
+        "checksum": "adler32:a2b1e14a",
+        "size": 698620,
+        "uri": "root://eospublic.cern.ch//eos/opendata/atlas/rucio/user/egramsta/mc_600686.PhPy8EG_NNPDF3_AZNLO_ggZH125_Htautau_Zinc.2bjets70.root"
       },
       {
-        "checksum": "adler32:3fe72314",
-        "size": 13446263,
-        "uri": "root://eospublic.cern.ch//eos/opendata/atlas/rucio/opendata/ODEO_FEB2025_v0_2bjets_mc_601352.PhPy8EG_tW_dyn_DR_incl_antitop.2bjets.root"
+        "checksum": "adler32:7c5f4757",
+        "size": 109347513,
+        "uri": "root://eospublic.cern.ch//eos/opendata/atlas/rucio/user/egramsta/mc_601352.PhPy8EG_tW_dyn_DR_incl_antitop.2bjets70.root"
       },
       {
-        "checksum": "adler32:d9b2ce0c",
-        "size": 13336796,
-        "uri": "root://eospublic.cern.ch//eos/opendata/atlas/rucio/opendata/ODEO_FEB2025_v0_2bjets_mc_601355.PhPy8EG_tW_dyn_DR_incl_top.2bjets.root"
+        "checksum": "adler32:7f2bb72e",
+        "size": 107332763,
+        "uri": "root://eospublic.cern.ch//eos/opendata/atlas/rucio/user/egramsta/mc_601355.PhPy8EG_tW_dyn_DR_incl_top.2bjets70.root"
       },
       {
-        "checksum": "adler32:9f41dfa3",
-        "size": 2707135,
-        "uri": "root://eospublic.cern.ch//eos/opendata/atlas/rucio/opendata/ODEO_FEB2025_v0_2bjets_mc_601487.PhPy8EG_A14_tchan_pThard1_lep_antitop.2bjets.root"
+        "checksum": "adler32:644f3b2d",
+        "size": 57561398,
+        "uri": "root://eospublic.cern.ch//eos/opendata/atlas/rucio/user/egramsta/mc_601487.PhPy8EG_A14_tchan_pThard1_lep_antitop.2bjets70.root"
       },
       {
-        "checksum": "adler32:5fe31173",
-        "size": 4040421,
-        "uri": "root://eospublic.cern.ch//eos/opendata/atlas/rucio/opendata/ODEO_FEB2025_v0_2bjets_mc_601489.PhPy8EG_A14_tchan_pThard1_lep_top.2bjets.root"
+        "checksum": "adler32:35a001e6",
+        "size": 93644121,
+        "uri": "root://eospublic.cern.ch//eos/opendata/atlas/rucio/user/egramsta/mc_601489.PhPy8EG_A14_tchan_pThard1_lep_top.2bjets70.root"
       },
       {
-        "checksum": "adler32:37ee0c76",
-        "size": 20210137,
-        "uri": "root://eospublic.cern.ch//eos/opendata/atlas/rucio/opendata/ODEO_FEB2025_v0_2bjets_mc_601491.PhPy8EG_A14_ttbar_pThard1_dil.2bjets.root"
+        "checksum": "adler32:c1173391",
+        "size": 608412014,
+        "uri": "root://eospublic.cern.ch//eos/opendata/atlas/rucio/user/egramsta/mc_601491.PhPy8EG_A14_ttbar_pThard1_dil.2bjets70.root"
       },
       {
-        "checksum": "adler32:495079dd",
-        "size": 1831271,
-        "uri": "root://eospublic.cern.ch//eos/opendata/atlas/rucio/opendata/ODEO_FEB2025_v0_2bjets_mc_601495.PhPy8EG_A14_ttbar_pThard1_allhad.2bjets.root"
+        "checksum": "adler32:b792cb42",
+        "size": 20374902,
+        "uri": "root://eospublic.cern.ch//eos/opendata/atlas/rucio/user/egramsta/mc_601495.PhPy8EG_A14_ttbar_pThard1_allhad.2bjets70.root"
       },
       {
-        "checksum": "adler32:7e42fa43",
-        "size": 151310143,
-        "uri": "root://eospublic.cern.ch//eos/opendata/atlas/rucio/opendata/ODEO_FEB2025_v0_2bjets_mc_601497.PhPy8EG_A14_ttbar_pThard1_singlelep.2bjets.root"
+        "checksum": "adler32:4ae53e66",
+        "size": 2620039455,
+        "uri": "root://eospublic.cern.ch//eos/opendata/atlas/rucio/user/egramsta/mc_601497.PhPy8EG_A14_ttbar_pThard1_singlelep.2bjets70.root"
       },
       {
-        "checksum": "adler32:af305c7b",
-        "size": 582351,
-        "uri": "root://eospublic.cern.ch//eos/opendata/atlas/rucio/opendata/ODEO_FEB2025_v0_2bjets_mc_601624.PhPy8EG_tW_DS_dyn_dil_antitop.2bjets.root"
+        "checksum": "adler32:854334bc",
+        "size": 10476065,
+        "uri": "root://eospublic.cern.ch//eos/opendata/atlas/rucio/user/egramsta/mc_601624.PhPy8EG_tW_DS_dyn_dil_antitop.2bjets70.root"
       },
       {
-        "checksum": "adler32:1190a824",
-        "size": 12913272,
-        "uri": "root://eospublic.cern.ch//eos/opendata/atlas/rucio/opendata/ODEO_FEB2025_v0_2bjets_mc_601627.PhPy8EG_tW_DS_dyn_incl_antitop.2bjets.root"
+        "checksum": "adler32:74291750",
+        "size": 105562561,
+        "uri": "root://eospublic.cern.ch//eos/opendata/atlas/rucio/user/egramsta/mc_601627.PhPy8EG_tW_DS_dyn_incl_antitop.2bjets70.root"
       },
       {
-        "checksum": "adler32:d2e248ec",
-        "size": 716919,
-        "uri": "root://eospublic.cern.ch//eos/opendata/atlas/rucio/opendata/ODEO_FEB2025_v0_2bjets_mc_601628.PhPy8EG_tW_DS_dyn_dil_top.2bjets.root"
+        "checksum": "adler32:b849c0aa",
+        "size": 13245163,
+        "uri": "root://eospublic.cern.ch//eos/opendata/atlas/rucio/user/egramsta/mc_601628.PhPy8EG_tW_DS_dyn_dil_top.2bjets70.root"
       },
       {
-        "checksum": "adler32:dae64062",
-        "size": 12738992,
-        "uri": "root://eospublic.cern.ch//eos/opendata/atlas/rucio/opendata/ODEO_FEB2025_v0_2bjets_mc_601631.PhPy8EG_tW_DS_dyn_incl_top.2bjets.root"
+        "checksum": "adler32:448ee915",
+        "size": 102383996,
+        "uri": "root://eospublic.cern.ch//eos/opendata/atlas/rucio/user/egramsta/mc_601631.PhPy8EG_tW_DS_dyn_incl_top.2bjets70.root"
       },
       {
-        "checksum": "adler32:e23481df",
-        "size": 13558676,
-        "uri": "root://eospublic.cern.ch//eos/opendata/atlas/rucio/opendata/ODEO_FEB2025_v0_2bjets_mc_601761.PhPy8EG_tW_dyn_DR_pThard1_incl_top.2bjets.root"
+        "checksum": "adler32:ab359c8b",
+        "size": 110104012,
+        "uri": "root://eospublic.cern.ch//eos/opendata/atlas/rucio/user/egramsta/mc_601761.PhPy8EG_tW_dyn_DR_pThard1_incl_top.2bjets70.root"
       },
       {
-        "checksum": "adler32:4484e22e",
-        "size": 13410128,
-        "uri": "root://eospublic.cern.ch//eos/opendata/atlas/rucio/opendata/ODEO_FEB2025_v0_2bjets_mc_601762.PhPy8EG_tW_dyn_DR_pThard1_incl_antitop.2bjets.root"
+        "checksum": "adler32:531a6c44",
+        "size": 109215645,
+        "uri": "root://eospublic.cern.ch//eos/opendata/atlas/rucio/user/egramsta/mc_601762.PhPy8EG_tW_dyn_DR_pThard1_incl_antitop.2bjets70.root"
       },
       {
-        "checksum": "adler32:fd73b71a",
-        "size": 758632,
-        "uri": "root://eospublic.cern.ch//eos/opendata/atlas/rucio/opendata/ODEO_FEB2025_v0_2bjets_mc_601763.PhPy8EG_tW_dyn_DR_pThard1_dil_top.2bjets.root"
+        "checksum": "adler32:6b4a9bd3",
+        "size": 13722071,
+        "uri": "root://eospublic.cern.ch//eos/opendata/atlas/rucio/user/egramsta/mc_601763.PhPy8EG_tW_dyn_DR_pThard1_dil_top.2bjets70.root"
       },
       {
-        "checksum": "adler32:17adad71",
-        "size": 783488,
-        "uri": "root://eospublic.cern.ch//eos/opendata/atlas/rucio/opendata/ODEO_FEB2025_v0_2bjets_mc_601764.PhPy8EG_tW_dyn_DR_pThard1_dil_antitop.2bjets.root"
+        "checksum": "adler32:8398b52f",
+        "size": 13895388,
+        "uri": "root://eospublic.cern.ch//eos/opendata/atlas/rucio/user/egramsta/mc_601764.PhPy8EG_tW_dyn_DR_pThard1_dil_antitop.2bjets70.root"
       },
       {
-        "checksum": "adler32:15adc87b",
-        "size": 1924968,
-        "uri": "root://eospublic.cern.ch//eos/opendata/atlas/rucio/opendata/ODEO_FEB2025_v0_2bjets_mc_700000.Sh_228_ttW.2bjets.root"
+        "checksum": "adler32:cdda69ec",
+        "size": 21434928,
+        "uri": "root://eospublic.cern.ch//eos/opendata/atlas/rucio/user/egramsta/mc_700000.Sh_228_ttW.2bjets70.root"
       },
       {
-        "checksum": "adler32:92502189",
-        "size": 50536,
-        "uri": "root://eospublic.cern.ch//eos/opendata/atlas/rucio/opendata/ODEO_FEB2025_v0_2bjets_mc_700007.Sh_228_yyy_01NLO.2bjets.root"
+        "checksum": "adler32:851c281a",
+        "size": 57509,
+        "uri": "root://eospublic.cern.ch//eos/opendata/atlas/rucio/user/egramsta/mc_700007.Sh_228_yyy_01NLO.2bjets70.root"
       },
       {
-        "checksum": "adler32:e0714498",
-        "size": 58012,
-        "uri": "root://eospublic.cern.ch//eos/opendata/atlas/rucio/opendata/ODEO_FEB2025_v0_2bjets_mc_700195.Sh_2210_eegammagamma.2bjets.root"
+        "checksum": "adler32:c69cec0d",
+        "size": 93388,
+        "uri": "root://eospublic.cern.ch//eos/opendata/atlas/rucio/user/egramsta/mc_700195.Sh_2210_eegammagamma.2bjets70.root"
       },
       {
-        "checksum": "adler32:d4da000d",
-        "size": 111344,
-        "uri": "root://eospublic.cern.ch//eos/opendata/atlas/rucio/opendata/ODEO_FEB2025_v0_2bjets_mc_700196.Sh_2210_mumugammagamma.2bjets.root"
+        "checksum": "adler32:428e680a",
+        "size": 160852,
+        "uri": "root://eospublic.cern.ch//eos/opendata/atlas/rucio/user/egramsta/mc_700196.Sh_2210_mumugammagamma.2bjets70.root"
       },
       {
-        "checksum": "adler32:38afe205",
-        "size": 87636,
-        "uri": "root://eospublic.cern.ch//eos/opendata/atlas/rucio/opendata/ODEO_FEB2025_v0_2bjets_mc_700197.Sh_2210_tautaugammagamma.2bjets.root"
+        "checksum": "adler32:4a5e2112",
+        "size": 76971,
+        "uri": "root://eospublic.cern.ch//eos/opendata/atlas/rucio/user/egramsta/mc_700197.Sh_2210_tautaugammagamma.2bjets70.root"
       },
       {
-        "checksum": "adler32:98a5d5ae",
-        "size": 33664,
-        "uri": "root://eospublic.cern.ch//eos/opendata/atlas/rucio/opendata/ODEO_FEB2025_v0_2bjets_mc_700198.Sh_2210_nunugammagamma.2bjets.root"
+        "checksum": "adler32:3262116a",
+        "size": 44046,
+        "uri": "root://eospublic.cern.ch//eos/opendata/atlas/rucio/user/egramsta/mc_700198.Sh_2210_nunugammagamma.2bjets70.root"
       },
       {
-        "checksum": "adler32:0727f0a0",
-        "size": 72246,
-        "uri": "root://eospublic.cern.ch//eos/opendata/atlas/rucio/opendata/ODEO_FEB2025_v0_2bjets_mc_700199.Sh_2210_enugammagamma.2bjets.root"
+        "checksum": "adler32:3c3c7bae",
+        "size": 83947,
+        "uri": "root://eospublic.cern.ch//eos/opendata/atlas/rucio/user/egramsta/mc_700199.Sh_2210_enugammagamma.2bjets70.root"
       },
       {
-        "checksum": "adler32:e29ba8d0",
-        "size": 63683,
-        "uri": "root://eospublic.cern.ch//eos/opendata/atlas/rucio/opendata/ODEO_FEB2025_v0_2bjets_mc_700200.Sh_2210_munugammagamma.2bjets.root"
+        "checksum": "adler32:200d6f14",
+        "size": 72733,
+        "uri": "root://eospublic.cern.ch//eos/opendata/atlas/rucio/user/egramsta/mc_700200.Sh_2210_munugammagamma.2bjets70.root"
       },
       {
-        "checksum": "adler32:2b9139d0",
-        "size": 74610,
-        "uri": "root://eospublic.cern.ch//eos/opendata/atlas/rucio/opendata/ODEO_FEB2025_v0_2bjets_mc_700201.Sh_2210_taunugammagamma.2bjets.root"
+        "checksum": "adler32:f8281216",
+        "size": 80938,
+        "uri": "root://eospublic.cern.ch//eos/opendata/atlas/rucio/user/egramsta/mc_700201.Sh_2210_taunugammagamma.2bjets70.root"
       },
       {
-        "checksum": "adler32:801d6747",
-        "size": 9153818,
-        "uri": "root://eospublic.cern.ch//eos/opendata/atlas/rucio/opendata/ODEO_FEB2025_v0_2bjets_mc_700320.Sh_2211_Zee_maxHTpTV2_BFilter.2bjets.root"
+        "checksum": "adler32:ce90b0a4",
+        "size": 110952497,
+        "uri": "root://eospublic.cern.ch//eos/opendata/atlas/rucio/user/egramsta/mc_700320.Sh_2211_Zee_maxHTpTV2_BFilter.2bjets70.root"
       },
       {
-        "checksum": "adler32:5945ec05",
-        "size": 43248812,
-        "uri": "root://eospublic.cern.ch//eos/opendata/atlas/rucio/opendata/ODEO_FEB2025_v0_2bjets_mc_700321.Sh_2211_Zee_maxHTpTV2_CFilterBVeto.2bjets.root"
+        "checksum": "adler32:f39beccb",
+        "size": 9244911,
+        "uri": "root://eospublic.cern.ch//eos/opendata/atlas/rucio/user/egramsta/mc_700321.Sh_2211_Zee_maxHTpTV2_CFilterBVeto.2bjets70.root"
       },
       {
-        "checksum": "adler32:30460ad3",
-        "size": 25281103,
-        "uri": "root://eospublic.cern.ch//eos/opendata/atlas/rucio/opendata/ODEO_FEB2025_v0_2bjets_mc_700322.Sh_2211_Zee_maxHTpTV2_CVetoBVeto.2bjets.root"
+        "checksum": "adler32:957eb98b",
+        "size": 5245331,
+        "uri": "root://eospublic.cern.ch//eos/opendata/atlas/rucio/user/egramsta/mc_700322.Sh_2211_Zee_maxHTpTV2_CVetoBVeto.2bjets70.root"
       },
       {
-        "checksum": "adler32:71db3078",
-        "size": 8605015,
-        "uri": "root://eospublic.cern.ch//eos/opendata/atlas/rucio/opendata/ODEO_FEB2025_v0_2bjets_mc_700323.Sh_2211_Zmumu_maxHTpTV2_BFilter.2bjets.root"
+        "checksum": "adler32:ccd35608",
+        "size": 109177099,
+        "uri": "root://eospublic.cern.ch//eos/opendata/atlas/rucio/user/egramsta/mc_700323.Sh_2211_Zmumu_maxHTpTV2_BFilter.2bjets70.root"
       },
       {
-        "checksum": "adler32:3b812e4d",
-        "size": 43029329,
-        "uri": "root://eospublic.cern.ch//eos/opendata/atlas/rucio/opendata/ODEO_FEB2025_v0_2bjets_mc_700324.Sh_2211_Zmumu_maxHTpTV2_CFilterBVeto.2bjets.root"
+        "checksum": "adler32:6a71ac9f",
+        "size": 9455041,
+        "uri": "root://eospublic.cern.ch//eos/opendata/atlas/rucio/user/egramsta/mc_700324.Sh_2211_Zmumu_maxHTpTV2_CFilterBVeto.2bjets70.root"
       },
       {
-        "checksum": "adler32:62a5f212",
-        "size": 25871069,
-        "uri": "root://eospublic.cern.ch//eos/opendata/atlas/rucio/opendata/ODEO_FEB2025_v0_2bjets_mc_700325.Sh_2211_Zmumu_maxHTpTV2_CVetoBVeto.2bjets.root"
+        "checksum": "adler32:2c2ee191",
+        "size": 4383564,
+        "uri": "root://eospublic.cern.ch//eos/opendata/atlas/rucio/user/egramsta/mc_700325.Sh_2211_Zmumu_maxHTpTV2_CVetoBVeto.2bjets70.root"
       },
       {
-        "checksum": "adler32:8be7318d",
-        "size": 3116979,
-        "uri": "root://eospublic.cern.ch//eos/opendata/atlas/rucio/opendata/ODEO_FEB2025_v0_2bjets_mc_700335.Sh_2211_Znunu_pTV2_BFilter.2bjets.root"
+        "checksum": "adler32:dc406f4f",
+        "size": 40471510,
+        "uri": "root://eospublic.cern.ch//eos/opendata/atlas/rucio/user/egramsta/mc_700335.Sh_2211_Znunu_pTV2_BFilter.2bjets70.root"
       },
       {
-        "checksum": "adler32:2f7bcb1d",
-        "size": 6997663,
-        "uri": "root://eospublic.cern.ch//eos/opendata/atlas/rucio/opendata/ODEO_FEB2025_v0_2bjets_mc_700336.Sh_2211_Znunu_pTV2_CFilterBVeto.2bjets.root"
+        "checksum": "adler32:56ab1cd6",
+        "size": 1871286,
+        "uri": "root://eospublic.cern.ch//eos/opendata/atlas/rucio/user/egramsta/mc_700336.Sh_2211_Znunu_pTV2_CFilterBVeto.2bjets70.root"
       },
       {
-        "checksum": "adler32:65be29c5",
-        "size": 5344772,
-        "uri": "root://eospublic.cern.ch//eos/opendata/atlas/rucio/opendata/ODEO_FEB2025_v0_2bjets_mc_700337.Sh_2211_Znunu_pTV2_CVetoBVeto.2bjets.root"
+        "checksum": "adler32:e1f68b08",
+        "size": 2001836,
+        "uri": "root://eospublic.cern.ch//eos/opendata/atlas/rucio/user/egramsta/mc_700337.Sh_2211_Znunu_pTV2_CVetoBVeto.2bjets70.root"
       },
       {
-        "checksum": "adler32:c41599cd",
-        "size": 35741803,
-        "uri": "root://eospublic.cern.ch//eos/opendata/atlas/rucio/opendata/ODEO_FEB2025_v0_2bjets_mc_700338.Sh_2211_Wenu_maxHTpTV2_BFilter.2bjets.root"
+        "checksum": "adler32:d3780899",
+        "size": 319611764,
+        "uri": "root://eospublic.cern.ch//eos/opendata/atlas/rucio/user/egramsta/mc_700338.Sh_2211_Wenu_maxHTpTV2_BFilter.2bjets70.root"
       },
       {
-        "checksum": "adler32:66aeeac2",
-        "size": 187813289,
-        "uri": "root://eospublic.cern.ch//eos/opendata/atlas/rucio/opendata/ODEO_FEB2025_v0_2bjets_mc_700339.Sh_2211_Wenu_maxHTpTV2_CFilterBVeto.2bjets.root"
+        "checksum": "adler32:1c3884cb",
+        "size": 29541511,
+        "uri": "root://eospublic.cern.ch//eos/opendata/atlas/rucio/user/egramsta/mc_700339.Sh_2211_Wenu_maxHTpTV2_CFilterBVeto.2bjets70.root"
       },
       {
-        "checksum": "adler32:46e5af00",
-        "size": 37304229,
-        "uri": "root://eospublic.cern.ch//eos/opendata/atlas/rucio/opendata/ODEO_FEB2025_v0_2bjets_mc_700340.Sh_2211_Wenu_maxHTpTV2_CVetoBVeto.2bjets.root"
+        "checksum": "adler32:a829a9f4",
+        "size": 9510636,
+        "uri": "root://eospublic.cern.ch//eos/opendata/atlas/rucio/user/egramsta/mc_700340.Sh_2211_Wenu_maxHTpTV2_CVetoBVeto.2bjets70.root"
       },
       {
-        "checksum": "adler32:97e7e41d",
-        "size": 37094706,
-        "uri": "root://eospublic.cern.ch//eos/opendata/atlas/rucio/opendata/ODEO_FEB2025_v0_2bjets_mc_700341.Sh_2211_Wmunu_maxHTpTV2_BFilter.2bjets.root"
+        "checksum": "adler32:2b1a186d",
+        "size": 340324462,
+        "uri": "root://eospublic.cern.ch//eos/opendata/atlas/rucio/user/egramsta/mc_700341.Sh_2211_Wmunu_maxHTpTV2_BFilter.2bjets70.root"
       },
       {
-        "checksum": "adler32:38bd6802",
-        "size": 172766270,
-        "uri": "root://eospublic.cern.ch//eos/opendata/atlas/rucio/opendata/ODEO_FEB2025_v0_2bjets_mc_700342.Sh_2211_Wmunu_maxHTpTV2_CFilterBVeto.2bjets.root"
+        "checksum": "adler32:bc67368c",
+        "size": 27575999,
+        "uri": "root://eospublic.cern.ch//eos/opendata/atlas/rucio/user/egramsta/mc_700342.Sh_2211_Wmunu_maxHTpTV2_CFilterBVeto.2bjets70.root"
       },
       {
-        "checksum": "adler32:c47db955",
-        "size": 33067019,
-        "uri": "root://eospublic.cern.ch//eos/opendata/atlas/rucio/opendata/ODEO_FEB2025_v0_2bjets_mc_700343.Sh_2211_Wmunu_maxHTpTV2_CVetoBVeto.2bjets.root"
+        "checksum": "adler32:6357ee4e",
+        "size": 8115973,
+        "uri": "root://eospublic.cern.ch//eos/opendata/atlas/rucio/user/egramsta/mc_700343.Sh_2211_Wmunu_maxHTpTV2_CVetoBVeto.2bjets70.root"
       },
       {
-        "checksum": "adler32:364cd6eb",
-        "size": 13338050,
-        "uri": "root://eospublic.cern.ch//eos/opendata/atlas/rucio/opendata/ODEO_FEB2025_v0_2bjets_mc_700344.Sh_2211_Wtaunu_L_maxHTpTV2_BFilter.2bjets.root"
+        "checksum": "adler32:2cd94093",
+        "size": 111601260,
+        "uri": "root://eospublic.cern.ch//eos/opendata/atlas/rucio/user/egramsta/mc_700344.Sh_2211_Wtaunu_L_maxHTpTV2_BFilter.2bjets70.root"
       },
       {
-        "checksum": "adler32:27e570b5",
-        "size": 42197396,
-        "uri": "root://eospublic.cern.ch//eos/opendata/atlas/rucio/opendata/ODEO_FEB2025_v0_2bjets_mc_700345.Sh_2211_Wtaunu_L_maxHTpTV2_CFilterBVeto.2bjets.root"
+        "checksum": "adler32:0ae640b8",
+        "size": 9276025,
+        "uri": "root://eospublic.cern.ch//eos/opendata/atlas/rucio/user/egramsta/mc_700345.Sh_2211_Wtaunu_L_maxHTpTV2_CFilterBVeto.2bjets70.root"
       },
       {
-        "checksum": "adler32:9a0466af",
-        "size": 18789688,
-        "uri": "root://eospublic.cern.ch//eos/opendata/atlas/rucio/opendata/ODEO_FEB2025_v0_2bjets_mc_700346.Sh_2211_Wtaunu_L_maxHTpTV2_CVetoBVeto.2bjets.root"
+        "checksum": "adler32:25851483",
+        "size": 6179202,
+        "uri": "root://eospublic.cern.ch//eos/opendata/atlas/rucio/user/egramsta/mc_700346.Sh_2211_Wtaunu_L_maxHTpTV2_CVetoBVeto.2bjets70.root"
       },
       {
-        "checksum": "adler32:e5bc7cc5",
-        "size": 23456489,
-        "uri": "root://eospublic.cern.ch//eos/opendata/atlas/rucio/opendata/ODEO_FEB2025_v0_2bjets_mc_700347.Sh_2211_Wtaunu_H_maxHTpTV2_BFilter.2bjets.root"
+        "checksum": "adler32:26efa218",
+        "size": 150880752,
+        "uri": "root://eospublic.cern.ch//eos/opendata/atlas/rucio/user/egramsta/mc_700347.Sh_2211_Wtaunu_H_maxHTpTV2_BFilter.2bjets70.root"
       },
       {
-        "checksum": "adler32:20043235",
-        "size": 18471616,
-        "uri": "root://eospublic.cern.ch//eos/opendata/atlas/rucio/opendata/ODEO_FEB2025_v0_2bjets_mc_700348.Sh_2211_Wtaunu_H_maxHTpTV2_CFilterBVeto.2bjets.root"
+        "checksum": "adler32:114b69b5",
+        "size": 3482795,
+        "uri": "root://eospublic.cern.ch//eos/opendata/atlas/rucio/user/egramsta/mc_700348.Sh_2211_Wtaunu_H_maxHTpTV2_CFilterBVeto.2bjets70.root"
       },
       {
-        "checksum": "adler32:ff5bc0e9",
-        "size": 27263950,
-        "uri": "root://eospublic.cern.ch//eos/opendata/atlas/rucio/opendata/ODEO_FEB2025_v0_2bjets_mc_700349.Sh_2211_Wtaunu_H_maxHTpTV2_CVetoBVeto.2bjets.root"
+        "checksum": "adler32:95223bfa",
+        "size": 6481076,
+        "uri": "root://eospublic.cern.ch//eos/opendata/atlas/rucio/user/egramsta/mc_700349.Sh_2211_Wtaunu_H_maxHTpTV2_CVetoBVeto.2bjets70.root"
       },
       {
-        "checksum": "adler32:c4573848",
-        "size": 777248,
-        "uri": "root://eospublic.cern.ch//eos/opendata/atlas/rucio/opendata/ODEO_FEB2025_v0_2bjets_mc_700352.Sh_2211_pTZ100_Zqqgamma.2bjets.root"
+        "checksum": "adler32:6a037c91",
+        "size": 412343,
+        "uri": "root://eospublic.cern.ch//eos/opendata/atlas/rucio/user/egramsta/mc_700352.Sh_2211_pTZ100_Zqqgamma.2bjets70.root"
       },
       {
-        "checksum": "adler32:f98b6414",
-        "size": 430577,
-        "uri": "root://eospublic.cern.ch//eos/opendata/atlas/rucio/opendata/ODEO_FEB2025_v0_2bjets_mc_700353.Sh_2211_pTZ100_Zbbgamma.2bjets.root"
+        "checksum": "adler32:274debd7",
+        "size": 9717702,
+        "uri": "root://eospublic.cern.ch//eos/opendata/atlas/rucio/user/egramsta/mc_700353.Sh_2211_pTZ100_Zbbgamma.2bjets70.root"
       },
       {
-        "checksum": "adler32:933e9260",
-        "size": 128210,
-        "uri": "root://eospublic.cern.ch//eos/opendata/atlas/rucio/opendata/ODEO_FEB2025_v0_2bjets_mc_700358.Sh_2211_Zee2jets_Min_N_TChannel.2bjets.root"
+        "checksum": "adler32:cedb7c28",
+        "size": 156891,
+        "uri": "root://eospublic.cern.ch//eos/opendata/atlas/rucio/user/egramsta/mc_700358.Sh_2211_Zee2jets_Min_N_TChannel.2bjets70.root"
       },
       {
-        "checksum": "adler32:ec1e7736",
-        "size": 103676,
-        "uri": "root://eospublic.cern.ch//eos/opendata/atlas/rucio/opendata/ODEO_FEB2025_v0_2bjets_mc_700359.Sh_2211_Zmm2jets_Min_N_TChannel.2bjets.root"
+        "checksum": "adler32:08630c5d",
+        "size": 137694,
+        "uri": "root://eospublic.cern.ch//eos/opendata/atlas/rucio/user/egramsta/mc_700359.Sh_2211_Zmm2jets_Min_N_TChannel.2bjets70.root"
       },
       {
-        "checksum": "adler32:397aa05f",
-        "size": 230238,
-        "uri": "root://eospublic.cern.ch//eos/opendata/atlas/rucio/opendata/ODEO_FEB2025_v0_2bjets_mc_700360.Sh_2211_Ztt2jets_Min_N_TChannel.2bjets.root"
+        "checksum": "adler32:77e06ed3",
+        "size": 151010,
+        "uri": "root://eospublic.cern.ch//eos/opendata/atlas/rucio/user/egramsta/mc_700360.Sh_2211_Ztt2jets_Min_N_TChannel.2bjets70.root"
       },
       {
-        "checksum": "adler32:133e3623",
-        "size": 148192,
-        "uri": "root://eospublic.cern.ch//eos/opendata/atlas/rucio/opendata/ODEO_FEB2025_v0_2bjets_mc_700361.Sh_2211_Znunu2jets_Min_N_TChannel.2bjets.root"
+        "checksum": "adler32:f7c25299",
+        "size": 193151,
+        "uri": "root://eospublic.cern.ch//eos/opendata/atlas/rucio/user/egramsta/mc_700361.Sh_2211_Znunu2jets_Min_N_TChannel.2bjets70.root"
       },
       {
-        "checksum": "adler32:be52f412",
-        "size": 438588,
-        "uri": "root://eospublic.cern.ch//eos/opendata/atlas/rucio/opendata/ODEO_FEB2025_v0_2bjets_mc_700362.Sh_2211_Wenu2jets_Min_N_TChannel.2bjets.root"
+        "checksum": "adler32:37fc0654",
+        "size": 279866,
+        "uri": "root://eospublic.cern.ch//eos/opendata/atlas/rucio/user/egramsta/mc_700362.Sh_2211_Wenu2jets_Min_N_TChannel.2bjets70.root"
       },
       {
-        "checksum": "adler32:ef4cab76",
-        "size": 481211,
-        "uri": "root://eospublic.cern.ch//eos/opendata/atlas/rucio/opendata/ODEO_FEB2025_v0_2bjets_mc_700363.Sh_2211_Wmunu2jets_Min_N_TChannel.2bjets.root"
+        "checksum": "adler32:782fb0a1",
+        "size": 333625,
+        "uri": "root://eospublic.cern.ch//eos/opendata/atlas/rucio/user/egramsta/mc_700363.Sh_2211_Wmunu2jets_Min_N_TChannel.2bjets70.root"
       },
       {
-        "checksum": "adler32:0c52b7ca",
-        "size": 554498,
-        "uri": "root://eospublic.cern.ch//eos/opendata/atlas/rucio/opendata/ODEO_FEB2025_v0_2bjets_mc_700364.Sh_2211_Wtaunu2jets_Min_N_TChannel.2bjets.root"
+        "checksum": "adler32:4807a879",
+        "size": 275524,
+        "uri": "root://eospublic.cern.ch//eos/opendata/atlas/rucio/user/egramsta/mc_700364.Sh_2211_Wtaunu2jets_Min_N_TChannel.2bjets70.root"
       },
       {
-        "checksum": "adler32:fe5b4fa5",
-        "size": 4420802,
-        "uri": "root://eospublic.cern.ch//eos/opendata/atlas/rucio/opendata/ODEO_FEB2025_v0_2bjets_mc_700398.Sh_2211_mumugamma.2bjets.root"
+        "checksum": "adler32:67c6eb12",
+        "size": 9088094,
+        "uri": "root://eospublic.cern.ch//eos/opendata/atlas/rucio/user/egramsta/mc_700398.Sh_2211_mumugamma.2bjets70.root"
       },
       {
-        "checksum": "adler32:7f3847d0",
-        "size": 4207433,
-        "uri": "root://eospublic.cern.ch//eos/opendata/atlas/rucio/opendata/ODEO_FEB2025_v0_2bjets_mc_700399.Sh_2211_eegamma.2bjets.root"
+        "checksum": "adler32:d0fb42d9",
+        "size": 8753113,
+        "uri": "root://eospublic.cern.ch//eos/opendata/atlas/rucio/user/egramsta/mc_700399.Sh_2211_eegamma.2bjets70.root"
       },
       {
-        "checksum": "adler32:e0517d0c",
-        "size": 7842696,
-        "uri": "root://eospublic.cern.ch//eos/opendata/atlas/rucio/opendata/ODEO_FEB2025_v0_2bjets_mc_700400.Sh_2211_tautaugamma.2bjets.root"
+        "checksum": "adler32:7f45f6e7",
+        "size": 9497616,
+        "uri": "root://eospublic.cern.ch//eos/opendata/atlas/rucio/user/egramsta/mc_700400.Sh_2211_tautaugamma.2bjets70.root"
       },
       {
-        "checksum": "adler32:5cf54a24",
-        "size": 2027400,
-        "uri": "root://eospublic.cern.ch//eos/opendata/atlas/rucio/opendata/ODEO_FEB2025_v0_2bjets_mc_700401.Sh_2211_nunugamma.2bjets.root"
+        "checksum": "adler32:67c018a4",
+        "size": 4089771,
+        "uri": "root://eospublic.cern.ch//eos/opendata/atlas/rucio/user/egramsta/mc_700401.Sh_2211_nunugamma.2bjets70.root"
       },
       {
-        "checksum": "adler32:36fe0a62",
-        "size": 14338775,
-        "uri": "root://eospublic.cern.ch//eos/opendata/atlas/rucio/opendata/ODEO_FEB2025_v0_2bjets_mc_700402.Sh_2211_munugamma.2bjets.root"
+        "checksum": "adler32:90bc088a",
+        "size": 19704258,
+        "uri": "root://eospublic.cern.ch//eos/opendata/atlas/rucio/user/egramsta/mc_700402.Sh_2211_munugamma.2bjets70.root"
       },
       {
-        "checksum": "adler32:f2a57c58",
-        "size": 13620200,
-        "uri": "root://eospublic.cern.ch//eos/opendata/atlas/rucio/opendata/ODEO_FEB2025_v0_2bjets_mc_700403.Sh_2211_enugamma.2bjets.root"
+        "checksum": "adler32:156e078b",
+        "size": 19476859,
+        "uri": "root://eospublic.cern.ch//eos/opendata/atlas/rucio/user/egramsta/mc_700403.Sh_2211_enugamma.2bjets70.root"
       },
       {
-        "checksum": "adler32:81b1724e",
-        "size": 18917942,
-        "uri": "root://eospublic.cern.ch//eos/opendata/atlas/rucio/opendata/ODEO_FEB2025_v0_2bjets_mc_700404.Sh_2211_taunugamma.2bjets.root"
+        "checksum": "adler32:1604cfa5",
+        "size": 20044561,
+        "uri": "root://eospublic.cern.ch//eos/opendata/atlas/rucio/user/egramsta/mc_700404.Sh_2211_taunugamma.2bjets70.root"
       },
       {
-        "checksum": "adler32:e162dc8d",
-        "size": 94395,
-        "uri": "root://eospublic.cern.ch//eos/opendata/atlas/rucio/opendata/ODEO_FEB2025_v0_2bjets_mc_700442.Sh_2211_gamma2jets_pTy140_Min_N_TChannel.2bjets.root"
+        "checksum": "adler32:1e9339b0",
+        "size": 124347,
+        "uri": "root://eospublic.cern.ch//eos/opendata/atlas/rucio/user/egramsta/mc_700442.Sh_2211_gamma2jets_pTy140_Min_N_TChannel.2bjets70.root"
       },
       {
-        "checksum": "adler32:152b93e9",
-        "size": 1484942,
-        "uri": "root://eospublic.cern.ch//eos/opendata/atlas/rucio/opendata/ODEO_FEB2025_v0_2bjets_mc_700467.Sh_2211_Zee_maxHTpTV2_m10_40_pT5_BFilter.2bjets.root"
+        "checksum": "adler32:c80d201c",
+        "size": 14280192,
+        "uri": "root://eospublic.cern.ch//eos/opendata/atlas/rucio/user/egramsta/mc_700467.Sh_2211_Zee_maxHTpTV2_m10_40_pT5_BFilter.2bjets70.root"
       },
       {
-        "checksum": "adler32:6b7da527",
-        "size": 7049110,
-        "uri": "root://eospublic.cern.ch//eos/opendata/atlas/rucio/opendata/ODEO_FEB2025_v0_2bjets_mc_700468.Sh_2211_Zee_maxHTpTV2_m10_40_pT5_CFilterBVeto.2bjets.root"
+        "checksum": "adler32:3f8db1e1",
+        "size": 1454756,
+        "uri": "root://eospublic.cern.ch//eos/opendata/atlas/rucio/user/egramsta/mc_700468.Sh_2211_Zee_maxHTpTV2_m10_40_pT5_CFilterBVeto.2bjets70.root"
       },
       {
-        "checksum": "adler32:3359f727",
-        "size": 10548898,
-        "uri": "root://eospublic.cern.ch//eos/opendata/atlas/rucio/opendata/ODEO_FEB2025_v0_2bjets_mc_700469.Sh_2211_Zee_maxHTpTV2_m10_40_pT5_CVetoBVeto.2bjets.root"
+        "checksum": "adler32:31c6d0b2",
+        "size": 4778520,
+        "uri": "root://eospublic.cern.ch//eos/opendata/atlas/rucio/user/egramsta/mc_700469.Sh_2211_Zee_maxHTpTV2_m10_40_pT5_CVetoBVeto.2bjets70.root"
       },
       {
-        "checksum": "adler32:c45011d9",
-        "size": 1478870,
-        "uri": "root://eospublic.cern.ch//eos/opendata/atlas/rucio/opendata/ODEO_FEB2025_v0_2bjets_mc_700470.Sh_2211_Zmumu_maxHTpTV2_m10_40_pT5_BFilter.2bjets.root"
+        "checksum": "adler32:c1e69558",
+        "size": 15838185,
+        "uri": "root://eospublic.cern.ch//eos/opendata/atlas/rucio/user/egramsta/mc_700470.Sh_2211_Zmumu_maxHTpTV2_m10_40_pT5_BFilter.2bjets70.root"
       },
       {
-        "checksum": "adler32:87cc6c83",
-        "size": 6221467,
-        "uri": "root://eospublic.cern.ch//eos/opendata/atlas/rucio/opendata/ODEO_FEB2025_v0_2bjets_mc_700471.Sh_2211_Zmumu_maxHTpTV2_m10_40_pT5_CFilterBVeto.2bjets.root"
+        "checksum": "adler32:e42fba3d",
+        "size": 1502007,
+        "uri": "root://eospublic.cern.ch//eos/opendata/atlas/rucio/user/egramsta/mc_700471.Sh_2211_Zmumu_maxHTpTV2_m10_40_pT5_CFilterBVeto.2bjets70.root"
       },
       {
-        "checksum": "adler32:dc215854",
-        "size": 9490916,
-        "uri": "root://eospublic.cern.ch//eos/opendata/atlas/rucio/opendata/ODEO_FEB2025_v0_2bjets_mc_700472.Sh_2211_Zmumu_maxHTpTV2_m10_40_pT5_CVetoBVeto.2bjets.root"
+        "checksum": "adler32:0b1b2aaf",
+        "size": 4876888,
+        "uri": "root://eospublic.cern.ch//eos/opendata/atlas/rucio/user/egramsta/mc_700472.Sh_2211_Zmumu_maxHTpTV2_m10_40_pT5_CVetoBVeto.2bjets70.root"
       },
       {
-        "checksum": "adler32:c15821a8",
-        "size": 4122768,
-        "uri": "root://eospublic.cern.ch//eos/opendata/atlas/rucio/opendata/ODEO_FEB2025_v0_2bjets_mc_700488.Sh_2211_WlvWqq.2bjets.root"
+        "checksum": "adler32:6d34d802",
+        "size": 1931024,
+        "uri": "root://eospublic.cern.ch//eos/opendata/atlas/rucio/user/egramsta/mc_700488.Sh_2211_WlvWqq.2bjets70.root"
       },
       {
-        "checksum": "adler32:a50805de",
-        "size": 1315496,
-        "uri": "root://eospublic.cern.ch//eos/opendata/atlas/rucio/opendata/ODEO_FEB2025_v0_2bjets_mc_700489.Sh_2211_WlvZqq.2bjets.root"
+        "checksum": "adler32:b7923741",
+        "size": 733056,
+        "uri": "root://eospublic.cern.ch//eos/opendata/atlas/rucio/user/egramsta/mc_700489.Sh_2211_WlvZqq.2bjets70.root"
       },
       {
-        "checksum": "adler32:cf4fe932",
-        "size": 491912,
-        "uri": "root://eospublic.cern.ch//eos/opendata/atlas/rucio/opendata/ODEO_FEB2025_v0_2bjets_mc_700490.Sh_2211_WlvZbb.2bjets.root"
+        "checksum": "adler32:0cc5cb42",
+        "size": 11868997,
+        "uri": "root://eospublic.cern.ch//eos/opendata/atlas/rucio/user/egramsta/mc_700490.Sh_2211_WlvZbb.2bjets70.root"
       },
       {
-        "checksum": "adler32:b04c8c7a",
-        "size": 536550,
-        "uri": "root://eospublic.cern.ch//eos/opendata/atlas/rucio/opendata/ODEO_FEB2025_v0_2bjets_mc_700491.Sh_2211_WqqZvv.2bjets.root"
+        "checksum": "adler32:0a2b5aff",
+        "size": 417303,
+        "uri": "root://eospublic.cern.ch//eos/opendata/atlas/rucio/user/egramsta/mc_700491.Sh_2211_WqqZvv.2bjets70.root"
       },
       {
-        "checksum": "adler32:cc236eb2",
-        "size": 491976,
-        "uri": "root://eospublic.cern.ch//eos/opendata/atlas/rucio/opendata/ODEO_FEB2025_v0_2bjets_mc_700492.Sh_2211_WqqZll.2bjets.root"
+        "checksum": "adler32:9681a396",
+        "size": 279826,
+        "uri": "root://eospublic.cern.ch//eos/opendata/atlas/rucio/user/egramsta/mc_700492.Sh_2211_WqqZll.2bjets70.root"
       },
       {
-        "checksum": "adler32:d48daa8c",
-        "size": 382779,
-        "uri": "root://eospublic.cern.ch//eos/opendata/atlas/rucio/opendata/ODEO_FEB2025_v0_2bjets_mc_700493.Sh_2211_ZqqZll.2bjets.root"
+        "checksum": "adler32:53735bbf",
+        "size": 257089,
+        "uri": "root://eospublic.cern.ch//eos/opendata/atlas/rucio/user/egramsta/mc_700493.Sh_2211_ZqqZll.2bjets70.root"
       },
       {
-        "checksum": "adler32:4d9f33d3",
-        "size": 443903,
-        "uri": "root://eospublic.cern.ch//eos/opendata/atlas/rucio/opendata/ODEO_FEB2025_v0_2bjets_mc_700494.Sh_2211_ZbbZll.2bjets.root"
+        "checksum": "adler32:881f86ad",
+        "size": 11339122,
+        "uri": "root://eospublic.cern.ch//eos/opendata/atlas/rucio/user/egramsta/mc_700494.Sh_2211_ZbbZll.2bjets70.root"
       },
       {
-        "checksum": "adler32:93929ba3",
-        "size": 318424,
-        "uri": "root://eospublic.cern.ch//eos/opendata/atlas/rucio/opendata/ODEO_FEB2025_v0_2bjets_mc_700495.Sh_2211_ZqqZvv.2bjets.root"
+        "checksum": "adler32:708ad330",
+        "size": 294280,
+        "uri": "root://eospublic.cern.ch//eos/opendata/atlas/rucio/user/egramsta/mc_700495.Sh_2211_ZqqZvv.2bjets70.root"
       },
       {
-        "checksum": "adler32:a021eefc",
-        "size": 157611,
-        "uri": "root://eospublic.cern.ch//eos/opendata/atlas/rucio/opendata/ODEO_FEB2025_v0_2bjets_mc_700496.Sh_2211_ZbbZvv.2bjets.root"
+        "checksum": "adler32:ec23a6ec",
+        "size": 4126416,
+        "uri": "root://eospublic.cern.ch//eos/opendata/atlas/rucio/user/egramsta/mc_700496.Sh_2211_ZbbZvv.2bjets70.root"
       },
       {
-        "checksum": "adler32:62c7b1eb",
-        "size": 184636,
-        "uri": "root://eospublic.cern.ch//eos/opendata/atlas/rucio/opendata/ODEO_FEB2025_v0_2bjets_mc_700507.Sh_2211_pTW140_Wqqgamma.2bjets.root"
+        "checksum": "adler32:f5591f5a",
+        "size": 184329,
+        "uri": "root://eospublic.cern.ch//eos/opendata/atlas/rucio/user/egramsta/mc_700507.Sh_2211_pTW140_Wqqgamma.2bjets70.root"
       },
       {
-        "checksum": "adler32:73490cde",
-        "size": 170297,
-        "uri": "root://eospublic.cern.ch//eos/opendata/atlas/rucio/opendata/ODEO_FEB2025_v0_2bjets_mc_700587.Sh_2212_lllljj.2bjets.root"
+        "checksum": "adler32:e7d378b9",
+        "size": 88533,
+        "uri": "root://eospublic.cern.ch//eos/opendata/atlas/rucio/user/egramsta/mc_700587.Sh_2212_lllljj.2bjets70.root"
       },
       {
-        "checksum": "adler32:8ff0bf95",
-        "size": 78478,
-        "uri": "root://eospublic.cern.ch//eos/opendata/atlas/rucio/opendata/ODEO_FEB2025_v0_2bjets_mc_700588.Sh_2212_lllvjj.2bjets.root"
+        "checksum": "adler32:7a5b1c5d",
+        "size": 45572,
+        "uri": "root://eospublic.cern.ch//eos/opendata/atlas/rucio/user/egramsta/mc_700588.Sh_2212_lllvjj.2bjets70.root"
       },
       {
-        "checksum": "adler32:38036be1",
-        "size": 65913,
-        "uri": "root://eospublic.cern.ch//eos/opendata/atlas/rucio/opendata/ODEO_FEB2025_v0_2bjets_mc_700589.Sh_2212_llvvjj_os.2bjets.root"
+        "checksum": "adler32:11863f09",
+        "size": 42533,
+        "uri": "root://eospublic.cern.ch//eos/opendata/atlas/rucio/user/egramsta/mc_700589.Sh_2212_llvvjj_os.2bjets70.root"
       },
       {
-        "checksum": "adler32:72c77853",
-        "size": 149430,
-        "uri": "root://eospublic.cern.ch//eos/opendata/atlas/rucio/opendata/ODEO_FEB2025_v0_2bjets_mc_700590.Sh_2212_llvvjj_ss.2bjets.root"
+        "checksum": "adler32:16d945ad",
+        "size": 79488,
+        "uri": "root://eospublic.cern.ch//eos/opendata/atlas/rucio/user/egramsta/mc_700590.Sh_2212_llvvjj_ss.2bjets70.root"
       },
       {
-        "checksum": "adler32:54c31912",
-        "size": 43181,
-        "uri": "root://eospublic.cern.ch//eos/opendata/atlas/rucio/opendata/ODEO_FEB2025_v0_2bjets_mc_700591.Sh_2212_lllljj_Int.2bjets.root"
+        "checksum": "adler32:8791b443",
+        "size": 38271,
+        "uri": "root://eospublic.cern.ch//eos/opendata/atlas/rucio/user/egramsta/mc_700591.Sh_2212_lllljj_Int.2bjets70.root"
       },
       {
-        "checksum": "adler32:76a803db",
-        "size": 50305,
-        "uri": "root://eospublic.cern.ch//eos/opendata/atlas/rucio/opendata/ODEO_FEB2025_v0_2bjets_mc_700592.Sh_2212_lllvjj_Int.2bjets.root"
+        "checksum": "adler32:2b733dfd",
+        "size": 36883,
+        "uri": "root://eospublic.cern.ch//eos/opendata/atlas/rucio/user/egramsta/mc_700592.Sh_2212_lllvjj_Int.2bjets70.root"
       },
       {
-        "checksum": "adler32:53f37462",
-        "size": 54357,
-        "uri": "root://eospublic.cern.ch//eos/opendata/atlas/rucio/opendata/ODEO_FEB2025_v0_2bjets_mc_700593.Sh_2212_llvvjj_os_Int.2bjets.root"
+        "checksum": "adler32:c7de2ce6",
+        "size": 37960,
+        "uri": "root://eospublic.cern.ch//eos/opendata/atlas/rucio/user/egramsta/mc_700593.Sh_2212_llvvjj_os_Int.2bjets70.root"
       },
       {
-        "checksum": "adler32:bb275c00",
-        "size": 53740,
-        "uri": "root://eospublic.cern.ch//eos/opendata/atlas/rucio/opendata/ODEO_FEB2025_v0_2bjets_mc_700594.Sh_2212_llvvjj_ss_Int.2bjets.root"
+        "checksum": "adler32:9b04f01e",
+        "size": 41005,
+        "uri": "root://eospublic.cern.ch//eos/opendata/atlas/rucio/user/egramsta/mc_700594.Sh_2212_llvvjj_ss_Int.2bjets70.root"
       },
       {
-        "checksum": "adler32:b2c1f452",
-        "size": 236203,
-        "uri": "root://eospublic.cern.ch//eos/opendata/atlas/rucio/opendata/ODEO_FEB2025_v0_2bjets_mc_700600.Sh_2212_llll.2bjets.root"
+        "checksum": "adler32:d48c143b",
+        "size": 339675,
+        "uri": "root://eospublic.cern.ch//eos/opendata/atlas/rucio/user/egramsta/mc_700600.Sh_2212_llll.2bjets70.root"
       },
       {
-        "checksum": "adler32:4fa4e445",
-        "size": 442427,
-        "uri": "root://eospublic.cern.ch//eos/opendata/atlas/rucio/opendata/ODEO_FEB2025_v0_2bjets_mc_700601.Sh_2212_lllv.2bjets.root"
+        "checksum": "adler32:2c725ec5",
+        "size": 440283,
+        "uri": "root://eospublic.cern.ch//eos/opendata/atlas/rucio/user/egramsta/mc_700601.Sh_2212_lllv.2bjets70.root"
       },
       {
-        "checksum": "adler32:76e79657",
-        "size": 718239,
-        "uri": "root://eospublic.cern.ch//eos/opendata/atlas/rucio/opendata/ODEO_FEB2025_v0_2bjets_mc_700602.Sh_2212_llvv_os.2bjets.root"
+        "checksum": "adler32:23b1f37c",
+        "size": 583867,
+        "uri": "root://eospublic.cern.ch//eos/opendata/atlas/rucio/user/egramsta/mc_700602.Sh_2212_llvv_os.2bjets70.root"
       },
       {
-        "checksum": "adler32:35e49297",
-        "size": 203264,
-        "uri": "root://eospublic.cern.ch//eos/opendata/atlas/rucio/opendata/ODEO_FEB2025_v0_2bjets_mc_700603.Sh_2212_llvv_ss.2bjets.root"
+        "checksum": "adler32:006b9a11",
+        "size": 129839,
+        "uri": "root://eospublic.cern.ch//eos/opendata/atlas/rucio/user/egramsta/mc_700603.Sh_2212_llvv_ss.2bjets70.root"
       },
       {
-        "checksum": "adler32:de004fe7",
-        "size": 210106,
-        "uri": "root://eospublic.cern.ch//eos/opendata/atlas/rucio/opendata/ODEO_FEB2025_v0_2bjets_mc_700604.Sh_2212_lvvv.2bjets.root"
+        "checksum": "adler32:9251631f",
+        "size": 349312,
+        "uri": "root://eospublic.cern.ch//eos/opendata/atlas/rucio/user/egramsta/mc_700604.Sh_2212_lvvv.2bjets70.root"
       },
       {
-        "checksum": "adler32:cad08f9d",
-        "size": 71906,
-        "uri": "root://eospublic.cern.ch//eos/opendata/atlas/rucio/opendata/ODEO_FEB2025_v0_2bjets_mc_700605.Sh_2212_vvvv.2bjets.root"
+        "checksum": "adler32:7d85f862",
+        "size": 179695,
+        "uri": "root://eospublic.cern.ch//eos/opendata/atlas/rucio/user/egramsta/mc_700605.Sh_2212_vvvv.2bjets70.root"
       },
       {
-        "checksum": "adler32:a552e6cd",
-        "size": 172614,
-        "uri": "root://eospublic.cern.ch//eos/opendata/atlas/rucio/opendata/ODEO_FEB2025_v0_2bjets_mc_700709.Sh_2212_lvgammajj.2bjets.root"
+        "checksum": "adler32:a239de8b",
+        "size": 109346,
+        "uri": "root://eospublic.cern.ch//eos/opendata/atlas/rucio/user/egramsta/mc_700709.Sh_2212_lvgammajj.2bjets70.root"
       },
       {
-        "checksum": "adler32:fde4f0a2",
-        "size": 340438,
-        "uri": "root://eospublic.cern.ch//eos/opendata/atlas/rucio/opendata/ODEO_FEB2025_v0_2bjets_mc_700710.Sh_2212_llgammajj.2bjets.root"
+        "checksum": "adler32:a67a0995",
+        "size": 174986,
+        "uri": "root://eospublic.cern.ch//eos/opendata/atlas/rucio/user/egramsta/mc_700710.Sh_2212_llgammajj.2bjets70.root"
       },
       {
-        "checksum": "adler32:d84bce5a",
-        "size": 15907572,
-        "uri": "root://eospublic.cern.ch//eos/opendata/atlas/rucio/opendata/ODEO_FEB2025_v0_2bjets_mc_700792.Sh_2214_Ztautau_maxHTpTV2_BFilter.2bjets.root"
+        "checksum": "adler32:98b3cdf8",
+        "size": 116540234,
+        "uri": "root://eospublic.cern.ch//eos/opendata/atlas/rucio/user/egramsta/mc_700792.Sh_2214_Ztautau_maxHTpTV2_BFilter.2bjets70.root"
       },
       {
-        "checksum": "adler32:8a0bda1f",
-        "size": 76867952,
-        "uri": "root://eospublic.cern.ch//eos/opendata/atlas/rucio/opendata/ODEO_FEB2025_v0_2bjets_mc_700793.Sh_2214_Ztautau_maxHTpTV2_CFilterBVeto.2bjets.root"
+        "checksum": "adler32:12e018c3",
+        "size": 12941548,
+        "uri": "root://eospublic.cern.ch//eos/opendata/atlas/rucio/user/egramsta/mc_700793.Sh_2214_Ztautau_maxHTpTV2_CFilterBVeto.2bjets70.root"
       },
       {
-        "checksum": "adler32:0bc4fdfe",
-        "size": 43444944,
-        "uri": "root://eospublic.cern.ch//eos/opendata/atlas/rucio/opendata/ODEO_FEB2025_v0_2bjets_mc_700794.Sh_2214_Ztautau_maxHTpTV2_CVetoBVeto.2bjets.root"
+        "checksum": "adler32:f698aa8c",
+        "size": 13096880,
+        "uri": "root://eospublic.cern.ch//eos/opendata/atlas/rucio/user/egramsta/mc_700794.Sh_2214_Ztautau_maxHTpTV2_CVetoBVeto.2bjets70.root"
       },
       {
-        "checksum": "adler32:d8d60caf",
-        "size": 15682377,
-        "uri": "root://eospublic.cern.ch//eos/opendata/atlas/rucio/opendata/ODEO_FEB2025_v0_2bjets_mc_700843.Sh_2214_Wqq_ptW_200_ECMS.2bjets.root"
+        "checksum": "adler32:75afeb13",
+        "size": 13672563,
+        "uri": "root://eospublic.cern.ch//eos/opendata/atlas/rucio/user/egramsta/mc_700843.Sh_2214_Wqq_ptW_200_ECMS.2bjets70.root"
       },
       {
-        "checksum": "adler32:a119c84b",
-        "size": 6724367,
-        "uri": "root://eospublic.cern.ch//eos/opendata/atlas/rucio/opendata/ODEO_FEB2025_v0_2bjets_mc_700849.Sh_2214_Zqq_ptZ_200_ECMS.2bjets.root"
+        "checksum": "adler32:0b9f4e26",
+        "size": 8067926,
+        "uri": "root://eospublic.cern.ch//eos/opendata/atlas/rucio/user/egramsta/mc_700849.Sh_2214_Zqq_ptZ_200_ECMS.2bjets70.root"
       },
       {
-        "checksum": "adler32:df9cb4d4",
-        "size": 2592570,
-        "uri": "root://eospublic.cern.ch//eos/opendata/atlas/rucio/opendata/ODEO_FEB2025_v0_2bjets_mc_700855.Sh_2214_Zbb_ptZ_200_ECMS.2bjets.root"
+        "checksum": "adler32:baea9d85",
+        "size": 57072168,
+        "uri": "root://eospublic.cern.ch//eos/opendata/atlas/rucio/user/egramsta/mc_700855.Sh_2214_Zbb_ptZ_200_ECMS.2bjets70.root"
       },
       {
-        "checksum": "adler32:c960c585",
-        "size": 3847169,
-        "uri": "root://eospublic.cern.ch//eos/opendata/atlas/rucio/opendata/ODEO_FEB2025_v0_2bjets_mc_700901.Sh_2214_Ztt_maxHTpTV2_Mll10_40_BFilter.2bjets.root"
+        "checksum": "adler32:badb72bd",
+        "size": 27770716,
+        "uri": "root://eospublic.cern.ch//eos/opendata/atlas/rucio/user/egramsta/mc_700901.Sh_2214_Ztt_maxHTpTV2_Mll10_40_BFilter.2bjets70.root"
       },
       {
-        "checksum": "adler32:d3c63a7d",
-        "size": 23255368,
-        "uri": "root://eospublic.cern.ch//eos/opendata/atlas/rucio/opendata/ODEO_FEB2025_v0_2bjets_mc_700902.Sh_2214_Ztt_maxHTpTV2_Mll10_40_CFilterBVeto.2bjets.root"
+        "checksum": "adler32:21c71d20",
+        "size": 4805325,
+        "uri": "root://eospublic.cern.ch//eos/opendata/atlas/rucio/user/egramsta/mc_700902.Sh_2214_Ztt_maxHTpTV2_Mll10_40_CFilterBVeto.2bjets70.root"
       },
       {
-        "checksum": "adler32:0b9325d5",
-        "size": 12893728,
-        "uri": "root://eospublic.cern.ch//eos/opendata/atlas/rucio/opendata/ODEO_FEB2025_v0_2bjets_mc_700903.Sh_2214_Ztt_maxHTpTV2_Mll10_40_CVetoBVeto.2bjets.root"
+        "checksum": "adler32:0ea62c12",
+        "size": 5360730,
+        "uri": "root://eospublic.cern.ch//eos/opendata/atlas/rucio/user/egramsta/mc_700903.Sh_2214_Ztt_maxHTpTV2_Mll10_40_CVetoBVeto.2bjets70.root"
       },
       {
-        "checksum": "adler32:1e4366c6",
-        "size": 50769,
-        "uri": "root://eospublic.cern.ch//eos/opendata/atlas/rucio/opendata/ODEO_FEB2025_v0_2bjets_mc_801976.Py8EG_A14NNPDF23LO_Zprime_NoInt_tautau_SSM3000.2bjets.root"
+        "checksum": "adler32:6ae407bf",
+        "size": 59715,
+        "uri": "root://eospublic.cern.ch//eos/opendata/atlas/rucio/user/egramsta/mc_801976.Py8EG_A14NNPDF23LO_Zprime_NoInt_tautau_SSM3000.2bjets70.root"
       },
       {
-        "checksum": "adler32:d8653f1b",
-        "size": 32963,
-        "uri": "root://eospublic.cern.ch//eos/opendata/atlas/rucio/opendata/ODEO_FEB2025_v0_2bjets_mc_801978.Py8EG_A14NNPDF23LO_Wprime_taunu_SSM3000.2bjets.root"
+        "checksum": "adler32:469cee4a",
+        "size": 40248,
+        "uri": "root://eospublic.cern.ch//eos/opendata/atlas/rucio/user/egramsta/mc_801978.Py8EG_A14NNPDF23LO_Wprime_taunu_SSM3000.2bjets70.root"
       }
     ],
     "license": {
@@ -1939,15 +1939,15 @@
         },
         {
           "description": "Resources to understand and use the open data for education and outreach",
-          "url": "https://opendata.atlas.cern/docs/category/13-tev-tutorials-for-education"
+          "url": "https://opendata.atlas.cern/docs/category/13-tev-2025-beta-release"
         },
         {
           "description": "More about this ntuple format",
-          "url": "https://opendata.atlas.cern/docs/data/for_education/13TeV25_details"
+          "url": "https://opendata.atlas.cern/docs/data/for_education/13TeV25_details#variable-list"
         },
         {
-          "description": "Ntuple making framework",
-          "url": "http://gitlab.cern.ch/atlas-outreach-data-tools/physlitetoopendata"
+          "description": "Ntuple making framework (PhysLiteToOpenData)",
+          "url": "https://doi.org/10.5281/zenodo.15791091"
         },
         {
           "description": "Citation policy",

--- a/data/records/atlas-odeo-FEB2025-2j2lmet30-data.json
+++ b/data/records/atlas-odeo-FEB2025-2j2lmet30-data.json
@@ -1,0 +1,174 @@
+[
+  {
+    "abstract": {
+      "description": "Run 2 2015+2016 proton-proton collision data beta release, 2J2LMET30 skim from the ATLAS experiment"
+    },
+    "accelerator": "CERN-LHC",
+    "categories": {
+      "source": "ATLAS Collaboration"
+    },
+    "collaboration": {
+      "name": "ATLAS collaboration"
+    },
+    "collections": [
+      "ATLAS-Primary-Datasets"
+    ],
+    "collision_information": {
+      "energy": "13TeV",
+      "type": "pp"
+    },
+    "date_created": [
+      "2015",
+      "2016"
+    ],
+    "date_published": "2025",
+    "date_reprocessed": "2020",
+    "distribution": {
+      "formats": [
+        "root"
+      ],
+      "number_events": 6242521,
+      "number_files": 16,
+      "size": 1987123953
+    },
+    "doi": "10.7483/OPENDATA.ATLAS.0CJR.N7ZT",
+    "experiment": [
+      "ATLAS"
+    ],
+    "files": [
+      {
+        "checksum": "adler32:e850adce",
+        "size": 4124334,
+        "uri": "root://eospublic.cern.ch//eos/opendata/atlas/rucio/opendata/ODEO_FEB2025_v0_2J2LMET30_data15_periodD.2J2LMET30.root"
+      },
+      {
+        "checksum": "adler32:f019dff6",
+        "size": 27445579,
+        "uri": "root://eospublic.cern.ch//eos/opendata/atlas/rucio/opendata/ODEO_FEB2025_v0_2J2LMET30_data15_periodE.2J2LMET30.root"
+      },
+      {
+        "checksum": "adler32:1c882c2b",
+        "size": 18683345,
+        "uri": "root://eospublic.cern.ch//eos/opendata/atlas/rucio/opendata/ODEO_FEB2025_v0_2J2LMET30_data15_periodF.2J2LMET30.root"
+      },
+      {
+        "checksum": "adler32:b4e856c1",
+        "size": 42164519,
+        "uri": "root://eospublic.cern.ch//eos/opendata/atlas/rucio/opendata/ODEO_FEB2025_v0_2J2LMET30_data15_periodG.2J2LMET30.root"
+      },
+      {
+        "checksum": "adler32:336063e4",
+        "size": 14212155,
+        "uri": "root://eospublic.cern.ch//eos/opendata/atlas/rucio/opendata/ODEO_FEB2025_v0_2J2LMET30_data15_periodH.2J2LMET30.root"
+      },
+      {
+        "checksum": "adler32:7d49b2e5",
+        "size": 80528156,
+        "uri": "root://eospublic.cern.ch//eos/opendata/atlas/rucio/opendata/ODEO_FEB2025_v0_2J2LMET30_data15_periodJ.2J2LMET30.root"
+      },
+      {
+        "checksum": "adler32:95ca2281",
+        "size": 35719363,
+        "uri": "root://eospublic.cern.ch//eos/opendata/atlas/rucio/opendata/ODEO_FEB2025_v0_2J2LMET30_data16_periodA.2J2LMET30.root"
+      },
+      {
+        "checksum": "adler32:f338e771",
+        "size": 100927399,
+        "uri": "root://eospublic.cern.ch//eos/opendata/atlas/rucio/opendata/ODEO_FEB2025_v0_2J2LMET30_data16_periodB.2J2LMET30.root"
+      },
+      {
+        "checksum": "adler32:14971ee9",
+        "size": 128526443,
+        "uri": "root://eospublic.cern.ch//eos/opendata/atlas/rucio/opendata/ODEO_FEB2025_v0_2J2LMET30_data16_periodC.2J2LMET30.root"
+      },
+      {
+        "checksum": "adler32:0968acdf",
+        "size": 256267057,
+        "uri": "root://eospublic.cern.ch//eos/opendata/atlas/rucio/opendata/ODEO_FEB2025_v0_2J2LMET30_data16_periodD.2J2LMET30.root"
+      },
+      {
+        "checksum": "adler32:866b485f",
+        "size": 77449038,
+        "uri": "root://eospublic.cern.ch//eos/opendata/atlas/rucio/opendata/ODEO_FEB2025_v0_2J2LMET30_data16_periodE.2J2LMET30.root"
+      },
+      {
+        "checksum": "adler32:6ff4ec6e",
+        "size": 185372045,
+        "uri": "root://eospublic.cern.ch//eos/opendata/atlas/rucio/opendata/ODEO_FEB2025_v0_2J2LMET30_data16_periodF.2J2LMET30.root"
+      },
+      {
+        "checksum": "adler32:76db97dd",
+        "size": 209341921,
+        "uri": "root://eospublic.cern.ch//eos/opendata/atlas/rucio/opendata/ODEO_FEB2025_v0_2J2LMET30_data16_periodG.2J2LMET30.root"
+      },
+      {
+        "checksum": "adler32:2f1f72fd",
+        "size": 319352245,
+        "uri": "root://eospublic.cern.ch//eos/opendata/atlas/rucio/opendata/ODEO_FEB2025_v0_2J2LMET30_data16_periodI.2J2LMET30.root"
+      },
+      {
+        "checksum": "adler32:2af083ed",
+        "size": 125256067,
+        "uri": "root://eospublic.cern.ch//eos/opendata/atlas/rucio/opendata/ODEO_FEB2025_v0_2J2LMET30_data16_periodK.2J2LMET30.root"
+      },
+      {
+        "checksum": "adler32:52e20914",
+        "size": 361754287,
+        "uri": "root://eospublic.cern.ch//eos/opendata/atlas/rucio/opendata/ODEO_FEB2025_v0_2J2LMET30_data16_periodL.2J2LMET30.root"
+      }
+    ],
+    "license": {
+      "attribution": "CC0-1.0"
+    },
+    "methodology": {
+      "description": "<p>These data were created during LS2 as part of a major reprocessing campaign of the Run 2 data. All data were reprocessed using Athena Release 22, and new corresponding MC simulation samples were produced. These data and MC simulation datasets were processed into ROOT ntuple files from the DAOD_PHYSLITE format that is released as open data for research. For the files in this record, the following skimming selection was applied: At least two jets with at least 20 GeV of p<sub>T</sub>, at least two leptons passing tight identification requirements with at least 7 GeV of p<sub>T</sub>, and 30 GeV of missing transverse momentum (i.e. a di-leptonic top-quark enhanced selection)"
+    },
+    "publisher": "CERN Open Data Portal",
+    "recid": "93934",
+    "relations": [
+      {
+        "description": "For citing all the Open Data for Education and Outreach from this release, and to find other related datasets, please see",
+        "doi": "10.7483/OPENDATA.ATLAS.B5M9.44TN",
+        "recid": "93910",
+        "title": "ROOT ntuple format 2015-2016 proton-proton Open Data for Education and Outreach from the ATLAS experiment",
+        "type": "isChildOf"
+      }
+    ],
+    "run_period": [
+      "2015",
+      "2016"
+    ],
+    "title": "ATLAS ROOT ntuple format Run 2 2015+2016 proton-proton collision data beta release, 2J2LMET30 skim",
+    "type": {
+      "primary": "Dataset",
+      "secondary": [
+        "Collision"
+      ]
+    },
+    "usage": {
+      "description": "<p> The data and MC simulation provided by the ATLAS experiment in root ntuple format is released under a CC0 license; citation of the data and acknowledgement of the collaboration is requested. This format can be used directly using ROOT or uproot for simple studies and is primarily intended for educational and outreach purposes. <p>Extensive instructions for interacting with the data, as well as documentation of the dataset naming conventions and their contents, are provided on the ATLAS Open Data website linked below. For those interested in implementing a research-quality data analysis, the open data designed for research (also linked below) may be a better starting point. Please be sure to cite the Open Data that you use, in line with the policy below.",
+      "links": [
+        {
+          "description": "ATLAS Open Data Website",
+          "url": "http://opendata.atlas.cern"
+        },
+        {
+          "description": "Resources to understand and use the open data for education and outreach",
+          "url": "https://opendata.atlas.cern/docs/category/13-tev-tutorials-for-education"
+        },
+        {
+          "description": "More about this ntuple format",
+          "url": "https://opendata.atlas.cern/docs/data/for_education/13TeV25_details"
+        },
+        {
+          "description": "Ntuple making framework",
+          "url": "http://gitlab.cern.ch/atlas-outreach-data-tools/physlitetoopendata"
+        },
+        {
+          "description": "Citation policy",
+          "url": "https://opendata.atlas.cern/docs/documentation/ethical_legal/citation_policy"
+        }
+      ]
+    }
+  }
+]

--- a/data/records/atlas-odeo-FEB2025-2j2lmet30-data.json
+++ b/data/records/atlas-odeo-FEB2025-2j2lmet30-data.json
@@ -154,15 +154,15 @@
         },
         {
           "description": "Resources to understand and use the open data for education and outreach",
-          "url": "https://opendata.atlas.cern/docs/category/13-tev-tutorials-for-education"
+          "url": "https://opendata.atlas.cern/docs/category/13-tev-2025-beta-release"
         },
         {
           "description": "More about this ntuple format",
-          "url": "https://opendata.atlas.cern/docs/data/for_education/13TeV25_details"
+          "url": "https://opendata.atlas.cern/docs/data/for_education/13TeV25_details#variable-list"
         },
         {
-          "description": "Ntuple making framework",
-          "url": "http://gitlab.cern.ch/atlas-outreach-data-tools/physlitetoopendata"
+          "description": "Ntuple making framework (PhysLiteToOpenData)",
+          "url": "https://doi.org/10.5281/zenodo.15791091"
         },
         {
           "description": "Citation policy",

--- a/data/records/atlas-odeo-FEB2025-2j2lmet30-mc.json
+++ b/data/records/atlas-odeo-FEB2025-2j2lmet30-mc.json
@@ -1,0 +1,1959 @@
+[
+  {
+    "abstract": {
+      "description": "MC simulation, 2015+2016 proton-proton collisions beta release, 2J2LMET30 skim from the ATLAS experiment"
+    },
+    "accelerator": "CERN-LHC",
+    "categories": {
+      "source": "ATLAS Collaboration"
+    },
+    "collaboration": {
+      "name": "ATLAS collaboration"
+    },
+    "collections": [
+      "ATLAS-Primary-Datasets"
+    ],
+    "collision_information": {
+      "energy": "13TeV",
+      "type": "pp"
+    },
+    "date_created": [
+      "2015",
+      "2016"
+    ],
+    "date_published": "2025",
+    "date_reprocessed": "2020",
+    "distribution": {
+      "formats": [
+        "root"
+      ],
+      "number_events": 34405468,
+      "number_files": 373,
+      "size": 16646000110
+    },
+    "doi": "10.7483/OPENDATA.ATLAS.NNF8.76IX",
+    "experiment": [
+      "ATLAS"
+    ],
+    "files": [
+      {
+        "checksum": "adler32:6c0a46a9",
+        "size": 720195,
+        "uri": "root://eospublic.cern.ch//eos/opendata/atlas/rucio/opendata/ODEO_FEB2025_v0_2J2LMET30_mc_301204.Pythia8EvtGen_A14MSTW2008LO_Zprime_NoInt_ee_SSM3000.2J2LMET30.root"
+      },
+      {
+        "checksum": "adler32:d6125a5e",
+        "size": 1433609,
+        "uri": "root://eospublic.cern.ch//eos/opendata/atlas/rucio/opendata/ODEO_FEB2025_v0_2J2LMET30_mc_301209.Pythia8EvtGen_A14MSTW2008LO_Zprime_NoInt_mumu_SSM3000.2J2LMET30.root"
+      },
+      {
+        "checksum": "adler32:073f414d",
+        "size": 27506,
+        "uri": "root://eospublic.cern.ch//eos/opendata/atlas/rucio/opendata/ODEO_FEB2025_v0_2J2LMET30_mc_301243.Pythia8EvtGen_A14NNPDF23LO_Wprime_enu_SSM3000.2J2LMET30.root"
+      },
+      {
+        "checksum": "adler32:4087b464",
+        "size": 34323,
+        "uri": "root://eospublic.cern.ch//eos/opendata/atlas/rucio/opendata/ODEO_FEB2025_v0_2J2LMET30_mc_301247.Pythia8EvtGen_A14NNPDF23LO_Wprime_munu_SSM3000.2J2LMET30.root"
+      },
+      {
+        "checksum": "adler32:9c60bd04",
+        "size": 241444,
+        "uri": "root://eospublic.cern.ch//eos/opendata/atlas/rucio/opendata/ODEO_FEB2025_v0_2J2LMET30_mc_301333.Pythia8EvtGen_A14NNPDF23LO_zprime3000_tt.2J2LMET30.root"
+      },
+      {
+        "checksum": "adler32:6479782c",
+        "size": 1331,
+        "uri": "root://eospublic.cern.ch//eos/opendata/atlas/rucio/opendata/ODEO_FEB2025_v0_2J2LMET30_mc_301826.Pythia8EvtGen_A14NNPDF23LO_Wprime_qq_3000.2J2LMET30.root"
+      },
+      {
+        "checksum": "adler32:a8606e90",
+        "size": 1315,
+        "uri": "root://eospublic.cern.ch//eos/opendata/atlas/rucio/opendata/ODEO_FEB2025_v0_2J2LMET30_mc_301928.Pythia8EvtGen_A14NNPDF23LO_Zprimebb3000.2J2LMET30.root"
+      },
+      {
+        "checksum": "adler32:3637d741",
+        "size": 383045,
+        "uri": "root://eospublic.cern.ch//eos/opendata/atlas/rucio/opendata/ODEO_FEB2025_v0_2J2LMET30_mc_302520.Pythia8EvtGen_A14NNPDF23LO_2DP20_Mass_55_100.2J2LMET30.root"
+      },
+      {
+        "checksum": "adler32:33909064",
+        "size": 86835,
+        "uri": "root://eospublic.cern.ch//eos/opendata/atlas/rucio/opendata/ODEO_FEB2025_v0_2J2LMET30_mc_302521.Pythia8EvtGen_A14NNPDF23LO_2DP20_Mass_100_160.2J2LMET30.root"
+      },
+      {
+        "checksum": "adler32:3ee65a62",
+        "size": 40092,
+        "uri": "root://eospublic.cern.ch//eos/opendata/atlas/rucio/opendata/ODEO_FEB2025_v0_2J2LMET30_mc_302522.Pythia8EvtGen_A14NNPDF23LO_2DP20_Mass_160_250.2J2LMET30.root"
+      },
+      {
+        "checksum": "adler32:62b23666",
+        "size": 27550,
+        "uri": "root://eospublic.cern.ch//eos/opendata/atlas/rucio/opendata/ODEO_FEB2025_v0_2J2LMET30_mc_302523.Pythia8EvtGen_A14NNPDF23LO_2DP20_Mass_250_400.2J2LMET30.root"
+      },
+      {
+        "checksum": "adler32:7cdc9069",
+        "size": 26363,
+        "uri": "root://eospublic.cern.ch//eos/opendata/atlas/rucio/opendata/ODEO_FEB2025_v0_2J2LMET30_mc_302524.Pythia8EvtGen_A14NNPDF23LO_2DP20_Mass_400_650.2J2LMET30.root"
+      },
+      {
+        "checksum": "adler32:0dee7a5c",
+        "size": 1371,
+        "uri": "root://eospublic.cern.ch//eos/opendata/atlas/rucio/opendata/ODEO_FEB2025_v0_2J2LMET30_mc_302525.Pythia8EvtGen_A14NNPDF23LO_2DP20_Mass_650_1000.2J2LMET30.root"
+      },
+      {
+        "checksum": "adler32:9bd030c8",
+        "size": 26666,
+        "uri": "root://eospublic.cern.ch//eos/opendata/atlas/rucio/opendata/ODEO_FEB2025_v0_2J2LMET30_mc_302526.Pythia8EvtGen_A14NNPDF23LO_2DP20_Mass_1000_1500.2J2LMET30.root"
+      },
+      {
+        "checksum": "adler32:ff285859",
+        "size": 27604,
+        "uri": "root://eospublic.cern.ch//eos/opendata/atlas/rucio/opendata/ODEO_FEB2025_v0_2J2LMET30_mc_302527.Pythia8EvtGen_A14NNPDF23LO_2DP20_Mass_1500_2000.2J2LMET30.root"
+      },
+      {
+        "checksum": "adler32:5e95bb68",
+        "size": 56311,
+        "uri": "root://eospublic.cern.ch//eos/opendata/atlas/rucio/opendata/ODEO_FEB2025_v0_2J2LMET30_mc_302528.Pythia8EvtGen_A14NNPDF23LO_2DP20_Mass_2000_2500.2J2LMET30.root"
+      },
+      {
+        "checksum": "adler32:e4a3a1df",
+        "size": 45190,
+        "uri": "root://eospublic.cern.ch//eos/opendata/atlas/rucio/opendata/ODEO_FEB2025_v0_2J2LMET30_mc_302529.Pythia8EvtGen_A14NNPDF23LO_2DP20_Mass_2500_3000.2J2LMET30.root"
+      },
+      {
+        "checksum": "adler32:2a217514",
+        "size": 58645,
+        "uri": "root://eospublic.cern.ch//eos/opendata/atlas/rucio/opendata/ODEO_FEB2025_v0_2J2LMET30_mc_302530.Pythia8EvtGen_A14NNPDF23LO_2DP20_Mass_3000_3500.2J2LMET30.root"
+      },
+      {
+        "checksum": "adler32:91575653",
+        "size": 29682,
+        "uri": "root://eospublic.cern.ch//eos/opendata/atlas/rucio/opendata/ODEO_FEB2025_v0_2J2LMET30_mc_302531.Pythia8EvtGen_A14NNPDF23LO_2DP20_Mass_3500_4000.2J2LMET30.root"
+      },
+      {
+        "checksum": "adler32:bbb7a7f5",
+        "size": 43392,
+        "uri": "root://eospublic.cern.ch//eos/opendata/atlas/rucio/opendata/ODEO_FEB2025_v0_2J2LMET30_mc_302532.Pythia8EvtGen_A14NNPDF23LO_2DP20_Mass_4000_4500.2J2LMET30.root"
+      },
+      {
+        "checksum": "adler32:7cf3f80f",
+        "size": 29539,
+        "uri": "root://eospublic.cern.ch//eos/opendata/atlas/rucio/opendata/ODEO_FEB2025_v0_2J2LMET30_mc_302533.Pythia8EvtGen_A14NNPDF23LO_2DP20_Mass_4500_5000.2J2LMET30.root"
+      },
+      {
+        "checksum": "adler32:f01ea86c",
+        "size": 45842,
+        "uri": "root://eospublic.cern.ch//eos/opendata/atlas/rucio/opendata/ODEO_FEB2025_v0_2J2LMET30_mc_302534.Pythia8EvtGen_A14NNPDF23LO_2DP20_Mass_5000_inf.2J2LMET30.root"
+      },
+      {
+        "checksum": "adler32:16e268e4",
+        "size": 66251,
+        "uri": "root://eospublic.cern.ch//eos/opendata/atlas/rucio/opendata/ODEO_FEB2025_v0_2J2LMET30_mc_302733.MadGraphPythia8EvtGen_A14NNPDF23LO_WpL_tblep_M3000.2J2LMET30.root"
+      },
+      {
+        "checksum": "adler32:27d313c3",
+        "size": 2525618,
+        "uri": "root://eospublic.cern.ch//eos/opendata/atlas/rucio/opendata/ODEO_FEB2025_v0_2J2LMET30_mc_304014.MadGraphPythia8EvtGen_A14NNPDF23_3top_SM.2J2LMET30.root"
+      },
+      {
+        "checksum": "adler32:93a346c9",
+        "size": 27669,
+        "uri": "root://eospublic.cern.ch//eos/opendata/atlas/rucio/opendata/ODEO_FEB2025_v0_2J2LMET30_mc_306149.MadGraphPythia8EvtGen_A14NNPDF23LO_WpL_tbhad_M3000.2J2LMET30.root"
+      },
+      {
+        "checksum": "adler32:04ba66a8",
+        "size": 1315,
+        "uri": "root://eospublic.cern.ch//eos/opendata/atlas/rucio/opendata/ODEO_FEB2025_v0_2J2LMET30_mc_311490.PowhegPy8EG_A14N23LO_DMA_500_700_gq0p25.2J2LMET30.root"
+      },
+      {
+        "checksum": "adler32:b7a65543",
+        "size": 12603837,
+        "uri": "root://eospublic.cern.ch//eos/opendata/atlas/rucio/opendata/ODEO_FEB2025_v0_2J2LMET30_mc_312613.aMcAtNloPy8EG_A14N30NLO_LQd_gstML_0p3_nonallhad_M1000.2J2LMET30.root"
+      },
+      {
+        "checksum": "adler32:99c98300",
+        "size": 31996,
+        "uri": "root://eospublic.cern.ch//eos/opendata/atlas/rucio/opendata/ODEO_FEB2025_v0_2J2LMET30_mc_341456.PowhegPythia8EvtGen_CT10_AZNLO_ZH125J_MINLO_veveWWlvqq_VpT.2J2LMET30.root"
+      },
+      {
+        "checksum": "adler32:4ca7218e",
+        "size": 39386,
+        "uri": "root://eospublic.cern.ch//eos/opendata/atlas/rucio/opendata/ODEO_FEB2025_v0_2J2LMET30_mc_341458.PowhegPythia8EvtGen_CT10_AZNLO_ZH125J_MINLO_vmuvmuWWlvqq_VpT.2J2LMET30.root"
+      },
+      {
+        "checksum": "adler32:8e18adb6",
+        "size": 40149,
+        "uri": "root://eospublic.cern.ch//eos/opendata/atlas/rucio/opendata/ODEO_FEB2025_v0_2J2LMET30_mc_341460.PowhegPy8EG_CT10_AZNLO_ZH125J_MINLO_vtauvtauWWlvqq_VpT.2J2LMET30.root"
+      },
+      {
+        "checksum": "adler32:706ef620",
+        "size": 72636,
+        "uri": "root://eospublic.cern.ch//eos/opendata/atlas/rucio/opendata/ODEO_FEB2025_v0_2J2LMET30_mc_343981.PowhegPythia8EvtGen_NNLOPS_nnlo_30_ggH125_gamgam.2J2LMET30.root"
+      },
+      {
+        "checksum": "adler32:103180ab",
+        "size": 7008609,
+        "uri": "root://eospublic.cern.ch//eos/opendata/atlas/rucio/opendata/ODEO_FEB2025_v0_2J2LMET30_mc_344158.aMcAtNloPythia8EvtGen_A14NNPDF23LO_ppx0_FxFx_Np012_SM.2J2LMET30.root"
+      },
+      {
+        "checksum": "adler32:cb2d0a0c",
+        "size": 39889,
+        "uri": "root://eospublic.cern.ch//eos/opendata/atlas/rucio/opendata/ODEO_FEB2025_v0_2J2LMET30_mc_345056.PowhegPythia8EvtGen_NNPDF3_AZNLO_ZH125J_MINLO_vvbb_VpT.2J2LMET30.root"
+      },
+      {
+        "checksum": "adler32:48fa0666",
+        "size": 41195,
+        "uri": "root://eospublic.cern.ch//eos/opendata/atlas/rucio/opendata/ODEO_FEB2025_v0_2J2LMET30_mc_345058.PowhegPythia8EvtGen_NNPDF3_AZNLO_ggZH125_vvbb.2J2LMET30.root"
+      },
+      {
+        "checksum": "adler32:4b4816be",
+        "size": 79486921,
+        "uri": "root://eospublic.cern.ch//eos/opendata/atlas/rucio/opendata/ODEO_FEB2025_v0_2J2LMET30_mc_345060.PowhegPythia8EvtGen_NNLOPS_nnlo_30_ggH125_ZZ4l.2J2LMET30.root"
+      },
+      {
+        "checksum": "adler32:d138ff40",
+        "size": 247425,
+        "uri": "root://eospublic.cern.ch//eos/opendata/atlas/rucio/opendata/ODEO_FEB2025_v0_2J2LMET30_mc_345061.PowhegPythia8EvtGen_NNPDF3_AZNLO_ggZH125_HgamgamZinc.2J2LMET30.root"
+      },
+      {
+        "checksum": "adler32:d4e26760",
+        "size": 6023790,
+        "uri": "root://eospublic.cern.ch//eos/opendata/atlas/rucio/opendata/ODEO_FEB2025_v0_2J2LMET30_mc_345066.PowhegPythia8EvtGen_NNPDF3_AZNLO_ggZH125_ZZ4lepZinc.2J2LMET30.root"
+      },
+      {
+        "checksum": "adler32:3790aeee",
+        "size": 5412108,
+        "uri": "root://eospublic.cern.ch//eos/opendata/atlas/rucio/opendata/ODEO_FEB2025_v0_2J2LMET30_mc_345097.PowhegPythia8EvtGen_NNLOPS_nnlo_30_ggH125_mumu.2J2LMET30.root"
+      },
+      {
+        "checksum": "adler32:2753d8b7",
+        "size": 6101306,
+        "uri": "root://eospublic.cern.ch//eos/opendata/atlas/rucio/opendata/ODEO_FEB2025_v0_2J2LMET30_mc_345098.PowhegPythia8EvtGen_NNPDF3_AZNLO_ggZH125_Hmumu_Zinc.2J2LMET30.root"
+      },
+      {
+        "checksum": "adler32:8bafbd80",
+        "size": 4278565,
+        "uri": "root://eospublic.cern.ch//eos/opendata/atlas/rucio/opendata/ODEO_FEB2025_v0_2J2LMET30_mc_345103.PowhegPythia8EvtGen_NNPDF30_AZNLO_ZH125J_Hmumu_Zincl_MINLO.2J2LMET30.root"
+      },
+      {
+        "checksum": "adler32:891f289a",
+        "size": 4076956,
+        "uri": "root://eospublic.cern.ch//eos/opendata/atlas/rucio/opendata/ODEO_FEB2025_v0_2J2LMET30_mc_345104.PowhegPythia8EvtGen_NNPDF30_AZNLO_WpH125J_Hmumu_Wincl_MINLO.2J2LMET30.root"
+      },
+      {
+        "checksum": "adler32:625de2e3",
+        "size": 2551031,
+        "uri": "root://eospublic.cern.ch//eos/opendata/atlas/rucio/opendata/ODEO_FEB2025_v0_2J2LMET30_mc_345105.PowhegPythia8EvtGen_NNPDF30_AZNLO_WmH125J_Hmumu_Wincl_MINLO.2J2LMET30.root"
+      },
+      {
+        "checksum": "adler32:708aa14f",
+        "size": 5913973,
+        "uri": "root://eospublic.cern.ch//eos/opendata/atlas/rucio/opendata/ODEO_FEB2025_v0_2J2LMET30_mc_345106.PowhegPythia8EvtGen_NNPDF30_AZNLOCTEQ6L1_VBFH125_mumu.2J2LMET30.root"
+      },
+      {
+        "checksum": "adler32:b5c4a0fa",
+        "size": 1435,
+        "uri": "root://eospublic.cern.ch//eos/opendata/atlas/rucio/opendata/ODEO_FEB2025_v0_2J2LMET30_mc_345112.PowhegPythia8EvtGen_NNPDF3_AZNLO_ZH125J_MINLO_vvcc_VpT.2J2LMET30.root"
+      },
+      {
+        "checksum": "adler32:6e876449",
+        "size": 40005,
+        "uri": "root://eospublic.cern.ch//eos/opendata/atlas/rucio/opendata/ODEO_FEB2025_v0_2J2LMET30_mc_345114.PowhegPythia8EvtGen_NNPDF3_AZNLO_ggZH125_vvcc.2J2LMET30.root"
+      },
+      {
+        "checksum": "adler32:7764fe72",
+        "size": 3990639,
+        "uri": "root://eospublic.cern.ch//eos/opendata/atlas/rucio/opendata/ODEO_FEB2025_v0_2J2LMET30_mc_345120.PowhegPy8EG_NNLOPS_nnlo_30_ggH125_tautaul13l7.2J2LMET30.root"
+      },
+      {
+        "checksum": "adler32:20474608",
+        "size": 75226,
+        "uri": "root://eospublic.cern.ch//eos/opendata/atlas/rucio/opendata/ODEO_FEB2025_v0_2J2LMET30_mc_345121.PowhegPy8EG_NNLOPS_nnlo_30_ggH125_tautaulm15hp20.2J2LMET30.root"
+      },
+      {
+        "checksum": "adler32:cd70a188",
+        "size": 98965,
+        "uri": "root://eospublic.cern.ch//eos/opendata/atlas/rucio/opendata/ODEO_FEB2025_v0_2J2LMET30_mc_345122.PowhegPy8EG_NNLOPS_nnlo_30_ggH125_tautaulp15hm20.2J2LMET30.root"
+      },
+      {
+        "checksum": "adler32:0bee3ae5",
+        "size": 26485,
+        "uri": "root://eospublic.cern.ch//eos/opendata/atlas/rucio/opendata/ODEO_FEB2025_v0_2J2LMET30_mc_345123.PowhegPy8EG_NNLOPS_nnlo_30_ggH125_tautauh30h20.2J2LMET30.root"
+      },
+      {
+        "checksum": "adler32:8813e7c9",
+        "size": 9864955,
+        "uri": "root://eospublic.cern.ch//eos/opendata/atlas/rucio/opendata/ODEO_FEB2025_v0_2J2LMET30_mc_345124.PowhegPy8EG_NNLOPS_nnlo_30_ggH125_etau_filt.2J2LMET30.root"
+      },
+      {
+        "checksum": "adler32:91f24f71",
+        "size": 16013295,
+        "uri": "root://eospublic.cern.ch//eos/opendata/atlas/rucio/opendata/ODEO_FEB2025_v0_2J2LMET30_mc_345125.PowhegPy8EG_NNLOPS_nnlo_30_ggH125_mutau_filt.2J2LMET30.root"
+      },
+      {
+        "checksum": "adler32:371c6c7f",
+        "size": 300463,
+        "uri": "root://eospublic.cern.ch//eos/opendata/atlas/rucio/opendata/ODEO_FEB2025_v0_2J2LMET30_mc_345211.PowhegPy8EG_NNPDF30_AZNLO_WmH125J_Winc_MINLO_tautau.2J2LMET30.root"
+      },
+      {
+        "checksum": "adler32:91521c57",
+        "size": 356752,
+        "uri": "root://eospublic.cern.ch//eos/opendata/atlas/rucio/opendata/ODEO_FEB2025_v0_2J2LMET30_mc_345212.PowhegPy8EG_NNPDF30_AZNLO_WpH125J_Winc_MINLO_tautau.2J2LMET30.root"
+      },
+      {
+        "checksum": "adler32:da4f5911",
+        "size": 982616,
+        "uri": "root://eospublic.cern.ch//eos/opendata/atlas/rucio/opendata/ODEO_FEB2025_v0_2J2LMET30_mc_345213.PowhegPy8EG_NNPDF30_AZNLO_WmH125J_Winc_MINLO_etau.2J2LMET30.root"
+      },
+      {
+        "checksum": "adler32:5b9c201a",
+        "size": 1704753,
+        "uri": "root://eospublic.cern.ch//eos/opendata/atlas/rucio/opendata/ODEO_FEB2025_v0_2J2LMET30_mc_345214.PowhegPy8EG_NNPDF30_AZNLO_WpH125J_Winc_MINLO_etau.2J2LMET30.root"
+      },
+      {
+        "checksum": "adler32:127eec2a",
+        "size": 1490534,
+        "uri": "root://eospublic.cern.ch//eos/opendata/atlas/rucio/opendata/ODEO_FEB2025_v0_2J2LMET30_mc_345215.PowhegPy8EG_NNPDF30_AZNLO_WmH125J_Winc_MINLO_mutau.2J2LMET30.root"
+      },
+      {
+        "checksum": "adler32:e1442ae6",
+        "size": 2489225,
+        "uri": "root://eospublic.cern.ch//eos/opendata/atlas/rucio/opendata/ODEO_FEB2025_v0_2J2LMET30_mc_345216.PowhegPy8EG_NNPDF30_AZNLO_WpH125J_Winc_MINLO_mutau.2J2LMET30.root"
+      },
+      {
+        "checksum": "adler32:99c424fd",
+        "size": 573280,
+        "uri": "root://eospublic.cern.ch//eos/opendata/atlas/rucio/opendata/ODEO_FEB2025_v0_2J2LMET30_mc_345217.PowhegPy8EG_NNPDF30_AZNLO_ZH125J_Zinc_MINLO_tautau.2J2LMET30.root"
+      },
+      {
+        "checksum": "adler32:c3f90ce7",
+        "size": 1412562,
+        "uri": "root://eospublic.cern.ch//eos/opendata/atlas/rucio/opendata/ODEO_FEB2025_v0_2J2LMET30_mc_345218.PowhegPy8EG_NNPDF30_AZNLO_ZH125J_Zinc_MINLO_etau.2J2LMET30.root"
+      },
+      {
+        "checksum": "adler32:39b5d555",
+        "size": 1647466,
+        "uri": "root://eospublic.cern.ch//eos/opendata/atlas/rucio/opendata/ODEO_FEB2025_v0_2J2LMET30_mc_345219.PowhegPy8EG_NNPDF30_AZNLO_ZH125J_Zinc_MINLO_mutau.2J2LMET30.root"
+      },
+      {
+        "checksum": "adler32:dd56780a",
+        "size": 16035256,
+        "uri": "root://eospublic.cern.ch//eos/opendata/atlas/rucio/opendata/ODEO_FEB2025_v0_2J2LMET30_mc_345316.PowhegPythia8EvtGen_NNLOPS_nnlo_30_ggH125_Zy_Zll.2J2LMET30.root"
+      },
+      {
+        "checksum": "adler32:9ebbb9e9",
+        "size": 194111,
+        "uri": "root://eospublic.cern.ch//eos/opendata/atlas/rucio/opendata/ODEO_FEB2025_v0_2J2LMET30_mc_345317.PowhegPythia8EvtGen_NNPDF30_AZNLO_WmH125J_Hyy_Wincl_MINLO.2J2LMET30.root"
+      },
+      {
+        "checksum": "adler32:db304b2e",
+        "size": 114601,
+        "uri": "root://eospublic.cern.ch//eos/opendata/atlas/rucio/opendata/ODEO_FEB2025_v0_2J2LMET30_mc_345318.PowhegPythia8EvtGen_NNPDF30_AZNLO_WpH125J_Hyy_Wincl_MINLO.2J2LMET30.root"
+      },
+      {
+        "checksum": "adler32:68d8db8e",
+        "size": 232836,
+        "uri": "root://eospublic.cern.ch//eos/opendata/atlas/rucio/opendata/ODEO_FEB2025_v0_2J2LMET30_mc_345319.PowhegPythia8EvtGen_NNPDF30_AZNLO_ZH125J_Hyy_Zincl_MINLO.2J2LMET30.root"
+      },
+      {
+        "checksum": "adler32:ddb21948",
+        "size": 1150693,
+        "uri": "root://eospublic.cern.ch//eos/opendata/atlas/rucio/opendata/ODEO_FEB2025_v0_2J2LMET30_mc_345320.PowhegPythia8EvtGen_NNPDF30_AZNLO_WmH125J_HZy_Wincl_MINLO.2J2LMET30.root"
+      },
+      {
+        "checksum": "adler32:a100a982",
+        "size": 1056778,
+        "uri": "root://eospublic.cern.ch//eos/opendata/atlas/rucio/opendata/ODEO_FEB2025_v0_2J2LMET30_mc_345321.PowhegPythia8EvtGen_NNPDF30_AZNLO_WpH125J_HZy_Wincl_MINLO.2J2LMET30.root"
+      },
+      {
+        "checksum": "adler32:e0a440da",
+        "size": 2179871,
+        "uri": "root://eospublic.cern.ch//eos/opendata/atlas/rucio/opendata/ODEO_FEB2025_v0_2J2LMET30_mc_345322.PowhegPythia8EvtGen_NNPDF30_AZNLO_ZH125J_HZy_Zincl_MINLO.2J2LMET30.root"
+      },
+      {
+        "checksum": "adler32:e1630505",
+        "size": 5426399,
+        "uri": "root://eospublic.cern.ch//eos/opendata/atlas/rucio/opendata/ODEO_FEB2025_v0_2J2LMET30_mc_345324.PowhegPythia8EvtGen_NNLOPS_NN30_ggH125_WWlvlv_EF_15_5.2J2LMET30.root"
+      },
+      {
+        "checksum": "adler32:9f26a9ac",
+        "size": 3930751,
+        "uri": "root://eospublic.cern.ch//eos/opendata/atlas/rucio/opendata/ODEO_FEB2025_v0_2J2LMET30_mc_345325.PowhegPythia8EvtGen_NNPDF3_AZNLO_WpH125J_MINLO_qqWWlvlv.2J2LMET30.root"
+      },
+      {
+        "checksum": "adler32:5e913876",
+        "size": 5093032,
+        "uri": "root://eospublic.cern.ch//eos/opendata/atlas/rucio/opendata/ODEO_FEB2025_v0_2J2LMET30_mc_345433.PowhegPythia8EvtGen_NNPDF3_AZNLO_WmH125J_MINLO_qqWWlvlv.2J2LMET30.root"
+      },
+      {
+        "checksum": "adler32:e11fb137",
+        "size": 1054801,
+        "uri": "root://eospublic.cern.ch//eos/opendata/atlas/rucio/opendata/ODEO_FEB2025_v0_2J2LMET30_mc_345445.PowhegPythia8EvtGen_NNPDF3_AZNLO_ZH125J_MINLO_vvWWlvlv.2J2LMET30.root"
+      },
+      {
+        "checksum": "adler32:b5cc6048",
+        "size": 223955,
+        "uri": "root://eospublic.cern.ch//eos/opendata/atlas/rucio/opendata/ODEO_FEB2025_v0_2J2LMET30_mc_345596.PowhegPythia8EvtGen_NNPDF3_AZNLO_ggZH125_Zinc_HZZinv.2J2LMET30.root"
+      },
+      {
+        "checksum": "adler32:f1ac222e",
+        "size": 7347602,
+        "uri": "root://eospublic.cern.ch//eos/opendata/atlas/rucio/opendata/ODEO_FEB2025_v0_2J2LMET30_mc_345697.MadGraphPythia8EvtGen_AZNLOCTEQ6L1_ggfhtautaullNp2.2J2LMET30.root"
+      },
+      {
+        "checksum": "adler32:4dc4a485",
+        "size": 237724,
+        "uri": "root://eospublic.cern.ch//eos/opendata/atlas/rucio/opendata/ODEO_FEB2025_v0_2J2LMET30_mc_345698.MadGraphPythia8EvtGen_AZNLOCTEQ6L1_ggfhtautaulhNp2.2J2LMET30.root"
+      },
+      {
+        "checksum": "adler32:1f819fe2",
+        "size": 79998,
+        "uri": "root://eospublic.cern.ch//eos/opendata/atlas/rucio/opendata/ODEO_FEB2025_v0_2J2LMET30_mc_345699.MadGraphPythia8EvtGen_AZNLOCTEQ6L1_ggfhtautauhhNp2.2J2LMET30.root"
+      },
+      {
+        "checksum": "adler32:08e90311",
+        "size": 10470750,
+        "uri": "root://eospublic.cern.ch//eos/opendata/atlas/rucio/opendata/ODEO_FEB2025_v0_2J2LMET30_mc_345833.PowhegPythia8EvtGen_NNPDF30_AZNLOCTEQ6L1_VBFH125_Zllgam.2J2LMET30.root"
+      },
+      {
+        "checksum": "adler32:d4960759",
+        "size": 340249,
+        "uri": "root://eospublic.cern.ch//eos/opendata/atlas/rucio/opendata/ODEO_FEB2025_v0_2J2LMET30_mc_345834.PowhegPythia8EvtGen_NNPDF30_AZNLOCTEQ6L1_VBFH125_gamstargam.2J2LMET30.root"
+      },
+      {
+        "checksum": "adler32:71d44666",
+        "size": 1742566,
+        "uri": "root://eospublic.cern.ch//eos/opendata/atlas/rucio/opendata/ODEO_FEB2025_v0_2J2LMET30_mc_345876.PowhegPythia8EvtGen_NNPDF30_AZNLO_ZH125J_Hee__Zincl_MINLO.2J2LMET30.root"
+      },
+      {
+        "checksum": "adler32:d1960260",
+        "size": 1073732,
+        "uri": "root://eospublic.cern.ch//eos/opendata/atlas/rucio/opendata/ODEO_FEB2025_v0_2J2LMET30_mc_345877.PowhegPythia8EvtGen_NNPDF30_AZNLO_WpH125J_Hee_Wincl_MINLO.2J2LMET30.root"
+      },
+      {
+        "checksum": "adler32:5663c1f9",
+        "size": 1143567,
+        "uri": "root://eospublic.cern.ch//eos/opendata/atlas/rucio/opendata/ODEO_FEB2025_v0_2J2LMET30_mc_345878.PowhegPythia8EvtGen_NNPDF30_AZNLO_WmH125J_Hee_Wincl_MINLO.2J2LMET30.root"
+      },
+      {
+        "checksum": "adler32:a5a79525",
+        "size": 84597,
+        "uri": "root://eospublic.cern.ch//eos/opendata/atlas/rucio/opendata/ODEO_FEB2025_v0_2J2LMET30_mc_345944.aMcAtNloPy8EG_A14NNPDF23LO_ppx0yy_FxFx_Np012_SM.2J2LMET30.root"
+      },
+      {
+        "checksum": "adler32:9bf5fb1f",
+        "size": 6550204,
+        "uri": "root://eospublic.cern.ch//eos/opendata/atlas/rucio/opendata/ODEO_FEB2025_v0_2J2LMET30_mc_345948.PowhegPy8EG_NNPDF30_AZNLOCTEQ6L1_VBFH125_WWlvlv.2J2LMET30.root"
+      },
+      {
+        "checksum": "adler32:b640187e",
+        "size": 38396,
+        "uri": "root://eospublic.cern.ch//eos/opendata/atlas/rucio/opendata/ODEO_FEB2025_v0_2J2LMET30_mc_345949.PowhegPythia8EvtGen_NNPDF30_AZNLOCTEQ6L1_VBFH125_bb.2J2LMET30.root"
+      },
+      {
+        "checksum": "adler32:3ec2de70",
+        "size": 640657,
+        "uri": "root://eospublic.cern.ch//eos/opendata/atlas/rucio/opendata/ODEO_FEB2025_v0_2J2LMET30_mc_345961.PowhegPythia8EvtGen_NNLOPS_nnlo_30_ggH125_gamstargam.2J2LMET30.root"
+      },
+      {
+        "checksum": "adler32:353ff141",
+        "size": 378776,
+        "uri": "root://eospublic.cern.ch//eos/opendata/atlas/rucio/opendata/ODEO_FEB2025_v0_2J2LMET30_mc_345963.PowhegPythia8EvtGen_NNPDF30_AZNLO_WmH125J_Hgamstargam_MINLO.2J2LMET30.root"
+      },
+      {
+        "checksum": "adler32:9d3fe635",
+        "size": 380577,
+        "uri": "root://eospublic.cern.ch//eos/opendata/atlas/rucio/opendata/ODEO_FEB2025_v0_2J2LMET30_mc_345964.PowhegPythia8EvtGen_NNPDF30_AZNLO_WpH125J_Hgamstargam_MINLO.2J2LMET30.root"
+      },
+      {
+        "checksum": "adler32:c3075c8d",
+        "size": 653739,
+        "uri": "root://eospublic.cern.ch//eos/opendata/atlas/rucio/opendata/ODEO_FEB2025_v0_2J2LMET30_mc_345965.PowhegPythia8EvtGen_NNPDF30_AZNLO_ZH125J_Hgamstargam_MINLO.2J2LMET30.root"
+      },
+      {
+        "checksum": "adler32:0c9cecbd",
+        "size": 126913,
+        "uri": "root://eospublic.cern.ch//eos/opendata/atlas/rucio/opendata/ODEO_FEB2025_v0_2J2LMET30_mc_346188.aMcAtNloPythia8EvtGen_tHjb125_4fl_gamgam.2J2LMET30.root"
+      },
+      {
+        "checksum": "adler32:7d20f1fd",
+        "size": 1146065,
+        "uri": "root://eospublic.cern.ch//eos/opendata/atlas/rucio/opendata/ODEO_FEB2025_v0_2J2LMET30_mc_346189.aMcAtNloPythia8EvtGen_ttH_gamgam.2J2LMET30.root"
+      },
+      {
+        "checksum": "adler32:3129a5ab",
+        "size": 4026508,
+        "uri": "root://eospublic.cern.ch//eos/opendata/atlas/rucio/opendata/ODEO_FEB2025_v0_2J2LMET30_mc_346190.PowhegPy8EG_NNPDF30_AZNLOCTEQ6L1_VBFH125_tautaul13l7.2J2LMET30.root"
+      },
+      {
+        "checksum": "adler32:1b804e2a",
+        "size": 75877,
+        "uri": "root://eospublic.cern.ch//eos/opendata/atlas/rucio/opendata/ODEO_FEB2025_v0_2J2LMET30_mc_346191.PowhegPy8EG_NNPDF30_AZNLOCTEQ6L1_VBFH125_tautaulm15hp20.2J2LMET30.root"
+      },
+      {
+        "checksum": "adler32:a658b3fd",
+        "size": 67548,
+        "uri": "root://eospublic.cern.ch//eos/opendata/atlas/rucio/opendata/ODEO_FEB2025_v0_2J2LMET30_mc_346192.PowhegPy8EG_NNPDF30_AZNLOCTEQ6L1_VBFH125_tautaulp15hm20.2J2LMET30.root"
+      },
+      {
+        "checksum": "adler32:86aae14b",
+        "size": 27772,
+        "uri": "root://eospublic.cern.ch//eos/opendata/atlas/rucio/opendata/ODEO_FEB2025_v0_2J2LMET30_mc_346193.PowhegPy8EG_NNPDF30_AZNLOCTEQ6L1_VBFH125_tautauh30h20.2J2LMET30.root"
+      },
+      {
+        "checksum": "adler32:a9e99842",
+        "size": 2690041,
+        "uri": "root://eospublic.cern.ch//eos/opendata/atlas/rucio/opendata/ODEO_FEB2025_v0_2J2LMET30_mc_346194.PowhegPy8EG_NNPDF30_AZNLOCTEQ6L1_VBFH125_etau_filt.2J2LMET30.root"
+      },
+      {
+        "checksum": "adler32:ae0049a4",
+        "size": 3123089,
+        "uri": "root://eospublic.cern.ch//eos/opendata/atlas/rucio/opendata/ODEO_FEB2025_v0_2J2LMET30_mc_346195.PowhegPy8EG_NNPDF30_AZNLOCTEQ6L1_VBFH125_mutau_filt.2J2LMET30.root"
+      },
+      {
+        "checksum": "adler32:7de00f78",
+        "size": 21023965,
+        "uri": "root://eospublic.cern.ch//eos/opendata/atlas/rucio/opendata/ODEO_FEB2025_v0_2J2LMET30_mc_346198.PhPy8EG_A14NNPDF23_NNPDF30ME_ttH125_Zgam.2J2LMET30.root"
+      },
+      {
+        "checksum": "adler32:09b282a5",
+        "size": 50673,
+        "uri": "root://eospublic.cern.ch//eos/opendata/atlas/rucio/opendata/ODEO_FEB2025_v0_2J2LMET30_mc_346214.PowhegPy8EG_NNPDF30_AZNLOCTEQ6L1_VBFH125_gamgam.2J2LMET30.root"
+      },
+      {
+        "checksum": "adler32:743c14dc",
+        "size": 17227544,
+        "uri": "root://eospublic.cern.ch//eos/opendata/atlas/rucio/opendata/ODEO_FEB2025_v0_2J2LMET30_mc_346228.PowhegPy8EG_NNPDF30_AZNLOCTEQ6L1_VBFH125_ZZ4lep_notau.2J2LMET30.root"
+      },
+      {
+        "checksum": "adler32:3e0d39dd",
+        "size": 593147,
+        "uri": "root://eospublic.cern.ch//eos/opendata/atlas/rucio/opendata/ODEO_FEB2025_v0_2J2LMET30_mc_346310.PowhegPythia8EvtGen_NNPDF30_AZNLO_ZH125J_Zincl_H_incl_MINLO.2J2LMET30.root"
+      },
+      {
+        "checksum": "adler32:bc0843ee",
+        "size": 186454,
+        "uri": "root://eospublic.cern.ch//eos/opendata/atlas/rucio/opendata/ODEO_FEB2025_v0_2J2LMET30_mc_346311.PowhegPythia8EvtGen_NNPDF30_AZNLO_WpH125J_Wincl_H_incl_MINLO.2J2LMET30.root"
+      },
+      {
+        "checksum": "adler32:38403053",
+        "size": 148149,
+        "uri": "root://eospublic.cern.ch//eos/opendata/atlas/rucio/opendata/ODEO_FEB2025_v0_2J2LMET30_mc_346312.PowhegPythia8EvtGen_NNPDF30_AZNLO_WmH125J_Wincl_H_incl_MINLO.2J2LMET30.root"
+      },
+      {
+        "checksum": "adler32:734caa7b",
+        "size": 287354,
+        "uri": "root://eospublic.cern.ch//eos/opendata/atlas/rucio/opendata/ODEO_FEB2025_v0_2J2LMET30_mc_346317.PowhegPy8EG_NNPDF30_AZNLOCTEQ6L1_VBFH125_incl.2J2LMET30.root"
+      },
+      {
+        "checksum": "adler32:544ddb7a",
+        "size": 11347570,
+        "uri": "root://eospublic.cern.ch//eos/opendata/atlas/rucio/opendata/ODEO_FEB2025_v0_2J2LMET30_mc_346340.PowhegPy8EG_A14NNPDF23_NNPDF30ME_ttH125_ZZ4l_allhad.2J2LMET30.root"
+      },
+      {
+        "checksum": "adler32:6e2c19f5",
+        "size": 15250341,
+        "uri": "root://eospublic.cern.ch//eos/opendata/atlas/rucio/opendata/ODEO_FEB2025_v0_2J2LMET30_mc_346341.PowhegPy8EG_A14NNPDF23_NNPDF30ME_ttH125_ZZ4l_semilep.2J2LMET30.root"
+      },
+      {
+        "checksum": "adler32:66ff2163",
+        "size": 14666408,
+        "uri": "root://eospublic.cern.ch//eos/opendata/atlas/rucio/opendata/ODEO_FEB2025_v0_2J2LMET30_mc_346342.PowhegPy8EG_A14NNPDF23_NNPDF30ME_ttH125_ZZ4l_dilep.2J2LMET30.root"
+      },
+      {
+        "checksum": "adler32:42aa6cfe",
+        "size": 599439,
+        "uri": "root://eospublic.cern.ch//eos/opendata/atlas/rucio/opendata/ODEO_FEB2025_v0_2J2LMET30_mc_346343.PhPy8EG_A14NNPDF23_NNPDF30ME_ttH125_allhad.2J2LMET30.root"
+      },
+      {
+        "checksum": "adler32:d49de851",
+        "size": 2710351,
+        "uri": "root://eospublic.cern.ch//eos/opendata/atlas/rucio/opendata/ODEO_FEB2025_v0_2J2LMET30_mc_346344.PhPy8EG_A14NNPDF23_NNPDF30ME_ttH125_semilep.2J2LMET30.root"
+      },
+      {
+        "checksum": "adler32:c990c76c",
+        "size": 28948883,
+        "uri": "root://eospublic.cern.ch//eos/opendata/atlas/rucio/opendata/ODEO_FEB2025_v0_2J2LMET30_mc_346345.PhPy8EG_A14NNPDF23_NNPDF30ME_ttH125_dilep.2J2LMET30.root"
+      },
+      {
+        "checksum": "adler32:2da0edc7",
+        "size": 27533,
+        "uri": "root://eospublic.cern.ch//eos/opendata/atlas/rucio/opendata/ODEO_FEB2025_v0_2J2LMET30_mc_346398.PowhegHerwig7EvtGen_NNPDF3_AZNLO_ZH125J_MINLO_vvbb_VpT.2J2LMET30.root"
+      },
+      {
+        "checksum": "adler32:541c6d62",
+        "size": 41269,
+        "uri": "root://eospublic.cern.ch//eos/opendata/atlas/rucio/opendata/ODEO_FEB2025_v0_2J2LMET30_mc_346400.PowhegHerwig7EvtGen_NNPDF3_AZNLO_ggZH125J_vvbb.2J2LMET30.root"
+      },
+      {
+        "checksum": "adler32:611855d8",
+        "size": 6489288,
+        "uri": "root://eospublic.cern.ch//eos/opendata/atlas/rucio/opendata/ODEO_FEB2025_v0_2J2LMET30_mc_346414.aMcAtNloPythia8EvtGen_tHjb125_4fl_ZZ4l.2J2LMET30.root"
+      },
+      {
+        "checksum": "adler32:6600ce79",
+        "size": 55525487,
+        "uri": "root://eospublic.cern.ch//eos/opendata/atlas/rucio/opendata/ODEO_FEB2025_v0_2J2LMET30_mc_346446.PhH7EG_H7UE_NNLOPS_nnlo_30_ggH125_ZZ4l_noTau.2J2LMET30.root"
+      },
+      {
+        "checksum": "adler32:22cad151",
+        "size": 19645428,
+        "uri": "root://eospublic.cern.ch//eos/opendata/atlas/rucio/opendata/ODEO_FEB2025_v0_2J2LMET30_mc_346447.PhH7EG_H7UE_NNPDF30_VBFH125_ZZ4lep_noTau.2J2LMET30.root"
+      },
+      {
+        "checksum": "adler32:b5d93ae4",
+        "size": 9082412,
+        "uri": "root://eospublic.cern.ch//eos/opendata/atlas/rucio/opendata/ODEO_FEB2025_v0_2J2LMET30_mc_346448.PhH7EG_H7UE_NNPDF30_ZH125J_Zincl_MINLO.2J2LMET30.root"
+      },
+      {
+        "checksum": "adler32:f405ac67",
+        "size": 6970953,
+        "uri": "root://eospublic.cern.ch//eos/opendata/atlas/rucio/opendata/ODEO_FEB2025_v0_2J2LMET30_mc_346449.PhH7EG_H7UE_NNPDF30_WpH125J_Wincl_MINLO.2J2LMET30.root"
+      },
+      {
+        "checksum": "adler32:3880024f",
+        "size": 3657858,
+        "uri": "root://eospublic.cern.ch//eos/opendata/atlas/rucio/opendata/ODEO_FEB2025_v0_2J2LMET30_mc_346450.PhH7EG_H7UE_NNPDF30_WmH125J_Wincl_MINLO.2J2LMET30.root"
+      },
+      {
+        "checksum": "adler32:d59b851c",
+        "size": 6415242,
+        "uri": "root://eospublic.cern.ch//eos/opendata/atlas/rucio/opendata/ODEO_FEB2025_v0_2J2LMET30_mc_346451.PhH7EG_H7UE_NNPDF3_ggZH125_ZZ4lepZinc.2J2LMET30.root"
+      },
+      {
+        "checksum": "adler32:aa5cdf86",
+        "size": 11480823,
+        "uri": "root://eospublic.cern.ch//eos/opendata/atlas/rucio/opendata/ODEO_FEB2025_v0_2J2LMET30_mc_346452.PhH7EG_H7UE_NNPDF30ME_ttH125_ZZ4l_allhad_noTau.2J2LMET30.root"
+      },
+      {
+        "checksum": "adler32:4ca368bc",
+        "size": 15485842,
+        "uri": "root://eospublic.cern.ch//eos/opendata/atlas/rucio/opendata/ODEO_FEB2025_v0_2J2LMET30_mc_346453.PhH7EG_H7UE_NNPDF30ME_ttH125_ZZ4l_semilep_noTau.2J2LMET30.root"
+      },
+      {
+        "checksum": "adler32:7301577e",
+        "size": 15031262,
+        "uri": "root://eospublic.cern.ch//eos/opendata/atlas/rucio/opendata/ODEO_FEB2025_v0_2J2LMET30_mc_346454.PhH7EG_H7UE_NNPDF30ME_ttH125_ZZ4l_dilep_noTau.2J2LMET30.root"
+      },
+      {
+        "checksum": "adler32:147a3e04",
+        "size": 569307,
+        "uri": "root://eospublic.cern.ch//eos/opendata/atlas/rucio/opendata/ODEO_FEB2025_v0_2J2LMET30_mc_346486.aMcAtNloPythia8EvtGen_tWH125_yy.2J2LMET30.root"
+      },
+      {
+        "checksum": "adler32:51b68b2b",
+        "size": 9887628,
+        "uri": "root://eospublic.cern.ch//eos/opendata/atlas/rucio/opendata/ODEO_FEB2025_v0_2J2LMET30_mc_346511.aMcAtNloPythia8EvtGen_tWH125_ZZ4l.2J2LMET30.root"
+      },
+      {
+        "checksum": "adler32:78d2bb0d",
+        "size": 2951112,
+        "uri": "root://eospublic.cern.ch//eos/opendata/atlas/rucio/opendata/ODEO_FEB2025_v0_2J2LMET30_mc_346524.PowhegPythia8EvtGen_NNPDF3_AZNLO_ggZH125J_MINLO_ZinclWWlvlv.2J2LMET30.root"
+      },
+      {
+        "checksum": "adler32:b057ec36",
+        "size": 2402497,
+        "uri": "root://eospublic.cern.ch//eos/opendata/atlas/rucio/opendata/ODEO_FEB2025_v0_2J2LMET30_mc_346525.PowhegPythia8EvtGen_A14NNPDF23_NNPDF30ME_ttH125_gamgam.2J2LMET30.root"
+      },
+      {
+        "checksum": "adler32:8484da41",
+        "size": 2351039,
+        "uri": "root://eospublic.cern.ch//eos/opendata/atlas/rucio/opendata/ODEO_FEB2025_v0_2J2LMET30_mc_346526.PowhegHerwig7EvtGen_H7UE_NNPDF30ME_ttH125_gamgam.2J2LMET30.root"
+      },
+      {
+        "checksum": "adler32:1a62d143",
+        "size": 26554,
+        "uri": "root://eospublic.cern.ch//eos/opendata/atlas/rucio/opendata/ODEO_FEB2025_v0_2J2LMET30_mc_346588.PowhegPythia8EvtGen_NNLOPS_nnlo_30_ggH125_ZZ4nu_MET75.2J2LMET30.root"
+      },
+      {
+        "checksum": "adler32:5d5fc64b",
+        "size": 1669891,
+        "uri": "root://eospublic.cern.ch//eos/opendata/atlas/rucio/opendata/ODEO_FEB2025_v0_2J2LMET30_mc_346601.aMcAtNloHerwig7EvtGen_MEN30NLO_ttH125_gamgam.2J2LMET30.root"
+      },
+      {
+        "checksum": "adler32:209be514",
+        "size": 72412,
+        "uri": "root://eospublic.cern.ch//eos/opendata/atlas/rucio/opendata/ODEO_FEB2025_v0_2J2LMET30_mc_346602.aMcAtNloHerwig7EvtGen_MEN30NLO_tHjb125_gamgam.2J2LMET30.root"
+      },
+      {
+        "checksum": "adler32:fb70be0c",
+        "size": 46365,
+        "uri": "root://eospublic.cern.ch//eos/opendata/atlas/rucio/opendata/ODEO_FEB2025_v0_2J2LMET30_mc_346605.PowhegPythia8EvtGen_NNPDF30_AZNLO_WpH125J_WinclHinv_MET75.2J2LMET30.root"
+      },
+      {
+        "checksum": "adler32:666898d0",
+        "size": 46968,
+        "uri": "root://eospublic.cern.ch//eos/opendata/atlas/rucio/opendata/ODEO_FEB2025_v0_2J2LMET30_mc_346606.PowhegPythia8EvtGen_NNPDF30_AZNLO_WmH125J_WinclHinv_MET75.2J2LMET30.root"
+      },
+      {
+        "checksum": "adler32:2b3fd93f",
+        "size": 558872,
+        "uri": "root://eospublic.cern.ch//eos/opendata/atlas/rucio/opendata/ODEO_FEB2025_v0_2J2LMET30_mc_346607.PowhegPythia8EvtGen_NNPDF30_AZNLO_ZH125J_ZinclHinv_MET75.2J2LMET30.root"
+      },
+      {
+        "checksum": "adler32:ddf03473",
+        "size": 663733,
+        "uri": "root://eospublic.cern.ch//eos/opendata/atlas/rucio/opendata/ODEO_FEB2025_v0_2J2LMET30_mc_346632.PowhegPy8EG_A14NNPDF23_NNPDF30ME_ttH125_ZZ4nu_semilep.2J2LMET30.root"
+      },
+      {
+        "checksum": "adler32:deda8ccb",
+        "size": 51180,
+        "uri": "root://eospublic.cern.ch//eos/opendata/atlas/rucio/opendata/ODEO_FEB2025_v0_2J2LMET30_mc_346633.PowhegPy8EG_A14NNPDF23_NNPDF30ME_ttH125_ZZ4nu_allhad.2J2LMET30.root"
+      },
+      {
+        "checksum": "adler32:0a63a498",
+        "size": 4495352,
+        "uri": "root://eospublic.cern.ch//eos/opendata/atlas/rucio/opendata/ODEO_FEB2025_v0_2J2LMET30_mc_346634.PowhegPy8EG_A14NNPDF23_NNPDF30ME_ttH125_ZZ4nu_dilep.2J2LMET30.root"
+      },
+      {
+        "checksum": "adler32:8b43a3b0",
+        "size": 12140179,
+        "uri": "root://eospublic.cern.ch//eos/opendata/atlas/rucio/opendata/ODEO_FEB2025_v0_2J2LMET30_mc_346645.PowhegPythia8EvtGen_NNPDF30_AZNLO_ZH125J_Zincl_MINLO_shw.2J2LMET30.root"
+      },
+      {
+        "checksum": "adler32:d70f3e9c",
+        "size": 6740276,
+        "uri": "root://eospublic.cern.ch//eos/opendata/atlas/rucio/opendata/ODEO_FEB2025_v0_2J2LMET30_mc_346646.PowhegPythia8EvtGen_NNPDF30_AZNLO_WpH125J_Wincl_MINLO_shw.2J2LMET30.root"
+      },
+      {
+        "checksum": "adler32:6d118db6",
+        "size": 3537654,
+        "uri": "root://eospublic.cern.ch//eos/opendata/atlas/rucio/opendata/ODEO_FEB2025_v0_2J2LMET30_mc_346647.PowhegPythia8EvtGen_NNPDF30_AZNLO_WmH125J_Wincl_MINLO_shw.2J2LMET30.root"
+      },
+      {
+        "checksum": "adler32:c36d985f",
+        "size": 38570,
+        "uri": "root://eospublic.cern.ch//eos/opendata/atlas/rucio/opendata/ODEO_FEB2025_v0_2J2LMET30_mc_346726.PowhegHerwig7EvtGen_NNPDF3_AZNLO_ZH125J_MINLO_vvcc_VpT.2J2LMET30.root"
+      },
+      {
+        "checksum": "adler32:b3ec17e7",
+        "size": 26433,
+        "uri": "root://eospublic.cern.ch//eos/opendata/atlas/rucio/opendata/ODEO_FEB2025_v0_2J2LMET30_mc_346728.PowhegHerwig7EvtGen_NNPDF3_AZNLO_ggZH125J_vvcc.2J2LMET30.root"
+      },
+      {
+        "checksum": "adler32:e322871a",
+        "size": 338882,
+        "uri": "root://eospublic.cern.ch//eos/opendata/atlas/rucio/opendata/ODEO_FEB2025_v0_2J2LMET30_mc_346797.PhH7EG_H7UE_NNLOPS_nnlo_30_ggH125_gamgam.2J2LMET30.root"
+      },
+      {
+        "checksum": "adler32:bde0a9de",
+        "size": 39926419,
+        "uri": "root://eospublic.cern.ch//eos/opendata/atlas/rucio/opendata/ODEO_FEB2025_v0_2J2LMET30_mc_346802.PhH7EG_NNLOPS_nnlo_30_ggH125_WWlvlv_noTau.2J2LMET30.root"
+      },
+      {
+        "checksum": "adler32:ac68702a",
+        "size": 6203722,
+        "uri": "root://eospublic.cern.ch//eos/opendata/atlas/rucio/opendata/ODEO_FEB2025_v0_2J2LMET30_mc_346877.PhH7EG_NNPDF30_VBFH125_WWlvlv.2J2LMET30.root"
+      },
+      {
+        "checksum": "adler32:4e5401aa",
+        "size": 65968,
+        "uri": "root://eospublic.cern.ch//eos/opendata/atlas/rucio/opendata/ODEO_FEB2025_v0_2J2LMET30_mc_346878.PhH7EG_H7UE_NNPDF30_VBF125_gammagamma.2J2LMET30.root"
+      },
+      {
+        "checksum": "adler32:c4d482e3",
+        "size": 287537,
+        "uri": "root://eospublic.cern.ch//eos/opendata/atlas/rucio/opendata/ODEO_FEB2025_v0_2J2LMET30_mc_346879.PhH7EG_H7UE_NNPDF30_ZH125J_Zincl_MINLO_gammagamma.2J2LMET30.root"
+      },
+      {
+        "checksum": "adler32:a64bacba",
+        "size": 39222,
+        "uri": "root://eospublic.cern.ch//eos/opendata/atlas/rucio/opendata/ODEO_FEB2025_v0_2J2LMET30_mc_346880.PhH7EG_H7UE_NNPDF30_WmH125J_Wincl_MINLO_gammagamma.2J2LMET30.root"
+      },
+      {
+        "checksum": "adler32:3e18cf13",
+        "size": 63127,
+        "uri": "root://eospublic.cern.ch//eos/opendata/atlas/rucio/opendata/ODEO_FEB2025_v0_2J2LMET30_mc_346881.PhH7EG_H7UE_NNPDF30_WpH125J_Wincl_MINLO_gammagamma.2J2LMET30.root"
+      },
+      {
+        "checksum": "adler32:da7921d8",
+        "size": 261498,
+        "uri": "root://eospublic.cern.ch//eos/opendata/atlas/rucio/opendata/ODEO_FEB2025_v0_2J2LMET30_mc_346882.PhH7EG_H7UE_NNPDF30_ggZH125_gammagamma.2J2LMET30.root"
+      },
+      {
+        "checksum": "adler32:fcff440a",
+        "size": 1894546,
+        "uri": "root://eospublic.cern.ch//eos/opendata/atlas/rucio/opendata/ODEO_FEB2025_v0_2J2LMET30_mc_346919.PhPy8EG_A14NNPDF23_NNPDF30ME_ttH125_allhad_tautau_unpol.2J2LMET30.root"
+      },
+      {
+        "checksum": "adler32:82266326",
+        "size": 10060087,
+        "uri": "root://eospublic.cern.ch//eos/opendata/atlas/rucio/opendata/ODEO_FEB2025_v0_2J2LMET30_mc_346923.PhPy8EG_A14NNPDF23_NNPDF30ME_ttH125_semilep_tautau_unpol.2J2LMET30.root"
+      },
+      {
+        "checksum": "adler32:736cf247",
+        "size": 15804225,
+        "uri": "root://eospublic.cern.ch//eos/opendata/atlas/rucio/opendata/ODEO_FEB2025_v0_2J2LMET30_mc_346927.PhPy8EG_A14NNPDF23_NNPDF30ME_ttH125_dilep_tautau_unpol.2J2LMET30.root"
+      },
+      {
+        "checksum": "adler32:e185f660",
+        "size": 12223113,
+        "uri": "root://eospublic.cern.ch//eos/opendata/atlas/rucio/opendata/ODEO_FEB2025_v0_2J2LMET30_mc_364242.Sherpa_222_NNPDF30NNLO_WWW_3l3v_EW6.2J2LMET30.root"
+      },
+      {
+        "checksum": "adler32:8ddf6fb9",
+        "size": 6347978,
+        "uri": "root://eospublic.cern.ch//eos/opendata/atlas/rucio/opendata/ODEO_FEB2025_v0_2J2LMET30_mc_364243.Sherpa_222_NNPDF30NNLO_WWZ_4l2v_EW6.2J2LMET30.root"
+      },
+      {
+        "checksum": "adler32:cf2c115a",
+        "size": 1895119,
+        "uri": "root://eospublic.cern.ch//eos/opendata/atlas/rucio/opendata/ODEO_FEB2025_v0_2J2LMET30_mc_364244.Sherpa_222_NNPDF30NNLO_WWZ_2l4v_EW6.2J2LMET30.root"
+      },
+      {
+        "checksum": "adler32:e161315a",
+        "size": 6556085,
+        "uri": "root://eospublic.cern.ch//eos/opendata/atlas/rucio/opendata/ODEO_FEB2025_v0_2J2LMET30_mc_364245.Sherpa_222_NNPDF30NNLO_WZZ_5l1v_EW6.2J2LMET30.root"
+      },
+      {
+        "checksum": "adler32:bf6b5571",
+        "size": 4427882,
+        "uri": "root://eospublic.cern.ch//eos/opendata/atlas/rucio/opendata/ODEO_FEB2025_v0_2J2LMET30_mc_364246.Sherpa_222_NNPDF30NNLO_WZZ_3l3v_EW6.2J2LMET30.root"
+      },
+      {
+        "checksum": "adler32:6dca084d",
+        "size": 3537948,
+        "uri": "root://eospublic.cern.ch//eos/opendata/atlas/rucio/opendata/ODEO_FEB2025_v0_2J2LMET30_mc_364247.Sherpa_222_NNPDF30NNLO_ZZZ_6l0v_EW6.2J2LMET30.root"
+      },
+      {
+        "checksum": "adler32:9226522c",
+        "size": 845724,
+        "uri": "root://eospublic.cern.ch//eos/opendata/atlas/rucio/opendata/ODEO_FEB2025_v0_2J2LMET30_mc_364248.Sherpa_222_NNPDF30NNLO_ZZZ_4l2v_EW6.2J2LMET30.root"
+      },
+      {
+        "checksum": "adler32:76e06cf7",
+        "size": 879056,
+        "uri": "root://eospublic.cern.ch//eos/opendata/atlas/rucio/opendata/ODEO_FEB2025_v0_2J2LMET30_mc_364249.Sherpa_222_NNPDF30NNLO_ZZZ_2l4v_EW6.2J2LMET30.root"
+      },
+      {
+        "checksum": "adler32:980142df",
+        "size": 5568168,
+        "uri": "root://eospublic.cern.ch//eos/opendata/atlas/rucio/opendata/ODEO_FEB2025_v0_2J2LMET30_mc_364336.Sherpa_222_NNPDF30NNLO_WpWpWn_sslvlvjj_EW6.2J2LMET30.root"
+      },
+      {
+        "checksum": "adler32:83f0235d",
+        "size": 4354796,
+        "uri": "root://eospublic.cern.ch//eos/opendata/atlas/rucio/opendata/ODEO_FEB2025_v0_2J2LMET30_mc_364337.Sherpa_222_NNPDF30NNLO_WnWnWp_sslvlvjj_EW6.2J2LMET30.root"
+      },
+      {
+        "checksum": "adler32:be429066",
+        "size": 1694582,
+        "uri": "root://eospublic.cern.ch//eos/opendata/atlas/rucio/opendata/ODEO_FEB2025_v0_2J2LMET30_mc_364338.Sherpa_222_NNPDF30NNLO_WpWpWn_oslvlvjj_EW6.2J2LMET30.root"
+      },
+      {
+        "checksum": "adler32:da9e46dd",
+        "size": 639371,
+        "uri": "root://eospublic.cern.ch//eos/opendata/atlas/rucio/opendata/ODEO_FEB2025_v0_2J2LMET30_mc_364339.Sherpa_222_NNPDF30NNLO_WnWnWp_oslvlvjj_EW6.2J2LMET30.root"
+      },
+      {
+        "checksum": "adler32:26a57e16",
+        "size": 208869,
+        "uri": "root://eospublic.cern.ch//eos/opendata/atlas/rucio/opendata/ODEO_FEB2025_v0_2J2LMET30_mc_364350.Sherpa_224_NNPDF30NNLO_Diphoton_myy_0_50.2J2LMET30.root"
+      },
+      {
+        "checksum": "adler32:44b9466c",
+        "size": 1792567,
+        "uri": "root://eospublic.cern.ch//eos/opendata/atlas/rucio/opendata/ODEO_FEB2025_v0_2J2LMET30_mc_364351.Sherpa_224_NNPDF30NNLO_Diphoton_myy_50_90.2J2LMET30.root"
+      },
+      {
+        "checksum": "adler32:59b5ec24",
+        "size": 653240,
+        "uri": "root://eospublic.cern.ch//eos/opendata/atlas/rucio/opendata/ODEO_FEB2025_v0_2J2LMET30_mc_364352.Sherpa_224_NNPDF30NNLO_Diphoton_myy_90_175.2J2LMET30.root"
+      },
+      {
+        "checksum": "adler32:9abc568a",
+        "size": 153730,
+        "uri": "root://eospublic.cern.ch//eos/opendata/atlas/rucio/opendata/ODEO_FEB2025_v0_2J2LMET30_mc_364353.Sherpa_224_NNPDF30NNLO_Diphoton_myy_175_2000.2J2LMET30.root"
+      },
+      {
+        "checksum": "adler32:5bb983e6",
+        "size": 1371,
+        "uri": "root://eospublic.cern.ch//eos/opendata/atlas/rucio/opendata/ODEO_FEB2025_v0_2J2LMET30_mc_364354.Sherpa_224_NNPDF30NNLO_Diphoton_myy_2000_E_CMS.2J2LMET30.root"
+      },
+      {
+        "checksum": "adler32:7a90600f",
+        "size": 866662,
+        "uri": "root://eospublic.cern.ch//eos/opendata/atlas/rucio/opendata/ODEO_FEB2025_v0_2J2LMET30_mc_364541.Sherpa_222_NNPDF30NNLO_SinglePhoton_pty_17_35.2J2LMET30.root"
+      },
+      {
+        "checksum": "adler32:8bb5068a",
+        "size": 1033660,
+        "uri": "root://eospublic.cern.ch//eos/opendata/atlas/rucio/opendata/ODEO_FEB2025_v0_2J2LMET30_mc_364542.Sherpa_222_NNPDF30NNLO_SinglePhoton_pty_35_70.2J2LMET30.root"
+      },
+      {
+        "checksum": "adler32:1c74a88b",
+        "size": 815276,
+        "uri": "root://eospublic.cern.ch//eos/opendata/atlas/rucio/opendata/ODEO_FEB2025_v0_2J2LMET30_mc_364543.Sherpa_222_NNPDF30NNLO_SinglePhoton_pty_70_140.2J2LMET30.root"
+      },
+      {
+        "checksum": "adler32:0504959b",
+        "size": 634651,
+        "uri": "root://eospublic.cern.ch//eos/opendata/atlas/rucio/opendata/ODEO_FEB2025_v0_2J2LMET30_mc_364544.Sherpa_222_NNPDF30NNLO_SinglePhoton_pty_140_280.2J2LMET30.root"
+      },
+      {
+        "checksum": "adler32:538c243e",
+        "size": 151828,
+        "uri": "root://eospublic.cern.ch//eos/opendata/atlas/rucio/opendata/ODEO_FEB2025_v0_2J2LMET30_mc_364545.Sherpa_222_NNPDF30NNLO_SinglePhoton_pty_280_500.2J2LMET30.root"
+      },
+      {
+        "checksum": "adler32:b8f4fe71",
+        "size": 26607,
+        "uri": "root://eospublic.cern.ch//eos/opendata/atlas/rucio/opendata/ODEO_FEB2025_v0_2J2LMET30_mc_364546.Sherpa_222_NNPDF30NNLO_SinglePhoton_pty_500_1000.2J2LMET30.root"
+      },
+      {
+        "checksum": "adler32:ba637978",
+        "size": 40104,
+        "uri": "root://eospublic.cern.ch//eos/opendata/atlas/rucio/opendata/ODEO_FEB2025_v0_2J2LMET30_mc_364547.Sherpa_222_NNPDF30NNLO_SinglePhoton_pty_1000_E_CMS.2J2LMET30.root"
+      },
+      {
+        "checksum": "adler32:bc2cd662",
+        "size": 38082,
+        "uri": "root://eospublic.cern.ch//eos/opendata/atlas/rucio/opendata/ODEO_FEB2025_v0_2J2LMET30_mc_364700.Pythia8EvtGen_A14NNPDF23LO_jetjet_JZ0WithSW.2J2LMET30.root"
+      },
+      {
+        "checksum": "adler32:8c017a2b",
+        "size": 122989,
+        "uri": "root://eospublic.cern.ch//eos/opendata/atlas/rucio/opendata/ODEO_FEB2025_v0_2J2LMET30_mc_364701.Pythia8EvtGen_A14NNPDF23LO_jetjet_JZ1WithSW.2J2LMET30.root"
+      },
+      {
+        "checksum": "adler32:0a62e9a9",
+        "size": 1764924,
+        "uri": "root://eospublic.cern.ch//eos/opendata/atlas/rucio/opendata/ODEO_FEB2025_v0_2J2LMET30_mc_364702.Pythia8EvtGen_A14NNPDF23LO_jetjet_JZ2WithSW.2J2LMET30.root"
+      },
+      {
+        "checksum": "adler32:49ce53e6",
+        "size": 3064416,
+        "uri": "root://eospublic.cern.ch//eos/opendata/atlas/rucio/opendata/ODEO_FEB2025_v0_2J2LMET30_mc_364703.Pythia8EvtGen_A14NNPDF23LO_jetjet_JZ3WithSW.2J2LMET30.root"
+      },
+      {
+        "checksum": "adler32:0dedd11a",
+        "size": 4765248,
+        "uri": "root://eospublic.cern.ch//eos/opendata/atlas/rucio/opendata/ODEO_FEB2025_v0_2J2LMET30_mc_364704.Pythia8EvtGen_A14NNPDF23LO_jetjet_JZ4WithSW.2J2LMET30.root"
+      },
+      {
+        "checksum": "adler32:16827e11",
+        "size": 525199,
+        "uri": "root://eospublic.cern.ch//eos/opendata/atlas/rucio/opendata/ODEO_FEB2025_v0_2J2LMET30_mc_364705.Pythia8EvtGen_A14NNPDF23LO_jetjet_JZ5WithSW.2J2LMET30.root"
+      },
+      {
+        "checksum": "adler32:765c19c0",
+        "size": 54609,
+        "uri": "root://eospublic.cern.ch//eos/opendata/atlas/rucio/opendata/ODEO_FEB2025_v0_2J2LMET30_mc_364706.Pythia8EvtGen_A14NNPDF23LO_jetjet_JZ6WithSW.2J2LMET30.root"
+      },
+      {
+        "checksum": "adler32:8bfb6906",
+        "size": 40188,
+        "uri": "root://eospublic.cern.ch//eos/opendata/atlas/rucio/opendata/ODEO_FEB2025_v0_2J2LMET30_mc_364707.Pythia8EvtGen_A14NNPDF23LO_jetjet_JZ7WithSW.2J2LMET30.root"
+      },
+      {
+        "checksum": "adler32:b4a5d3a6",
+        "size": 28239,
+        "uri": "root://eospublic.cern.ch//eos/opendata/atlas/rucio/opendata/ODEO_FEB2025_v0_2J2LMET30_mc_364708.Pythia8EvtGen_A14NNPDF23LO_jetjet_JZ8WithSW.2J2LMET30.root"
+      },
+      {
+        "checksum": "adler32:67c281cd",
+        "size": 40370,
+        "uri": "root://eospublic.cern.ch//eos/opendata/atlas/rucio/opendata/ODEO_FEB2025_v0_2J2LMET30_mc_364709.Pythia8EvtGen_A14NNPDF23LO_jetjet_JZ9WithSW.2J2LMET30.root"
+      },
+      {
+        "checksum": "adler32:56717a23",
+        "size": 74021,
+        "uri": "root://eospublic.cern.ch//eos/opendata/atlas/rucio/opendata/ODEO_FEB2025_v0_2J2LMET30_mc_364710.Pythia8EvtGen_A14NNPDF23LO_jetjet_JZ10WithSW.2J2LMET30.root"
+      },
+      {
+        "checksum": "adler32:c5aaba32",
+        "size": 38650,
+        "uri": "root://eospublic.cern.ch//eos/opendata/atlas/rucio/opendata/ODEO_FEB2025_v0_2J2LMET30_mc_364711.Pythia8EvtGen_A14NNPDF23LO_jetjet_JZ11WithSW.2J2LMET30.root"
+      },
+      {
+        "checksum": "adler32:5c818e73",
+        "size": 40922,
+        "uri": "root://eospublic.cern.ch//eos/opendata/atlas/rucio/opendata/ODEO_FEB2025_v0_2J2LMET30_mc_364712.Pythia8EvtGen_A14NNPDF23LO_jetjet_JZ12WithSW.2J2LMET30.root"
+      },
+      {
+        "checksum": "adler32:73d84a72",
+        "size": 746766,
+        "uri": "root://eospublic.cern.ch//eos/opendata/atlas/rucio/opendata/ODEO_FEB2025_v0_2J2LMET30_mc_375884.MGPy8EG_A14N_GG_ttn1_2000_5000_200.2J2LMET30.root"
+      },
+      {
+        "checksum": "adler32:837285db",
+        "size": 66753,
+        "uri": "root://eospublic.cern.ch//eos/opendata/atlas/rucio/opendata/ODEO_FEB2025_v0_2J2LMET30_mc_376359.MGPy8EG_A14N23LO_SS_onestepCC_1600_900_200.2J2LMET30.root"
+      },
+      {
+        "checksum": "adler32:22859642",
+        "size": 1427,
+        "uri": "root://eospublic.cern.ch//eos/opendata/atlas/rucio/opendata/ODEO_FEB2025_v0_2J2LMET30_mc_376518.MadGraphPythia8EvtGen_A14NNPDF23LO_GG_direct_2400_200.2J2LMET30.root"
+      },
+      {
+        "checksum": "adler32:d333d85c",
+        "size": 968814,
+        "uri": "root://eospublic.cern.ch//eos/opendata/atlas/rucio/opendata/ODEO_FEB2025_v0_2J2LMET30_mc_392202.MGPy8EG_A14N23LO_C1N2_WZ_500p0_100p0_3L_2L7.2J2LMET30.root"
+      },
+      {
+        "checksum": "adler32:3fdd2a69",
+        "size": 81807,
+        "uri": "root://eospublic.cern.ch//eos/opendata/atlas/rucio/opendata/ODEO_FEB2025_v0_2J2LMET30_mc_394997.MGPy8EG_A14N23LO_SM_N2C1p_105_100_2L2MET75_MadSpin.2J2LMET30.root"
+      },
+      {
+        "checksum": "adler32:c1a9335c",
+        "size": 503931,
+        "uri": "root://eospublic.cern.ch//eos/opendata/atlas/rucio/opendata/ODEO_FEB2025_v0_2J2LMET30_mc_398384.MGPy8EG_A14N23LO_C1N2N1_GGMHinoZh50_800_noFilter.2J2LMET30.root"
+      },
+      {
+        "checksum": "adler32:1e3912ed",
+        "size": 2229311,
+        "uri": "root://eospublic.cern.ch//eos/opendata/atlas/rucio/opendata/ODEO_FEB2025_v0_2J2LMET30_mc_410081.MadGraphPythia8EvtGen_A14NNPDF23_ttbarWW.2J2LMET30.root"
+      },
+      {
+        "checksum": "adler32:5ad2a28e",
+        "size": 10411016,
+        "uri": "root://eospublic.cern.ch//eos/opendata/atlas/rucio/opendata/ODEO_FEB2025_v0_2J2LMET30_mc_410082.MadGraphPythia8EvtGen_A14NNPDF23LO_ttgamma_noallhad.2J2LMET30.root"
+      },
+      {
+        "checksum": "adler32:ba337a57",
+        "size": 153661,
+        "uri": "root://eospublic.cern.ch//eos/opendata/atlas/rucio/opendata/ODEO_FEB2025_v0_2J2LMET30_mc_410087.MadGraphPythia8EvtGen_A14NNPDF23LO_ttgamma_allhad.2J2LMET30.root"
+      },
+      {
+        "checksum": "adler32:7836f2a8",
+        "size": 3669677,
+        "uri": "root://eospublic.cern.ch//eos/opendata/atlas/rucio/opendata/ODEO_FEB2025_v0_2J2LMET30_mc_410155.aMcAtNloPythia8EvtGen_MEN30NLO_A14N23LO_ttW.2J2LMET30.root"
+      },
+      {
+        "checksum": "adler32:872589d8",
+        "size": 1604755,
+        "uri": "root://eospublic.cern.ch//eos/opendata/atlas/rucio/opendata/ODEO_FEB2025_v0_2J2LMET30_mc_410156.aMcAtNloPythia8EvtGen_MEN30NLO_A14N23LO_ttZnunu.2J2LMET30.root"
+      },
+      {
+        "checksum": "adler32:6e3015da",
+        "size": 2543635,
+        "uri": "root://eospublic.cern.ch//eos/opendata/atlas/rucio/opendata/ODEO_FEB2025_v0_2J2LMET30_mc_410157.aMcAtNloPythia8EvtGen_MEN30NLO_A14N23LO_ttZqq.2J2LMET30.root"
+      },
+      {
+        "checksum": "adler32:6445af1a",
+        "size": 18047614,
+        "uri": "root://eospublic.cern.ch//eos/opendata/atlas/rucio/opendata/ODEO_FEB2025_v0_2J2LMET30_mc_410218.aMcAtNloPythia8EvtGen_MEN30NLO_A14N23LO_ttee.2J2LMET30.root"
+      },
+      {
+        "checksum": "adler32:0830cbf2",
+        "size": 36587754,
+        "uri": "root://eospublic.cern.ch//eos/opendata/atlas/rucio/opendata/ODEO_FEB2025_v0_2J2LMET30_mc_410219.aMcAtNloPythia8EvtGen_MEN30NLO_A14N23LO_ttmumu.2J2LMET30.root"
+      },
+      {
+        "checksum": "adler32:0acaa26a",
+        "size": 8579715,
+        "uri": "root://eospublic.cern.ch//eos/opendata/atlas/rucio/opendata/ODEO_FEB2025_v0_2J2LMET30_mc_410220.aMcAtNloPythia8EvtGen_MEN30NLO_A14N23LO_tttautau.2J2LMET30.root"
+      },
+      {
+        "checksum": "adler32:534bcc20",
+        "size": 14406744,
+        "uri": "root://eospublic.cern.ch//eos/opendata/atlas/rucio/opendata/ODEO_FEB2025_v0_2J2LMET30_mc_410389.MadGraphPythia8EvtGen_A14NNPDF23_ttgamma_nonallhadronic.2J2LMET30.root"
+      },
+      {
+        "checksum": "adler32:21171ad3",
+        "size": 13018956,
+        "uri": "root://eospublic.cern.ch//eos/opendata/atlas/rucio/opendata/ODEO_FEB2025_v0_2J2LMET30_mc_410395.MGH7EG_H7UE_ttgamma_nonallhadronic.2J2LMET30.root"
+      },
+      {
+        "checksum": "adler32:7dce8c34",
+        "size": 147012,
+        "uri": "root://eospublic.cern.ch//eos/opendata/atlas/rucio/opendata/ODEO_FEB2025_v0_2J2LMET30_mc_410396.MGH7EG_H7UE_ttgamma_allhadronic.2J2LMET30.root"
+      },
+      {
+        "checksum": "adler32:d68bf462",
+        "size": 6306100,
+        "uri": "root://eospublic.cern.ch//eos/opendata/atlas/rucio/opendata/ODEO_FEB2025_v0_2J2LMET30_mc_410408.aMcAtNloPythia8EvtGen_tWZ_Ztoll_minDR1.2J2LMET30.root"
+      },
+      {
+        "checksum": "adler32:8d5c9cdd",
+        "size": 699911723,
+        "uri": "root://eospublic.cern.ch//eos/opendata/atlas/rucio/opendata/ODEO_FEB2025_v0_2J2LMET30_mc_410470.PhPy8EG_A14_ttbar_hdamp258p75_nonallhad.2J2LMET30.root"
+      },
+      {
+        "checksum": "adler32:3070cb70",
+        "size": 5006131,
+        "uri": "root://eospublic.cern.ch//eos/opendata/atlas/rucio/opendata/ODEO_FEB2025_v0_2J2LMET30_mc_410471.PhPy8EG_A14_ttbar_hdamp258p75_allhad.2J2LMET30.root"
+      },
+      {
+        "checksum": "adler32:8cf1f331",
+        "size": 4230630,
+        "uri": "root://eospublic.cern.ch//eos/opendata/atlas/rucio/opendata/ODEO_FEB2025_v0_2J2LMET30_mc_410560.MadGraphPythia8EvtGen_A14_tZ_4fl_tchan_noAllHad.2J2LMET30.root"
+      },
+      {
+        "checksum": "adler32:b37dc28f",
+        "size": 276122,
+        "uri": "root://eospublic.cern.ch//eos/opendata/atlas/rucio/opendata/ODEO_FEB2025_v0_2J2LMET30_mc_410644.PowhegPythia8EvtGen_A14_singletop_schan_lept_top.2J2LMET30.root"
+      },
+      {
+        "checksum": "adler32:e328e664",
+        "size": 194945,
+        "uri": "root://eospublic.cern.ch//eos/opendata/atlas/rucio/opendata/ODEO_FEB2025_v0_2J2LMET30_mc_410645.PowhegPythia8EvtGen_A14_singletop_schan_lept_antitop.2J2LMET30.root"
+      },
+      {
+        "checksum": "adler32:48510f09",
+        "size": 4196978,
+        "uri": "root://eospublic.cern.ch//eos/opendata/atlas/rucio/opendata/ODEO_FEB2025_v0_2J2LMET30_mc_410658.PhPy8EG_A14_tchan_BW50_lept_top.2J2LMET30.root"
+      },
+      {
+        "checksum": "adler32:ee6e167f",
+        "size": 2550784,
+        "uri": "root://eospublic.cern.ch//eos/opendata/atlas/rucio/opendata/ODEO_FEB2025_v0_2J2LMET30_mc_410659.PhPy8EG_A14_tchan_BW50_lept_antitop.2J2LMET30.root"
+      },
+      {
+        "checksum": "adler32:52259ab7",
+        "size": 23696928,
+        "uri": "root://eospublic.cern.ch//eos/opendata/atlas/rucio/opendata/ODEO_FEB2025_v0_2J2LMET30_mc_411233.PowhegHerwig7EvtGen_tt_hdamp258p75_713_SingleLep.2J2LMET30.root"
+      },
+      {
+        "checksum": "adler32:f1b4568a",
+        "size": 322797239,
+        "uri": "root://eospublic.cern.ch//eos/opendata/atlas/rucio/opendata/ODEO_FEB2025_v0_2J2LMET30_mc_411234.PowhegHerwig7EvtGen_tt_hdamp258p75_713_dil.2J2LMET30.root"
+      },
+      {
+        "checksum": "adler32:e1bbedbb",
+        "size": 5527450,
+        "uri": "root://eospublic.cern.ch//eos/opendata/atlas/rucio/opendata/ODEO_FEB2025_v0_2J2LMET30_mc_411316.PowhegHerwig7EvtGen_tt_hdamp258p75_713_allhad.2J2LMET30.root"
+      },
+      {
+        "checksum": "adler32:070b2c6b",
+        "size": 14501962,
+        "uri": "root://eospublic.cern.ch//eos/opendata/atlas/rucio/opendata/ODEO_FEB2025_v0_2J2LMET30_mc_412043.aMcAtNloPythia8EvtGen_A14NNPDF31_SM4topsNLO.2J2LMET30.root"
+      },
+      {
+        "checksum": "adler32:57f902b9",
+        "size": 14586353,
+        "uri": "root://eospublic.cern.ch//eos/opendata/atlas/rucio/opendata/ODEO_FEB2025_v0_2J2LMET30_mc_412044.aMcAtNloHerwig7EvtGen_H7UE_SM4topsNLO.2J2LMET30.root"
+      },
+      {
+        "checksum": "adler32:b74b806d",
+        "size": 26523,
+        "uri": "root://eospublic.cern.ch//eos/opendata/atlas/rucio/opendata/ODEO_FEB2025_v0_2J2LMET30_mc_423099.Pythia8EvtGen_A14NNPDF23LO_gammajet_DP8_17.2J2LMET30.root"
+      },
+      {
+        "checksum": "adler32:bdc9c7bf",
+        "size": 261853,
+        "uri": "root://eospublic.cern.ch//eos/opendata/atlas/rucio/opendata/ODEO_FEB2025_v0_2J2LMET30_mc_423100.Pythia8EvtGen_A14NNPDF23LO_gammajet_DP17_35.2J2LMET30.root"
+      },
+      {
+        "checksum": "adler32:29617b39",
+        "size": 266744,
+        "uri": "root://eospublic.cern.ch//eos/opendata/atlas/rucio/opendata/ODEO_FEB2025_v0_2J2LMET30_mc_423101.Pythia8EvtGen_A14NNPDF23LO_gammajet_DP35_50.2J2LMET30.root"
+      },
+      {
+        "checksum": "adler32:cc3d7f0a",
+        "size": 294552,
+        "uri": "root://eospublic.cern.ch//eos/opendata/atlas/rucio/opendata/ODEO_FEB2025_v0_2J2LMET30_mc_423102.Pythia8EvtGen_A14NNPDF23LO_gammajet_DP50_70.2J2LMET30.root"
+      },
+      {
+        "checksum": "adler32:a793093e",
+        "size": 234836,
+        "uri": "root://eospublic.cern.ch//eos/opendata/atlas/rucio/opendata/ODEO_FEB2025_v0_2J2LMET30_mc_423103.Pythia8EvtGen_A14NNPDF23LO_gammajet_DP70_140.2J2LMET30.root"
+      },
+      {
+        "checksum": "adler32:280e1cf0",
+        "size": 213068,
+        "uri": "root://eospublic.cern.ch//eos/opendata/atlas/rucio/opendata/ODEO_FEB2025_v0_2J2LMET30_mc_423104.Pythia8EvtGen_A14NNPDF23LO_gammajet_DP140_280.2J2LMET30.root"
+      },
+      {
+        "checksum": "adler32:5b22e1fa",
+        "size": 211157,
+        "uri": "root://eospublic.cern.ch//eos/opendata/atlas/rucio/opendata/ODEO_FEB2025_v0_2J2LMET30_mc_423105.Pythia8EvtGen_A14NNPDF23LO_gammajet_DP280_500.2J2LMET30.root"
+      },
+      {
+        "checksum": "adler32:da6e96ef",
+        "size": 26614,
+        "uri": "root://eospublic.cern.ch//eos/opendata/atlas/rucio/opendata/ODEO_FEB2025_v0_2J2LMET30_mc_423106.Pythia8EvtGen_A14NNPDF23LO_gammajet_DP500_800.2J2LMET30.root"
+      },
+      {
+        "checksum": "adler32:c59e551b",
+        "size": 29222,
+        "uri": "root://eospublic.cern.ch//eos/opendata/atlas/rucio/opendata/ODEO_FEB2025_v0_2J2LMET30_mc_423107.Pythia8EvtGen_A14NNPDF23LO_gammajet_DP800_1000.2J2LMET30.root"
+      },
+      {
+        "checksum": "adler32:fbf302b0",
+        "size": 27859,
+        "uri": "root://eospublic.cern.ch//eos/opendata/atlas/rucio/opendata/ODEO_FEB2025_v0_2J2LMET30_mc_423108.Pythia8EvtGen_A14NNPDF23LO_gammajet_DP1000_1500.2J2LMET30.root"
+      },
+      {
+        "checksum": "adler32:8fb0a5b4",
+        "size": 26646,
+        "uri": "root://eospublic.cern.ch//eos/opendata/atlas/rucio/opendata/ODEO_FEB2025_v0_2J2LMET30_mc_423109.Pythia8EvtGen_A14NNPDF23LO_gammajet_DP1500_2000.2J2LMET30.root"
+      },
+      {
+        "checksum": "adler32:26144508",
+        "size": 28773,
+        "uri": "root://eospublic.cern.ch//eos/opendata/atlas/rucio/opendata/ODEO_FEB2025_v0_2J2LMET30_mc_423110.Pythia8EvtGen_A14NNPDF23LO_gammajet_DP2000_2500.2J2LMET30.root"
+      },
+      {
+        "checksum": "adler32:dcbd8830",
+        "size": 1379,
+        "uri": "root://eospublic.cern.ch//eos/opendata/atlas/rucio/opendata/ODEO_FEB2025_v0_2J2LMET30_mc_423111.Pythia8EvtGen_A14NNPDF23LO_gammajet_DP2500_3000.2J2LMET30.root"
+      },
+      {
+        "checksum": "adler32:55287c04",
+        "size": 26669,
+        "uri": "root://eospublic.cern.ch//eos/opendata/atlas/rucio/opendata/ODEO_FEB2025_v0_2J2LMET30_mc_423112.Pythia8EvtGen_A14NNPDF23LO_gammajet_DP3000_inf.2J2LMET30.root"
+      },
+      {
+        "checksum": "adler32:0648be91",
+        "size": 395637,
+        "uri": "root://eospublic.cern.ch//eos/opendata/atlas/rucio/opendata/ODEO_FEB2025_v0_2J2LMET30_mc_448624.MGPy8EG_A14N23LO_TT_higgsinoRPV_1075_700.2J2LMET30.root"
+      },
+      {
+        "checksum": "adler32:a029fb52",
+        "size": 1796657,
+        "uri": "root://eospublic.cern.ch//eos/opendata/atlas/rucio/opendata/ODEO_FEB2025_v0_2J2LMET30_mc_449595.MGPy8EG_A14N23LO_TT_RPVdirectBL_1400.2J2LMET30.root"
+      },
+      {
+        "checksum": "adler32:27637242",
+        "size": 1950129,
+        "uri": "root://eospublic.cern.ch//eos/opendata/atlas/rucio/opendata/ODEO_FEB2025_v0_2J2LMET30_mc_450576.PowhegPythia8EvtGen_NNLOPS_nnlo_30_VBFH125_ZZllbb.2J2LMET30.root"
+      },
+      {
+        "checksum": "adler32:f88fdbce",
+        "size": 6324523,
+        "uri": "root://eospublic.cern.ch//eos/opendata/atlas/rucio/opendata/ODEO_FEB2025_v0_2J2LMET30_mc_500335.MGH7EG_VBFHWWlvlv.2J2LMET30.root"
+      },
+      {
+        "checksum": "adler32:8a898262",
+        "size": 518478,
+        "uri": "root://eospublic.cern.ch//eos/opendata/atlas/rucio/opendata/ODEO_FEB2025_v0_2J2LMET30_mc_500553.aMCPy8EG_ZH_FxFx_Hyy.2J2LMET30.root"
+      },
+      {
+        "checksum": "adler32:cdbc4153",
+        "size": 87206,
+        "uri": "root://eospublic.cern.ch//eos/opendata/atlas/rucio/opendata/ODEO_FEB2025_v0_2J2LMET30_mc_500554.aMCPy8EG_WH_FxFx_Hyy.2J2LMET30.root"
+      },
+      {
+        "checksum": "adler32:2c373faa",
+        "size": 749032,
+        "uri": "root://eospublic.cern.ch//eos/opendata/atlas/rucio/opendata/ODEO_FEB2025_v0_2J2LMET30_mc_500555.aMCPy8EG_ggZH_Hyy.2J2LMET30.root"
+      },
+      {
+        "checksum": "adler32:8f5a38cb",
+        "size": 167363,
+        "uri": "root://eospublic.cern.ch//eos/opendata/atlas/rucio/opendata/ODEO_FEB2025_v0_2J2LMET30_mc_501058.MGPy8EG_StauStauDirect_200p0_1p0_TFilt.2J2LMET30.root"
+      },
+      {
+        "checksum": "adler32:5b5415d3",
+        "size": 624196,
+        "uri": "root://eospublic.cern.ch//eos/opendata/atlas/rucio/opendata/ODEO_FEB2025_v0_2J2LMET30_mc_506098.aMCPy8EG_WpH_FxFx_Htautau.2J2LMET30.root"
+      },
+      {
+        "checksum": "adler32:5464c353",
+        "size": 516079,
+        "uri": "root://eospublic.cern.ch//eos/opendata/atlas/rucio/opendata/ODEO_FEB2025_v0_2J2LMET30_mc_506099.aMCPy8EG_ZH_FxFx_Htautau.2J2LMET30.root"
+      },
+      {
+        "checksum": "adler32:35b47ec9",
+        "size": 27550,
+        "uri": "root://eospublic.cern.ch//eos/opendata/atlas/rucio/opendata/ODEO_FEB2025_v0_2J2LMET30_mc_506101.aMCH7EG_VBF_Htautauh30h20.2J2LMET30.root"
+      },
+      {
+        "checksum": "adler32:5eddf47e",
+        "size": 5001541,
+        "uri": "root://eospublic.cern.ch//eos/opendata/atlas/rucio/opendata/ODEO_FEB2025_v0_2J2LMET30_mc_506102.aMCH7EG_VBF_Htautaul13l7.2J2LMET30.root"
+      },
+      {
+        "checksum": "adler32:598c739a",
+        "size": 71457,
+        "uri": "root://eospublic.cern.ch//eos/opendata/atlas/rucio/opendata/ODEO_FEB2025_v0_2J2LMET30_mc_506103.aMCH7EG_VBF_Htautaulp15hm20.2J2LMET30.root"
+      },
+      {
+        "checksum": "adler32:fd300e96",
+        "size": 116167,
+        "uri": "root://eospublic.cern.ch//eos/opendata/atlas/rucio/opendata/ODEO_FEB2025_v0_2J2LMET30_mc_506104.aMCH7EG_VBF_Htautaulm15hp20.2J2LMET30.root"
+      },
+      {
+        "checksum": "adler32:de39f5ec",
+        "size": 42686,
+        "uri": "root://eospublic.cern.ch//eos/opendata/atlas/rucio/opendata/ODEO_FEB2025_v0_2J2LMET30_mc_506811.aMCH7EG_VBF_HC_Hyy.2J2LMET30.root"
+      },
+      {
+        "checksum": "adler32:21a5feac",
+        "size": 38343,
+        "uri": "root://eospublic.cern.ch//eos/opendata/atlas/rucio/opendata/ODEO_FEB2025_v0_2J2LMET30_mc_506813.aMCPy8EG_ZH_had_FxFx_Hyy.2J2LMET30.root"
+      },
+      {
+        "checksum": "adler32:24780aa8",
+        "size": 42192,
+        "uri": "root://eospublic.cern.ch//eos/opendata/atlas/rucio/opendata/ODEO_FEB2025_v0_2J2LMET30_mc_506814.aMCPy8EG_ggZH_Zhad_Hyy.2J2LMET30.root"
+      },
+      {
+        "checksum": "adler32:8a45523d",
+        "size": 113295,
+        "uri": "root://eospublic.cern.ch//eos/opendata/atlas/rucio/opendata/ODEO_FEB2025_v0_2J2LMET30_mc_507366.MGPy8EG_A14NNPDF23LO_GGM_N1N2C1_950.2J2LMET30.root"
+      },
+      {
+        "checksum": "adler32:7bbe0b63",
+        "size": 2379250,
+        "uri": "root://eospublic.cern.ch//eos/opendata/atlas/rucio/opendata/ODEO_FEB2025_v0_2J2LMET30_mc_510097.MGPy8EG_A14N23LO_DM_4topscalar_p1000_c1_nonallhad.2J2LMET30.root"
+      },
+      {
+        "checksum": "adler32:fa091e6a",
+        "size": 161128,
+        "uri": "root://eospublic.cern.ch//eos/opendata/atlas/rucio/opendata/ODEO_FEB2025_v0_2J2LMET30_mc_523692.MGPy8EG_A14N23LO_TT_tN1_1200_200_MS.2J2LMET30.root"
+      },
+      {
+        "checksum": "adler32:e255756a",
+        "size": 1948258,
+        "uri": "root://eospublic.cern.ch//eos/opendata/atlas/rucio/opendata/ODEO_FEB2025_v0_2J2LMET30_mc_600017.PhH7EG_H7UE_716_tchan_lept_antitop.2J2LMET30.root"
+      },
+      {
+        "checksum": "adler32:078a6f42",
+        "size": 3257496,
+        "uri": "root://eospublic.cern.ch//eos/opendata/atlas/rucio/opendata/ODEO_FEB2025_v0_2J2LMET30_mc_600018.PhH7EG_H7UE_716_tchan_lept_top.2J2LMET30.root"
+      },
+      {
+        "checksum": "adler32:ddda99ec",
+        "size": 218278,
+        "uri": "root://eospublic.cern.ch//eos/opendata/atlas/rucio/opendata/ODEO_FEB2025_v0_2J2LMET30_mc_600019.PhH7EG_H7UE_716_schan_lept_antitop.2J2LMET30.root"
+      },
+      {
+        "checksum": "adler32:2240a714",
+        "size": 231221,
+        "uri": "root://eospublic.cern.ch//eos/opendata/atlas/rucio/opendata/ODEO_FEB2025_v0_2J2LMET30_mc_600020.PhH7EG_H7UE_716_schan_lept_top.2J2LMET30.root"
+      },
+      {
+        "checksum": "adler32:6c444436",
+        "size": 64822,
+        "uri": "root://eospublic.cern.ch//eos/opendata/atlas/rucio/opendata/ODEO_FEB2025_v0_2J2LMET30_mc_600565.PhH7EG_ggH125_tautauh30h20_ShowerSys_fix.2J2LMET30.root"
+      },
+      {
+        "checksum": "adler32:3153a253",
+        "size": 17341701,
+        "uri": "root://eospublic.cern.ch//eos/opendata/atlas/rucio/opendata/ODEO_FEB2025_v0_2J2LMET30_mc_600566.PhH7EG_ggH125_tautaul13l7_ShowerSys_fix.2J2LMET30.root"
+      },
+      {
+        "checksum": "adler32:7c70a3e2",
+        "size": 166901,
+        "uri": "root://eospublic.cern.ch//eos/opendata/atlas/rucio/opendata/ODEO_FEB2025_v0_2J2LMET30_mc_600567.PhH7EG_ggH125_ttlp15hm20_ShowerSys_fix.2J2LMET30.root"
+      },
+      {
+        "checksum": "adler32:3855abd2",
+        "size": 210183,
+        "uri": "root://eospublic.cern.ch//eos/opendata/atlas/rucio/opendata/ODEO_FEB2025_v0_2J2LMET30_mc_600568.PhH7EG_ggH125_ttlm15hp20_ShowerSys_fix.2J2LMET30.root"
+      },
+      {
+        "checksum": "adler32:29994123",
+        "size": 50808,
+        "uri": "root://eospublic.cern.ch//eos/opendata/atlas/rucio/opendata/ODEO_FEB2025_v0_2J2LMET30_mc_600569.PhH7EG_VBFH125_tautauh30h20_ShowerSys_fix.2J2LMET30.root"
+      },
+      {
+        "checksum": "adler32:0460e794",
+        "size": 4933242,
+        "uri": "root://eospublic.cern.ch//eos/opendata/atlas/rucio/opendata/ODEO_FEB2025_v0_2J2LMET30_mc_600570.PhH7EG_VBFH125_tautaul13l7_ShowerSys_fix.2J2LMET30.root"
+      },
+      {
+        "checksum": "adler32:529f7a73",
+        "size": 70788,
+        "uri": "root://eospublic.cern.ch//eos/opendata/atlas/rucio/opendata/ODEO_FEB2025_v0_2J2LMET30_mc_600571.PhH7EG_VBFH125_tautaulp15hm20_ShowerSys_fix.2J2LMET30.root"
+      },
+      {
+        "checksum": "adler32:5ac3fb4c",
+        "size": 62849,
+        "uri": "root://eospublic.cern.ch//eos/opendata/atlas/rucio/opendata/ODEO_FEB2025_v0_2J2LMET30_mc_600572.PhH7EG_VBFH125_tautaulm15hp20_ShowerSys_fix.2J2LMET30.root"
+      },
+      {
+        "checksum": "adler32:b74b3ebd",
+        "size": 380612,
+        "uri": "root://eospublic.cern.ch//eos/opendata/atlas/rucio/opendata/ODEO_FEB2025_v0_2J2LMET30_mc_600573.PhH7EG_WmH125J_Winc_MINLO_tt_ShowerSys_fix.2J2LMET30.root"
+      },
+      {
+        "checksum": "adler32:69e5743d",
+        "size": 563095,
+        "uri": "root://eospublic.cern.ch//eos/opendata/atlas/rucio/opendata/ODEO_FEB2025_v0_2J2LMET30_mc_600574.PhH7EG_WpH125J_Winc_MINLO_tt_ShowerSys_fix.2J2LMET30.root"
+      },
+      {
+        "checksum": "adler32:f332bf3a",
+        "size": 721960,
+        "uri": "root://eospublic.cern.ch//eos/opendata/atlas/rucio/opendata/ODEO_FEB2025_v0_2J2LMET30_mc_600575.PhH7EG_ZH125J_Zinc_MINLO_tautau_ShowerSys_fix.2J2LMET30.root"
+      },
+      {
+        "checksum": "adler32:b77d95c3",
+        "size": 631336,
+        "uri": "root://eospublic.cern.ch//eos/opendata/atlas/rucio/opendata/ODEO_FEB2025_v0_2J2LMET30_mc_600686.PhPy8EG_NNPDF3_AZNLO_ggZH125_Htautau_Zinc.2J2LMET30.root"
+      },
+      {
+        "checksum": "adler32:d0f4004b",
+        "size": 20374144,
+        "uri": "root://eospublic.cern.ch//eos/opendata/atlas/rucio/opendata/ODEO_FEB2025_v0_2J2LMET30_mc_601352.PhPy8EG_tW_dyn_DR_incl_antitop.2J2LMET30.root"
+      },
+      {
+        "checksum": "adler32:749e05a9",
+        "size": 20026948,
+        "uri": "root://eospublic.cern.ch//eos/opendata/atlas/rucio/opendata/ODEO_FEB2025_v0_2J2LMET30_mc_601355.PhPy8EG_tW_dyn_DR_incl_top.2J2LMET30.root"
+      },
+      {
+        "checksum": "adler32:f495f142",
+        "size": 2047468,
+        "uri": "root://eospublic.cern.ch//eos/opendata/atlas/rucio/opendata/ODEO_FEB2025_v0_2J2LMET30_mc_601487.PhPy8EG_A14_tchan_pThard1_lep_antitop.2J2LMET30.root"
+      },
+      {
+        "checksum": "adler32:a50d150e",
+        "size": 3270136,
+        "uri": "root://eospublic.cern.ch//eos/opendata/atlas/rucio/opendata/ODEO_FEB2025_v0_2J2LMET30_mc_601489.PhPy8EG_A14_tchan_pThard1_lep_top.2J2LMET30.root"
+      },
+      {
+        "checksum": "adler32:07fac77f",
+        "size": 532828220,
+        "uri": "root://eospublic.cern.ch//eos/opendata/atlas/rucio/opendata/ODEO_FEB2025_v0_2J2LMET30_mc_601491.PhPy8EG_A14_ttbar_pThard1_dil.2J2LMET30.root"
+      },
+      {
+        "checksum": "adler32:a017255f",
+        "size": 67134,
+        "uri": "root://eospublic.cern.ch//eos/opendata/atlas/rucio/opendata/ODEO_FEB2025_v0_2J2LMET30_mc_601495.PhPy8EG_A14_ttbar_pThard1_allhad.2J2LMET30.root"
+      },
+      {
+        "checksum": "adler32:db12047d",
+        "size": 89109540,
+        "uri": "root://eospublic.cern.ch//eos/opendata/atlas/rucio/opendata/ODEO_FEB2025_v0_2J2LMET30_mc_601497.PhPy8EG_A14_ttbar_pThard1_singlelep.2J2LMET30.root"
+      },
+      {
+        "checksum": "adler32:c44dda6e",
+        "size": 18013335,
+        "uri": "root://eospublic.cern.ch//eos/opendata/atlas/rucio/opendata/ODEO_FEB2025_v0_2J2LMET30_mc_601624.PhPy8EG_tW_DS_dyn_dil_antitop.2J2LMET30.root"
+      },
+      {
+        "checksum": "adler32:0b44a3bd",
+        "size": 18980034,
+        "uri": "root://eospublic.cern.ch//eos/opendata/atlas/rucio/opendata/ODEO_FEB2025_v0_2J2LMET30_mc_601627.PhPy8EG_tW_DS_dyn_incl_antitop.2J2LMET30.root"
+      },
+      {
+        "checksum": "adler32:466c75c6",
+        "size": 23051097,
+        "uri": "root://eospublic.cern.ch//eos/opendata/atlas/rucio/opendata/ODEO_FEB2025_v0_2J2LMET30_mc_601628.PhPy8EG_tW_DS_dyn_dil_top.2J2LMET30.root"
+      },
+      {
+        "checksum": "adler32:7843af8f",
+        "size": 18695078,
+        "uri": "root://eospublic.cern.ch//eos/opendata/atlas/rucio/opendata/ODEO_FEB2025_v0_2J2LMET30_mc_601631.PhPy8EG_tW_DS_dyn_incl_top.2J2LMET30.root"
+      },
+      {
+        "checksum": "adler32:f8f85202",
+        "size": 20519740,
+        "uri": "root://eospublic.cern.ch//eos/opendata/atlas/rucio/opendata/ODEO_FEB2025_v0_2J2LMET30_mc_601761.PhPy8EG_tW_dyn_DR_pThard1_incl_top.2J2LMET30.root"
+      },
+      {
+        "checksum": "adler32:d6d9f253",
+        "size": 20154994,
+        "uri": "root://eospublic.cern.ch//eos/opendata/atlas/rucio/opendata/ODEO_FEB2025_v0_2J2LMET30_mc_601762.PhPy8EG_tW_dyn_DR_pThard1_incl_antitop.2J2LMET30.root"
+      },
+      {
+        "checksum": "adler32:8a78b88e",
+        "size": 24379539,
+        "uri": "root://eospublic.cern.ch//eos/opendata/atlas/rucio/opendata/ODEO_FEB2025_v0_2J2LMET30_mc_601763.PhPy8EG_tW_dyn_DR_pThard1_dil_top.2J2LMET30.root"
+      },
+      {
+        "checksum": "adler32:83394c74",
+        "size": 24625022,
+        "uri": "root://eospublic.cern.ch//eos/opendata/atlas/rucio/opendata/ODEO_FEB2025_v0_2J2LMET30_mc_601764.PhPy8EG_tW_dyn_DR_pThard1_dil_antitop.2J2LMET30.root"
+      },
+      {
+        "checksum": "adler32:56a1b684",
+        "size": 5860981,
+        "uri": "root://eospublic.cern.ch//eos/opendata/atlas/rucio/opendata/ODEO_FEB2025_v0_2J2LMET30_mc_700000.Sh_228_ttW.2J2LMET30.root"
+      },
+      {
+        "checksum": "adler32:20505d09",
+        "size": 32221,
+        "uri": "root://eospublic.cern.ch//eos/opendata/atlas/rucio/opendata/ODEO_FEB2025_v0_2J2LMET30_mc_700007.Sh_228_yyy_01NLO.2J2LMET30.root"
+      },
+      {
+        "checksum": "adler32:d4ad29ff",
+        "size": 1227567,
+        "uri": "root://eospublic.cern.ch//eos/opendata/atlas/rucio/opendata/ODEO_FEB2025_v0_2J2LMET30_mc_700195.Sh_2210_eegammagamma.2J2LMET30.root"
+      },
+      {
+        "checksum": "adler32:fa3612b4",
+        "size": 4230179,
+        "uri": "root://eospublic.cern.ch//eos/opendata/atlas/rucio/opendata/ODEO_FEB2025_v0_2J2LMET30_mc_700196.Sh_2210_mumugammagamma.2J2LMET30.root"
+      },
+      {
+        "checksum": "adler32:244b811e",
+        "size": 96847,
+        "uri": "root://eospublic.cern.ch//eos/opendata/atlas/rucio/opendata/ODEO_FEB2025_v0_2J2LMET30_mc_700197.Sh_2210_tautaugammagamma.2J2LMET30.root"
+      },
+      {
+        "checksum": "adler32:ba996afb",
+        "size": 26211,
+        "uri": "root://eospublic.cern.ch//eos/opendata/atlas/rucio/opendata/ODEO_FEB2025_v0_2J2LMET30_mc_700198.Sh_2210_nunugammagamma.2J2LMET30.root"
+      },
+      {
+        "checksum": "adler32:9ebe2a81",
+        "size": 88998,
+        "uri": "root://eospublic.cern.ch//eos/opendata/atlas/rucio/opendata/ODEO_FEB2025_v0_2J2LMET30_mc_700199.Sh_2210_enugammagamma.2J2LMET30.root"
+      },
+      {
+        "checksum": "adler32:6fd3d235",
+        "size": 95234,
+        "uri": "root://eospublic.cern.ch//eos/opendata/atlas/rucio/opendata/ODEO_FEB2025_v0_2J2LMET30_mc_700200.Sh_2210_munugammagamma.2J2LMET30.root"
+      },
+      {
+        "checksum": "adler32:cdb9d067",
+        "size": 52433,
+        "uri": "root://eospublic.cern.ch//eos/opendata/atlas/rucio/opendata/ODEO_FEB2025_v0_2J2LMET30_mc_700201.Sh_2210_taunugammagamma.2J2LMET30.root"
+      },
+      {
+        "checksum": "adler32:89abe0ba",
+        "size": 245240820,
+        "uri": "root://eospublic.cern.ch//eos/opendata/atlas/rucio/opendata/ODEO_FEB2025_v0_2J2LMET30_mc_700320.Sh_2211_Zee_maxHTpTV2_BFilter.2J2LMET30.root"
+      },
+      {
+        "checksum": "adler32:d8edecea",
+        "size": 905601379,
+        "uri": "root://eospublic.cern.ch//eos/opendata/atlas/rucio/opendata/ODEO_FEB2025_v0_2J2LMET30_mc_700321.Sh_2211_Zee_maxHTpTV2_CFilterBVeto.2J2LMET30.root"
+      },
+      {
+        "checksum": "adler32:101e045e",
+        "size": 2244567753,
+        "uri": "root://eospublic.cern.ch//eos/opendata/atlas/rucio/opendata/ODEO_FEB2025_v0_2J2LMET30_mc_700322.Sh_2211_Zee_maxHTpTV2_CVetoBVeto.2J2LMET30.root"
+      },
+      {
+        "checksum": "adler32:64f95ad1",
+        "size": 487576131,
+        "uri": "root://eospublic.cern.ch//eos/opendata/atlas/rucio/opendata/ODEO_FEB2025_v0_2J2LMET30_mc_700323.Sh_2211_Zmumu_maxHTpTV2_BFilter.2J2LMET30.root"
+      },
+      {
+        "checksum": "adler32:c77d1af9",
+        "size": 2013809823,
+        "uri": "root://eospublic.cern.ch//eos/opendata/atlas/rucio/opendata/ODEO_FEB2025_v0_2J2LMET30_mc_700324.Sh_2211_Zmumu_maxHTpTV2_CFilterBVeto.2J2LMET30.root"
+      },
+      {
+        "checksum": "adler32:a0e88016",
+        "size": 5607695678,
+        "uri": "root://eospublic.cern.ch//eos/opendata/atlas/rucio/opendata/ODEO_FEB2025_v0_2J2LMET30_mc_700325.Sh_2211_Zmumu_maxHTpTV2_CVetoBVeto.2J2LMET30.root"
+      },
+      {
+        "checksum": "adler32:97c7005b",
+        "size": 335381,
+        "uri": "root://eospublic.cern.ch//eos/opendata/atlas/rucio/opendata/ODEO_FEB2025_v0_2J2LMET30_mc_700335.Sh_2211_Znunu_pTV2_BFilter.2J2LMET30.root"
+      },
+      {
+        "checksum": "adler32:16a0f504",
+        "size": 247319,
+        "uri": "root://eospublic.cern.ch//eos/opendata/atlas/rucio/opendata/ODEO_FEB2025_v0_2J2LMET30_mc_700336.Sh_2211_Znunu_pTV2_CFilterBVeto.2J2LMET30.root"
+      },
+      {
+        "checksum": "adler32:cae5b14e",
+        "size": 356132,
+        "uri": "root://eospublic.cern.ch//eos/opendata/atlas/rucio/opendata/ODEO_FEB2025_v0_2J2LMET30_mc_700337.Sh_2211_Znunu_pTV2_CVetoBVeto.2J2LMET30.root"
+      },
+      {
+        "checksum": "adler32:181d93af",
+        "size": 28800999,
+        "uri": "root://eospublic.cern.ch//eos/opendata/atlas/rucio/opendata/ODEO_FEB2025_v0_2J2LMET30_mc_700338.Sh_2211_Wenu_maxHTpTV2_BFilter.2J2LMET30.root"
+      },
+      {
+        "checksum": "adler32:14b3d258",
+        "size": 60615547,
+        "uri": "root://eospublic.cern.ch//eos/opendata/atlas/rucio/opendata/ODEO_FEB2025_v0_2J2LMET30_mc_700339.Sh_2211_Wenu_maxHTpTV2_CFilterBVeto.2J2LMET30.root"
+      },
+      {
+        "checksum": "adler32:6d1417ad",
+        "size": 37182050,
+        "uri": "root://eospublic.cern.ch//eos/opendata/atlas/rucio/opendata/ODEO_FEB2025_v0_2J2LMET30_mc_700340.Sh_2211_Wenu_maxHTpTV2_CVetoBVeto.2J2LMET30.root"
+      },
+      {
+        "checksum": "adler32:e3cfa1fd",
+        "size": 36606916,
+        "uri": "root://eospublic.cern.ch//eos/opendata/atlas/rucio/opendata/ODEO_FEB2025_v0_2J2LMET30_mc_700341.Sh_2211_Wmunu_maxHTpTV2_BFilter.2J2LMET30.root"
+      },
+      {
+        "checksum": "adler32:7936de09",
+        "size": 65860132,
+        "uri": "root://eospublic.cern.ch//eos/opendata/atlas/rucio/opendata/ODEO_FEB2025_v0_2J2LMET30_mc_700342.Sh_2211_Wmunu_maxHTpTV2_CFilterBVeto.2J2LMET30.root"
+      },
+      {
+        "checksum": "adler32:a78ef81b",
+        "size": 37664801,
+        "uri": "root://eospublic.cern.ch//eos/opendata/atlas/rucio/opendata/ODEO_FEB2025_v0_2J2LMET30_mc_700343.Sh_2211_Wmunu_maxHTpTV2_CVetoBVeto.2J2LMET30.root"
+      },
+      {
+        "checksum": "adler32:d7bb537b",
+        "size": 6791978,
+        "uri": "root://eospublic.cern.ch//eos/opendata/atlas/rucio/opendata/ODEO_FEB2025_v0_2J2LMET30_mc_700344.Sh_2211_Wtaunu_L_maxHTpTV2_BFilter.2J2LMET30.root"
+      },
+      {
+        "checksum": "adler32:5bd20b62",
+        "size": 11072586,
+        "uri": "root://eospublic.cern.ch//eos/opendata/atlas/rucio/opendata/ODEO_FEB2025_v0_2J2LMET30_mc_700345.Sh_2211_Wtaunu_L_maxHTpTV2_CFilterBVeto.2J2LMET30.root"
+      },
+      {
+        "checksum": "adler32:af53b2c6",
+        "size": 13070538,
+        "uri": "root://eospublic.cern.ch//eos/opendata/atlas/rucio/opendata/ODEO_FEB2025_v0_2J2LMET30_mc_700346.Sh_2211_Wtaunu_L_maxHTpTV2_CVetoBVeto.2J2LMET30.root"
+      },
+      {
+        "checksum": "adler32:b69e1804",
+        "size": 1664632,
+        "uri": "root://eospublic.cern.ch//eos/opendata/atlas/rucio/opendata/ODEO_FEB2025_v0_2J2LMET30_mc_700347.Sh_2211_Wtaunu_H_maxHTpTV2_BFilter.2J2LMET30.root"
+      },
+      {
+        "checksum": "adler32:f2feef7f",
+        "size": 909224,
+        "uri": "root://eospublic.cern.ch//eos/opendata/atlas/rucio/opendata/ODEO_FEB2025_v0_2J2LMET30_mc_700348.Sh_2211_Wtaunu_H_maxHTpTV2_CFilterBVeto.2J2LMET30.root"
+      },
+      {
+        "checksum": "adler32:ed40b9a7",
+        "size": 2726153,
+        "uri": "root://eospublic.cern.ch//eos/opendata/atlas/rucio/opendata/ODEO_FEB2025_v0_2J2LMET30_mc_700349.Sh_2211_Wtaunu_H_maxHTpTV2_CVetoBVeto.2J2LMET30.root"
+      },
+      {
+        "checksum": "adler32:f2bd290f",
+        "size": 88331,
+        "uri": "root://eospublic.cern.ch//eos/opendata/atlas/rucio/opendata/ODEO_FEB2025_v0_2J2LMET30_mc_700352.Sh_2211_pTZ100_Zqqgamma.2J2LMET30.root"
+      },
+      {
+        "checksum": "adler32:14ca9c20",
+        "size": 63908,
+        "uri": "root://eospublic.cern.ch//eos/opendata/atlas/rucio/opendata/ODEO_FEB2025_v0_2J2LMET30_mc_700353.Sh_2211_pTZ100_Zbbgamma.2J2LMET30.root"
+      },
+      {
+        "checksum": "adler32:1f6aad10",
+        "size": 4018070,
+        "uri": "root://eospublic.cern.ch//eos/opendata/atlas/rucio/opendata/ODEO_FEB2025_v0_2J2LMET30_mc_700358.Sh_2211_Zee2jets_Min_N_TChannel.2J2LMET30.root"
+      },
+      {
+        "checksum": "adler32:76e7ef09",
+        "size": 9596636,
+        "uri": "root://eospublic.cern.ch//eos/opendata/atlas/rucio/opendata/ODEO_FEB2025_v0_2J2LMET30_mc_700359.Sh_2211_Zmm2jets_Min_N_TChannel.2J2LMET30.root"
+      },
+      {
+        "checksum": "adler32:3dcae827",
+        "size": 417182,
+        "uri": "root://eospublic.cern.ch//eos/opendata/atlas/rucio/opendata/ODEO_FEB2025_v0_2J2LMET30_mc_700360.Sh_2211_Ztt2jets_Min_N_TChannel.2J2LMET30.root"
+      },
+      {
+        "checksum": "adler32:082768d6",
+        "size": 1267,
+        "uri": "root://eospublic.cern.ch//eos/opendata/atlas/rucio/opendata/ODEO_FEB2025_v0_2J2LMET30_mc_700361.Sh_2211_Znunu2jets_Min_N_TChannel.2J2LMET30.root"
+      },
+      {
+        "checksum": "adler32:4cde4b65",
+        "size": 298212,
+        "uri": "root://eospublic.cern.ch//eos/opendata/atlas/rucio/opendata/ODEO_FEB2025_v0_2J2LMET30_mc_700362.Sh_2211_Wenu2jets_Min_N_TChannel.2J2LMET30.root"
+      },
+      {
+        "checksum": "adler32:9dfd4902",
+        "size": 365091,
+        "uri": "root://eospublic.cern.ch//eos/opendata/atlas/rucio/opendata/ODEO_FEB2025_v0_2J2LMET30_mc_700363.Sh_2211_Wmunu2jets_Min_N_TChannel.2J2LMET30.root"
+      },
+      {
+        "checksum": "adler32:82589c0f",
+        "size": 154441,
+        "uri": "root://eospublic.cern.ch//eos/opendata/atlas/rucio/opendata/ODEO_FEB2025_v0_2J2LMET30_mc_700364.Sh_2211_Wtaunu2jets_Min_N_TChannel.2J2LMET30.root"
+      },
+      {
+        "checksum": "adler32:b1c2c9db",
+        "size": 341489589,
+        "uri": "root://eospublic.cern.ch//eos/opendata/atlas/rucio/opendata/ODEO_FEB2025_v0_2J2LMET30_mc_700398.Sh_2211_mumugamma.2J2LMET30.root"
+      },
+      {
+        "checksum": "adler32:f07bcf9b",
+        "size": 155103816,
+        "uri": "root://eospublic.cern.ch//eos/opendata/atlas/rucio/opendata/ODEO_FEB2025_v0_2J2LMET30_mc_700399.Sh_2211_eegamma.2J2LMET30.root"
+      },
+      {
+        "checksum": "adler32:63b0cbd9",
+        "size": 15464866,
+        "uri": "root://eospublic.cern.ch//eos/opendata/atlas/rucio/opendata/ODEO_FEB2025_v0_2J2LMET30_mc_700400.Sh_2211_tautaugamma.2J2LMET30.root"
+      },
+      {
+        "checksum": "adler32:aa2f8ea1",
+        "size": 662592,
+        "uri": "root://eospublic.cern.ch//eos/opendata/atlas/rucio/opendata/ODEO_FEB2025_v0_2J2LMET30_mc_700401.Sh_2211_nunugamma.2J2LMET30.root"
+      },
+      {
+        "checksum": "adler32:554ea4bc",
+        "size": 19328712,
+        "uri": "root://eospublic.cern.ch//eos/opendata/atlas/rucio/opendata/ODEO_FEB2025_v0_2J2LMET30_mc_700402.Sh_2211_munugamma.2J2LMET30.root"
+      },
+      {
+        "checksum": "adler32:41db0b00",
+        "size": 17980081,
+        "uri": "root://eospublic.cern.ch//eos/opendata/atlas/rucio/opendata/ODEO_FEB2025_v0_2J2LMET30_mc_700403.Sh_2211_enugamma.2J2LMET30.root"
+      },
+      {
+        "checksum": "adler32:321b38b1",
+        "size": 8341973,
+        "uri": "root://eospublic.cern.ch//eos/opendata/atlas/rucio/opendata/ODEO_FEB2025_v0_2J2LMET30_mc_700404.Sh_2211_taunugamma.2J2LMET30.root"
+      },
+      {
+        "checksum": "adler32:2b002ce8",
+        "size": 27436,
+        "uri": "root://eospublic.cern.ch//eos/opendata/atlas/rucio/opendata/ODEO_FEB2025_v0_2J2LMET30_mc_700442.Sh_2211_gamma2jets_pTy140_Min_N_TChannel.2J2LMET30.root"
+      },
+      {
+        "checksum": "adler32:8bff3ae4",
+        "size": 14633533,
+        "uri": "root://eospublic.cern.ch//eos/opendata/atlas/rucio/opendata/ODEO_FEB2025_v0_2J2LMET30_mc_700467.Sh_2211_Zee_maxHTpTV2_m10_40_pT5_BFilter.2J2LMET30.root"
+      },
+      {
+        "checksum": "adler32:7a4b29bb",
+        "size": 55539140,
+        "uri": "root://eospublic.cern.ch//eos/opendata/atlas/rucio/opendata/ODEO_FEB2025_v0_2J2LMET30_mc_700468.Sh_2211_Zee_maxHTpTV2_m10_40_pT5_CFilterBVeto.2J2LMET30.root"
+      },
+      {
+        "checksum": "adler32:3f7c1025",
+        "size": 255506776,
+        "uri": "root://eospublic.cern.ch//eos/opendata/atlas/rucio/opendata/ODEO_FEB2025_v0_2J2LMET30_mc_700469.Sh_2211_Zee_maxHTpTV2_m10_40_pT5_CVetoBVeto.2J2LMET30.root"
+      },
+      {
+        "checksum": "adler32:acb4072c",
+        "size": 30137278,
+        "uri": "root://eospublic.cern.ch//eos/opendata/atlas/rucio/opendata/ODEO_FEB2025_v0_2J2LMET30_mc_700470.Sh_2211_Zmumu_maxHTpTV2_m10_40_pT5_BFilter.2J2LMET30.root"
+      },
+      {
+        "checksum": "adler32:1252c268",
+        "size": 117231801,
+        "uri": "root://eospublic.cern.ch//eos/opendata/atlas/rucio/opendata/ODEO_FEB2025_v0_2J2LMET30_mc_700471.Sh_2211_Zmumu_maxHTpTV2_m10_40_pT5_CFilterBVeto.2J2LMET30.root"
+      },
+      {
+        "checksum": "adler32:47ed1e73",
+        "size": 560358907,
+        "uri": "root://eospublic.cern.ch//eos/opendata/atlas/rucio/opendata/ODEO_FEB2025_v0_2J2LMET30_mc_700472.Sh_2211_Zmumu_maxHTpTV2_m10_40_pT5_CVetoBVeto.2J2LMET30.root"
+      },
+      {
+        "checksum": "adler32:07661610",
+        "size": 1766760,
+        "uri": "root://eospublic.cern.ch//eos/opendata/atlas/rucio/opendata/ODEO_FEB2025_v0_2J2LMET30_mc_700488.Sh_2211_WlvWqq.2J2LMET30.root"
+      },
+      {
+        "checksum": "adler32:4280b9f6",
+        "size": 416667,
+        "uri": "root://eospublic.cern.ch//eos/opendata/atlas/rucio/opendata/ODEO_FEB2025_v0_2J2LMET30_mc_700489.Sh_2211_WlvZqq.2J2LMET30.root"
+      },
+      {
+        "checksum": "adler32:e8f5a498",
+        "size": 392681,
+        "uri": "root://eospublic.cern.ch//eos/opendata/atlas/rucio/opendata/ODEO_FEB2025_v0_2J2LMET30_mc_700490.Sh_2211_WlvZbb.2J2LMET30.root"
+      },
+      {
+        "checksum": "adler32:997ee094",
+        "size": 39739,
+        "uri": "root://eospublic.cern.ch//eos/opendata/atlas/rucio/opendata/ODEO_FEB2025_v0_2J2LMET30_mc_700491.Sh_2211_WqqZvv.2J2LMET30.root"
+      },
+      {
+        "checksum": "adler32:33f5ee1d",
+        "size": 12888048,
+        "uri": "root://eospublic.cern.ch//eos/opendata/atlas/rucio/opendata/ODEO_FEB2025_v0_2J2LMET30_mc_700492.Sh_2211_WqqZll.2J2LMET30.root"
+      },
+      {
+        "checksum": "adler32:ea709aea",
+        "size": 9282679,
+        "uri": "root://eospublic.cern.ch//eos/opendata/atlas/rucio/opendata/ODEO_FEB2025_v0_2J2LMET30_mc_700493.Sh_2211_ZqqZll.2J2LMET30.root"
+      },
+      {
+        "checksum": "adler32:07bdb743",
+        "size": 8999552,
+        "uri": "root://eospublic.cern.ch//eos/opendata/atlas/rucio/opendata/ODEO_FEB2025_v0_2J2LMET30_mc_700494.Sh_2211_ZbbZll.2J2LMET30.root"
+      },
+      {
+        "checksum": "adler32:cc09b69c",
+        "size": 26170,
+        "uri": "root://eospublic.cern.ch//eos/opendata/atlas/rucio/opendata/ODEO_FEB2025_v0_2J2LMET30_mc_700495.Sh_2211_ZqqZvv.2J2LMET30.root"
+      },
+      {
+        "checksum": "adler32:da7b1d2b",
+        "size": 27407,
+        "uri": "root://eospublic.cern.ch//eos/opendata/atlas/rucio/opendata/ODEO_FEB2025_v0_2J2LMET30_mc_700496.Sh_2211_ZbbZvv.2J2LMET30.root"
+      },
+      {
+        "checksum": "adler32:b8cbaab4",
+        "size": 27678,
+        "uri": "root://eospublic.cern.ch//eos/opendata/atlas/rucio/opendata/ODEO_FEB2025_v0_2J2LMET30_mc_700507.Sh_2211_pTW140_Wqqgamma.2J2LMET30.root"
+      },
+      {
+        "checksum": "adler32:9daa382e",
+        "size": 5721649,
+        "uri": "root://eospublic.cern.ch//eos/opendata/atlas/rucio/opendata/ODEO_FEB2025_v0_2J2LMET30_mc_700587.Sh_2212_lllljj.2J2LMET30.root"
+      },
+      {
+        "checksum": "adler32:87fecc9e",
+        "size": 3139479,
+        "uri": "root://eospublic.cern.ch//eos/opendata/atlas/rucio/opendata/ODEO_FEB2025_v0_2J2LMET30_mc_700588.Sh_2212_lllvjj.2J2LMET30.root"
+      },
+      {
+        "checksum": "adler32:5d6c7968",
+        "size": 2200971,
+        "uri": "root://eospublic.cern.ch//eos/opendata/atlas/rucio/opendata/ODEO_FEB2025_v0_2J2LMET30_mc_700589.Sh_2212_llvvjj_os.2J2LMET30.root"
+      },
+      {
+        "checksum": "adler32:6538f850",
+        "size": 5557509,
+        "uri": "root://eospublic.cern.ch//eos/opendata/atlas/rucio/opendata/ODEO_FEB2025_v0_2J2LMET30_mc_700590.Sh_2212_llvvjj_ss.2J2LMET30.root"
+      },
+      {
+        "checksum": "adler32:8698f69a",
+        "size": 620793,
+        "uri": "root://eospublic.cern.ch//eos/opendata/atlas/rucio/opendata/ODEO_FEB2025_v0_2J2LMET30_mc_700591.Sh_2212_lllljj_Int.2J2LMET30.root"
+      },
+      {
+        "checksum": "adler32:df4c7c69",
+        "size": 1238926,
+        "uri": "root://eospublic.cern.ch//eos/opendata/atlas/rucio/opendata/ODEO_FEB2025_v0_2J2LMET30_mc_700592.Sh_2212_lllvjj_Int.2J2LMET30.root"
+      },
+      {
+        "checksum": "adler32:d0369513",
+        "size": 1285990,
+        "uri": "root://eospublic.cern.ch//eos/opendata/atlas/rucio/opendata/ODEO_FEB2025_v0_2J2LMET30_mc_700593.Sh_2212_llvvjj_os_Int.2J2LMET30.root"
+      },
+      {
+        "checksum": "adler32:12f2abd4",
+        "size": 1454656,
+        "uri": "root://eospublic.cern.ch//eos/opendata/atlas/rucio/opendata/ODEO_FEB2025_v0_2J2LMET30_mc_700594.Sh_2212_llvvjj_ss_Int.2J2LMET30.root"
+      },
+      {
+        "checksum": "adler32:644274fd",
+        "size": 8825700,
+        "uri": "root://eospublic.cern.ch//eos/opendata/atlas/rucio/opendata/ODEO_FEB2025_v0_2J2LMET30_mc_700600.Sh_2212_llll.2J2LMET30.root"
+      },
+      {
+        "checksum": "adler32:cab6f571",
+        "size": 26576427,
+        "uri": "root://eospublic.cern.ch//eos/opendata/atlas/rucio/opendata/ODEO_FEB2025_v0_2J2LMET30_mc_700601.Sh_2212_lllv.2J2LMET30.root"
+      },
+      {
+        "checksum": "adler32:2503063f",
+        "size": 36438790,
+        "uri": "root://eospublic.cern.ch//eos/opendata/atlas/rucio/opendata/ODEO_FEB2025_v0_2J2LMET30_mc_700602.Sh_2212_llvv_os.2J2LMET30.root"
+      },
+      {
+        "checksum": "adler32:f3a36509",
+        "size": 8620328,
+        "uri": "root://eospublic.cern.ch//eos/opendata/atlas/rucio/opendata/ODEO_FEB2025_v0_2J2LMET30_mc_700603.Sh_2212_llvv_ss.2J2LMET30.root"
+      },
+      {
+        "checksum": "adler32:68cb8880",
+        "size": 152615,
+        "uri": "root://eospublic.cern.ch//eos/opendata/atlas/rucio/opendata/ODEO_FEB2025_v0_2J2LMET30_mc_700604.Sh_2212_lvvv.2J2LMET30.root"
+      },
+      {
+        "checksum": "adler32:c6c6791f",
+        "size": 26213,
+        "uri": "root://eospublic.cern.ch//eos/opendata/atlas/rucio/opendata/ODEO_FEB2025_v0_2J2LMET30_mc_700605.Sh_2212_vvvv.2J2LMET30.root"
+      },
+      {
+        "checksum": "adler32:601c96ef",
+        "size": 134092,
+        "uri": "root://eospublic.cern.ch//eos/opendata/atlas/rucio/opendata/ODEO_FEB2025_v0_2J2LMET30_mc_700709.Sh_2212_lvgammajj.2J2LMET30.root"
+      },
+      {
+        "checksum": "adler32:97a46a9c",
+        "size": 7811150,
+        "uri": "root://eospublic.cern.ch//eos/opendata/atlas/rucio/opendata/ODEO_FEB2025_v0_2J2LMET30_mc_700710.Sh_2212_llgammajj.2J2LMET30.root"
+      },
+      {
+        "checksum": "adler32:a6b4244f",
+        "size": 20006997,
+        "uri": "root://eospublic.cern.ch//eos/opendata/atlas/rucio/opendata/ODEO_FEB2025_v0_2J2LMET30_mc_700792.Sh_2214_Ztautau_maxHTpTV2_BFilter.2J2LMET30.root"
+      },
+      {
+        "checksum": "adler32:ebf6cf5a",
+        "size": 78722691,
+        "uri": "root://eospublic.cern.ch//eos/opendata/atlas/rucio/opendata/ODEO_FEB2025_v0_2J2LMET30_mc_700793.Sh_2214_Ztautau_maxHTpTV2_CFilterBVeto.2J2LMET30.root"
+      },
+      {
+        "checksum": "adler32:006114ef",
+        "size": 132031033,
+        "uri": "root://eospublic.cern.ch//eos/opendata/atlas/rucio/opendata/ODEO_FEB2025_v0_2J2LMET30_mc_700794.Sh_2214_Ztautau_maxHTpTV2_CVetoBVeto.2J2LMET30.root"
+      },
+      {
+        "checksum": "adler32:9e03dc79",
+        "size": 441991,
+        "uri": "root://eospublic.cern.ch//eos/opendata/atlas/rucio/opendata/ODEO_FEB2025_v0_2J2LMET30_mc_700843.Sh_2214_Wqq_ptW_200_ECMS.2J2LMET30.root"
+      },
+      {
+        "checksum": "adler32:cbd236b3",
+        "size": 162910,
+        "uri": "root://eospublic.cern.ch//eos/opendata/atlas/rucio/opendata/ODEO_FEB2025_v0_2J2LMET30_mc_700849.Sh_2214_Zqq_ptZ_200_ECMS.2J2LMET30.root"
+      },
+      {
+        "checksum": "adler32:69288b97",
+        "size": 150244,
+        "uri": "root://eospublic.cern.ch//eos/opendata/atlas/rucio/opendata/ODEO_FEB2025_v0_2J2LMET30_mc_700855.Sh_2214_Zbb_ptZ_200_ECMS.2J2LMET30.root"
+      },
+      {
+        "checksum": "adler32:0bac08f0",
+        "size": 1595091,
+        "uri": "root://eospublic.cern.ch//eos/opendata/atlas/rucio/opendata/ODEO_FEB2025_v0_2J2LMET30_mc_700901.Sh_2214_Ztt_maxHTpTV2_Mll10_40_BFilter.2J2LMET30.root"
+      },
+      {
+        "checksum": "adler32:b8c83df2",
+        "size": 7796271,
+        "uri": "root://eospublic.cern.ch//eos/opendata/atlas/rucio/opendata/ODEO_FEB2025_v0_2J2LMET30_mc_700902.Sh_2214_Ztt_maxHTpTV2_Mll10_40_CFilterBVeto.2J2LMET30.root"
+      },
+      {
+        "checksum": "adler32:2e4df1a3",
+        "size": 14424187,
+        "uri": "root://eospublic.cern.ch//eos/opendata/atlas/rucio/opendata/ODEO_FEB2025_v0_2J2LMET30_mc_700903.Sh_2214_Ztt_maxHTpTV2_Mll10_40_CVetoBVeto.2J2LMET30.root"
+      },
+      {
+        "checksum": "adler32:aae7bda4",
+        "size": 457537,
+        "uri": "root://eospublic.cern.ch//eos/opendata/atlas/rucio/opendata/ODEO_FEB2025_v0_2J2LMET30_mc_801976.Py8EG_A14NNPDF23LO_Zprime_NoInt_tautau_SSM3000.2J2LMET30.root"
+      },
+      {
+        "checksum": "adler32:e26bd800",
+        "size": 26396,
+        "uri": "root://eospublic.cern.ch//eos/opendata/atlas/rucio/opendata/ODEO_FEB2025_v0_2J2LMET30_mc_801978.Py8EG_A14NNPDF23LO_Wprime_taunu_SSM3000.2J2LMET30.root"
+      }
+    ],
+    "license": {
+      "attribution": "CC0-1.0"
+    },
+    "methodology": {
+      "description": "<p>These data were created during LS2 as part of a major reprocessing campaign of the Run 2 data. All data were reprocessed using Athena Release 22, and new corresponding MC simulation samples were produced. These data and MC simulation datasets were processed into ROOT ntuple files from the DAOD_PHYSLITE format that is released as open data for research. For the files in this record, the following skimming selection was applied: At least two jets with at least 20 GeV of p<sub>T</sub>, at least two leptons passing tight identification requirements with at least 7 GeV of p<sub>T</sub>, and 30 GeV of missing transverse momentum (i.e. a di-leptonic top-quark enhanced selection)"
+    },
+    "publisher": "CERN Open Data Portal",
+    "recid": "93913",
+    "relations": [
+      {
+        "description": "For citing all the Open Data for Education and Outreach from this release, and to find other related datasets, please see",
+        "doi": "10.7483/OPENDATA.ATLAS.B5M9.44TN",
+        "recid": "93910",
+        "title": "ROOT ntuple format 2015-2016 proton-proton Open Data for Education and Outreach from the ATLAS experiment",
+        "type": "isChildOf"
+      }
+    ],
+    "run_period": [
+      "2015",
+      "2016"
+    ],
+    "title": "ATLAS ROOT ntuple format MC simulation, 2015+2016 proton-proton collisions beta release, 2J2LMET30 skim",
+    "type": {
+      "primary": "Dataset",
+      "secondary": [
+        "Simulated"
+      ]
+    },
+    "usage": {
+      "description": "<p> The data and MC simulation provided by the ATLAS experiment in root ntuple format is released under a CC0 license; citation of the data and acknowledgement of the collaboration is requested. This format can be used directly using ROOT or uproot for simple studies and is primarily intended for educational and outreach purposes. <p>Extensive instructions for interacting with the data, as well as documentation of the dataset naming conventions and their contents, are provided on the ATLAS Open Data website linked below. For those interested in implementing a research-quality data analysis, the open data designed for research (also linked below) may be a better starting point. Please be sure to cite the Open Data that you use, in line with the policy below.",
+      "links": [
+        {
+          "description": "ATLAS Open Data Website",
+          "url": "http://opendata.atlas.cern"
+        },
+        {
+          "description": "Resources to understand and use the open data for education and outreach",
+          "url": "https://opendata.atlas.cern/docs/category/13-tev-tutorials-for-education"
+        },
+        {
+          "description": "More about this ntuple format",
+          "url": "https://opendata.atlas.cern/docs/data/for_education/13TeV25_details"
+        },
+        {
+          "description": "Ntuple making framework",
+          "url": "http://gitlab.cern.ch/atlas-outreach-data-tools/physlitetoopendata"
+        },
+        {
+          "description": "Citation policy",
+          "url": "https://opendata.atlas.cern/docs/documentation/ethical_legal/citation_policy"
+        }
+      ]
+    }
+  }
+]

--- a/data/records/atlas-odeo-FEB2025-2j2lmet30-mc.json
+++ b/data/records/atlas-odeo-FEB2025-2j2lmet30-mc.json
@@ -1939,15 +1939,15 @@
         },
         {
           "description": "Resources to understand and use the open data for education and outreach",
-          "url": "https://opendata.atlas.cern/docs/category/13-tev-tutorials-for-education"
+          "url": "https://opendata.atlas.cern/docs/category/13-tev-2025-beta-release"
         },
         {
           "description": "More about this ntuple format",
-          "url": "https://opendata.atlas.cern/docs/data/for_education/13TeV25_details"
+          "url": "https://opendata.atlas.cern/docs/data/for_education/13TeV25_details#variable-list"
         },
         {
-          "description": "Ntuple making framework",
-          "url": "http://gitlab.cern.ch/atlas-outreach-data-tools/physlitetoopendata"
+          "description": "Ntuple making framework (PhysLiteToOpenData)",
+          "url": "https://doi.org/10.5281/zenodo.15791091"
         },
         {
           "description": "Citation policy",

--- a/data/records/atlas-odeo-FEB2025-2muons-data.json
+++ b/data/records/atlas-odeo-FEB2025-2muons-data.json
@@ -1,0 +1,174 @@
+[
+  {
+    "abstract": {
+      "description": "Run 2 2015+2016 proton-proton collision data beta release, 2muons skim from the ATLAS experiment"
+    },
+    "accelerator": "CERN-LHC",
+    "categories": {
+      "source": "ATLAS Collaboration"
+    },
+    "collaboration": {
+      "name": "ATLAS collaboration"
+    },
+    "collections": [
+      "ATLAS-Primary-Datasets"
+    ],
+    "collision_information": {
+      "energy": "13TeV",
+      "type": "pp"
+    },
+    "date_created": [
+      "2015",
+      "2016"
+    ],
+    "date_published": "2025",
+    "date_reprocessed": "2020",
+    "distribution": {
+      "formats": [
+        "root"
+      ],
+      "number_events": 72563712,
+      "number_files": 16,
+      "size": 19626604357
+    },
+    "doi": "10.7483/OPENDATA.ATLAS.6VGH.HN41",
+    "experiment": [
+      "ATLAS"
+    ],
+    "files": [
+      {
+        "checksum": "adler32:17f281d8",
+        "size": 34181982,
+        "uri": "root://eospublic.cern.ch//eos/opendata/atlas/rucio/opendata/ODEO_FEB2025_v0_2muons_data15_periodD.2muons.root"
+      },
+      {
+        "checksum": "adler32:e0380173",
+        "size": 284335909,
+        "uri": "root://eospublic.cern.ch//eos/opendata/atlas/rucio/opendata/ODEO_FEB2025_v0_2muons_data15_periodE.2muons.root"
+      },
+      {
+        "checksum": "adler32:7be5c86b",
+        "size": 190572117,
+        "uri": "root://eospublic.cern.ch//eos/opendata/atlas/rucio/opendata/ODEO_FEB2025_v0_2muons_data15_periodF.2muons.root"
+      },
+      {
+        "checksum": "adler32:70f4c26f",
+        "size": 452886737,
+        "uri": "root://eospublic.cern.ch//eos/opendata/atlas/rucio/opendata/ODEO_FEB2025_v0_2muons_data15_periodG.2muons.root"
+      },
+      {
+        "checksum": "adler32:3b2861d2",
+        "size": 157082301,
+        "uri": "root://eospublic.cern.ch//eos/opendata/atlas/rucio/opendata/ODEO_FEB2025_v0_2muons_data15_periodH.2muons.root"
+      },
+      {
+        "checksum": "adler32:398384d1",
+        "size": 893409776,
+        "uri": "root://eospublic.cern.ch//eos/opendata/atlas/rucio/opendata/ODEO_FEB2025_v0_2muons_data15_periodJ.2muons.root"
+      },
+      {
+        "checksum": "adler32:c81b40be",
+        "size": 365193839,
+        "uri": "root://eospublic.cern.ch//eos/opendata/atlas/rucio/opendata/ODEO_FEB2025_v0_2muons_data16_periodA.2muons.root"
+      },
+      {
+        "checksum": "adler32:6c46075c",
+        "size": 1032172360,
+        "uri": "root://eospublic.cern.ch//eos/opendata/atlas/rucio/opendata/ODEO_FEB2025_v0_2muons_data16_periodB.2muons.root"
+      },
+      {
+        "checksum": "adler32:bc4cb1bc",
+        "size": 1317898281,
+        "uri": "root://eospublic.cern.ch//eos/opendata/atlas/rucio/opendata/ODEO_FEB2025_v0_2muons_data16_periodC.2muons.root"
+      },
+      {
+        "checksum": "adler32:87510dd8",
+        "size": 2590419357,
+        "uri": "root://eospublic.cern.ch//eos/opendata/atlas/rucio/opendata/ODEO_FEB2025_v0_2muons_data16_periodD.2muons.root"
+      },
+      {
+        "checksum": "adler32:9fb95a2d",
+        "size": 819452028,
+        "uri": "root://eospublic.cern.ch//eos/opendata/atlas/rucio/opendata/ODEO_FEB2025_v0_2muons_data16_periodE.2muons.root"
+      },
+      {
+        "checksum": "adler32:c6ffd04d",
+        "size": 1818236864,
+        "uri": "root://eospublic.cern.ch//eos/opendata/atlas/rucio/opendata/ODEO_FEB2025_v0_2muons_data16_periodF.2muons.root"
+      },
+      {
+        "checksum": "adler32:f947064b",
+        "size": 2052209952,
+        "uri": "root://eospublic.cern.ch//eos/opendata/atlas/rucio/opendata/ODEO_FEB2025_v0_2muons_data16_periodG.2muons.root"
+      },
+      {
+        "checksum": "adler32:4ee6b10e",
+        "size": 3104180109,
+        "uri": "root://eospublic.cern.ch//eos/opendata/atlas/rucio/opendata/ODEO_FEB2025_v0_2muons_data16_periodI.2muons.root"
+      },
+      {
+        "checksum": "adler32:1cac589c",
+        "size": 1191870521,
+        "uri": "root://eospublic.cern.ch//eos/opendata/atlas/rucio/opendata/ODEO_FEB2025_v0_2muons_data16_periodK.2muons.root"
+      },
+      {
+        "checksum": "adler32:c3e15e36",
+        "size": 3322502224,
+        "uri": "root://eospublic.cern.ch//eos/opendata/atlas/rucio/opendata/ODEO_FEB2025_v0_2muons_data16_periodL.2muons.root"
+      }
+    ],
+    "license": {
+      "attribution": "CC0-1.0"
+    },
+    "methodology": {
+      "description": "<p>These data were created during LS2 as part of a major reprocessing campaign of the Run 2 data. All data were reprocessed using Athena Release 22, and new corresponding MC simulation samples were produced. These data and MC simulation datasets were processed into ROOT ntuple files from the DAOD_PHYSLITE format that is released as open data for research. For the files in this record, the following skimming selection was applied: At least two muons with at least 10 GeV of p<sub>T</sub> (i.e. a leptonically-decaying Z-boson enhanced selection)"
+    },
+    "publisher": "CERN Open Data Portal",
+    "recid": "93921",
+    "relations": [
+      {
+        "description": "For citing all the Open Data for Education and Outreach from this release, and to find other related datasets, please see",
+        "doi": "10.7483/OPENDATA.ATLAS.B5M9.44TN",
+        "recid": "93910",
+        "title": "ROOT ntuple format 2015-2016 proton-proton Open Data for Education and Outreach from the ATLAS experiment",
+        "type": "isChildOf"
+      }
+    ],
+    "run_period": [
+      "2015",
+      "2016"
+    ],
+    "title": "ATLAS ROOT ntuple format Run 2 2015+2016 proton-proton collision data beta release, 2muons skim",
+    "type": {
+      "primary": "Dataset",
+      "secondary": [
+        "Collision"
+      ]
+    },
+    "usage": {
+      "description": "<p> The data and MC simulation provided by the ATLAS experiment in root ntuple format is released under a CC0 license; citation of the data and acknowledgement of the collaboration is requested. This format can be used directly using ROOT or uproot for simple studies and is primarily intended for educational and outreach purposes. <p>Extensive instructions for interacting with the data, as well as documentation of the dataset naming conventions and their contents, are provided on the ATLAS Open Data website linked below. For those interested in implementing a research-quality data analysis, the open data designed for research (also linked below) may be a better starting point. Please be sure to cite the Open Data that you use, in line with the policy below.",
+      "links": [
+        {
+          "description": "ATLAS Open Data Website",
+          "url": "http://opendata.atlas.cern"
+        },
+        {
+          "description": "Resources to understand and use the open data for education and outreach",
+          "url": "https://opendata.atlas.cern/docs/category/13-tev-tutorials-for-education"
+        },
+        {
+          "description": "More about this ntuple format",
+          "url": "https://opendata.atlas.cern/docs/data/for_education/13TeV25_details"
+        },
+        {
+          "description": "Ntuple making framework",
+          "url": "http://gitlab.cern.ch/atlas-outreach-data-tools/physlitetoopendata"
+        },
+        {
+          "description": "Citation policy",
+          "url": "https://opendata.atlas.cern/docs/documentation/ethical_legal/citation_policy"
+        }
+      ]
+    }
+  }
+]

--- a/data/records/atlas-odeo-FEB2025-2muons-data.json
+++ b/data/records/atlas-odeo-FEB2025-2muons-data.json
@@ -154,15 +154,15 @@
         },
         {
           "description": "Resources to understand and use the open data for education and outreach",
-          "url": "https://opendata.atlas.cern/docs/category/13-tev-tutorials-for-education"
+          "url": "https://opendata.atlas.cern/docs/category/13-tev-2025-beta-release"
         },
         {
           "description": "More about this ntuple format",
-          "url": "https://opendata.atlas.cern/docs/data/for_education/13TeV25_details"
+          "url": "https://opendata.atlas.cern/docs/data/for_education/13TeV25_details#variable-list"
         },
         {
-          "description": "Ntuple making framework",
-          "url": "http://gitlab.cern.ch/atlas-outreach-data-tools/physlitetoopendata"
+          "description": "Ntuple making framework (PhysLiteToOpenData)",
+          "url": "https://doi.org/10.5281/zenodo.15791091"
         },
         {
           "description": "Citation policy",

--- a/data/records/atlas-odeo-FEB2025-2muons-mc.json
+++ b/data/records/atlas-odeo-FEB2025-2muons-mc.json
@@ -1939,15 +1939,15 @@
         },
         {
           "description": "Resources to understand and use the open data for education and outreach",
-          "url": "https://opendata.atlas.cern/docs/category/13-tev-tutorials-for-education"
+          "url": "https://opendata.atlas.cern/docs/category/13-tev-2025-beta-release"
         },
         {
           "description": "More about this ntuple format",
-          "url": "https://opendata.atlas.cern/docs/data/for_education/13TeV25_details"
+          "url": "https://opendata.atlas.cern/docs/data/for_education/13TeV25_details#variable-list"
         },
         {
-          "description": "Ntuple making framework",
-          "url": "http://gitlab.cern.ch/atlas-outreach-data-tools/physlitetoopendata"
+          "description": "Ntuple making framework (PhysLiteToOpenData)",
+          "url": "https://doi.org/10.5281/zenodo.15791091"
         },
         {
           "description": "Citation policy",

--- a/data/records/atlas-odeo-FEB2025-2muons-mc.json
+++ b/data/records/atlas-odeo-FEB2025-2muons-mc.json
@@ -1,0 +1,1959 @@
+[
+  {
+    "abstract": {
+      "description": "MC simulation, 2015+2016 proton-proton collisions beta release, 2muons skim from the ATLAS experiment"
+    },
+    "accelerator": "CERN-LHC",
+    "categories": {
+      "source": "ATLAS Collaboration"
+    },
+    "collaboration": {
+      "name": "ATLAS collaboration"
+    },
+    "collections": [
+      "ATLAS-Primary-Datasets"
+    ],
+    "collision_information": {
+      "energy": "13TeV",
+      "type": "pp"
+    },
+    "date_created": [
+      "2015",
+      "2016"
+    ],
+    "date_published": "2025",
+    "date_reprocessed": "2020",
+    "distribution": {
+      "formats": [
+        "root"
+      ],
+      "number_events": 68737415,
+      "number_files": 373,
+      "size": 28650197320
+    },
+    "doi": "10.7483/OPENDATA.ATLAS.AR66.6RTA",
+    "experiment": [
+      "ATLAS"
+    ],
+    "files": [
+      {
+        "checksum": "adler32:5a52942e",
+        "size": 1363,
+        "uri": "root://eospublic.cern.ch//eos/opendata/atlas/rucio/opendata/ODEO_FEB2025_v0_2muons_mc_301204.Pythia8EvtGen_A14MSTW2008LO_Zprime_NoInt_ee_SSM3000.2muons.root"
+      },
+      {
+        "checksum": "adler32:61d435ef",
+        "size": 5237668,
+        "uri": "root://eospublic.cern.ch//eos/opendata/atlas/rucio/opendata/ODEO_FEB2025_v0_2muons_mc_301209.Pythia8EvtGen_A14MSTW2008LO_Zprime_NoInt_mumu_SSM3000.2muons.root"
+      },
+      {
+        "checksum": "adler32:d7a683d2",
+        "size": 1315,
+        "uri": "root://eospublic.cern.ch//eos/opendata/atlas/rucio/opendata/ODEO_FEB2025_v0_2muons_mc_301243.Pythia8EvtGen_A14NNPDF23LO_Wprime_enu_SSM3000.2muons.root"
+      },
+      {
+        "checksum": "adler32:be918027",
+        "size": 26201,
+        "uri": "root://eospublic.cern.ch//eos/opendata/atlas/rucio/opendata/ODEO_FEB2025_v0_2muons_mc_301247.Pythia8EvtGen_A14NNPDF23LO_Wprime_munu_SSM3000.2muons.root"
+      },
+      {
+        "checksum": "adler32:92bd05a9",
+        "size": 73089,
+        "uri": "root://eospublic.cern.ch//eos/opendata/atlas/rucio/opendata/ODEO_FEB2025_v0_2muons_mc_301333.Pythia8EvtGen_A14NNPDF23LO_zprime3000_tt.2muons.root"
+      },
+      {
+        "checksum": "adler32:97da7a60",
+        "size": 1283,
+        "uri": "root://eospublic.cern.ch//eos/opendata/atlas/rucio/opendata/ODEO_FEB2025_v0_2muons_mc_301826.Pythia8EvtGen_A14NNPDF23LO_Wprime_qq_3000.2muons.root"
+      },
+      {
+        "checksum": "adler32:af91769c",
+        "size": 1267,
+        "uri": "root://eospublic.cern.ch//eos/opendata/atlas/rucio/opendata/ODEO_FEB2025_v0_2muons_mc_301928.Pythia8EvtGen_A14NNPDF23LO_Zprimebb3000.2muons.root"
+      },
+      {
+        "checksum": "adler32:694e7b92",
+        "size": 1307,
+        "uri": "root://eospublic.cern.ch//eos/opendata/atlas/rucio/opendata/ODEO_FEB2025_v0_2muons_mc_302520.Pythia8EvtGen_A14NNPDF23LO_2DP20_Mass_55_100.2muons.root"
+      },
+      {
+        "checksum": "adler32:c8587aa0",
+        "size": 1315,
+        "uri": "root://eospublic.cern.ch//eos/opendata/atlas/rucio/opendata/ODEO_FEB2025_v0_2muons_mc_302521.Pythia8EvtGen_A14NNPDF23LO_2DP20_Mass_100_160.2muons.root"
+      },
+      {
+        "checksum": "adler32:c877789a",
+        "size": 1315,
+        "uri": "root://eospublic.cern.ch//eos/opendata/atlas/rucio/opendata/ODEO_FEB2025_v0_2muons_mc_302522.Pythia8EvtGen_A14NNPDF23LO_2DP20_Mass_160_250.2muons.root"
+      },
+      {
+        "checksum": "adler32:5e377944",
+        "size": 1315,
+        "uri": "root://eospublic.cern.ch//eos/opendata/atlas/rucio/opendata/ODEO_FEB2025_v0_2muons_mc_302523.Pythia8EvtGen_A14NNPDF23LO_2DP20_Mass_250_400.2muons.root"
+      },
+      {
+        "checksum": "adler32:8d5879ea",
+        "size": 1315,
+        "uri": "root://eospublic.cern.ch//eos/opendata/atlas/rucio/opendata/ODEO_FEB2025_v0_2muons_mc_302524.Pythia8EvtGen_A14NNPDF23LO_2DP20_Mass_400_650.2muons.root"
+      },
+      {
+        "checksum": "adler32:bf417b46",
+        "size": 1323,
+        "uri": "root://eospublic.cern.ch//eos/opendata/atlas/rucio/opendata/ODEO_FEB2025_v0_2muons_mc_302525.Pythia8EvtGen_A14NNPDF23LO_2DP20_Mass_650_1000.2muons.root"
+      },
+      {
+        "checksum": "adler32:31a67c24",
+        "size": 1331,
+        "uri": "root://eospublic.cern.ch//eos/opendata/atlas/rucio/opendata/ODEO_FEB2025_v0_2muons_mc_302526.Pythia8EvtGen_A14NNPDF23LO_2DP20_Mass_1000_1500.2muons.root"
+      },
+      {
+        "checksum": "adler32:f08a7ce4",
+        "size": 1331,
+        "uri": "root://eospublic.cern.ch//eos/opendata/atlas/rucio/opendata/ODEO_FEB2025_v0_2muons_mc_302527.Pythia8EvtGen_A14NNPDF23LO_2DP20_Mass_1500_2000.2muons.root"
+      },
+      {
+        "checksum": "adler32:5f237f20",
+        "size": 1331,
+        "uri": "root://eospublic.cern.ch//eos/opendata/atlas/rucio/opendata/ODEO_FEB2025_v0_2muons_mc_302528.Pythia8EvtGen_A14NNPDF23LO_2DP20_Mass_2000_2500.2muons.root"
+      },
+      {
+        "checksum": "adler32:a40c10df",
+        "size": 26518,
+        "uri": "root://eospublic.cern.ch//eos/opendata/atlas/rucio/opendata/ODEO_FEB2025_v0_2muons_mc_302529.Pythia8EvtGen_A14NNPDF23LO_2DP20_Mass_2500_3000.2muons.root"
+      },
+      {
+        "checksum": "adler32:52091dbc",
+        "size": 39794,
+        "uri": "root://eospublic.cern.ch//eos/opendata/atlas/rucio/opendata/ODEO_FEB2025_v0_2muons_mc_302530.Pythia8EvtGen_A14NNPDF23LO_2DP20_Mass_3000_3500.2muons.root"
+      },
+      {
+        "checksum": "adler32:b2cd7d60",
+        "size": 1331,
+        "uri": "root://eospublic.cern.ch//eos/opendata/atlas/rucio/opendata/ODEO_FEB2025_v0_2muons_mc_302531.Pythia8EvtGen_A14NNPDF23LO_2DP20_Mass_3500_4000.2muons.root"
+      },
+      {
+        "checksum": "adler32:34447742",
+        "size": 38384,
+        "uri": "root://eospublic.cern.ch//eos/opendata/atlas/rucio/opendata/ODEO_FEB2025_v0_2muons_mc_302532.Pythia8EvtGen_A14NNPDF23LO_2DP20_Mass_4000_4500.2muons.root"
+      },
+      {
+        "checksum": "adler32:80e97d20",
+        "size": 1331,
+        "uri": "root://eospublic.cern.ch//eos/opendata/atlas/rucio/opendata/ODEO_FEB2025_v0_2muons_mc_302533.Pythia8EvtGen_A14NNPDF23LO_2DP20_Mass_4500_5000.2muons.root"
+      },
+      {
+        "checksum": "adler32:04968060",
+        "size": 1323,
+        "uri": "root://eospublic.cern.ch//eos/opendata/atlas/rucio/opendata/ODEO_FEB2025_v0_2muons_mc_302534.Pythia8EvtGen_A14NNPDF23LO_2DP20_Mass_5000_inf.2muons.root"
+      },
+      {
+        "checksum": "adler32:b405ced3",
+        "size": 32171,
+        "uri": "root://eospublic.cern.ch//eos/opendata/atlas/rucio/opendata/ODEO_FEB2025_v0_2muons_mc_302733.MadGraphPythia8EvtGen_A14NNPDF23LO_WpL_tblep_M3000.2muons.root"
+      },
+      {
+        "checksum": "adler32:d5bee3ab",
+        "size": 822726,
+        "uri": "root://eospublic.cern.ch//eos/opendata/atlas/rucio/opendata/ODEO_FEB2025_v0_2muons_mc_304014.MadGraphPythia8EvtGen_A14NNPDF23_3top_SM.2muons.root"
+      },
+      {
+        "checksum": "adler32:15e89056",
+        "size": 1355,
+        "uri": "root://eospublic.cern.ch//eos/opendata/atlas/rucio/opendata/ODEO_FEB2025_v0_2muons_mc_306149.MadGraphPythia8EvtGen_A14NNPDF23LO_WpL_tbhad_M3000.2muons.root"
+      },
+      {
+        "checksum": "adler32:40e36b96",
+        "size": 1267,
+        "uri": "root://eospublic.cern.ch//eos/opendata/atlas/rucio/opendata/ODEO_FEB2025_v0_2muons_mc_311490.PowhegPy8EG_A14N23LO_DMA_500_700_gq0p25.2muons.root"
+      },
+      {
+        "checksum": "adler32:c4ec2ef7",
+        "size": 14478668,
+        "uri": "root://eospublic.cern.ch//eos/opendata/atlas/rucio/opendata/ODEO_FEB2025_v0_2muons_mc_312613.aMcAtNloPy8EG_A14N30NLO_LQd_gstML_0p3_nonallhad_M1000.2muons.root"
+      },
+      {
+        "checksum": "adler32:2129ae78",
+        "size": 1419,
+        "uri": "root://eospublic.cern.ch//eos/opendata/atlas/rucio/opendata/ODEO_FEB2025_v0_2muons_mc_341456.PowhegPythia8EvtGen_CT10_AZNLO_ZH125J_MINLO_veveWWlvqq_VpT.2muons.root"
+      },
+      {
+        "checksum": "adler32:7d055231",
+        "size": 27374,
+        "uri": "root://eospublic.cern.ch//eos/opendata/atlas/rucio/opendata/ODEO_FEB2025_v0_2muons_mc_341458.PowhegPythia8EvtGen_CT10_AZNLO_ZH125J_MINLO_vmuvmuWWlvqq_VpT.2muons.root"
+      },
+      {
+        "checksum": "adler32:4829a37c",
+        "size": 1387,
+        "uri": "root://eospublic.cern.ch//eos/opendata/atlas/rucio/opendata/ODEO_FEB2025_v0_2muons_mc_341460.PowhegPy8EG_CT10_AZNLO_ZH125J_MINLO_vtauvtauWWlvqq_VpT.2muons.root"
+      },
+      {
+        "checksum": "adler32:6cfba4c2",
+        "size": 84267,
+        "uri": "root://eospublic.cern.ch//eos/opendata/atlas/rucio/opendata/ODEO_FEB2025_v0_2muons_mc_343981.PowhegPythia8EvtGen_NNLOPS_nnlo_30_ggH125_gamgam.2muons.root"
+      },
+      {
+        "checksum": "adler32:18859b09",
+        "size": 19416116,
+        "uri": "root://eospublic.cern.ch//eos/opendata/atlas/rucio/opendata/ODEO_FEB2025_v0_2muons_mc_344158.aMcAtNloPythia8EvtGen_A14NNPDF23LO_ppx0_FxFx_Np012_SM.2muons.root"
+      },
+      {
+        "checksum": "adler32:206da1fe",
+        "size": 1387,
+        "uri": "root://eospublic.cern.ch//eos/opendata/atlas/rucio/opendata/ODEO_FEB2025_v0_2muons_mc_345056.PowhegPythia8EvtGen_NNPDF3_AZNLO_ZH125J_MINLO_vvbb_VpT.2muons.root"
+      },
+      {
+        "checksum": "adler32:eb40883c",
+        "size": 1315,
+        "uri": "root://eospublic.cern.ch//eos/opendata/atlas/rucio/opendata/ODEO_FEB2025_v0_2muons_mc_345058.PowhegPythia8EvtGen_NNPDF3_AZNLO_ggZH125_vvbb.2muons.root"
+      },
+      {
+        "checksum": "adler32:bb165cbb",
+        "size": 301180241,
+        "uri": "root://eospublic.cern.ch//eos/opendata/atlas/rucio/opendata/ODEO_FEB2025_v0_2muons_mc_345060.PowhegPythia8EvtGen_NNLOPS_nnlo_30_ggH125_ZZ4l.2muons.root"
+      },
+      {
+        "checksum": "adler32:9d951a40",
+        "size": 536879,
+        "uri": "root://eospublic.cern.ch//eos/opendata/atlas/rucio/opendata/ODEO_FEB2025_v0_2muons_mc_345061.PowhegPythia8EvtGen_NNPDF3_AZNLO_ggZH125_HgamgamZinc.2muons.root"
+      },
+      {
+        "checksum": "adler32:edac14e9",
+        "size": 7466770,
+        "uri": "root://eospublic.cern.ch//eos/opendata/atlas/rucio/opendata/ODEO_FEB2025_v0_2muons_mc_345066.PowhegPythia8EvtGen_NNPDF3_AZNLO_ggZH125_ZZ4lepZinc.2muons.root"
+      },
+      {
+        "checksum": "adler32:e7602a95",
+        "size": 32509448,
+        "uri": "root://eospublic.cern.ch//eos/opendata/atlas/rucio/opendata/ODEO_FEB2025_v0_2muons_mc_345097.PowhegPythia8EvtGen_NNLOPS_nnlo_30_ggH125_mumu.2muons.root"
+      },
+      {
+        "checksum": "adler32:3981b445",
+        "size": 12880164,
+        "uri": "root://eospublic.cern.ch//eos/opendata/atlas/rucio/opendata/ODEO_FEB2025_v0_2muons_mc_345098.PowhegPythia8EvtGen_NNPDF3_AZNLO_ggZH125_Hmumu_Zinc.2muons.root"
+      },
+      {
+        "checksum": "adler32:ebf36239",
+        "size": 12745648,
+        "uri": "root://eospublic.cern.ch//eos/opendata/atlas/rucio/opendata/ODEO_FEB2025_v0_2muons_mc_345103.PowhegPythia8EvtGen_NNPDF30_AZNLO_ZH125J_Hmumu_Zincl_MINLO.2muons.root"
+      },
+      {
+        "checksum": "adler32:65adf1a2",
+        "size": 12600239,
+        "uri": "root://eospublic.cern.ch//eos/opendata/atlas/rucio/opendata/ODEO_FEB2025_v0_2muons_mc_345104.PowhegPythia8EvtGen_NNPDF30_AZNLO_WpH125J_Hmumu_Wincl_MINLO.2muons.root"
+      },
+      {
+        "checksum": "adler32:6082f373",
+        "size": 8129716,
+        "uri": "root://eospublic.cern.ch//eos/opendata/atlas/rucio/opendata/ODEO_FEB2025_v0_2muons_mc_345105.PowhegPythia8EvtGen_NNPDF30_AZNLO_WmH125J_Hmumu_Wincl_MINLO.2muons.root"
+      },
+      {
+        "checksum": "adler32:9fccdffc",
+        "size": 30284711,
+        "uri": "root://eospublic.cern.ch//eos/opendata/atlas/rucio/opendata/ODEO_FEB2025_v0_2muons_mc_345106.PowhegPythia8EvtGen_NNPDF30_AZNLOCTEQ6L1_VBFH125_mumu.2muons.root"
+      },
+      {
+        "checksum": "adler32:ea31a2de",
+        "size": 1387,
+        "uri": "root://eospublic.cern.ch//eos/opendata/atlas/rucio/opendata/ODEO_FEB2025_v0_2muons_mc_345112.PowhegPythia8EvtGen_NNPDF3_AZNLO_ZH125J_MINLO_vvcc_VpT.2muons.root"
+      },
+      {
+        "checksum": "adler32:888e8a2a",
+        "size": 1315,
+        "uri": "root://eospublic.cern.ch//eos/opendata/atlas/rucio/opendata/ODEO_FEB2025_v0_2muons_mc_345114.PowhegPythia8EvtGen_NNPDF3_AZNLO_ggZH125_vvcc.2muons.root"
+      },
+      {
+        "checksum": "adler32:071bc9f6",
+        "size": 4790100,
+        "uri": "root://eospublic.cern.ch//eos/opendata/atlas/rucio/opendata/ODEO_FEB2025_v0_2muons_mc_345120.PowhegPy8EG_NNLOPS_nnlo_30_ggH125_tautaul13l7.2muons.root"
+      },
+      {
+        "checksum": "adler32:bcfede66",
+        "size": 51911,
+        "uri": "root://eospublic.cern.ch//eos/opendata/atlas/rucio/opendata/ODEO_FEB2025_v0_2muons_mc_345121.PowhegPy8EG_NNLOPS_nnlo_30_ggH125_tautaulm15hp20.2muons.root"
+      },
+      {
+        "checksum": "adler32:1de2608e",
+        "size": 72259,
+        "uri": "root://eospublic.cern.ch//eos/opendata/atlas/rucio/opendata/ODEO_FEB2025_v0_2muons_mc_345122.PowhegPy8EG_NNLOPS_nnlo_30_ggH125_tautaulp15hm20.2muons.root"
+      },
+      {
+        "checksum": "adler32:a863890a",
+        "size": 1323,
+        "uri": "root://eospublic.cern.ch//eos/opendata/atlas/rucio/opendata/ODEO_FEB2025_v0_2muons_mc_345123.PowhegPy8EG_NNLOPS_nnlo_30_ggH125_tautauh30h20.2muons.root"
+      },
+      {
+        "checksum": "adler32:e4a3585c",
+        "size": 147488,
+        "uri": "root://eospublic.cern.ch//eos/opendata/atlas/rucio/opendata/ODEO_FEB2025_v0_2muons_mc_345124.PowhegPy8EG_NNLOPS_nnlo_30_ggH125_etau_filt.2muons.root"
+      },
+      {
+        "checksum": "adler32:f5229740",
+        "size": 39115389,
+        "uri": "root://eospublic.cern.ch//eos/opendata/atlas/rucio/opendata/ODEO_FEB2025_v0_2muons_mc_345125.PowhegPy8EG_NNLOPS_nnlo_30_ggH125_mutau_filt.2muons.root"
+      },
+      {
+        "checksum": "adler32:ad0442c2",
+        "size": 277371,
+        "uri": "root://eospublic.cern.ch//eos/opendata/atlas/rucio/opendata/ODEO_FEB2025_v0_2muons_mc_345211.PowhegPy8EG_NNPDF30_AZNLO_WmH125J_Winc_MINLO_tautau.2muons.root"
+      },
+      {
+        "checksum": "adler32:5e8566c0",
+        "size": 339244,
+        "uri": "root://eospublic.cern.ch//eos/opendata/atlas/rucio/opendata/ODEO_FEB2025_v0_2muons_mc_345212.PowhegPy8EG_NNPDF30_AZNLO_WpH125J_Winc_MINLO_tautau.2muons.root"
+      },
+      {
+        "checksum": "adler32:35106c18",
+        "size": 135689,
+        "uri": "root://eospublic.cern.ch//eos/opendata/atlas/rucio/opendata/ODEO_FEB2025_v0_2muons_mc_345213.PowhegPy8EG_NNPDF30_AZNLO_WmH125J_Winc_MINLO_etau.2muons.root"
+      },
+      {
+        "checksum": "adler32:467f1b62",
+        "size": 241260,
+        "uri": "root://eospublic.cern.ch//eos/opendata/atlas/rucio/opendata/ODEO_FEB2025_v0_2muons_mc_345214.PowhegPy8EG_NNPDF30_AZNLO_WpH125J_Winc_MINLO_etau.2muons.root"
+      },
+      {
+        "checksum": "adler32:84e6e452",
+        "size": 2542021,
+        "uri": "root://eospublic.cern.ch//eos/opendata/atlas/rucio/opendata/ODEO_FEB2025_v0_2muons_mc_345215.PowhegPy8EG_NNPDF30_AZNLO_WmH125J_Winc_MINLO_mutau.2muons.root"
+      },
+      {
+        "checksum": "adler32:c5ce966a",
+        "size": 4546873,
+        "uri": "root://eospublic.cern.ch//eos/opendata/atlas/rucio/opendata/ODEO_FEB2025_v0_2muons_mc_345216.PowhegPy8EG_NNPDF30_AZNLO_WpH125J_Winc_MINLO_mutau.2muons.root"
+      },
+      {
+        "checksum": "adler32:759fa39b",
+        "size": 913377,
+        "uri": "root://eospublic.cern.ch//eos/opendata/atlas/rucio/opendata/ODEO_FEB2025_v0_2muons_mc_345217.PowhegPy8EG_NNPDF30_AZNLO_ZH125J_Zinc_MINLO_tautau.2muons.root"
+      },
+      {
+        "checksum": "adler32:cbd5bc34",
+        "size": 826922,
+        "uri": "root://eospublic.cern.ch//eos/opendata/atlas/rucio/opendata/ODEO_FEB2025_v0_2muons_mc_345218.PowhegPy8EG_NNPDF30_AZNLO_ZH125J_Zinc_MINLO_etau.2muons.root"
+      },
+      {
+        "checksum": "adler32:30c3451a",
+        "size": 2456940,
+        "uri": "root://eospublic.cern.ch//eos/opendata/atlas/rucio/opendata/ODEO_FEB2025_v0_2muons_mc_345219.PowhegPy8EG_NNPDF30_AZNLO_ZH125J_Zinc_MINLO_mutau.2muons.root"
+      },
+      {
+        "checksum": "adler32:9d2b3edb",
+        "size": 50419787,
+        "uri": "root://eospublic.cern.ch//eos/opendata/atlas/rucio/opendata/ODEO_FEB2025_v0_2muons_mc_345316.PowhegPythia8EvtGen_NNLOPS_nnlo_30_ggH125_Zy_Zll.2muons.root"
+      },
+      {
+        "checksum": "adler32:ef90729d",
+        "size": 116461,
+        "uri": "root://eospublic.cern.ch//eos/opendata/atlas/rucio/opendata/ODEO_FEB2025_v0_2muons_mc_345317.PowhegPythia8EvtGen_NNPDF30_AZNLO_WmH125J_Hyy_Wincl_MINLO.2muons.root"
+      },
+      {
+        "checksum": "adler32:32d0eb9e",
+        "size": 71139,
+        "uri": "root://eospublic.cern.ch//eos/opendata/atlas/rucio/opendata/ODEO_FEB2025_v0_2muons_mc_345318.PowhegPythia8EvtGen_NNPDF30_AZNLO_WpH125J_Hyy_Wincl_MINLO.2muons.root"
+      },
+      {
+        "checksum": "adler32:29528052",
+        "size": 754309,
+        "uri": "root://eospublic.cern.ch//eos/opendata/atlas/rucio/opendata/ODEO_FEB2025_v0_2muons_mc_345319.PowhegPythia8EvtGen_NNPDF30_AZNLO_ZH125J_Hyy_Zincl_MINLO.2muons.root"
+      },
+      {
+        "checksum": "adler32:33c8b730",
+        "size": 2019907,
+        "uri": "root://eospublic.cern.ch//eos/opendata/atlas/rucio/opendata/ODEO_FEB2025_v0_2muons_mc_345320.PowhegPythia8EvtGen_NNPDF30_AZNLO_WmH125J_HZy_Wincl_MINLO.2muons.root"
+      },
+      {
+        "checksum": "adler32:fdac8bd1",
+        "size": 1803954,
+        "uri": "root://eospublic.cern.ch//eos/opendata/atlas/rucio/opendata/ODEO_FEB2025_v0_2muons_mc_345321.PowhegPythia8EvtGen_NNPDF30_AZNLO_WpH125J_HZy_Wincl_MINLO.2muons.root"
+      },
+      {
+        "checksum": "adler32:af376b83",
+        "size": 3894883,
+        "uri": "root://eospublic.cern.ch//eos/opendata/atlas/rucio/opendata/ODEO_FEB2025_v0_2muons_mc_345322.PowhegPythia8EvtGen_NNPDF30_AZNLO_ZH125J_HZy_Zincl_MINLO.2muons.root"
+      },
+      {
+        "checksum": "adler32:1ab3332d",
+        "size": 7161009,
+        "uri": "root://eospublic.cern.ch//eos/opendata/atlas/rucio/opendata/ODEO_FEB2025_v0_2muons_mc_345324.PowhegPythia8EvtGen_NNLOPS_NN30_ggH125_WWlvlv_EF_15_5.2muons.root"
+      },
+      {
+        "checksum": "adler32:e451d67a",
+        "size": 3781439,
+        "uri": "root://eospublic.cern.ch//eos/opendata/atlas/rucio/opendata/ODEO_FEB2025_v0_2muons_mc_345325.PowhegPythia8EvtGen_NNPDF3_AZNLO_WpH125J_MINLO_qqWWlvlv.2muons.root"
+      },
+      {
+        "checksum": "adler32:b95c54da",
+        "size": 4729680,
+        "uri": "root://eospublic.cern.ch//eos/opendata/atlas/rucio/opendata/ODEO_FEB2025_v0_2muons_mc_345433.PowhegPythia8EvtGen_NNPDF3_AZNLO_WmH125J_MINLO_qqWWlvlv.2muons.root"
+      },
+      {
+        "checksum": "adler32:d78857ad",
+        "size": 1234446,
+        "uri": "root://eospublic.cern.ch//eos/opendata/atlas/rucio/opendata/ODEO_FEB2025_v0_2muons_mc_345445.PowhegPythia8EvtGen_NNPDF3_AZNLO_ZH125J_MINLO_vvWWlvlv.2muons.root"
+      },
+      {
+        "checksum": "adler32:566dc21a",
+        "size": 376612,
+        "uri": "root://eospublic.cern.ch//eos/opendata/atlas/rucio/opendata/ODEO_FEB2025_v0_2muons_mc_345596.PowhegPythia8EvtGen_NNPDF3_AZNLO_ggZH125_Zinc_HZZinv.2muons.root"
+      },
+      {
+        "checksum": "adler32:3e9bbc58",
+        "size": 6432045,
+        "uri": "root://eospublic.cern.ch//eos/opendata/atlas/rucio/opendata/ODEO_FEB2025_v0_2muons_mc_345697.MadGraphPythia8EvtGen_AZNLOCTEQ6L1_ggfhtautaullNp2.2muons.root"
+      },
+      {
+        "checksum": "adler32:1a437b31",
+        "size": 118828,
+        "uri": "root://eospublic.cern.ch//eos/opendata/atlas/rucio/opendata/ODEO_FEB2025_v0_2muons_mc_345698.MadGraphPythia8EvtGen_AZNLOCTEQ6L1_ggfhtautaulhNp2.2muons.root"
+      },
+      {
+        "checksum": "adler32:1eb74065",
+        "size": 26507,
+        "uri": "root://eospublic.cern.ch//eos/opendata/atlas/rucio/opendata/ODEO_FEB2025_v0_2muons_mc_345699.MadGraphPythia8EvtGen_AZNLOCTEQ6L1_ggfhtautauhhNp2.2muons.root"
+      },
+      {
+        "checksum": "adler32:7a534904",
+        "size": 28222184,
+        "uri": "root://eospublic.cern.ch//eos/opendata/atlas/rucio/opendata/ODEO_FEB2025_v0_2muons_mc_345833.PowhegPythia8EvtGen_NNPDF30_AZNLOCTEQ6L1_VBFH125_Zllgam.2muons.root"
+      },
+      {
+        "checksum": "adler32:f0529e35",
+        "size": 924361,
+        "uri": "root://eospublic.cern.ch//eos/opendata/atlas/rucio/opendata/ODEO_FEB2025_v0_2muons_mc_345834.PowhegPythia8EvtGen_NNPDF30_AZNLOCTEQ6L1_VBFH125_gamstargam.2muons.root"
+      },
+      {
+        "checksum": "adler32:2bbc8c69",
+        "size": 460279,
+        "uri": "root://eospublic.cern.ch//eos/opendata/atlas/rucio/opendata/ODEO_FEB2025_v0_2muons_mc_345876.PowhegPythia8EvtGen_NNPDF30_AZNLO_ZH125J_Hee__Zincl_MINLO.2muons.root"
+      },
+      {
+        "checksum": "adler32:62393667",
+        "size": 26590,
+        "uri": "root://eospublic.cern.ch//eos/opendata/atlas/rucio/opendata/ODEO_FEB2025_v0_2muons_mc_345877.PowhegPythia8EvtGen_NNPDF30_AZNLO_WpH125J_Hee_Wincl_MINLO.2muons.root"
+      },
+      {
+        "checksum": "adler32:c418ae1a",
+        "size": 1411,
+        "uri": "root://eospublic.cern.ch//eos/opendata/atlas/rucio/opendata/ODEO_FEB2025_v0_2muons_mc_345878.PowhegPythia8EvtGen_NNPDF30_AZNLO_WmH125J_Hee_Wincl_MINLO.2muons.root"
+      },
+      {
+        "checksum": "adler32:0a2e4f80",
+        "size": 81694,
+        "uri": "root://eospublic.cern.ch//eos/opendata/atlas/rucio/opendata/ODEO_FEB2025_v0_2muons_mc_345944.aMcAtNloPy8EG_A14NNPDF23LO_ppx0yy_FxFx_Np012_SM.2muons.root"
+      },
+      {
+        "checksum": "adler32:9ab1184f",
+        "size": 8937029,
+        "uri": "root://eospublic.cern.ch//eos/opendata/atlas/rucio/opendata/ODEO_FEB2025_v0_2muons_mc_345948.PowhegPy8EG_NNPDF30_AZNLOCTEQ6L1_VBFH125_WWlvlv.2muons.root"
+      },
+      {
+        "checksum": "adler32:be6b93a6",
+        "size": 1363,
+        "uri": "root://eospublic.cern.ch//eos/opendata/atlas/rucio/opendata/ODEO_FEB2025_v0_2muons_mc_345949.PowhegPythia8EvtGen_NNPDF30_AZNLOCTEQ6L1_VBFH125_bb.2muons.root"
+      },
+      {
+        "checksum": "adler32:8e2385b5",
+        "size": 1968393,
+        "uri": "root://eospublic.cern.ch//eos/opendata/atlas/rucio/opendata/ODEO_FEB2025_v0_2muons_mc_345961.PowhegPythia8EvtGen_NNLOPS_nnlo_30_ggH125_gamstargam.2muons.root"
+      },
+      {
+        "checksum": "adler32:458887e7",
+        "size": 561700,
+        "uri": "root://eospublic.cern.ch//eos/opendata/atlas/rucio/opendata/ODEO_FEB2025_v0_2muons_mc_345963.PowhegPythia8EvtGen_NNPDF30_AZNLO_WmH125J_Hgamstargam_MINLO.2muons.root"
+      },
+      {
+        "checksum": "adler32:48950b42",
+        "size": 517349,
+        "uri": "root://eospublic.cern.ch//eos/opendata/atlas/rucio/opendata/ODEO_FEB2025_v0_2muons_mc_345964.PowhegPythia8EvtGen_NNPDF30_AZNLO_WpH125J_Hgamstargam_MINLO.2muons.root"
+      },
+      {
+        "checksum": "adler32:96b80948",
+        "size": 1252354,
+        "uri": "root://eospublic.cern.ch//eos/opendata/atlas/rucio/opendata/ODEO_FEB2025_v0_2muons_mc_345965.PowhegPythia8EvtGen_NNPDF30_AZNLO_ZH125J_Hgamstargam_MINLO.2muons.root"
+      },
+      {
+        "checksum": "adler32:db8c0b83",
+        "size": 42160,
+        "uri": "root://eospublic.cern.ch//eos/opendata/atlas/rucio/opendata/ODEO_FEB2025_v0_2muons_mc_346188.aMcAtNloPythia8EvtGen_tHjb125_4fl_gamgam.2muons.root"
+      },
+      {
+        "checksum": "adler32:bd7ec02a",
+        "size": 345251,
+        "uri": "root://eospublic.cern.ch//eos/opendata/atlas/rucio/opendata/ODEO_FEB2025_v0_2muons_mc_346189.aMcAtNloPythia8EvtGen_ttH_gamgam.2muons.root"
+      },
+      {
+        "checksum": "adler32:716b6357",
+        "size": 4307119,
+        "uri": "root://eospublic.cern.ch//eos/opendata/atlas/rucio/opendata/ODEO_FEB2025_v0_2muons_mc_346190.PowhegPy8EG_NNPDF30_AZNLOCTEQ6L1_VBFH125_tautaul13l7.2muons.root"
+      },
+      {
+        "checksum": "adler32:c4822b9c",
+        "size": 51162,
+        "uri": "root://eospublic.cern.ch//eos/opendata/atlas/rucio/opendata/ODEO_FEB2025_v0_2muons_mc_346191.PowhegPy8EG_NNPDF30_AZNLOCTEQ6L1_VBFH125_tautaulm15hp20.2muons.root"
+      },
+      {
+        "checksum": "adler32:f4edafc0",
+        "size": 46179,
+        "uri": "root://eospublic.cern.ch//eos/opendata/atlas/rucio/opendata/ODEO_FEB2025_v0_2muons_mc_346192.PowhegPy8EG_NNPDF30_AZNLOCTEQ6L1_VBFH125_tautaulp15hm20.2muons.root"
+      },
+      {
+        "checksum": "adler32:27f394fa",
+        "size": 1379,
+        "uri": "root://eospublic.cern.ch//eos/opendata/atlas/rucio/opendata/ODEO_FEB2025_v0_2muons_mc_346193.PowhegPy8EG_NNPDF30_AZNLOCTEQ6L1_VBFH125_tautauh30h20.2muons.root"
+      },
+      {
+        "checksum": "adler32:48c467d9",
+        "size": 66779,
+        "uri": "root://eospublic.cern.ch//eos/opendata/atlas/rucio/opendata/ODEO_FEB2025_v0_2muons_mc_346194.PowhegPy8EG_NNPDF30_AZNLOCTEQ6L1_VBFH125_etau_filt.2muons.root"
+      },
+      {
+        "checksum": "adler32:faa5903c",
+        "size": 7793056,
+        "uri": "root://eospublic.cern.ch//eos/opendata/atlas/rucio/opendata/ODEO_FEB2025_v0_2muons_mc_346195.PowhegPy8EG_NNPDF30_AZNLOCTEQ6L1_VBFH125_mutau_filt.2muons.root"
+      },
+      {
+        "checksum": "adler32:f28ea164",
+        "size": 12865108,
+        "uri": "root://eospublic.cern.ch//eos/opendata/atlas/rucio/opendata/ODEO_FEB2025_v0_2muons_mc_346198.PhPy8EG_A14NNPDF23_NNPDF30ME_ttH125_Zgam.2muons.root"
+      },
+      {
+        "checksum": "adler32:4687b0a6",
+        "size": 39689,
+        "uri": "root://eospublic.cern.ch//eos/opendata/atlas/rucio/opendata/ODEO_FEB2025_v0_2muons_mc_346214.PowhegPy8EG_NNPDF30_AZNLOCTEQ6L1_VBFH125_gamgam.2muons.root"
+      },
+      {
+        "checksum": "adler32:eb0c98cf",
+        "size": 62963339,
+        "uri": "root://eospublic.cern.ch//eos/opendata/atlas/rucio/opendata/ODEO_FEB2025_v0_2muons_mc_346228.PowhegPy8EG_NNPDF30_AZNLOCTEQ6L1_VBFH125_ZZ4lep_notau.2muons.root"
+      },
+      {
+        "checksum": "adler32:114daca9",
+        "size": 806332,
+        "uri": "root://eospublic.cern.ch//eos/opendata/atlas/rucio/opendata/ODEO_FEB2025_v0_2muons_mc_346310.PowhegPythia8EvtGen_NNPDF30_AZNLO_ZH125J_Zincl_H_incl_MINLO.2muons.root"
+      },
+      {
+        "checksum": "adler32:4cea002c",
+        "size": 147847,
+        "uri": "root://eospublic.cern.ch//eos/opendata/atlas/rucio/opendata/ODEO_FEB2025_v0_2muons_mc_346311.PowhegPythia8EvtGen_NNPDF30_AZNLO_WpH125J_Wincl_H_incl_MINLO.2muons.root"
+      },
+      {
+        "checksum": "adler32:8e9e0d22",
+        "size": 128156,
+        "uri": "root://eospublic.cern.ch//eos/opendata/atlas/rucio/opendata/ODEO_FEB2025_v0_2muons_mc_346312.PowhegPythia8EvtGen_NNPDF30_AZNLO_WmH125J_Wincl_H_incl_MINLO.2muons.root"
+      },
+      {
+        "checksum": "adler32:9af25232",
+        "size": 402760,
+        "uri": "root://eospublic.cern.ch//eos/opendata/atlas/rucio/opendata/ODEO_FEB2025_v0_2muons_mc_346317.PowhegPy8EG_NNPDF30_AZNLOCTEQ6L1_VBFH125_incl.2muons.root"
+      },
+      {
+        "checksum": "adler32:fe4aad7b",
+        "size": 8281477,
+        "uri": "root://eospublic.cern.ch//eos/opendata/atlas/rucio/opendata/ODEO_FEB2025_v0_2muons_mc_346340.PowhegPy8EG_A14NNPDF23_NNPDF30ME_ttH125_ZZ4l_allhad.2muons.root"
+      },
+      {
+        "checksum": "adler32:c7b82fcb",
+        "size": 9884214,
+        "uri": "root://eospublic.cern.ch//eos/opendata/atlas/rucio/opendata/ODEO_FEB2025_v0_2muons_mc_346341.PowhegPy8EG_A14NNPDF23_NNPDF30ME_ttH125_ZZ4l_semilep.2muons.root"
+      },
+      {
+        "checksum": "adler32:2b85b07e",
+        "size": 11421442,
+        "uri": "root://eospublic.cern.ch//eos/opendata/atlas/rucio/opendata/ODEO_FEB2025_v0_2muons_mc_346342.PowhegPy8EG_A14NNPDF23_NNPDF30ME_ttH125_ZZ4l_dilep.2muons.root"
+      },
+      {
+        "checksum": "adler32:80a9c88e",
+        "size": 242997,
+        "uri": "root://eospublic.cern.ch//eos/opendata/atlas/rucio/opendata/ODEO_FEB2025_v0_2muons_mc_346343.PhPy8EG_A14NNPDF23_NNPDF30ME_ttH125_allhad.2muons.root"
+      },
+      {
+        "checksum": "adler32:abd4bd5a",
+        "size": 796482,
+        "uri": "root://eospublic.cern.ch//eos/opendata/atlas/rucio/opendata/ODEO_FEB2025_v0_2muons_mc_346344.PhPy8EG_A14NNPDF23_NNPDF30ME_ttH125_semilep.2muons.root"
+      },
+      {
+        "checksum": "adler32:5b609be0",
+        "size": 9932123,
+        "uri": "root://eospublic.cern.ch//eos/opendata/atlas/rucio/opendata/ODEO_FEB2025_v0_2muons_mc_346345.PhPy8EG_A14NNPDF23_NNPDF30ME_ttH125_dilep.2muons.root"
+      },
+      {
+        "checksum": "adler32:e813baaa",
+        "size": 26461,
+        "uri": "root://eospublic.cern.ch//eos/opendata/atlas/rucio/opendata/ODEO_FEB2025_v0_2muons_mc_346398.PowhegHerwig7EvtGen_NNPDF3_AZNLO_ZH125J_MINLO_vvbb_VpT.2muons.root"
+      },
+      {
+        "checksum": "adler32:48458868",
+        "size": 1323,
+        "uri": "root://eospublic.cern.ch//eos/opendata/atlas/rucio/opendata/ODEO_FEB2025_v0_2muons_mc_346400.PowhegHerwig7EvtGen_NNPDF3_AZNLO_ggZH125J_vvbb.2muons.root"
+      },
+      {
+        "checksum": "adler32:5503b443",
+        "size": 5471185,
+        "uri": "root://eospublic.cern.ch//eos/opendata/atlas/rucio/opendata/ODEO_FEB2025_v0_2muons_mc_346414.aMcAtNloPythia8EvtGen_tHjb125_4fl_ZZ4l.2muons.root"
+      },
+      {
+        "checksum": "adler32:d691599f",
+        "size": 182323970,
+        "uri": "root://eospublic.cern.ch//eos/opendata/atlas/rucio/opendata/ODEO_FEB2025_v0_2muons_mc_346446.PhH7EG_H7UE_NNLOPS_nnlo_30_ggH125_ZZ4l_noTau.2muons.root"
+      },
+      {
+        "checksum": "adler32:08c98a7e",
+        "size": 63473884,
+        "uri": "root://eospublic.cern.ch//eos/opendata/atlas/rucio/opendata/ODEO_FEB2025_v0_2muons_mc_346447.PhH7EG_H7UE_NNPDF30_VBFH125_ZZ4lep_noTau.2muons.root"
+      },
+      {
+        "checksum": "adler32:4618d7a7",
+        "size": 14757607,
+        "uri": "root://eospublic.cern.ch//eos/opendata/atlas/rucio/opendata/ODEO_FEB2025_v0_2muons_mc_346448.PhH7EG_H7UE_NNPDF30_ZH125J_Zincl_MINLO.2muons.root"
+      },
+      {
+        "checksum": "adler32:37087bf4",
+        "size": 11524930,
+        "uri": "root://eospublic.cern.ch//eos/opendata/atlas/rucio/opendata/ODEO_FEB2025_v0_2muons_mc_346449.PhH7EG_H7UE_NNPDF30_WpH125J_Wincl_MINLO.2muons.root"
+      },
+      {
+        "checksum": "adler32:fb9535b5",
+        "size": 6059187,
+        "uri": "root://eospublic.cern.ch//eos/opendata/atlas/rucio/opendata/ODEO_FEB2025_v0_2muons_mc_346450.PhH7EG_H7UE_NNPDF30_WmH125J_Wincl_MINLO.2muons.root"
+      },
+      {
+        "checksum": "adler32:1b4aed15",
+        "size": 7478004,
+        "uri": "root://eospublic.cern.ch//eos/opendata/atlas/rucio/opendata/ODEO_FEB2025_v0_2muons_mc_346451.PhH7EG_H7UE_NNPDF3_ggZH125_ZZ4lepZinc.2muons.root"
+      },
+      {
+        "checksum": "adler32:556c1af0",
+        "size": 8255986,
+        "uri": "root://eospublic.cern.ch//eos/opendata/atlas/rucio/opendata/ODEO_FEB2025_v0_2muons_mc_346452.PhH7EG_H7UE_NNPDF30ME_ttH125_ZZ4l_allhad_noTau.2muons.root"
+      },
+      {
+        "checksum": "adler32:5ec8ee50",
+        "size": 10073503,
+        "uri": "root://eospublic.cern.ch//eos/opendata/atlas/rucio/opendata/ODEO_FEB2025_v0_2muons_mc_346453.PhH7EG_H7UE_NNPDF30ME_ttH125_ZZ4l_semilep_noTau.2muons.root"
+      },
+      {
+        "checksum": "adler32:8b39ffd3",
+        "size": 11538024,
+        "uri": "root://eospublic.cern.ch//eos/opendata/atlas/rucio/opendata/ODEO_FEB2025_v0_2muons_mc_346454.PhH7EG_H7UE_NNPDF30ME_ttH125_ZZ4l_dilep_noTau.2muons.root"
+      },
+      {
+        "checksum": "adler32:3ece4771",
+        "size": 219469,
+        "uri": "root://eospublic.cern.ch//eos/opendata/atlas/rucio/opendata/ODEO_FEB2025_v0_2muons_mc_346486.aMcAtNloPythia8EvtGen_tWH125_yy.2muons.root"
+      },
+      {
+        "checksum": "adler32:17ae217e",
+        "size": 6651762,
+        "uri": "root://eospublic.cern.ch//eos/opendata/atlas/rucio/opendata/ODEO_FEB2025_v0_2muons_mc_346511.aMcAtNloPythia8EvtGen_tWH125_ZZ4l.2muons.root"
+      },
+      {
+        "checksum": "adler32:024fd09a",
+        "size": 1904363,
+        "uri": "root://eospublic.cern.ch//eos/opendata/atlas/rucio/opendata/ODEO_FEB2025_v0_2muons_mc_346524.PowhegPythia8EvtGen_NNPDF3_AZNLO_ggZH125J_MINLO_ZinclWWlvlv.2muons.root"
+      },
+      {
+        "checksum": "adler32:bcd78c06",
+        "size": 726154,
+        "uri": "root://eospublic.cern.ch//eos/opendata/atlas/rucio/opendata/ODEO_FEB2025_v0_2muons_mc_346525.PowhegPythia8EvtGen_A14NNPDF23_NNPDF30ME_ttH125_gamgam.2muons.root"
+      },
+      {
+        "checksum": "adler32:5e600542",
+        "size": 756048,
+        "uri": "root://eospublic.cern.ch//eos/opendata/atlas/rucio/opendata/ODEO_FEB2025_v0_2muons_mc_346526.PowhegHerwig7EvtGen_H7UE_NNPDF30ME_ttH125_gamgam.2muons.root"
+      },
+      {
+        "checksum": "adler32:8db79e96",
+        "size": 1379,
+        "uri": "root://eospublic.cern.ch//eos/opendata/atlas/rucio/opendata/ODEO_FEB2025_v0_2muons_mc_346588.PowhegPythia8EvtGen_NNLOPS_nnlo_30_ggH125_ZZ4nu_MET75.2muons.root"
+      },
+      {
+        "checksum": "adler32:9d5a9684",
+        "size": 521983,
+        "uri": "root://eospublic.cern.ch//eos/opendata/atlas/rucio/opendata/ODEO_FEB2025_v0_2muons_mc_346601.aMcAtNloHerwig7EvtGen_MEN30NLO_ttH125_gamgam.2muons.root"
+      },
+      {
+        "checksum": "adler32:f0d5ce93",
+        "size": 29540,
+        "uri": "root://eospublic.cern.ch//eos/opendata/atlas/rucio/opendata/ODEO_FEB2025_v0_2muons_mc_346602.aMcAtNloHerwig7EvtGen_MEN30NLO_tHjb125_gamgam.2muons.root"
+      },
+      {
+        "checksum": "adler32:16ebf0fb",
+        "size": 26435,
+        "uri": "root://eospublic.cern.ch//eos/opendata/atlas/rucio/opendata/ODEO_FEB2025_v0_2muons_mc_346605.PowhegPythia8EvtGen_NNPDF30_AZNLO_WpH125J_WinclHinv_MET75.2muons.root"
+      },
+      {
+        "checksum": "adler32:a7c39f72",
+        "size": 26476,
+        "uri": "root://eospublic.cern.ch//eos/opendata/atlas/rucio/opendata/ODEO_FEB2025_v0_2muons_mc_346606.PowhegPythia8EvtGen_NNPDF30_AZNLO_WmH125J_WinclHinv_MET75.2muons.root"
+      },
+      {
+        "checksum": "adler32:a8bab321",
+        "size": 1203956,
+        "uri": "root://eospublic.cern.ch//eos/opendata/atlas/rucio/opendata/ODEO_FEB2025_v0_2muons_mc_346607.PowhegPythia8EvtGen_NNPDF30_AZNLO_ZH125J_ZinclHinv_MET75.2muons.root"
+      },
+      {
+        "checksum": "adler32:9fed6a21",
+        "size": 102349,
+        "uri": "root://eospublic.cern.ch//eos/opendata/atlas/rucio/opendata/ODEO_FEB2025_v0_2muons_mc_346632.PowhegPy8EG_A14NNPDF23_NNPDF30ME_ttH125_ZZ4nu_semilep.2muons.root"
+      },
+      {
+        "checksum": "adler32:f6d3909a",
+        "size": 1371,
+        "uri": "root://eospublic.cern.ch//eos/opendata/atlas/rucio/opendata/ODEO_FEB2025_v0_2muons_mc_346633.PowhegPy8EG_A14NNPDF23_NNPDF30ME_ttH125_ZZ4nu_allhad.2muons.root"
+      },
+      {
+        "checksum": "adler32:2504588c",
+        "size": 1689751,
+        "uri": "root://eospublic.cern.ch//eos/opendata/atlas/rucio/opendata/ODEO_FEB2025_v0_2muons_mc_346634.PowhegPy8EG_A14NNPDF23_NNPDF30ME_ttH125_ZZ4nu_dilep.2muons.root"
+      },
+      {
+        "checksum": "adler32:86c0389b",
+        "size": 21141155,
+        "uri": "root://eospublic.cern.ch//eos/opendata/atlas/rucio/opendata/ODEO_FEB2025_v0_2muons_mc_346645.PowhegPythia8EvtGen_NNPDF30_AZNLO_ZH125J_Zincl_MINLO_shw.2muons.root"
+      },
+      {
+        "checksum": "adler32:d9418106",
+        "size": 11638627,
+        "uri": "root://eospublic.cern.ch//eos/opendata/atlas/rucio/opendata/ODEO_FEB2025_v0_2muons_mc_346646.PowhegPythia8EvtGen_NNPDF30_AZNLO_WpH125J_Wincl_MINLO_shw.2muons.root"
+      },
+      {
+        "checksum": "adler32:ef43c7c4",
+        "size": 6342424,
+        "uri": "root://eospublic.cern.ch//eos/opendata/atlas/rucio/opendata/ODEO_FEB2025_v0_2muons_mc_346647.PowhegPythia8EvtGen_NNPDF30_AZNLO_WmH125J_Wincl_MINLO_shw.2muons.root"
+      },
+      {
+        "checksum": "adler32:4b045067",
+        "size": 26657,
+        "uri": "root://eospublic.cern.ch//eos/opendata/atlas/rucio/opendata/ODEO_FEB2025_v0_2muons_mc_346726.PowhegHerwig7EvtGen_NNPDF3_AZNLO_ZH125J_MINLO_vvcc_VpT.2muons.root"
+      },
+      {
+        "checksum": "adler32:a4008de4",
+        "size": 1323,
+        "uri": "root://eospublic.cern.ch//eos/opendata/atlas/rucio/opendata/ODEO_FEB2025_v0_2muons_mc_346728.PowhegHerwig7EvtGen_NNPDF3_AZNLO_ggZH125J_vvcc.2muons.root"
+      },
+      {
+        "checksum": "adler32:e0a1756c",
+        "size": 1275,
+        "uri": "root://eospublic.cern.ch//eos/opendata/atlas/rucio/opendata/ODEO_FEB2025_v0_2muons_mc_346797.PhH7EG_H7UE_NNLOPS_nnlo_30_ggH125_gamgam.2muons.root"
+      },
+      {
+        "checksum": "adler32:dd060ca3",
+        "size": 45688667,
+        "uri": "root://eospublic.cern.ch//eos/opendata/atlas/rucio/opendata/ODEO_FEB2025_v0_2muons_mc_346802.PhH7EG_NNLOPS_nnlo_30_ggH125_WWlvlv_noTau.2muons.root"
+      },
+      {
+        "checksum": "adler32:42b2e126",
+        "size": 7514523,
+        "uri": "root://eospublic.cern.ch//eos/opendata/atlas/rucio/opendata/ODEO_FEB2025_v0_2muons_mc_346877.PhH7EG_NNPDF30_VBFH125_WWlvlv.2muons.root"
+      },
+      {
+        "checksum": "adler32:3c0c6e04",
+        "size": 1251,
+        "uri": "root://eospublic.cern.ch//eos/opendata/atlas/rucio/opendata/ODEO_FEB2025_v0_2muons_mc_346878.PhH7EG_H7UE_NNPDF30_VBF125_gammagamma.2muons.root"
+      },
+      {
+        "checksum": "adler32:9f762756",
+        "size": 926441,
+        "uri": "root://eospublic.cern.ch//eos/opendata/atlas/rucio/opendata/ODEO_FEB2025_v0_2muons_mc_346879.PhH7EG_H7UE_NNPDF30_ZH125J_Zincl_MINLO_gammagamma.2muons.root"
+      },
+      {
+        "checksum": "adler32:55a6920c",
+        "size": 1355,
+        "uri": "root://eospublic.cern.ch//eos/opendata/atlas/rucio/opendata/ODEO_FEB2025_v0_2muons_mc_346880.PhH7EG_H7UE_NNPDF30_WmH125J_Wincl_MINLO_gammagamma.2muons.root"
+      },
+      {
+        "checksum": "adler32:572991d8",
+        "size": 1355,
+        "uri": "root://eospublic.cern.ch//eos/opendata/atlas/rucio/opendata/ODEO_FEB2025_v0_2muons_mc_346881.PhH7EG_H7UE_NNPDF30_WpH125J_Wincl_MINLO_gammagamma.2muons.root"
+      },
+      {
+        "checksum": "adler32:9b3d5a98",
+        "size": 500261,
+        "uri": "root://eospublic.cern.ch//eos/opendata/atlas/rucio/opendata/ODEO_FEB2025_v0_2muons_mc_346882.PhH7EG_H7UE_NNPDF30_ggZH125_gammagamma.2muons.root"
+      },
+      {
+        "checksum": "adler32:abcd2dc4",
+        "size": 474324,
+        "uri": "root://eospublic.cern.ch//eos/opendata/atlas/rucio/opendata/ODEO_FEB2025_v0_2muons_mc_346919.PhPy8EG_A14NNPDF23_NNPDF30ME_ttH125_allhad_tautau_unpol.2muons.root"
+      },
+      {
+        "checksum": "adler32:48decf24",
+        "size": 2879391,
+        "uri": "root://eospublic.cern.ch//eos/opendata/atlas/rucio/opendata/ODEO_FEB2025_v0_2muons_mc_346923.PhPy8EG_A14NNPDF23_NNPDF30ME_ttH125_semilep_tautau_unpol.2muons.root"
+      },
+      {
+        "checksum": "adler32:c3304c6d",
+        "size": 6508703,
+        "uri": "root://eospublic.cern.ch//eos/opendata/atlas/rucio/opendata/ODEO_FEB2025_v0_2muons_mc_346927.PhPy8EG_A14NNPDF23_NNPDF30ME_ttH125_dilep_tautau_unpol.2muons.root"
+      },
+      {
+        "checksum": "adler32:346f4560",
+        "size": 13616905,
+        "uri": "root://eospublic.cern.ch//eos/opendata/atlas/rucio/opendata/ODEO_FEB2025_v0_2muons_mc_364242.Sherpa_222_NNPDF30NNLO_WWW_3l3v_EW6.2muons.root"
+      },
+      {
+        "checksum": "adler32:2e9ab7db",
+        "size": 8161244,
+        "uri": "root://eospublic.cern.ch//eos/opendata/atlas/rucio/opendata/ODEO_FEB2025_v0_2muons_mc_364243.Sherpa_222_NNPDF30NNLO_WWZ_4l2v_EW6.2muons.root"
+      },
+      {
+        "checksum": "adler32:f9f4c499",
+        "size": 1527858,
+        "uri": "root://eospublic.cern.ch//eos/opendata/atlas/rucio/opendata/ODEO_FEB2025_v0_2muons_mc_364244.Sherpa_222_NNPDF30NNLO_WWZ_2l4v_EW6.2muons.root"
+      },
+      {
+        "checksum": "adler32:d51b501b",
+        "size": 9758314,
+        "uri": "root://eospublic.cern.ch//eos/opendata/atlas/rucio/opendata/ODEO_FEB2025_v0_2muons_mc_364245.Sherpa_222_NNPDF30NNLO_WZZ_5l1v_EW6.2muons.root"
+      },
+      {
+        "checksum": "adler32:b27bfc5b",
+        "size": 5623126,
+        "uri": "root://eospublic.cern.ch//eos/opendata/atlas/rucio/opendata/ODEO_FEB2025_v0_2muons_mc_364246.Sherpa_222_NNPDF30NNLO_WZZ_3l3v_EW6.2muons.root"
+      },
+      {
+        "checksum": "adler32:668a220d",
+        "size": 9156204,
+        "uri": "root://eospublic.cern.ch//eos/opendata/atlas/rucio/opendata/ODEO_FEB2025_v0_2muons_mc_364247.Sherpa_222_NNPDF30NNLO_ZZZ_6l0v_EW6.2muons.root"
+      },
+      {
+        "checksum": "adler32:999c2ee8",
+        "size": 1898981,
+        "uri": "root://eospublic.cern.ch//eos/opendata/atlas/rucio/opendata/ODEO_FEB2025_v0_2muons_mc_364248.Sherpa_222_NNPDF30NNLO_ZZZ_4l2v_EW6.2muons.root"
+      },
+      {
+        "checksum": "adler32:2a7ffe56",
+        "size": 2221949,
+        "uri": "root://eospublic.cern.ch//eos/opendata/atlas/rucio/opendata/ODEO_FEB2025_v0_2muons_mc_364249.Sherpa_222_NNPDF30NNLO_ZZZ_2l4v_EW6.2muons.root"
+      },
+      {
+        "checksum": "adler32:966c5f9f",
+        "size": 2617704,
+        "uri": "root://eospublic.cern.ch//eos/opendata/atlas/rucio/opendata/ODEO_FEB2025_v0_2muons_mc_364336.Sherpa_222_NNPDF30NNLO_WpWpWn_sslvlvjj_EW6.2muons.root"
+      },
+      {
+        "checksum": "adler32:fadbf498",
+        "size": 2019663,
+        "uri": "root://eospublic.cern.ch//eos/opendata/atlas/rucio/opendata/ODEO_FEB2025_v0_2muons_mc_364337.Sherpa_222_NNPDF30NNLO_WnWnWp_sslvlvjj_EW6.2muons.root"
+      },
+      {
+        "checksum": "adler32:30613821",
+        "size": 1158202,
+        "uri": "root://eospublic.cern.ch//eos/opendata/atlas/rucio/opendata/ODEO_FEB2025_v0_2muons_mc_364338.Sherpa_222_NNPDF30NNLO_WpWpWn_oslvlvjj_EW6.2muons.root"
+      },
+      {
+        "checksum": "adler32:ee1f06b2",
+        "size": 410120,
+        "uri": "root://eospublic.cern.ch//eos/opendata/atlas/rucio/opendata/ODEO_FEB2025_v0_2muons_mc_364339.Sherpa_222_NNPDF30NNLO_WnWnWp_oslvlvjj_EW6.2muons.root"
+      },
+      {
+        "checksum": "adler32:21d17912",
+        "size": 1275,
+        "uri": "root://eospublic.cern.ch//eos/opendata/atlas/rucio/opendata/ODEO_FEB2025_v0_2muons_mc_364350.Sherpa_224_NNPDF30NNLO_Diphoton_myy_0_50.2muons.root"
+      },
+      {
+        "checksum": "adler32:7eb17a04",
+        "size": 1283,
+        "uri": "root://eospublic.cern.ch//eos/opendata/atlas/rucio/opendata/ODEO_FEB2025_v0_2muons_mc_364351.Sherpa_224_NNPDF30NNLO_Diphoton_myy_50_90.2muons.root"
+      },
+      {
+        "checksum": "adler32:d4227c60",
+        "size": 1291,
+        "uri": "root://eospublic.cern.ch//eos/opendata/atlas/rucio/opendata/ODEO_FEB2025_v0_2muons_mc_364352.Sherpa_224_NNPDF30NNLO_Diphoton_myy_90_175.2muons.root"
+      },
+      {
+        "checksum": "adler32:ef2f7cb6",
+        "size": 1307,
+        "uri": "root://eospublic.cern.ch//eos/opendata/atlas/rucio/opendata/ODEO_FEB2025_v0_2muons_mc_364353.Sherpa_224_NNPDF30NNLO_Diphoton_myy_175_2000.2muons.root"
+      },
+      {
+        "checksum": "adler32:6bba8570",
+        "size": 1323,
+        "uri": "root://eospublic.cern.ch//eos/opendata/atlas/rucio/opendata/ODEO_FEB2025_v0_2muons_mc_364354.Sherpa_224_NNPDF30NNLO_Diphoton_myy_2000_E_CMS.2muons.root"
+      },
+      {
+        "checksum": "adler32:b42b8562",
+        "size": 1315,
+        "uri": "root://eospublic.cern.ch//eos/opendata/atlas/rucio/opendata/ODEO_FEB2025_v0_2muons_mc_364541.Sherpa_222_NNPDF30NNLO_SinglePhoton_pty_17_35.2muons.root"
+      },
+      {
+        "checksum": "adler32:570c8264",
+        "size": 1315,
+        "uri": "root://eospublic.cern.ch//eos/opendata/atlas/rucio/opendata/ODEO_FEB2025_v0_2muons_mc_364542.Sherpa_222_NNPDF30NNLO_SinglePhoton_pty_35_70.2muons.root"
+      },
+      {
+        "checksum": "adler32:0819867c",
+        "size": 1323,
+        "uri": "root://eospublic.cern.ch//eos/opendata/atlas/rucio/opendata/ODEO_FEB2025_v0_2muons_mc_364543.Sherpa_222_NNPDF30NNLO_SinglePhoton_pty_70_140.2muons.root"
+      },
+      {
+        "checksum": "adler32:cd8b85ee",
+        "size": 1331,
+        "uri": "root://eospublic.cern.ch//eos/opendata/atlas/rucio/opendata/ODEO_FEB2025_v0_2muons_mc_364544.Sherpa_222_NNPDF30NNLO_SinglePhoton_pty_140_280.2muons.root"
+      },
+      {
+        "checksum": "adler32:352388ee",
+        "size": 1331,
+        "uri": "root://eospublic.cern.ch//eos/opendata/atlas/rucio/opendata/ODEO_FEB2025_v0_2muons_mc_364545.Sherpa_222_NNPDF30NNLO_SinglePhoton_pty_280_500.2muons.root"
+      },
+      {
+        "checksum": "adler32:d9518ac4",
+        "size": 1339,
+        "uri": "root://eospublic.cern.ch//eos/opendata/atlas/rucio/opendata/ODEO_FEB2025_v0_2muons_mc_364546.Sherpa_222_NNPDF30NNLO_SinglePhoton_pty_500_1000.2muons.root"
+      },
+      {
+        "checksum": "adler32:96419256",
+        "size": 1355,
+        "uri": "root://eospublic.cern.ch//eos/opendata/atlas/rucio/opendata/ODEO_FEB2025_v0_2muons_mc_364547.Sherpa_222_NNPDF30NNLO_SinglePhoton_pty_1000_E_CMS.2muons.root"
+      },
+      {
+        "checksum": "adler32:cd468926",
+        "size": 1299,
+        "uri": "root://eospublic.cern.ch//eos/opendata/atlas/rucio/opendata/ODEO_FEB2025_v0_2muons_mc_364700.Pythia8EvtGen_A14NNPDF23LO_jetjet_JZ0WithSW.2muons.root"
+      },
+      {
+        "checksum": "adler32:db0af8d6",
+        "size": 38037,
+        "uri": "root://eospublic.cern.ch//eos/opendata/atlas/rucio/opendata/ODEO_FEB2025_v0_2muons_mc_364701.Pythia8EvtGen_A14NNPDF23LO_jetjet_JZ1WithSW.2muons.root"
+      },
+      {
+        "checksum": "adler32:c3171b37",
+        "size": 257657,
+        "uri": "root://eospublic.cern.ch//eos/opendata/atlas/rucio/opendata/ODEO_FEB2025_v0_2muons_mc_364702.Pythia8EvtGen_A14NNPDF23LO_jetjet_JZ2WithSW.2muons.root"
+      },
+      {
+        "checksum": "adler32:5518f864",
+        "size": 310096,
+        "uri": "root://eospublic.cern.ch//eos/opendata/atlas/rucio/opendata/ODEO_FEB2025_v0_2muons_mc_364703.Pythia8EvtGen_A14NNPDF23LO_jetjet_JZ3WithSW.2muons.root"
+      },
+      {
+        "checksum": "adler32:8c3e17c3",
+        "size": 475682,
+        "uri": "root://eospublic.cern.ch//eos/opendata/atlas/rucio/opendata/ODEO_FEB2025_v0_2muons_mc_364704.Pythia8EvtGen_A14NNPDF23LO_jetjet_JZ4WithSW.2muons.root"
+      },
+      {
+        "checksum": "adler32:126f1e3f",
+        "size": 100303,
+        "uri": "root://eospublic.cern.ch//eos/opendata/atlas/rucio/opendata/ODEO_FEB2025_v0_2muons_mc_364705.Pythia8EvtGen_A14NNPDF23LO_jetjet_JZ5WithSW.2muons.root"
+      },
+      {
+        "checksum": "adler32:98338746",
+        "size": 1299,
+        "uri": "root://eospublic.cern.ch//eos/opendata/atlas/rucio/opendata/ODEO_FEB2025_v0_2muons_mc_364706.Pythia8EvtGen_A14NNPDF23LO_jetjet_JZ6WithSW.2muons.root"
+      },
+      {
+        "checksum": "adler32:e3c68874",
+        "size": 1299,
+        "uri": "root://eospublic.cern.ch//eos/opendata/atlas/rucio/opendata/ODEO_FEB2025_v0_2muons_mc_364707.Pythia8EvtGen_A14NNPDF23LO_jetjet_JZ7WithSW.2muons.root"
+      },
+      {
+        "checksum": "adler32:e9ad87b2",
+        "size": 1299,
+        "uri": "root://eospublic.cern.ch//eos/opendata/atlas/rucio/opendata/ODEO_FEB2025_v0_2muons_mc_364708.Pythia8EvtGen_A14NNPDF23LO_jetjet_JZ8WithSW.2muons.root"
+      },
+      {
+        "checksum": "adler32:b342898c",
+        "size": 1299,
+        "uri": "root://eospublic.cern.ch//eos/opendata/atlas/rucio/opendata/ODEO_FEB2025_v0_2muons_mc_364709.Pythia8EvtGen_A14NNPDF23LO_jetjet_JZ9WithSW.2muons.root"
+      },
+      {
+        "checksum": "adler32:1806f2ee",
+        "size": 26744,
+        "uri": "root://eospublic.cern.ch//eos/opendata/atlas/rucio/opendata/ODEO_FEB2025_v0_2muons_mc_364710.Pythia8EvtGen_A14NNPDF23LO_jetjet_JZ10WithSW.2muons.root"
+      },
+      {
+        "checksum": "adler32:78c2867c",
+        "size": 1307,
+        "uri": "root://eospublic.cern.ch//eos/opendata/atlas/rucio/opendata/ODEO_FEB2025_v0_2muons_mc_364711.Pythia8EvtGen_A14NNPDF23LO_jetjet_JZ11WithSW.2muons.root"
+      },
+      {
+        "checksum": "adler32:6753885a",
+        "size": 1307,
+        "uri": "root://eospublic.cern.ch//eos/opendata/atlas/rucio/opendata/ODEO_FEB2025_v0_2muons_mc_364712.Pythia8EvtGen_A14NNPDF23LO_jetjet_JZ12WithSW.2muons.root"
+      },
+      {
+        "checksum": "adler32:d1a8640e",
+        "size": 195871,
+        "uri": "root://eospublic.cern.ch//eos/opendata/atlas/rucio/opendata/ODEO_FEB2025_v0_2muons_mc_375884.MGPy8EG_A14N_GG_ttn1_2000_5000_200.2muons.root"
+      },
+      {
+        "checksum": "adler32:c022bc05",
+        "size": 38393,
+        "uri": "root://eospublic.cern.ch//eos/opendata/atlas/rucio/opendata/ODEO_FEB2025_v0_2muons_mc_376359.MGPy8EG_A14N23LO_SS_onestepCC_1600_900_200.2muons.root"
+      },
+      {
+        "checksum": "adler32:7c9f9834",
+        "size": 1379,
+        "uri": "root://eospublic.cern.ch//eos/opendata/atlas/rucio/opendata/ODEO_FEB2025_v0_2muons_mc_376518.MadGraphPythia8EvtGen_A14NNPDF23LO_GG_direct_2400_200.2muons.root"
+      },
+      {
+        "checksum": "adler32:e3e20442",
+        "size": 1631669,
+        "uri": "root://eospublic.cern.ch//eos/opendata/atlas/rucio/opendata/ODEO_FEB2025_v0_2muons_mc_392202.MGPy8EG_A14N23LO_C1N2_WZ_500p0_100p0_3L_2L7.2muons.root"
+      },
+      {
+        "checksum": "adler32:ce4fd21f",
+        "size": 29604,
+        "uri": "root://eospublic.cern.ch//eos/opendata/atlas/rucio/opendata/ODEO_FEB2025_v0_2muons_mc_394997.MGPy8EG_A14N23LO_SM_N2C1p_105_100_2L2MET75_MadSpin.2muons.root"
+      },
+      {
+        "checksum": "adler32:93e8111d",
+        "size": 524518,
+        "uri": "root://eospublic.cern.ch//eos/opendata/atlas/rucio/opendata/ODEO_FEB2025_v0_2muons_mc_398384.MGPy8EG_A14N23LO_C1N2N1_GGMHinoZh50_800_noFilter.2muons.root"
+      },
+      {
+        "checksum": "adler32:9fba5bea",
+        "size": 767314,
+        "uri": "root://eospublic.cern.ch//eos/opendata/atlas/rucio/opendata/ODEO_FEB2025_v0_2muons_mc_410081.MadGraphPythia8EvtGen_A14NNPDF23_ttbarWW.2muons.root"
+      },
+      {
+        "checksum": "adler32:ba3bf64a",
+        "size": 3236475,
+        "uri": "root://eospublic.cern.ch//eos/opendata/atlas/rucio/opendata/ODEO_FEB2025_v0_2muons_mc_410082.MadGraphPythia8EvtGen_A14NNPDF23LO_ttgamma_noallhad.2muons.root"
+      },
+      {
+        "checksum": "adler32:9df12732",
+        "size": 74008,
+        "uri": "root://eospublic.cern.ch//eos/opendata/atlas/rucio/opendata/ODEO_FEB2025_v0_2muons_mc_410087.MadGraphPythia8EvtGen_A14NNPDF23LO_ttgamma_allhad.2muons.root"
+      },
+      {
+        "checksum": "adler32:9671ee1e",
+        "size": 1269047,
+        "uri": "root://eospublic.cern.ch//eos/opendata/atlas/rucio/opendata/ODEO_FEB2025_v0_2muons_mc_410155.aMcAtNloPythia8EvtGen_MEN30NLO_A14N23LO_ttW.2muons.root"
+      },
+      {
+        "checksum": "adler32:ebac3b68",
+        "size": 508346,
+        "uri": "root://eospublic.cern.ch//eos/opendata/atlas/rucio/opendata/ODEO_FEB2025_v0_2muons_mc_410156.aMcAtNloPythia8EvtGen_MEN30NLO_A14N23LO_ttZnunu.2muons.root"
+      },
+      {
+        "checksum": "adler32:9d110d3a",
+        "size": 760037,
+        "uri": "root://eospublic.cern.ch//eos/opendata/atlas/rucio/opendata/ODEO_FEB2025_v0_2muons_mc_410157.aMcAtNloPythia8EvtGen_MEN30NLO_A14N23LO_ttZqq.2muons.root"
+      },
+      {
+        "checksum": "adler32:19d0ced5",
+        "size": 383281,
+        "uri": "root://eospublic.cern.ch//eos/opendata/atlas/rucio/opendata/ODEO_FEB2025_v0_2muons_mc_410218.aMcAtNloPythia8EvtGen_MEN30NLO_A14N23LO_ttee.2muons.root"
+      },
+      {
+        "checksum": "adler32:767a6292",
+        "size": 41851523,
+        "uri": "root://eospublic.cern.ch//eos/opendata/atlas/rucio/opendata/ODEO_FEB2025_v0_2muons_mc_410219.aMcAtNloPythia8EvtGen_MEN30NLO_A14N23LO_ttmumu.2muons.root"
+      },
+      {
+        "checksum": "adler32:9b873220",
+        "size": 2685496,
+        "uri": "root://eospublic.cern.ch//eos/opendata/atlas/rucio/opendata/ODEO_FEB2025_v0_2muons_mc_410220.aMcAtNloPythia8EvtGen_MEN30NLO_A14N23LO_tttautau.2muons.root"
+      },
+      {
+        "checksum": "adler32:9ee6d3bc",
+        "size": 4865353,
+        "uri": "root://eospublic.cern.ch//eos/opendata/atlas/rucio/opendata/ODEO_FEB2025_v0_2muons_mc_410389.MadGraphPythia8EvtGen_A14NNPDF23_ttgamma_nonallhadronic.2muons.root"
+      },
+      {
+        "checksum": "adler32:cfb5da26",
+        "size": 4358999,
+        "uri": "root://eospublic.cern.ch//eos/opendata/atlas/rucio/opendata/ODEO_FEB2025_v0_2muons_mc_410395.MGH7EG_H7UE_ttgamma_nonallhadronic.2muons.root"
+      },
+      {
+        "checksum": "adler32:81f56f87",
+        "size": 1203,
+        "uri": "root://eospublic.cern.ch//eos/opendata/atlas/rucio/opendata/ODEO_FEB2025_v0_2muons_mc_410396.MGH7EG_H7UE_ttgamma_allhadronic.2muons.root"
+      },
+      {
+        "checksum": "adler32:bdc7f393",
+        "size": 4411650,
+        "uri": "root://eospublic.cern.ch//eos/opendata/atlas/rucio/opendata/ODEO_FEB2025_v0_2muons_mc_410408.aMcAtNloPythia8EvtGen_tWZ_Ztoll_minDR1.2muons.root"
+      },
+      {
+        "checksum": "adler32:4ec3c637",
+        "size": 258950189,
+        "uri": "root://eospublic.cern.ch//eos/opendata/atlas/rucio/opendata/ODEO_FEB2025_v0_2muons_mc_410470.PhPy8EG_A14_ttbar_hdamp258p75_nonallhad.2muons.root"
+      },
+      {
+        "checksum": "adler32:dd3c84fe",
+        "size": 398133,
+        "uri": "root://eospublic.cern.ch//eos/opendata/atlas/rucio/opendata/ODEO_FEB2025_v0_2muons_mc_410471.PhPy8EG_A14_ttbar_hdamp258p75_allhad.2muons.root"
+      },
+      {
+        "checksum": "adler32:55dcc974",
+        "size": 3933404,
+        "uri": "root://eospublic.cern.ch//eos/opendata/atlas/rucio/opendata/ODEO_FEB2025_v0_2muons_mc_410560.MadGraphPythia8EvtGen_A14_tZ_4fl_tchan_noAllHad.2muons.root"
+      },
+      {
+        "checksum": "adler32:687148c5",
+        "size": 94172,
+        "uri": "root://eospublic.cern.ch//eos/opendata/atlas/rucio/opendata/ODEO_FEB2025_v0_2muons_mc_410644.PowhegPythia8EvtGen_A14_singletop_schan_lept_top.2muons.root"
+      },
+      {
+        "checksum": "adler32:a2bff82e",
+        "size": 67667,
+        "uri": "root://eospublic.cern.ch//eos/opendata/atlas/rucio/opendata/ODEO_FEB2025_v0_2muons_mc_410645.PowhegPythia8EvtGen_A14_singletop_schan_lept_antitop.2muons.root"
+      },
+      {
+        "checksum": "adler32:86366849",
+        "size": 1352142,
+        "uri": "root://eospublic.cern.ch//eos/opendata/atlas/rucio/opendata/ODEO_FEB2025_v0_2muons_mc_410658.PhPy8EG_A14_tchan_BW50_lept_top.2muons.root"
+      },
+      {
+        "checksum": "adler32:d7d24632",
+        "size": 800187,
+        "uri": "root://eospublic.cern.ch//eos/opendata/atlas/rucio/opendata/ODEO_FEB2025_v0_2muons_mc_410659.PhPy8EG_A14_tchan_BW50_lept_antitop.2muons.root"
+      },
+      {
+        "checksum": "adler32:ac389179",
+        "size": 3363949,
+        "uri": "root://eospublic.cern.ch//eos/opendata/atlas/rucio/opendata/ODEO_FEB2025_v0_2muons_mc_411233.PowhegHerwig7EvtGen_tt_hdamp258p75_713_SingleLep.2muons.root"
+      },
+      {
+        "checksum": "adler32:016ac7fd",
+        "size": 127810614,
+        "uri": "root://eospublic.cern.ch//eos/opendata/atlas/rucio/opendata/ODEO_FEB2025_v0_2muons_mc_411234.PowhegHerwig7EvtGen_tt_hdamp258p75_713_dil.2muons.root"
+      },
+      {
+        "checksum": "adler32:1bd4ff34",
+        "size": 702948,
+        "uri": "root://eospublic.cern.ch//eos/opendata/atlas/rucio/opendata/ODEO_FEB2025_v0_2muons_mc_411316.PowhegHerwig7EvtGen_tt_hdamp258p75_713_allhad.2muons.root"
+      },
+      {
+        "checksum": "adler32:da1304ed",
+        "size": 4356722,
+        "uri": "root://eospublic.cern.ch//eos/opendata/atlas/rucio/opendata/ODEO_FEB2025_v0_2muons_mc_412043.aMcAtNloPythia8EvtGen_A14NNPDF31_SM4topsNLO.2muons.root"
+      },
+      {
+        "checksum": "adler32:90cc4a99",
+        "size": 4332400,
+        "uri": "root://eospublic.cern.ch//eos/opendata/atlas/rucio/opendata/ODEO_FEB2025_v0_2muons_mc_412044.aMcAtNloHerwig7EvtGen_H7UE_SM4topsNLO.2muons.root"
+      },
+      {
+        "checksum": "adler32:3ada80d2",
+        "size": 1291,
+        "uri": "root://eospublic.cern.ch//eos/opendata/atlas/rucio/opendata/ODEO_FEB2025_v0_2muons_mc_423099.Pythia8EvtGen_A14NNPDF23LO_gammajet_DP8_17.2muons.root"
+      },
+      {
+        "checksum": "adler32:855b8206",
+        "size": 1299,
+        "uri": "root://eospublic.cern.ch//eos/opendata/atlas/rucio/opendata/ODEO_FEB2025_v0_2muons_mc_423100.Pythia8EvtGen_A14NNPDF23LO_gammajet_DP17_35.2muons.root"
+      },
+      {
+        "checksum": "adler32:31f6d57c",
+        "size": 99152,
+        "uri": "root://eospublic.cern.ch//eos/opendata/atlas/rucio/opendata/ODEO_FEB2025_v0_2muons_mc_423101.Pythia8EvtGen_A14NNPDF23LO_gammajet_DP35_50.2muons.root"
+      },
+      {
+        "checksum": "adler32:8513835c",
+        "size": 1299,
+        "uri": "root://eospublic.cern.ch//eos/opendata/atlas/rucio/opendata/ODEO_FEB2025_v0_2muons_mc_423102.Pythia8EvtGen_A14NNPDF23LO_gammajet_DP50_70.2muons.root"
+      },
+      {
+        "checksum": "adler32:08cb824a",
+        "size": 1307,
+        "uri": "root://eospublic.cern.ch//eos/opendata/atlas/rucio/opendata/ODEO_FEB2025_v0_2muons_mc_423103.Pythia8EvtGen_A14NNPDF23LO_gammajet_DP70_140.2muons.root"
+      },
+      {
+        "checksum": "adler32:0a981765",
+        "size": 26449,
+        "uri": "root://eospublic.cern.ch//eos/opendata/atlas/rucio/opendata/ODEO_FEB2025_v0_2muons_mc_423104.Pythia8EvtGen_A14NNPDF23LO_gammajet_DP140_280.2muons.root"
+      },
+      {
+        "checksum": "adler32:0d276451",
+        "size": 26554,
+        "uri": "root://eospublic.cern.ch//eos/opendata/atlas/rucio/opendata/ODEO_FEB2025_v0_2muons_mc_423105.Pythia8EvtGen_A14NNPDF23LO_gammajet_DP280_500.2muons.root"
+      },
+      {
+        "checksum": "adler32:5ed283c6",
+        "size": 1315,
+        "uri": "root://eospublic.cern.ch//eos/opendata/atlas/rucio/opendata/ODEO_FEB2025_v0_2muons_mc_423106.Pythia8EvtGen_A14NNPDF23LO_gammajet_DP500_800.2muons.root"
+      },
+      {
+        "checksum": "adler32:ace64d53",
+        "size": 26594,
+        "uri": "root://eospublic.cern.ch//eos/opendata/atlas/rucio/opendata/ODEO_FEB2025_v0_2muons_mc_423107.Pythia8EvtGen_A14NNPDF23LO_gammajet_DP800_1000.2muons.root"
+      },
+      {
+        "checksum": "adler32:09dd8782",
+        "size": 1331,
+        "uri": "root://eospublic.cern.ch//eos/opendata/atlas/rucio/opendata/ODEO_FEB2025_v0_2muons_mc_423108.Pythia8EvtGen_A14NNPDF23LO_gammajet_DP1000_1500.2muons.root"
+      },
+      {
+        "checksum": "adler32:d0f1873a",
+        "size": 1331,
+        "uri": "root://eospublic.cern.ch//eos/opendata/atlas/rucio/opendata/ODEO_FEB2025_v0_2muons_mc_423109.Pythia8EvtGen_A14NNPDF23LO_gammajet_DP1500_2000.2muons.root"
+      },
+      {
+        "checksum": "adler32:3259856e",
+        "size": 1331,
+        "uri": "root://eospublic.cern.ch//eos/opendata/atlas/rucio/opendata/ODEO_FEB2025_v0_2muons_mc_423110.Pythia8EvtGen_A14NNPDF23LO_gammajet_DP2000_2500.2muons.root"
+      },
+      {
+        "checksum": "adler32:54fc85c4",
+        "size": 1331,
+        "uri": "root://eospublic.cern.ch//eos/opendata/atlas/rucio/opendata/ODEO_FEB2025_v0_2muons_mc_423111.Pythia8EvtGen_A14NNPDF23LO_gammajet_DP2500_3000.2muons.root"
+      },
+      {
+        "checksum": "adler32:d3208958",
+        "size": 1323,
+        "uri": "root://eospublic.cern.ch//eos/opendata/atlas/rucio/opendata/ODEO_FEB2025_v0_2muons_mc_423112.Pythia8EvtGen_A14NNPDF23LO_gammajet_DP3000_inf.2muons.root"
+      },
+      {
+        "checksum": "adler32:4468f3f7",
+        "size": 113903,
+        "uri": "root://eospublic.cern.ch//eos/opendata/atlas/rucio/opendata/ODEO_FEB2025_v0_2muons_mc_448624.MGPy8EG_A14N23LO_TT_higgsinoRPV_1075_700.2muons.root"
+      },
+      {
+        "checksum": "adler32:d83a3bdb",
+        "size": 597712,
+        "uri": "root://eospublic.cern.ch//eos/opendata/atlas/rucio/opendata/ODEO_FEB2025_v0_2muons_mc_449595.MGPy8EG_A14N23LO_TT_RPVdirectBL_1400.2muons.root"
+      },
+      {
+        "checksum": "adler32:1707420d",
+        "size": 4043300,
+        "uri": "root://eospublic.cern.ch//eos/opendata/atlas/rucio/opendata/ODEO_FEB2025_v0_2muons_mc_450576.PowhegPythia8EvtGen_NNLOPS_nnlo_30_VBFH125_ZZllbb.2muons.root"
+      },
+      {
+        "checksum": "adler32:9c8b017d",
+        "size": 7467902,
+        "uri": "root://eospublic.cern.ch//eos/opendata/atlas/rucio/opendata/ODEO_FEB2025_v0_2muons_mc_500335.MGH7EG_VBFHWWlvlv.2muons.root"
+      },
+      {
+        "checksum": "adler32:9363ccb5",
+        "size": 1573892,
+        "uri": "root://eospublic.cern.ch//eos/opendata/atlas/rucio/opendata/ODEO_FEB2025_v0_2muons_mc_500553.aMCPy8EG_ZH_FxFx_Hyy.2muons.root"
+      },
+      {
+        "checksum": "adler32:0089988f",
+        "size": 50483,
+        "uri": "root://eospublic.cern.ch//eos/opendata/atlas/rucio/opendata/ODEO_FEB2025_v0_2muons_mc_500554.aMCPy8EG_WH_FxFx_Hyy.2muons.root"
+      },
+      {
+        "checksum": "adler32:6a85d99b",
+        "size": 1566539,
+        "uri": "root://eospublic.cern.ch//eos/opendata/atlas/rucio/opendata/ODEO_FEB2025_v0_2muons_mc_500555.aMCPy8EG_ggZH_Hyy.2muons.root"
+      },
+      {
+        "checksum": "adler32:5c1bbf77",
+        "size": 177217,
+        "uri": "root://eospublic.cern.ch//eos/opendata/atlas/rucio/opendata/ODEO_FEB2025_v0_2muons_mc_501058.MGPy8EG_StauStauDirect_200p0_1p0_TFilt.2muons.root"
+      },
+      {
+        "checksum": "adler32:609c2827",
+        "size": 564813,
+        "uri": "root://eospublic.cern.ch//eos/opendata/atlas/rucio/opendata/ODEO_FEB2025_v0_2muons_mc_506098.aMCPy8EG_WpH_FxFx_Htautau.2muons.root"
+      },
+      {
+        "checksum": "adler32:095ab5e1",
+        "size": 753552,
+        "uri": "root://eospublic.cern.ch//eos/opendata/atlas/rucio/opendata/ODEO_FEB2025_v0_2muons_mc_506099.aMCPy8EG_ZH_FxFx_Htautau.2muons.root"
+      },
+      {
+        "checksum": "adler32:fb4bf97d",
+        "size": 26430,
+        "uri": "root://eospublic.cern.ch//eos/opendata/atlas/rucio/opendata/ODEO_FEB2025_v0_2muons_mc_506101.aMCH7EG_VBF_Htautauh30h20.2muons.root"
+      },
+      {
+        "checksum": "adler32:087c6de8",
+        "size": 5252429,
+        "uri": "root://eospublic.cern.ch//eos/opendata/atlas/rucio/opendata/ODEO_FEB2025_v0_2muons_mc_506102.aMCH7EG_VBF_Htautaul13l7.2muons.root"
+      },
+      {
+        "checksum": "adler32:6317b9bc",
+        "size": 48450,
+        "uri": "root://eospublic.cern.ch//eos/opendata/atlas/rucio/opendata/ODEO_FEB2025_v0_2muons_mc_506103.aMCH7EG_VBF_Htautaulp15hm20.2muons.root"
+      },
+      {
+        "checksum": "adler32:792e3bfc",
+        "size": 75006,
+        "uri": "root://eospublic.cern.ch//eos/opendata/atlas/rucio/opendata/ODEO_FEB2025_v0_2muons_mc_506104.aMCH7EG_VBF_Htautaulm15hp20.2muons.root"
+      },
+      {
+        "checksum": "adler32:4963961f",
+        "size": 26187,
+        "uri": "root://eospublic.cern.ch//eos/opendata/atlas/rucio/opendata/ODEO_FEB2025_v0_2muons_mc_506811.aMCH7EG_VBF_HC_Hyy.2muons.root"
+      },
+      {
+        "checksum": "adler32:40c33e18",
+        "size": 31598,
+        "uri": "root://eospublic.cern.ch//eos/opendata/atlas/rucio/opendata/ODEO_FEB2025_v0_2muons_mc_506813.aMCPy8EG_ZH_had_FxFx_Hyy.2muons.root"
+      },
+      {
+        "checksum": "adler32:d1756519",
+        "size": 27344,
+        "uri": "root://eospublic.cern.ch//eos/opendata/atlas/rucio/opendata/ODEO_FEB2025_v0_2muons_mc_506814.aMCPy8EG_ggZH_Zhad_Hyy.2muons.root"
+      },
+      {
+        "checksum": "adler32:0b006eea",
+        "size": 112595,
+        "uri": "root://eospublic.cern.ch//eos/opendata/atlas/rucio/opendata/ODEO_FEB2025_v0_2muons_mc_507366.MGPy8EG_A14NNPDF23LO_GGM_N1N2C1_950.2muons.root"
+      },
+      {
+        "checksum": "adler32:14eb58b8",
+        "size": 710825,
+        "uri": "root://eospublic.cern.ch//eos/opendata/atlas/rucio/opendata/ODEO_FEB2025_v0_2muons_mc_510097.MGPy8EG_A14N23LO_DM_4topscalar_p1000_c1_nonallhad.2muons.root"
+      },
+      {
+        "checksum": "adler32:396269ae",
+        "size": 66610,
+        "uri": "root://eospublic.cern.ch//eos/opendata/atlas/rucio/opendata/ODEO_FEB2025_v0_2muons_mc_523692.MGPy8EG_A14N23LO_TT_tN1_1200_200_MS.2muons.root"
+      },
+      {
+        "checksum": "adler32:64017246",
+        "size": 598306,
+        "uri": "root://eospublic.cern.ch//eos/opendata/atlas/rucio/opendata/ODEO_FEB2025_v0_2muons_mc_600017.PhH7EG_H7UE_716_tchan_lept_antitop.2muons.root"
+      },
+      {
+        "checksum": "adler32:b53167db",
+        "size": 1012427,
+        "uri": "root://eospublic.cern.ch//eos/opendata/atlas/rucio/opendata/ODEO_FEB2025_v0_2muons_mc_600018.PhH7EG_H7UE_716_tchan_lept_top.2muons.root"
+      },
+      {
+        "checksum": "adler32:fd8f38db",
+        "size": 69928,
+        "uri": "root://eospublic.cern.ch//eos/opendata/atlas/rucio/opendata/ODEO_FEB2025_v0_2muons_mc_600019.PhH7EG_H7UE_716_schan_lept_antitop.2muons.root"
+      },
+      {
+        "checksum": "adler32:cfb266d9",
+        "size": 87031,
+        "uri": "root://eospublic.cern.ch//eos/opendata/atlas/rucio/opendata/ODEO_FEB2025_v0_2muons_mc_600020.PhH7EG_H7UE_716_schan_lept_top.2muons.root"
+      },
+      {
+        "checksum": "adler32:3cd08192",
+        "size": 1275,
+        "uri": "root://eospublic.cern.ch//eos/opendata/atlas/rucio/opendata/ODEO_FEB2025_v0_2muons_mc_600565.PhH7EG_ggH125_tautauh30h20_ShowerSys_fix.2muons.root"
+      },
+      {
+        "checksum": "adler32:8c978f1e",
+        "size": 19724886,
+        "uri": "root://eospublic.cern.ch//eos/opendata/atlas/rucio/opendata/ODEO_FEB2025_v0_2muons_mc_600566.PhH7EG_ggH125_tautaul13l7_ShowerSys_fix.2muons.root"
+      },
+      {
+        "checksum": "adler32:8f5dd2e5",
+        "size": 100457,
+        "uri": "root://eospublic.cern.ch//eos/opendata/atlas/rucio/opendata/ODEO_FEB2025_v0_2muons_mc_600567.PhH7EG_ggH125_ttlp15hm20_ShowerSys_fix.2muons.root"
+      },
+      {
+        "checksum": "adler32:e18d3ec6",
+        "size": 124627,
+        "uri": "root://eospublic.cern.ch//eos/opendata/atlas/rucio/opendata/ODEO_FEB2025_v0_2muons_mc_600568.PhH7EG_ggH125_ttlm15hp20_ShowerSys_fix.2muons.root"
+      },
+      {
+        "checksum": "adler32:46f265e1",
+        "size": 27442,
+        "uri": "root://eospublic.cern.ch//eos/opendata/atlas/rucio/opendata/ODEO_FEB2025_v0_2muons_mc_600569.PhH7EG_VBFH125_tautauh30h20_ShowerSys_fix.2muons.root"
+      },
+      {
+        "checksum": "adler32:c2ed8e48",
+        "size": 5033143,
+        "uri": "root://eospublic.cern.ch//eos/opendata/atlas/rucio/opendata/ODEO_FEB2025_v0_2muons_mc_600570.PhH7EG_VBFH125_tautaul13l7_ShowerSys_fix.2muons.root"
+      },
+      {
+        "checksum": "adler32:c7cab102",
+        "size": 42323,
+        "uri": "root://eospublic.cern.ch//eos/opendata/atlas/rucio/opendata/ODEO_FEB2025_v0_2muons_mc_600571.PhH7EG_VBFH125_tautaulp15hm20_ShowerSys_fix.2muons.root"
+      },
+      {
+        "checksum": "adler32:af11e655",
+        "size": 48959,
+        "uri": "root://eospublic.cern.ch//eos/opendata/atlas/rucio/opendata/ODEO_FEB2025_v0_2muons_mc_600572.PhH7EG_VBFH125_tautaulm15hp20_ShowerSys_fix.2muons.root"
+      },
+      {
+        "checksum": "adler32:b22c91da",
+        "size": 347124,
+        "uri": "root://eospublic.cern.ch//eos/opendata/atlas/rucio/opendata/ODEO_FEB2025_v0_2muons_mc_600573.PhH7EG_WmH125J_Winc_MINLO_tt_ShowerSys_fix.2muons.root"
+      },
+      {
+        "checksum": "adler32:47cfd819",
+        "size": 537715,
+        "uri": "root://eospublic.cern.ch//eos/opendata/atlas/rucio/opendata/ODEO_FEB2025_v0_2muons_mc_600574.PhH7EG_WpH125J_Winc_MINLO_tt_ShowerSys_fix.2muons.root"
+      },
+      {
+        "checksum": "adler32:a436ff84",
+        "size": 1061486,
+        "uri": "root://eospublic.cern.ch//eos/opendata/atlas/rucio/opendata/ODEO_FEB2025_v0_2muons_mc_600575.PhH7EG_ZH125J_Zinc_MINLO_tautau_ShowerSys_fix.2muons.root"
+      },
+      {
+        "checksum": "adler32:32383c34",
+        "size": 618518,
+        "uri": "root://eospublic.cern.ch//eos/opendata/atlas/rucio/opendata/ODEO_FEB2025_v0_2muons_mc_600686.PhPy8EG_NNPDF3_AZNLO_ggZH125_Htautau_Zinc.2muons.root"
+      },
+      {
+        "checksum": "adler32:816a2af5",
+        "size": 11260277,
+        "uri": "root://eospublic.cern.ch//eos/opendata/atlas/rucio/opendata/ODEO_FEB2025_v0_2muons_mc_601352.PhPy8EG_tW_dyn_DR_incl_antitop.2muons.root"
+      },
+      {
+        "checksum": "adler32:55211a2b",
+        "size": 11117744,
+        "uri": "root://eospublic.cern.ch//eos/opendata/atlas/rucio/opendata/ODEO_FEB2025_v0_2muons_mc_601355.PhPy8EG_tW_dyn_DR_incl_top.2muons.root"
+      },
+      {
+        "checksum": "adler32:8453dd8d",
+        "size": 703518,
+        "uri": "root://eospublic.cern.ch//eos/opendata/atlas/rucio/opendata/ODEO_FEB2025_v0_2muons_mc_601487.PhPy8EG_A14_tchan_pThard1_lep_antitop.2muons.root"
+      },
+      {
+        "checksum": "adler32:8835a6a5",
+        "size": 1082541,
+        "uri": "root://eospublic.cern.ch//eos/opendata/atlas/rucio/opendata/ODEO_FEB2025_v0_2muons_mc_601489.PhPy8EG_A14_tchan_pThard1_lep_top.2muons.root"
+      },
+      {
+        "checksum": "adler32:574e2851",
+        "size": 220324374,
+        "uri": "root://eospublic.cern.ch//eos/opendata/atlas/rucio/opendata/ODEO_FEB2025_v0_2muons_mc_601491.PhPy8EG_A14_ttbar_pThard1_dil.2muons.root"
+      },
+      {
+        "checksum": "adler32:fc1f6fbe",
+        "size": 1211,
+        "uri": "root://eospublic.cern.ch//eos/opendata/atlas/rucio/opendata/ODEO_FEB2025_v0_2muons_mc_601495.PhPy8EG_A14_ttbar_pThard1_allhad.2muons.root"
+      },
+      {
+        "checksum": "adler32:dad05f79",
+        "size": 12801525,
+        "uri": "root://eospublic.cern.ch//eos/opendata/atlas/rucio/opendata/ODEO_FEB2025_v0_2muons_mc_601497.PhPy8EG_A14_ttbar_pThard1_singlelep.2muons.root"
+      },
+      {
+        "checksum": "adler32:11db39c7",
+        "size": 11360732,
+        "uri": "root://eospublic.cern.ch//eos/opendata/atlas/rucio/opendata/ODEO_FEB2025_v0_2muons_mc_601624.PhPy8EG_tW_DS_dyn_dil_antitop.2muons.root"
+      },
+      {
+        "checksum": "adler32:1693267b",
+        "size": 10868705,
+        "uri": "root://eospublic.cern.ch//eos/opendata/atlas/rucio/opendata/ODEO_FEB2025_v0_2muons_mc_601627.PhPy8EG_tW_DS_dyn_incl_antitop.2muons.root"
+      },
+      {
+        "checksum": "adler32:9548a762",
+        "size": 14643575,
+        "uri": "root://eospublic.cern.ch//eos/opendata/atlas/rucio/opendata/ODEO_FEB2025_v0_2muons_mc_601628.PhPy8EG_tW_DS_dyn_dil_top.2muons.root"
+      },
+      {
+        "checksum": "adler32:f1f44500",
+        "size": 10568382,
+        "uri": "root://eospublic.cern.ch//eos/opendata/atlas/rucio/opendata/ODEO_FEB2025_v0_2muons_mc_601631.PhPy8EG_tW_DS_dyn_incl_top.2muons.root"
+      },
+      {
+        "checksum": "adler32:64a49631",
+        "size": 11193723,
+        "uri": "root://eospublic.cern.ch//eos/opendata/atlas/rucio/opendata/ODEO_FEB2025_v0_2muons_mc_601761.PhPy8EG_tW_dyn_DR_pThard1_incl_top.2muons.root"
+      },
+      {
+        "checksum": "adler32:19cad1c5",
+        "size": 11034899,
+        "uri": "root://eospublic.cern.ch//eos/opendata/atlas/rucio/opendata/ODEO_FEB2025_v0_2muons_mc_601762.PhPy8EG_tW_dyn_DR_pThard1_incl_antitop.2muons.root"
+      },
+      {
+        "checksum": "adler32:a19083c3",
+        "size": 14745484,
+        "uri": "root://eospublic.cern.ch//eos/opendata/atlas/rucio/opendata/ODEO_FEB2025_v0_2muons_mc_601763.PhPy8EG_tW_dyn_DR_pThard1_dil_top.2muons.root"
+      },
+      {
+        "checksum": "adler32:891c3d77",
+        "size": 14730139,
+        "uri": "root://eospublic.cern.ch//eos/opendata/atlas/rucio/opendata/ODEO_FEB2025_v0_2muons_mc_601764.PhPy8EG_tW_dyn_DR_pThard1_dil_antitop.2muons.root"
+      },
+      {
+        "checksum": "adler32:8933a203",
+        "size": 2061862,
+        "uri": "root://eospublic.cern.ch//eos/opendata/atlas/rucio/opendata/ODEO_FEB2025_v0_2muons_mc_700000.Sh_228_ttW.2muons.root"
+      },
+      {
+        "checksum": "adler32:39cc3bc1",
+        "size": 1083,
+        "uri": "root://eospublic.cern.ch//eos/opendata/atlas/rucio/opendata/ODEO_FEB2025_v0_2muons_mc_700007.Sh_228_yyy_01NLO.2muons.root"
+      },
+      {
+        "checksum": "adler32:fc274629",
+        "size": 1115,
+        "uri": "root://eospublic.cern.ch//eos/opendata/atlas/rucio/opendata/ODEO_FEB2025_v0_2muons_mc_700195.Sh_2210_eegammagamma.2muons.root"
+      },
+      {
+        "checksum": "adler32:3fb7f8ea",
+        "size": 27473898,
+        "uri": "root://eospublic.cern.ch//eos/opendata/atlas/rucio/opendata/ODEO_FEB2025_v0_2muons_mc_700196.Sh_2210_mumugammagamma.2muons.root"
+      },
+      {
+        "checksum": "adler32:2e07c8fb",
+        "size": 90771,
+        "uri": "root://eospublic.cern.ch//eos/opendata/atlas/rucio/opendata/ODEO_FEB2025_v0_2muons_mc_700197.Sh_2210_tautaugammagamma.2muons.root"
+      },
+      {
+        "checksum": "adler32:369851d1",
+        "size": 1131,
+        "uri": "root://eospublic.cern.ch//eos/opendata/atlas/rucio/opendata/ODEO_FEB2025_v0_2muons_mc_700198.Sh_2210_nunugammagamma.2muons.root"
+      },
+      {
+        "checksum": "adler32:36114b2f",
+        "size": 1123,
+        "uri": "root://eospublic.cern.ch//eos/opendata/atlas/rucio/opendata/ODEO_FEB2025_v0_2muons_mc_700199.Sh_2210_enugammagamma.2muons.root"
+      },
+      {
+        "checksum": "adler32:332abdb4",
+        "size": 28413,
+        "uri": "root://eospublic.cern.ch//eos/opendata/atlas/rucio/opendata/ODEO_FEB2025_v0_2muons_mc_700200.Sh_2210_munugammagamma.2muons.root"
+      },
+      {
+        "checksum": "adler32:e67651ae",
+        "size": 1139,
+        "uri": "root://eospublic.cern.ch//eos/opendata/atlas/rucio/opendata/ODEO_FEB2025_v0_2muons_mc_700201.Sh_2210_taunugammagamma.2muons.root"
+      },
+      {
+        "checksum": "adler32:6e9ede0e",
+        "size": 38481,
+        "uri": "root://eospublic.cern.ch//eos/opendata/atlas/rucio/opendata/ODEO_FEB2025_v0_2muons_mc_700320.Sh_2211_Zee_maxHTpTV2_BFilter.2muons.root"
+      },
+      {
+        "checksum": "adler32:ec9b6f1b",
+        "size": 1227,
+        "uri": "root://eospublic.cern.ch//eos/opendata/atlas/rucio/opendata/ODEO_FEB2025_v0_2muons_mc_700321.Sh_2211_Zee_maxHTpTV2_CFilterBVeto.2muons.root"
+      },
+      {
+        "checksum": "adler32:e7d5d321",
+        "size": 26391,
+        "uri": "root://eospublic.cern.ch//eos/opendata/atlas/rucio/opendata/ODEO_FEB2025_v0_2muons_mc_700322.Sh_2211_Zee_maxHTpTV2_CVetoBVeto.2muons.root"
+      },
+      {
+        "checksum": "adler32:09fac403",
+        "size": 1061597091,
+        "uri": "root://eospublic.cern.ch//eos/opendata/atlas/rucio/opendata/ODEO_FEB2025_v0_2muons_mc_700323.Sh_2211_Zmumu_maxHTpTV2_BFilter.2muons.root"
+      },
+      {
+        "checksum": "adler32:f3b549d1",
+        "size": 4853193365,
+        "uri": "root://eospublic.cern.ch//eos/opendata/atlas/rucio/opendata/ODEO_FEB2025_v0_2muons_mc_700324.Sh_2211_Zmumu_maxHTpTV2_CFilterBVeto.2muons.root"
+      },
+      {
+        "checksum": "adler32:7e6e1753",
+        "size": 16712423398,
+        "uri": "root://eospublic.cern.ch//eos/opendata/atlas/rucio/opendata/ODEO_FEB2025_v0_2muons_mc_700325.Sh_2211_Zmumu_maxHTpTV2_CVetoBVeto.2muons.root"
+      },
+      {
+        "checksum": "adler32:be92ac6f",
+        "size": 37997,
+        "uri": "root://eospublic.cern.ch//eos/opendata/atlas/rucio/opendata/ODEO_FEB2025_v0_2muons_mc_700335.Sh_2211_Znunu_pTV2_BFilter.2muons.root"
+      },
+      {
+        "checksum": "adler32:9eebb1f1",
+        "size": 26334,
+        "uri": "root://eospublic.cern.ch//eos/opendata/atlas/rucio/opendata/ODEO_FEB2025_v0_2muons_mc_700336.Sh_2211_Znunu_pTV2_CFilterBVeto.2muons.root"
+      },
+      {
+        "checksum": "adler32:172968a4",
+        "size": 1187,
+        "uri": "root://eospublic.cern.ch//eos/opendata/atlas/rucio/opendata/ODEO_FEB2025_v0_2muons_mc_700337.Sh_2211_Znunu_pTV2_CVetoBVeto.2muons.root"
+      },
+      {
+        "checksum": "adler32:9eee28b1",
+        "size": 50734,
+        "uri": "root://eospublic.cern.ch//eos/opendata/atlas/rucio/opendata/ODEO_FEB2025_v0_2muons_mc_700338.Sh_2211_Wenu_maxHTpTV2_BFilter.2muons.root"
+      },
+      {
+        "checksum": "adler32:d71915f8",
+        "size": 75134,
+        "uri": "root://eospublic.cern.ch//eos/opendata/atlas/rucio/opendata/ODEO_FEB2025_v0_2muons_mc_700339.Sh_2211_Wenu_maxHTpTV2_CFilterBVeto.2muons.root"
+      },
+      {
+        "checksum": "adler32:a1b5695f",
+        "size": 38359,
+        "uri": "root://eospublic.cern.ch//eos/opendata/atlas/rucio/opendata/ODEO_FEB2025_v0_2muons_mc_700340.Sh_2211_Wenu_maxHTpTV2_CVetoBVeto.2muons.root"
+      },
+      {
+        "checksum": "adler32:fbcc2948",
+        "size": 8257573,
+        "uri": "root://eospublic.cern.ch//eos/opendata/atlas/rucio/opendata/ODEO_FEB2025_v0_2muons_mc_700341.Sh_2211_Wmunu_maxHTpTV2_BFilter.2muons.root"
+      },
+      {
+        "checksum": "adler32:8a37f8f0",
+        "size": 20540791,
+        "uri": "root://eospublic.cern.ch//eos/opendata/atlas/rucio/opendata/ODEO_FEB2025_v0_2muons_mc_700342.Sh_2211_Wmunu_maxHTpTV2_CFilterBVeto.2muons.root"
+      },
+      {
+        "checksum": "adler32:3a1399d2",
+        "size": 9955905,
+        "uri": "root://eospublic.cern.ch//eos/opendata/atlas/rucio/opendata/ODEO_FEB2025_v0_2muons_mc_700343.Sh_2211_Wmunu_maxHTpTV2_CVetoBVeto.2muons.root"
+      },
+      {
+        "checksum": "adler32:40b3837e",
+        "size": 1469066,
+        "uri": "root://eospublic.cern.ch//eos/opendata/atlas/rucio/opendata/ODEO_FEB2025_v0_2muons_mc_700344.Sh_2211_Wtaunu_L_maxHTpTV2_BFilter.2muons.root"
+      },
+      {
+        "checksum": "adler32:f7ff5dc1",
+        "size": 4678166,
+        "uri": "root://eospublic.cern.ch//eos/opendata/atlas/rucio/opendata/ODEO_FEB2025_v0_2muons_mc_700345.Sh_2211_Wtaunu_L_maxHTpTV2_CFilterBVeto.2muons.root"
+      },
+      {
+        "checksum": "adler32:6382a53d",
+        "size": 2606099,
+        "uri": "root://eospublic.cern.ch//eos/opendata/atlas/rucio/opendata/ODEO_FEB2025_v0_2muons_mc_700346.Sh_2211_Wtaunu_L_maxHTpTV2_CVetoBVeto.2muons.root"
+      },
+      {
+        "checksum": "adler32:00c8ef5d",
+        "size": 212936,
+        "uri": "root://eospublic.cern.ch//eos/opendata/atlas/rucio/opendata/ODEO_FEB2025_v0_2muons_mc_700347.Sh_2211_Wtaunu_H_maxHTpTV2_BFilter.2muons.root"
+      },
+      {
+        "checksum": "adler32:58f2c7a8",
+        "size": 150999,
+        "uri": "root://eospublic.cern.ch//eos/opendata/atlas/rucio/opendata/ODEO_FEB2025_v0_2muons_mc_700348.Sh_2211_Wtaunu_H_maxHTpTV2_CFilterBVeto.2muons.root"
+      },
+      {
+        "checksum": "adler32:99859cb9",
+        "size": 62816,
+        "uri": "root://eospublic.cern.ch//eos/opendata/atlas/rucio/opendata/ODEO_FEB2025_v0_2muons_mc_700349.Sh_2211_Wtaunu_H_maxHTpTV2_CVetoBVeto.2muons.root"
+      },
+      {
+        "checksum": "adler32:68b24bf2",
+        "size": 1139,
+        "uri": "root://eospublic.cern.ch//eos/opendata/atlas/rucio/opendata/ODEO_FEB2025_v0_2muons_mc_700352.Sh_2211_pTZ100_Zqqgamma.2muons.root"
+      },
+      {
+        "checksum": "adler32:7bae4e12",
+        "size": 1139,
+        "uri": "root://eospublic.cern.ch//eos/opendata/atlas/rucio/opendata/ODEO_FEB2025_v0_2muons_mc_700353.Sh_2211_pTZ100_Zbbgamma.2muons.root"
+      },
+      {
+        "checksum": "adler32:36d36add",
+        "size": 1203,
+        "uri": "root://eospublic.cern.ch//eos/opendata/atlas/rucio/opendata/ODEO_FEB2025_v0_2muons_mc_700358.Sh_2211_Zee2jets_Min_N_TChannel.2muons.root"
+      },
+      {
+        "checksum": "adler32:1650a34e",
+        "size": 35357951,
+        "uri": "root://eospublic.cern.ch//eos/opendata/atlas/rucio/opendata/ODEO_FEB2025_v0_2muons_mc_700359.Sh_2211_Zmm2jets_Min_N_TChannel.2muons.root"
+      },
+      {
+        "checksum": "adler32:506ef91d",
+        "size": 262324,
+        "uri": "root://eospublic.cern.ch//eos/opendata/atlas/rucio/opendata/ODEO_FEB2025_v0_2muons_mc_700360.Sh_2211_Ztt2jets_Min_N_TChannel.2muons.root"
+      },
+      {
+        "checksum": "adler32:814b7121",
+        "size": 1219,
+        "uri": "root://eospublic.cern.ch//eos/opendata/atlas/rucio/opendata/ODEO_FEB2025_v0_2muons_mc_700361.Sh_2211_Znunu2jets_Min_N_TChannel.2muons.root"
+      },
+      {
+        "checksum": "adler32:b2d86deb",
+        "size": 1211,
+        "uri": "root://eospublic.cern.ch//eos/opendata/atlas/rucio/opendata/ODEO_FEB2025_v0_2muons_mc_700362.Sh_2211_Wenu2jets_Min_N_TChannel.2muons.root"
+      },
+      {
+        "checksum": "adler32:ea484499",
+        "size": 214318,
+        "uri": "root://eospublic.cern.ch//eos/opendata/atlas/rucio/opendata/ODEO_FEB2025_v0_2muons_mc_700363.Sh_2211_Wmunu2jets_Min_N_TChannel.2muons.root"
+      },
+      {
+        "checksum": "adler32:fa45c734",
+        "size": 64269,
+        "uri": "root://eospublic.cern.ch//eos/opendata/atlas/rucio/opendata/ODEO_FEB2025_v0_2muons_mc_700364.Sh_2211_Wtaunu2jets_Min_N_TChannel.2muons.root"
+      },
+      {
+        "checksum": "adler32:ac438768",
+        "size": 1199430323,
+        "uri": "root://eospublic.cern.ch//eos/opendata/atlas/rucio/opendata/ODEO_FEB2025_v0_2muons_mc_700398.Sh_2211_mumugamma.2muons.root"
+      },
+      {
+        "checksum": "adler32:63ee37fb",
+        "size": 1075,
+        "uri": "root://eospublic.cern.ch//eos/opendata/atlas/rucio/opendata/ODEO_FEB2025_v0_2muons_mc_700399.Sh_2211_eegamma.2muons.root"
+      },
+      {
+        "checksum": "adler32:d21d4e53",
+        "size": 7869457,
+        "uri": "root://eospublic.cern.ch//eos/opendata/atlas/rucio/opendata/ODEO_FEB2025_v0_2muons_mc_700400.Sh_2211_tautaugamma.2muons.root"
+      },
+      {
+        "checksum": "adler32:1c71422f",
+        "size": 1091,
+        "uri": "root://eospublic.cern.ch//eos/opendata/atlas/rucio/opendata/ODEO_FEB2025_v0_2muons_mc_700401.Sh_2211_nunugamma.2muons.root"
+      },
+      {
+        "checksum": "adler32:f8acc751",
+        "size": 5121617,
+        "uri": "root://eospublic.cern.ch//eos/opendata/atlas/rucio/opendata/ODEO_FEB2025_v0_2muons_mc_700402.Sh_2211_munugamma.2muons.root"
+      },
+      {
+        "checksum": "adler32:7c3a384e",
+        "size": 1083,
+        "uri": "root://eospublic.cern.ch//eos/opendata/atlas/rucio/opendata/ODEO_FEB2025_v0_2muons_mc_700403.Sh_2211_enugamma.2muons.root"
+      },
+      {
+        "checksum": "adler32:8bdcbc90",
+        "size": 1254849,
+        "uri": "root://eospublic.cern.ch//eos/opendata/atlas/rucio/opendata/ODEO_FEB2025_v0_2muons_mc_700404.Sh_2211_taunugamma.2muons.root"
+      },
+      {
+        "checksum": "adler32:0b947b24",
+        "size": 1275,
+        "uri": "root://eospublic.cern.ch//eos/opendata/atlas/rucio/opendata/ODEO_FEB2025_v0_2muons_mc_700442.Sh_2211_gamma2jets_pTy140_Min_N_TChannel.2muons.root"
+      },
+      {
+        "checksum": "adler32:51957c96",
+        "size": 1275,
+        "uri": "root://eospublic.cern.ch//eos/opendata/atlas/rucio/opendata/ODEO_FEB2025_v0_2muons_mc_700467.Sh_2211_Zee_maxHTpTV2_m10_40_pT5_BFilter.2muons.root"
+      },
+      {
+        "checksum": "adler32:6708f4c6",
+        "size": 26520,
+        "uri": "root://eospublic.cern.ch//eos/opendata/atlas/rucio/opendata/ODEO_FEB2025_v0_2muons_mc_700468.Sh_2211_Zee_maxHTpTV2_m10_40_pT5_CFilterBVeto.2muons.root"
+      },
+      {
+        "checksum": "adler32:09becb48",
+        "size": 26231,
+        "uri": "root://eospublic.cern.ch//eos/opendata/atlas/rucio/opendata/ODEO_FEB2025_v0_2muons_mc_700469.Sh_2211_Zee_maxHTpTV2_m10_40_pT5_CVetoBVeto.2muons.root"
+      },
+      {
+        "checksum": "adler32:1aea313e",
+        "size": 62790888,
+        "uri": "root://eospublic.cern.ch//eos/opendata/atlas/rucio/opendata/ODEO_FEB2025_v0_2muons_mc_700470.Sh_2211_Zmumu_maxHTpTV2_m10_40_pT5_BFilter.2muons.root"
+      },
+      {
+        "checksum": "adler32:121126e1",
+        "size": 312370647,
+        "uri": "root://eospublic.cern.ch//eos/opendata/atlas/rucio/opendata/ODEO_FEB2025_v0_2muons_mc_700471.Sh_2211_Zmumu_maxHTpTV2_m10_40_pT5_CFilterBVeto.2muons.root"
+      },
+      {
+        "checksum": "adler32:35a73b7d",
+        "size": 1872221291,
+        "uri": "root://eospublic.cern.ch//eos/opendata/atlas/rucio/opendata/ODEO_FEB2025_v0_2muons_mc_700472.Sh_2211_Zmumu_maxHTpTV2_m10_40_pT5_CVetoBVeto.2muons.root"
+      },
+      {
+        "checksum": "adler32:18cbcdef",
+        "size": 705548,
+        "uri": "root://eospublic.cern.ch//eos/opendata/atlas/rucio/opendata/ODEO_FEB2025_v0_2muons_mc_700488.Sh_2211_WlvWqq.2muons.root"
+      },
+      {
+        "checksum": "adler32:632e3969",
+        "size": 143781,
+        "uri": "root://eospublic.cern.ch//eos/opendata/atlas/rucio/opendata/ODEO_FEB2025_v0_2muons_mc_700489.Sh_2211_WlvZqq.2muons.root"
+      },
+      {
+        "checksum": "adler32:57eb7490",
+        "size": 103835,
+        "uri": "root://eospublic.cern.ch//eos/opendata/atlas/rucio/opendata/ODEO_FEB2025_v0_2muons_mc_700490.Sh_2211_WlvZbb.2muons.root"
+      },
+      {
+        "checksum": "adler32:db8a3543",
+        "size": 1067,
+        "uri": "root://eospublic.cern.ch//eos/opendata/atlas/rucio/opendata/ODEO_FEB2025_v0_2muons_mc_700491.Sh_2211_WqqZvv.2muons.root"
+      },
+      {
+        "checksum": "adler32:6a238dae",
+        "size": 20505849,
+        "uri": "root://eospublic.cern.ch//eos/opendata/atlas/rucio/opendata/ODEO_FEB2025_v0_2muons_mc_700492.Sh_2211_WqqZll.2muons.root"
+      },
+      {
+        "checksum": "adler32:f3f9b346",
+        "size": 16678779,
+        "uri": "root://eospublic.cern.ch//eos/opendata/atlas/rucio/opendata/ODEO_FEB2025_v0_2muons_mc_700493.Sh_2211_ZqqZll.2muons.root"
+      },
+      {
+        "checksum": "adler32:a4e3457a",
+        "size": 14723593,
+        "uri": "root://eospublic.cern.ch//eos/opendata/atlas/rucio/opendata/ODEO_FEB2025_v0_2muons_mc_700494.Sh_2211_ZbbZll.2muons.root"
+      },
+      {
+        "checksum": "adler32:36a1353d",
+        "size": 1067,
+        "uri": "root://eospublic.cern.ch//eos/opendata/atlas/rucio/opendata/ODEO_FEB2025_v0_2muons_mc_700495.Sh_2211_ZqqZvv.2muons.root"
+      },
+      {
+        "checksum": "adler32:ee9d33d3",
+        "size": 1067,
+        "uri": "root://eospublic.cern.ch//eos/opendata/atlas/rucio/opendata/ODEO_FEB2025_v0_2muons_mc_700496.Sh_2211_ZbbZvv.2muons.root"
+      },
+      {
+        "checksum": "adler32:54c84b70",
+        "size": 1139,
+        "uri": "root://eospublic.cern.ch//eos/opendata/atlas/rucio/opendata/ODEO_FEB2025_v0_2muons_mc_700507.Sh_2211_pTW140_Wqqgamma.2muons.root"
+      },
+      {
+        "checksum": "adler32:fbb3fb5b",
+        "size": 10195364,
+        "uri": "root://eospublic.cern.ch//eos/opendata/atlas/rucio/opendata/ODEO_FEB2025_v0_2muons_mc_700587.Sh_2212_lllljj.2muons.root"
+      },
+      {
+        "checksum": "adler32:1be1cd50",
+        "size": 2877456,
+        "uri": "root://eospublic.cern.ch//eos/opendata/atlas/rucio/opendata/ODEO_FEB2025_v0_2muons_mc_700588.Sh_2212_lllvjj.2muons.root"
+      },
+      {
+        "checksum": "adler32:6d5f76a2",
+        "size": 1760764,
+        "uri": "root://eospublic.cern.ch//eos/opendata/atlas/rucio/opendata/ODEO_FEB2025_v0_2muons_mc_700589.Sh_2212_llvvjj_os.2muons.root"
+      },
+      {
+        "checksum": "adler32:ed1e67ea",
+        "size": 3359932,
+        "uri": "root://eospublic.cern.ch//eos/opendata/atlas/rucio/opendata/ODEO_FEB2025_v0_2muons_mc_700590.Sh_2212_llvvjj_ss.2muons.root"
+      },
+      {
+        "checksum": "adler32:dea3fb30",
+        "size": 1131345,
+        "uri": "root://eospublic.cern.ch//eos/opendata/atlas/rucio/opendata/ODEO_FEB2025_v0_2muons_mc_700591.Sh_2212_lllljj_Int.2muons.root"
+      },
+      {
+        "checksum": "adler32:e8036447",
+        "size": 1019780,
+        "uri": "root://eospublic.cern.ch//eos/opendata/atlas/rucio/opendata/ODEO_FEB2025_v0_2muons_mc_700592.Sh_2212_lllvjj_Int.2muons.root"
+      },
+      {
+        "checksum": "adler32:7da87b9a",
+        "size": 759237,
+        "uri": "root://eospublic.cern.ch//eos/opendata/atlas/rucio/opendata/ODEO_FEB2025_v0_2muons_mc_700593.Sh_2212_llvvjj_os_Int.2muons.root"
+      },
+      {
+        "checksum": "adler32:738c343b",
+        "size": 742906,
+        "uri": "root://eospublic.cern.ch//eos/opendata/atlas/rucio/opendata/ODEO_FEB2025_v0_2muons_mc_700594.Sh_2212_llvvjj_ss_Int.2muons.root"
+      },
+      {
+        "checksum": "adler32:d807c5f5",
+        "size": 20216442,
+        "uri": "root://eospublic.cern.ch//eos/opendata/atlas/rucio/opendata/ODEO_FEB2025_v0_2muons_mc_700600.Sh_2212_llll.2muons.root"
+      },
+      {
+        "checksum": "adler32:7ff68e6d",
+        "size": 27086313,
+        "uri": "root://eospublic.cern.ch//eos/opendata/atlas/rucio/opendata/ODEO_FEB2025_v0_2muons_mc_700601.Sh_2212_lllv.2muons.root"
+      },
+      {
+        "checksum": "adler32:6428d7e6",
+        "size": 27638492,
+        "uri": "root://eospublic.cern.ch//eos/opendata/atlas/rucio/opendata/ODEO_FEB2025_v0_2muons_mc_700602.Sh_2212_llvv_os.2muons.root"
+      },
+      {
+        "checksum": "adler32:3ecd6537",
+        "size": 3925507,
+        "uri": "root://eospublic.cern.ch//eos/opendata/atlas/rucio/opendata/ODEO_FEB2025_v0_2muons_mc_700603.Sh_2212_llvv_ss.2muons.root"
+      },
+      {
+        "checksum": "adler32:db39e8b7",
+        "size": 68034,
+        "uri": "root://eospublic.cern.ch//eos/opendata/atlas/rucio/opendata/ODEO_FEB2025_v0_2muons_mc_700604.Sh_2212_lvvv.2muons.root"
+      },
+      {
+        "checksum": "adler32:dd7f2ea3",
+        "size": 1051,
+        "uri": "root://eospublic.cern.ch//eos/opendata/atlas/rucio/opendata/ODEO_FEB2025_v0_2muons_mc_700605.Sh_2212_vvvv.2muons.root"
+      },
+      {
+        "checksum": "adler32:3e5b978e",
+        "size": 28859,
+        "uri": "root://eospublic.cern.ch//eos/opendata/atlas/rucio/opendata/ODEO_FEB2025_v0_2muons_mc_700709.Sh_2212_lvgammajj.2muons.root"
+      },
+      {
+        "checksum": "adler32:d3125a32",
+        "size": 15374944,
+        "uri": "root://eospublic.cern.ch//eos/opendata/atlas/rucio/opendata/ODEO_FEB2025_v0_2muons_mc_700710.Sh_2212_llgammajj.2muons.root"
+      },
+      {
+        "checksum": "adler32:e93800e6",
+        "size": 7840520,
+        "uri": "root://eospublic.cern.ch//eos/opendata/atlas/rucio/opendata/ODEO_FEB2025_v0_2muons_mc_700792.Sh_2214_Ztautau_maxHTpTV2_BFilter.2muons.root"
+      },
+      {
+        "checksum": "adler32:062bf8e0",
+        "size": 34800784,
+        "uri": "root://eospublic.cern.ch//eos/opendata/atlas/rucio/opendata/ODEO_FEB2025_v0_2muons_mc_700793.Sh_2214_Ztautau_maxHTpTV2_CFilterBVeto.2muons.root"
+      },
+      {
+        "checksum": "adler32:4fd83c71",
+        "size": 70371046,
+        "uri": "root://eospublic.cern.ch//eos/opendata/atlas/rucio/opendata/ODEO_FEB2025_v0_2muons_mc_700794.Sh_2214_Ztautau_maxHTpTV2_CVetoBVeto.2muons.root"
+      },
+      {
+        "checksum": "adler32:6c9c5062",
+        "size": 1147,
+        "uri": "root://eospublic.cern.ch//eos/opendata/atlas/rucio/opendata/ODEO_FEB2025_v0_2muons_mc_700843.Sh_2214_Wqq_ptW_200_ECMS.2muons.root"
+      },
+      {
+        "checksum": "adler32:da544fc2",
+        "size": 1147,
+        "uri": "root://eospublic.cern.ch//eos/opendata/atlas/rucio/opendata/ODEO_FEB2025_v0_2muons_mc_700849.Sh_2214_Zqq_ptZ_200_ECMS.2muons.root"
+      },
+      {
+        "checksum": "adler32:32575102",
+        "size": 1147,
+        "uri": "root://eospublic.cern.ch//eos/opendata/atlas/rucio/opendata/ODEO_FEB2025_v0_2muons_mc_700855.Sh_2214_Zbb_ptZ_200_ECMS.2muons.root"
+      },
+      {
+        "checksum": "adler32:25308782",
+        "size": 628088,
+        "uri": "root://eospublic.cern.ch//eos/opendata/atlas/rucio/opendata/ODEO_FEB2025_v0_2muons_mc_700901.Sh_2214_Ztt_maxHTpTV2_Mll10_40_BFilter.2muons.root"
+      },
+      {
+        "checksum": "adler32:7f8ae62c",
+        "size": 3941316,
+        "uri": "root://eospublic.cern.ch//eos/opendata/atlas/rucio/opendata/ODEO_FEB2025_v0_2muons_mc_700902.Sh_2214_Ztt_maxHTpTV2_Mll10_40_CFilterBVeto.2muons.root"
+      },
+      {
+        "checksum": "adler32:873b5aad",
+        "size": 8660390,
+        "uri": "root://eospublic.cern.ch//eos/opendata/atlas/rucio/opendata/ODEO_FEB2025_v0_2muons_mc_700903.Sh_2214_Ztt_maxHTpTV2_Mll10_40_CVetoBVeto.2muons.root"
+      },
+      {
+        "checksum": "adler32:646d46d6",
+        "size": 179306,
+        "uri": "root://eospublic.cern.ch//eos/opendata/atlas/rucio/opendata/ODEO_FEB2025_v0_2muons_mc_801976.Py8EG_A14NNPDF23LO_Zprime_NoInt_tautau_SSM3000.2muons.root"
+      },
+      {
+        "checksum": "adler32:4864717c",
+        "size": 1267,
+        "uri": "root://eospublic.cern.ch//eos/opendata/atlas/rucio/opendata/ODEO_FEB2025_v0_2muons_mc_801978.Py8EG_A14NNPDF23LO_Wprime_taunu_SSM3000.2muons.root"
+      }
+    ],
+    "license": {
+      "attribution": "CC0-1.0"
+    },
+    "methodology": {
+      "description": "<p>These data were created during LS2 as part of a major reprocessing campaign of the Run 2 data. All data were reprocessed using Athena Release 22, and new corresponding MC simulation samples were produced. These data and MC simulation datasets were processed into ROOT ntuple files from the DAOD_PHYSLITE format that is released as open data for research. For the files in this record, the following skimming selection was applied: At least two muons with at least 10 GeV of p<sub>T</sub> (i.e. a leptonically-decaying Z-boson enhanced selection)"
+    },
+    "publisher": "CERN Open Data Portal",
+    "recid": "93930",
+    "relations": [
+      {
+        "description": "For citing all the Open Data for Education and Outreach from this release, and to find other related datasets, please see",
+        "doi": "10.7483/OPENDATA.ATLAS.B5M9.44TN",
+        "recid": "93910",
+        "title": "ROOT ntuple format 2015-2016 proton-proton Open Data for Education and Outreach from the ATLAS experiment",
+        "type": "isChildOf"
+      }
+    ],
+    "run_period": [
+      "2015",
+      "2016"
+    ],
+    "title": "ATLAS ROOT ntuple format MC simulation, 2015+2016 proton-proton collisions beta release, 2muons skim",
+    "type": {
+      "primary": "Dataset",
+      "secondary": [
+        "Simulated"
+      ]
+    },
+    "usage": {
+      "description": "<p> The data and MC simulation provided by the ATLAS experiment in root ntuple format is released under a CC0 license; citation of the data and acknowledgement of the collaboration is requested. This format can be used directly using ROOT or uproot for simple studies and is primarily intended for educational and outreach purposes. <p>Extensive instructions for interacting with the data, as well as documentation of the dataset naming conventions and their contents, are provided on the ATLAS Open Data website linked below. For those interested in implementing a research-quality data analysis, the open data designed for research (also linked below) may be a better starting point. Please be sure to cite the Open Data that you use, in line with the policy below.",
+      "links": [
+        {
+          "description": "ATLAS Open Data Website",
+          "url": "http://opendata.atlas.cern"
+        },
+        {
+          "description": "Resources to understand and use the open data for education and outreach",
+          "url": "https://opendata.atlas.cern/docs/category/13-tev-tutorials-for-education"
+        },
+        {
+          "description": "More about this ntuple format",
+          "url": "https://opendata.atlas.cern/docs/data/for_education/13TeV25_details"
+        },
+        {
+          "description": "Ntuple making framework",
+          "url": "http://gitlab.cern.ch/atlas-outreach-data-tools/physlitetoopendata"
+        },
+        {
+          "description": "Citation policy",
+          "url": "https://opendata.atlas.cern/docs/documentation/ethical_legal/citation_policy"
+        }
+      ]
+    }
+  }
+]

--- a/data/records/atlas-odeo-FEB2025-2to4lep-data.json
+++ b/data/records/atlas-odeo-FEB2025-2to4lep-data.json
@@ -154,15 +154,15 @@
         },
         {
           "description": "Resources to understand and use the open data for education and outreach",
-          "url": "https://opendata.atlas.cern/docs/category/13-tev-tutorials-for-education"
+          "url": "https://opendata.atlas.cern/docs/category/13-tev-2025-beta-release"
         },
         {
           "description": "More about this ntuple format",
-          "url": "https://opendata.atlas.cern/docs/data/for_education/13TeV25_details"
+          "url": "https://opendata.atlas.cern/docs/data/for_education/13TeV25_details#variable-list"
         },
         {
-          "description": "Ntuple making framework",
-          "url": "http://gitlab.cern.ch/atlas-outreach-data-tools/physlitetoopendata"
+          "description": "Ntuple making framework (PhysLiteToOpenData)",
+          "url": "https://doi.org/10.5281/zenodo.15791091"
         },
         {
           "description": "Citation policy",

--- a/data/records/atlas-odeo-FEB2025-2to4lep-data.json
+++ b/data/records/atlas-odeo-FEB2025-2to4lep-data.json
@@ -1,0 +1,174 @@
+[
+  {
+    "abstract": {
+      "description": "Run 2 2015+2016 proton-proton collision data beta release, 2to4lep skim from the ATLAS experiment"
+    },
+    "accelerator": "CERN-LHC",
+    "categories": {
+      "source": "ATLAS Collaboration"
+    },
+    "collaboration": {
+      "name": "ATLAS collaboration"
+    },
+    "collections": [
+      "ATLAS-Primary-Datasets"
+    ],
+    "collision_information": {
+      "energy": "13TeV",
+      "type": "pp"
+    },
+    "date_created": [
+      "2015",
+      "2016"
+    ],
+    "date_published": "2025",
+    "date_reprocessed": "2020",
+    "distribution": {
+      "formats": [
+        "root"
+      ],
+      "number_events": 283951733,
+      "number_files": 16,
+      "size": 79654625145
+    },
+    "doi": "10.7483/OPENDATA.ATLAS.ZXYW.FXJO",
+    "experiment": [
+      "ATLAS"
+    ],
+    "files": [
+      {
+        "checksum": "adler32:83660d51",
+        "size": 249234315,
+        "uri": "root://eospublic.cern.ch//eos/opendata/atlas/rucio/opendata/ODEO_FEB2025_v0_2to4lep_data15_periodD.2to4lep.root"
+      },
+      {
+        "checksum": "adler32:e2a9d16f",
+        "size": 1830825584,
+        "uri": "root://eospublic.cern.ch//eos/opendata/atlas/rucio/opendata/ODEO_FEB2025_v0_2to4lep_data15_periodE.2to4lep.root"
+      },
+      {
+        "checksum": "adler32:b3d610c0",
+        "size": 1171478228,
+        "uri": "root://eospublic.cern.ch//eos/opendata/atlas/rucio/opendata/ODEO_FEB2025_v0_2to4lep_data15_periodF.2to4lep.root"
+      },
+      {
+        "checksum": "adler32:5fbf2063",
+        "size": 2624026497,
+        "uri": "root://eospublic.cern.ch//eos/opendata/atlas/rucio/opendata/ODEO_FEB2025_v0_2to4lep_data15_periodG.2to4lep.root"
+      },
+      {
+        "checksum": "adler32:53a87e60",
+        "size": 804887033,
+        "uri": "root://eospublic.cern.ch//eos/opendata/atlas/rucio/opendata/ODEO_FEB2025_v0_2to4lep_data15_periodH.2to4lep.root"
+      },
+      {
+        "checksum": "adler32:acf9c12c",
+        "size": 4538806994,
+        "uri": "root://eospublic.cern.ch//eos/opendata/atlas/rucio/opendata/ODEO_FEB2025_v0_2to4lep_data15_periodJ.2to4lep.root"
+      },
+      {
+        "checksum": "adler32:d4c0afec",
+        "size": 2050315152,
+        "uri": "root://eospublic.cern.ch//eos/opendata/atlas/rucio/opendata/ODEO_FEB2025_v0_2to4lep_data16_periodA.2to4lep.root"
+      },
+      {
+        "checksum": "adler32:c8f08b1f",
+        "size": 4455994237,
+        "uri": "root://eospublic.cern.ch//eos/opendata/atlas/rucio/opendata/ODEO_FEB2025_v0_2to4lep_data16_periodB.2to4lep.root"
+      },
+      {
+        "checksum": "adler32:b39fcda0",
+        "size": 5777111508,
+        "uri": "root://eospublic.cern.ch//eos/opendata/atlas/rucio/opendata/ODEO_FEB2025_v0_2to4lep_data16_periodC.2to4lep.root"
+      },
+      {
+        "checksum": "adler32:960e4104",
+        "size": 10238877072,
+        "uri": "root://eospublic.cern.ch//eos/opendata/atlas/rucio/opendata/ODEO_FEB2025_v0_2to4lep_data16_periodD.2to4lep.root"
+      },
+      {
+        "checksum": "adler32:82008246",
+        "size": 3181881230,
+        "uri": "root://eospublic.cern.ch//eos/opendata/atlas/rucio/opendata/ODEO_FEB2025_v0_2to4lep_data16_periodE.2to4lep.root"
+      },
+      {
+        "checksum": "adler32:428ee1c7",
+        "size": 6542199757,
+        "uri": "root://eospublic.cern.ch//eos/opendata/atlas/rucio/opendata/ODEO_FEB2025_v0_2to4lep_data16_periodF.2to4lep.root"
+      },
+      {
+        "checksum": "adler32:7cdab1ea",
+        "size": 7418843461,
+        "uri": "root://eospublic.cern.ch//eos/opendata/atlas/rucio/opendata/ODEO_FEB2025_v0_2to4lep_data16_periodG.2to4lep.root"
+      },
+      {
+        "checksum": "adler32:004e092c",
+        "size": 11536143081,
+        "uri": "root://eospublic.cern.ch//eos/opendata/atlas/rucio/opendata/ODEO_FEB2025_v0_2to4lep_data16_periodI.2to4lep.root"
+      },
+      {
+        "checksum": "adler32:9ae61c6d",
+        "size": 4622472309,
+        "uri": "root://eospublic.cern.ch//eos/opendata/atlas/rucio/opendata/ODEO_FEB2025_v0_2to4lep_data16_periodK.2to4lep.root"
+      },
+      {
+        "checksum": "adler32:528b6bb1",
+        "size": 12611528687,
+        "uri": "root://eospublic.cern.ch//eos/opendata/atlas/rucio/opendata/ODEO_FEB2025_v0_2to4lep_data16_periodL.2to4lep.root"
+      }
+    ],
+    "license": {
+      "attribution": "CC0-1.0"
+    },
+    "methodology": {
+      "description": "<p>These data were created during LS2 as part of a major reprocessing campaign of the Run 2 data. All data were reprocessed using Athena Release 22, and new corresponding MC simulation samples were produced. These data and MC simulation datasets were processed into ROOT ntuple files from the DAOD_PHYSLITE format that is released as open data for research. For the files in this record, the following skimming selection was applied: Two to four leptons with at least 7 GeV of p<sub>T</sub> each"
+    },
+    "publisher": "CERN Open Data Portal",
+    "recid": "93919",
+    "relations": [
+      {
+        "description": "For citing all the Open Data for Education and Outreach from this release, and to find other related datasets, please see",
+        "doi": "10.7483/OPENDATA.ATLAS.B5M9.44TN",
+        "recid": "93910",
+        "title": "ROOT ntuple format 2015-2016 proton-proton Open Data for Education and Outreach from the ATLAS experiment",
+        "type": "isChildOf"
+      }
+    ],
+    "run_period": [
+      "2015",
+      "2016"
+    ],
+    "title": "ATLAS ROOT ntuple format Run 2 2015+2016 proton-proton collision data beta release, 2to4lep skim",
+    "type": {
+      "primary": "Dataset",
+      "secondary": [
+        "Collision"
+      ]
+    },
+    "usage": {
+      "description": "<p> The data and MC simulation provided by the ATLAS experiment in root ntuple format is released under a CC0 license; citation of the data and acknowledgement of the collaboration is requested. This format can be used directly using ROOT or uproot for simple studies and is primarily intended for educational and outreach purposes. <p>Extensive instructions for interacting with the data, as well as documentation of the dataset naming conventions and their contents, are provided on the ATLAS Open Data website linked below. For those interested in implementing a research-quality data analysis, the open data designed for research (also linked below) may be a better starting point. Please be sure to cite the Open Data that you use, in line with the policy below.",
+      "links": [
+        {
+          "description": "ATLAS Open Data Website",
+          "url": "http://opendata.atlas.cern"
+        },
+        {
+          "description": "Resources to understand and use the open data for education and outreach",
+          "url": "https://opendata.atlas.cern/docs/category/13-tev-tutorials-for-education"
+        },
+        {
+          "description": "More about this ntuple format",
+          "url": "https://opendata.atlas.cern/docs/data/for_education/13TeV25_details"
+        },
+        {
+          "description": "Ntuple making framework",
+          "url": "http://gitlab.cern.ch/atlas-outreach-data-tools/physlitetoopendata"
+        },
+        {
+          "description": "Citation policy",
+          "url": "https://opendata.atlas.cern/docs/documentation/ethical_legal/citation_policy"
+        }
+      ]
+    }
+  }
+]

--- a/data/records/atlas-odeo-FEB2025-2to4lep-mc.json
+++ b/data/records/atlas-odeo-FEB2025-2to4lep-mc.json
@@ -1939,15 +1939,15 @@
         },
         {
           "description": "Resources to understand and use the open data for education and outreach",
-          "url": "https://opendata.atlas.cern/docs/category/13-tev-tutorials-for-education"
+          "url": "https://opendata.atlas.cern/docs/category/13-tev-2025-beta-release"
         },
         {
           "description": "More about this ntuple format",
-          "url": "https://opendata.atlas.cern/docs/data/for_education/13TeV25_details"
+          "url": "https://opendata.atlas.cern/docs/data/for_education/13TeV25_details#variable-list"
         },
         {
-          "description": "Ntuple making framework",
-          "url": "http://gitlab.cern.ch/atlas-outreach-data-tools/physlitetoopendata"
+          "description": "Ntuple making framework (PhysLiteToOpenData)",
+          "url": "https://doi.org/10.5281/zenodo.15791091"
         },
         {
           "description": "Citation policy",

--- a/data/records/atlas-odeo-FEB2025-2to4lep-mc.json
+++ b/data/records/atlas-odeo-FEB2025-2to4lep-mc.json
@@ -1,0 +1,1959 @@
+[
+  {
+    "abstract": {
+      "description": "MC simulation, 2015+2016 proton-proton collisions beta release, 2to4lep skim from the ATLAS experiment"
+    },
+    "accelerator": "CERN-LHC",
+    "categories": {
+      "source": "ATLAS Collaboration"
+    },
+    "collaboration": {
+      "name": "ATLAS collaboration"
+    },
+    "collections": [
+      "ATLAS-Primary-Datasets"
+    ],
+    "collision_information": {
+      "energy": "13TeV",
+      "type": "pp"
+    },
+    "date_created": [
+      "2015",
+      "2016"
+    ],
+    "date_published": "2025",
+    "date_reprocessed": "2020",
+    "distribution": {
+      "formats": [
+        "root"
+      ],
+      "number_events": 172907592,
+      "number_files": 373,
+      "size": 73193058840
+    },
+    "doi": "10.7483/OPENDATA.ATLAS.OMF2.CICK",
+    "experiment": [
+      "ATLAS"
+    ],
+    "files": [
+      {
+        "checksum": "adler32:93cc6d7f",
+        "size": 6032108,
+        "uri": "root://eospublic.cern.ch//eos/opendata/atlas/rucio/opendata/ODEO_FEB2025_v0_2to4lep_mc_301204.Pythia8EvtGen_A14MSTW2008LO_Zprime_NoInt_ee_SSM3000.2to4lep.root"
+      },
+      {
+        "checksum": "adler32:c94c2307",
+        "size": 5309751,
+        "uri": "root://eospublic.cern.ch//eos/opendata/atlas/rucio/opendata/ODEO_FEB2025_v0_2to4lep_mc_301209.Pythia8EvtGen_A14MSTW2008LO_Zprime_NoInt_mumu_SSM3000.2to4lep.root"
+      },
+      {
+        "checksum": "adler32:09bfc979",
+        "size": 69047,
+        "uri": "root://eospublic.cern.ch//eos/opendata/atlas/rucio/opendata/ODEO_FEB2025_v0_2to4lep_mc_301243.Pythia8EvtGen_A14NNPDF23LO_Wprime_enu_SSM3000.2to4lep.root"
+      },
+      {
+        "checksum": "adler32:7e1aca30",
+        "size": 169434,
+        "uri": "root://eospublic.cern.ch//eos/opendata/atlas/rucio/opendata/ODEO_FEB2025_v0_2to4lep_mc_301247.Pythia8EvtGen_A14NNPDF23LO_Wprime_munu_SSM3000.2to4lep.root"
+      },
+      {
+        "checksum": "adler32:5fa002f5",
+        "size": 1593763,
+        "uri": "root://eospublic.cern.ch//eos/opendata/atlas/rucio/opendata/ODEO_FEB2025_v0_2to4lep_mc_301333.Pythia8EvtGen_A14NNPDF23LO_zprime3000_tt.2to4lep.root"
+      },
+      {
+        "checksum": "adler32:0ce83b30",
+        "size": 224296,
+        "uri": "root://eospublic.cern.ch//eos/opendata/atlas/rucio/opendata/ODEO_FEB2025_v0_2to4lep_mc_301826.Pythia8EvtGen_A14NNPDF23LO_Wprime_qq_3000.2to4lep.root"
+      },
+      {
+        "checksum": "adler32:be10645e",
+        "size": 251184,
+        "uri": "root://eospublic.cern.ch//eos/opendata/atlas/rucio/opendata/ODEO_FEB2025_v0_2to4lep_mc_301928.Pythia8EvtGen_A14NNPDF23LO_Zprimebb3000.2to4lep.root"
+      },
+      {
+        "checksum": "adler32:c0de5e3c",
+        "size": 11740089,
+        "uri": "root://eospublic.cern.ch//eos/opendata/atlas/rucio/opendata/ODEO_FEB2025_v0_2to4lep_mc_302520.Pythia8EvtGen_A14NNPDF23LO_2DP20_Mass_55_100.2to4lep.root"
+      },
+      {
+        "checksum": "adler32:b2c2592a",
+        "size": 1966748,
+        "uri": "root://eospublic.cern.ch//eos/opendata/atlas/rucio/opendata/ODEO_FEB2025_v0_2to4lep_mc_302521.Pythia8EvtGen_A14NNPDF23LO_2DP20_Mass_100_160.2to4lep.root"
+      },
+      {
+        "checksum": "adler32:807b82e2",
+        "size": 413223,
+        "uri": "root://eospublic.cern.ch//eos/opendata/atlas/rucio/opendata/ODEO_FEB2025_v0_2to4lep_mc_302522.Pythia8EvtGen_A14NNPDF23LO_2DP20_Mass_160_250.2to4lep.root"
+      },
+      {
+        "checksum": "adler32:8d24b3f6",
+        "size": 176034,
+        "uri": "root://eospublic.cern.ch//eos/opendata/atlas/rucio/opendata/ODEO_FEB2025_v0_2to4lep_mc_302523.Pythia8EvtGen_A14NNPDF23LO_2DP20_Mass_250_400.2to4lep.root"
+      },
+      {
+        "checksum": "adler32:1680bece",
+        "size": 347555,
+        "uri": "root://eospublic.cern.ch//eos/opendata/atlas/rucio/opendata/ODEO_FEB2025_v0_2to4lep_mc_302524.Pythia8EvtGen_A14NNPDF23LO_2DP20_Mass_400_650.2to4lep.root"
+      },
+      {
+        "checksum": "adler32:fc8b45e6",
+        "size": 151286,
+        "uri": "root://eospublic.cern.ch//eos/opendata/atlas/rucio/opendata/ODEO_FEB2025_v0_2to4lep_mc_302525.Pythia8EvtGen_A14NNPDF23LO_2DP20_Mass_650_1000.2to4lep.root"
+      },
+      {
+        "checksum": "adler32:b00b76a0",
+        "size": 305096,
+        "uri": "root://eospublic.cern.ch//eos/opendata/atlas/rucio/opendata/ODEO_FEB2025_v0_2to4lep_mc_302526.Pythia8EvtGen_A14NNPDF23LO_2DP20_Mass_1000_1500.2to4lep.root"
+      },
+      {
+        "checksum": "adler32:7cf26fd2",
+        "size": 373483,
+        "uri": "root://eospublic.cern.ch//eos/opendata/atlas/rucio/opendata/ODEO_FEB2025_v0_2to4lep_mc_302527.Pythia8EvtGen_A14NNPDF23LO_2DP20_Mass_1500_2000.2to4lep.root"
+      },
+      {
+        "checksum": "adler32:eedb0bef",
+        "size": 549898,
+        "uri": "root://eospublic.cern.ch//eos/opendata/atlas/rucio/opendata/ODEO_FEB2025_v0_2to4lep_mc_302528.Pythia8EvtGen_A14NNPDF23LO_2DP20_Mass_2000_2500.2to4lep.root"
+      },
+      {
+        "checksum": "adler32:6386f966",
+        "size": 407181,
+        "uri": "root://eospublic.cern.ch//eos/opendata/atlas/rucio/opendata/ODEO_FEB2025_v0_2to4lep_mc_302529.Pythia8EvtGen_A14NNPDF23LO_2DP20_Mass_2500_3000.2to4lep.root"
+      },
+      {
+        "checksum": "adler32:7c1a946f",
+        "size": 728818,
+        "uri": "root://eospublic.cern.ch//eos/opendata/atlas/rucio/opendata/ODEO_FEB2025_v0_2to4lep_mc_302530.Pythia8EvtGen_A14NNPDF23LO_2DP20_Mass_3000_3500.2to4lep.root"
+      },
+      {
+        "checksum": "adler32:bb3825c2",
+        "size": 372542,
+        "uri": "root://eospublic.cern.ch//eos/opendata/atlas/rucio/opendata/ODEO_FEB2025_v0_2to4lep_mc_302531.Pythia8EvtGen_A14NNPDF23LO_2DP20_Mass_3500_4000.2to4lep.root"
+      },
+      {
+        "checksum": "adler32:c2b12808",
+        "size": 643597,
+        "uri": "root://eospublic.cern.ch//eos/opendata/atlas/rucio/opendata/ODEO_FEB2025_v0_2to4lep_mc_302532.Pythia8EvtGen_A14NNPDF23LO_2DP20_Mass_4000_4500.2to4lep.root"
+      },
+      {
+        "checksum": "adler32:b005ed69",
+        "size": 269863,
+        "uri": "root://eospublic.cern.ch//eos/opendata/atlas/rucio/opendata/ODEO_FEB2025_v0_2to4lep_mc_302533.Pythia8EvtGen_A14NNPDF23LO_2DP20_Mass_4500_5000.2to4lep.root"
+      },
+      {
+        "checksum": "adler32:081d3c7b",
+        "size": 710297,
+        "uri": "root://eospublic.cern.ch//eos/opendata/atlas/rucio/opendata/ODEO_FEB2025_v0_2to4lep_mc_302534.Pythia8EvtGen_A14NNPDF23LO_2DP20_Mass_5000_inf.2to4lep.root"
+      },
+      {
+        "checksum": "adler32:c7872e90",
+        "size": 1770947,
+        "uri": "root://eospublic.cern.ch//eos/opendata/atlas/rucio/opendata/ODEO_FEB2025_v0_2to4lep_mc_302733.MadGraphPythia8EvtGen_A14NNPDF23LO_WpL_tblep_M3000.2to4lep.root"
+      },
+      {
+        "checksum": "adler32:ac6adcb7",
+        "size": 4648484,
+        "uri": "root://eospublic.cern.ch//eos/opendata/atlas/rucio/opendata/ODEO_FEB2025_v0_2to4lep_mc_304014.MadGraphPythia8EvtGen_A14NNPDF23_3top_SM.2to4lep.root"
+      },
+      {
+        "checksum": "adler32:0aea7b33",
+        "size": 779000,
+        "uri": "root://eospublic.cern.ch//eos/opendata/atlas/rucio/opendata/ODEO_FEB2025_v0_2to4lep_mc_306149.MadGraphPythia8EvtGen_A14NNPDF23LO_WpL_tbhad_M3000.2to4lep.root"
+      },
+      {
+        "checksum": "adler32:e4b2fa05",
+        "size": 82646,
+        "uri": "root://eospublic.cern.ch//eos/opendata/atlas/rucio/opendata/ODEO_FEB2025_v0_2to4lep_mc_311490.PowhegPy8EG_A14N23LO_DMA_500_700_gq0p25.2to4lep.root"
+      },
+      {
+        "checksum": "adler32:cf25b03d",
+        "size": 16363841,
+        "uri": "root://eospublic.cern.ch//eos/opendata/atlas/rucio/opendata/ODEO_FEB2025_v0_2to4lep_mc_312613.aMcAtNloPy8EG_A14N30NLO_LQd_gstML_0p3_nonallhad_M1000.2to4lep.root"
+      },
+      {
+        "checksum": "adler32:dbc0b74c",
+        "size": 117590,
+        "uri": "root://eospublic.cern.ch//eos/opendata/atlas/rucio/opendata/ODEO_FEB2025_v0_2to4lep_mc_341456.PowhegPythia8EvtGen_CT10_AZNLO_ZH125J_MINLO_veveWWlvqq_VpT.2to4lep.root"
+      },
+      {
+        "checksum": "adler32:2b85ca96",
+        "size": 233819,
+        "uri": "root://eospublic.cern.ch//eos/opendata/atlas/rucio/opendata/ODEO_FEB2025_v0_2to4lep_mc_341458.PowhegPythia8EvtGen_CT10_AZNLO_ZH125J_MINLO_vmuvmuWWlvqq_VpT.2to4lep.root"
+      },
+      {
+        "checksum": "adler32:183b9f79",
+        "size": 225801,
+        "uri": "root://eospublic.cern.ch//eos/opendata/atlas/rucio/opendata/ODEO_FEB2025_v0_2to4lep_mc_341460.PowhegPy8EG_CT10_AZNLO_ZH125J_MINLO_vtauvtauWWlvqq_VpT.2to4lep.root"
+      },
+      {
+        "checksum": "adler32:ee9aaf65",
+        "size": 875493,
+        "uri": "root://eospublic.cern.ch//eos/opendata/atlas/rucio/opendata/ODEO_FEB2025_v0_2to4lep_mc_343981.PowhegPythia8EvtGen_NNLOPS_nnlo_30_ggH125_gamgam.2to4lep.root"
+      },
+      {
+        "checksum": "adler32:53e2f78c",
+        "size": 38645430,
+        "uri": "root://eospublic.cern.ch//eos/opendata/atlas/rucio/opendata/ODEO_FEB2025_v0_2to4lep_mc_344158.aMcAtNloPythia8EvtGen_A14NNPDF23LO_ppx0_FxFx_Np012_SM.2to4lep.root"
+      },
+      {
+        "checksum": "adler32:6ca475fd",
+        "size": 286688,
+        "uri": "root://eospublic.cern.ch//eos/opendata/atlas/rucio/opendata/ODEO_FEB2025_v0_2to4lep_mc_345056.PowhegPythia8EvtGen_NNPDF3_AZNLO_ZH125J_MINLO_vvbb_VpT.2to4lep.root"
+      },
+      {
+        "checksum": "adler32:fbabca86",
+        "size": 225356,
+        "uri": "root://eospublic.cern.ch//eos/opendata/atlas/rucio/opendata/ODEO_FEB2025_v0_2to4lep_mc_345058.PowhegPythia8EvtGen_NNPDF3_AZNLO_ggZH125_vvbb.2to4lep.root"
+      },
+      {
+        "checksum": "adler32:f7dd9a78",
+        "size": 595071792,
+        "uri": "root://eospublic.cern.ch//eos/opendata/atlas/rucio/opendata/ODEO_FEB2025_v0_2to4lep_mc_345060.PowhegPythia8EvtGen_NNLOPS_nnlo_30_ggH125_ZZ4l.2to4lep.root"
+      },
+      {
+        "checksum": "adler32:0302fe0e",
+        "size": 1358474,
+        "uri": "root://eospublic.cern.ch//eos/opendata/atlas/rucio/opendata/ODEO_FEB2025_v0_2to4lep_mc_345061.PowhegPythia8EvtGen_NNPDF3_AZNLO_ggZH125_HgamgamZinc.2to4lep.root"
+      },
+      {
+        "checksum": "adler32:71bcab6b",
+        "size": 15054816,
+        "uri": "root://eospublic.cern.ch//eos/opendata/atlas/rucio/opendata/ODEO_FEB2025_v0_2to4lep_mc_345066.PowhegPythia8EvtGen_NNPDF3_AZNLO_ggZH125_ZZ4lepZinc.2to4lep.root"
+      },
+      {
+        "checksum": "adler32:b01e9baf",
+        "size": 32850796,
+        "uri": "root://eospublic.cern.ch//eos/opendata/atlas/rucio/opendata/ODEO_FEB2025_v0_2to4lep_mc_345097.PowhegPythia8EvtGen_NNLOPS_nnlo_30_ggH125_mumu.2to4lep.root"
+      },
+      {
+        "checksum": "adler32:db632b4f",
+        "size": 13280810,
+        "uri": "root://eospublic.cern.ch//eos/opendata/atlas/rucio/opendata/ODEO_FEB2025_v0_2to4lep_mc_345098.PowhegPythia8EvtGen_NNPDF3_AZNLO_ggZH125_Hmumu_Zinc.2to4lep.root"
+      },
+      {
+        "checksum": "adler32:47f3e9b5",
+        "size": 13232004,
+        "uri": "root://eospublic.cern.ch//eos/opendata/atlas/rucio/opendata/ODEO_FEB2025_v0_2to4lep_mc_345103.PowhegPythia8EvtGen_NNPDF30_AZNLO_ZH125J_Hmumu_Zincl_MINLO.2to4lep.root"
+      },
+      {
+        "checksum": "adler32:5cd7cb52",
+        "size": 13393110,
+        "uri": "root://eospublic.cern.ch//eos/opendata/atlas/rucio/opendata/ODEO_FEB2025_v0_2to4lep_mc_345104.PowhegPythia8EvtGen_NNPDF30_AZNLO_WpH125J_Hmumu_Wincl_MINLO.2to4lep.root"
+      },
+      {
+        "checksum": "adler32:de9abf7f",
+        "size": 8489724,
+        "uri": "root://eospublic.cern.ch//eos/opendata/atlas/rucio/opendata/ODEO_FEB2025_v0_2to4lep_mc_345105.PowhegPythia8EvtGen_NNPDF30_AZNLO_WmH125J_Hmumu_Wincl_MINLO.2to4lep.root"
+      },
+      {
+        "checksum": "adler32:3888faea",
+        "size": 30711041,
+        "uri": "root://eospublic.cern.ch//eos/opendata/atlas/rucio/opendata/ODEO_FEB2025_v0_2to4lep_mc_345106.PowhegPythia8EvtGen_NNPDF30_AZNLOCTEQ6L1_VBFH125_mumu.2to4lep.root"
+      },
+      {
+        "checksum": "adler32:93c14613",
+        "size": 202398,
+        "uri": "root://eospublic.cern.ch//eos/opendata/atlas/rucio/opendata/ODEO_FEB2025_v0_2to4lep_mc_345112.PowhegPythia8EvtGen_NNPDF3_AZNLO_ZH125J_MINLO_vvcc_VpT.2to4lep.root"
+      },
+      {
+        "checksum": "adler32:fcb56b2e",
+        "size": 175585,
+        "uri": "root://eospublic.cern.ch//eos/opendata/atlas/rucio/opendata/ODEO_FEB2025_v0_2to4lep_mc_345114.PowhegPythia8EvtGen_NNPDF3_AZNLO_ggZH125_vvcc.2to4lep.root"
+      },
+      {
+        "checksum": "adler32:46f26036",
+        "size": 31675536,
+        "uri": "root://eospublic.cern.ch//eos/opendata/atlas/rucio/opendata/ODEO_FEB2025_v0_2to4lep_mc_345120.PowhegPy8EG_NNLOPS_nnlo_30_ggH125_tautaul13l7.2to4lep.root"
+      },
+      {
+        "checksum": "adler32:93f3e6ea",
+        "size": 1117124,
+        "uri": "root://eospublic.cern.ch//eos/opendata/atlas/rucio/opendata/ODEO_FEB2025_v0_2to4lep_mc_345121.PowhegPy8EG_NNLOPS_nnlo_30_ggH125_tautaulm15hp20.2to4lep.root"
+      },
+      {
+        "checksum": "adler32:13fe4102",
+        "size": 1583995,
+        "uri": "root://eospublic.cern.ch//eos/opendata/atlas/rucio/opendata/ODEO_FEB2025_v0_2to4lep_mc_345122.PowhegPy8EG_NNLOPS_nnlo_30_ggH125_tautaulp15hm20.2to4lep.root"
+      },
+      {
+        "checksum": "adler32:91a594d0",
+        "size": 209985,
+        "uri": "root://eospublic.cern.ch//eos/opendata/atlas/rucio/opendata/ODEO_FEB2025_v0_2to4lep_mc_345123.PowhegPy8EG_NNLOPS_nnlo_30_ggH125_tautauh30h20.2to4lep.root"
+      },
+      {
+        "checksum": "adler32:40c26bde",
+        "size": 90125610,
+        "uri": "root://eospublic.cern.ch//eos/opendata/atlas/rucio/opendata/ODEO_FEB2025_v0_2to4lep_mc_345124.PowhegPy8EG_NNLOPS_nnlo_30_ggH125_etau_filt.2to4lep.root"
+      },
+      {
+        "checksum": "adler32:fca25051",
+        "size": 102178524,
+        "uri": "root://eospublic.cern.ch//eos/opendata/atlas/rucio/opendata/ODEO_FEB2025_v0_2to4lep_mc_345125.PowhegPy8EG_NNLOPS_nnlo_30_ggH125_mutau_filt.2to4lep.root"
+      },
+      {
+        "checksum": "adler32:2da2b86a",
+        "size": 1595123,
+        "uri": "root://eospublic.cern.ch//eos/opendata/atlas/rucio/opendata/ODEO_FEB2025_v0_2to4lep_mc_345211.PowhegPy8EG_NNPDF30_AZNLO_WmH125J_Winc_MINLO_tautau.2to4lep.root"
+      },
+      {
+        "checksum": "adler32:b48eabff",
+        "size": 1957319,
+        "uri": "root://eospublic.cern.ch//eos/opendata/atlas/rucio/opendata/ODEO_FEB2025_v0_2to4lep_mc_345212.PowhegPy8EG_NNPDF30_AZNLO_WpH125J_Winc_MINLO_tautau.2to4lep.root"
+      },
+      {
+        "checksum": "adler32:a97f0e90",
+        "size": 5240519,
+        "uri": "root://eospublic.cern.ch//eos/opendata/atlas/rucio/opendata/ODEO_FEB2025_v0_2to4lep_mc_345213.PowhegPy8EG_NNPDF30_AZNLO_WmH125J_Winc_MINLO_etau.2to4lep.root"
+      },
+      {
+        "checksum": "adler32:ef7bbf43",
+        "size": 8928831,
+        "uri": "root://eospublic.cern.ch//eos/opendata/atlas/rucio/opendata/ODEO_FEB2025_v0_2to4lep_mc_345214.PowhegPy8EG_NNPDF30_AZNLO_WpH125J_Winc_MINLO_etau.2to4lep.root"
+      },
+      {
+        "checksum": "adler32:573a3065",
+        "size": 5995021,
+        "uri": "root://eospublic.cern.ch//eos/opendata/atlas/rucio/opendata/ODEO_FEB2025_v0_2to4lep_mc_345215.PowhegPy8EG_NNPDF30_AZNLO_WmH125J_Winc_MINLO_mutau.2to4lep.root"
+      },
+      {
+        "checksum": "adler32:ef2f2466",
+        "size": 10755757,
+        "uri": "root://eospublic.cern.ch//eos/opendata/atlas/rucio/opendata/ODEO_FEB2025_v0_2to4lep_mc_345216.PowhegPy8EG_NNPDF30_AZNLO_WpH125J_Winc_MINLO_mutau.2to4lep.root"
+      },
+      {
+        "checksum": "adler32:446b8325",
+        "size": 2916251,
+        "uri": "root://eospublic.cern.ch//eos/opendata/atlas/rucio/opendata/ODEO_FEB2025_v0_2to4lep_mc_345217.PowhegPy8EG_NNPDF30_AZNLO_ZH125J_Zinc_MINLO_tautau.2to4lep.root"
+      },
+      {
+        "checksum": "adler32:af262e0e",
+        "size": 7234621,
+        "uri": "root://eospublic.cern.ch//eos/opendata/atlas/rucio/opendata/ODEO_FEB2025_v0_2to4lep_mc_345218.PowhegPy8EG_NNPDF30_AZNLO_ZH125J_Zinc_MINLO_etau.2to4lep.root"
+      },
+      {
+        "checksum": "adler32:d4a9b143",
+        "size": 6442406,
+        "uri": "root://eospublic.cern.ch//eos/opendata/atlas/rucio/opendata/ODEO_FEB2025_v0_2to4lep_mc_345219.PowhegPy8EG_NNPDF30_AZNLO_ZH125J_Zinc_MINLO_mutau.2to4lep.root"
+      },
+      {
+        "checksum": "adler32:6e35c54e",
+        "size": 108389605,
+        "uri": "root://eospublic.cern.ch//eos/opendata/atlas/rucio/opendata/ODEO_FEB2025_v0_2to4lep_mc_345316.PowhegPythia8EvtGen_NNLOPS_nnlo_30_ggH125_Zy_Zll.2to4lep.root"
+      },
+      {
+        "checksum": "adler32:a4b16d91",
+        "size": 2623574,
+        "uri": "root://eospublic.cern.ch//eos/opendata/atlas/rucio/opendata/ODEO_FEB2025_v0_2to4lep_mc_345317.PowhegPythia8EvtGen_NNPDF30_AZNLO_WmH125J_Hyy_Wincl_MINLO.2to4lep.root"
+      },
+      {
+        "checksum": "adler32:51d692a7",
+        "size": 1519449,
+        "uri": "root://eospublic.cern.ch//eos/opendata/atlas/rucio/opendata/ODEO_FEB2025_v0_2to4lep_mc_345318.PowhegPythia8EvtGen_NNPDF30_AZNLO_WpH125J_Hyy_Wincl_MINLO.2to4lep.root"
+      },
+      {
+        "checksum": "adler32:fd13fb67",
+        "size": 1982545,
+        "uri": "root://eospublic.cern.ch//eos/opendata/atlas/rucio/opendata/ODEO_FEB2025_v0_2to4lep_mc_345319.PowhegPythia8EvtGen_NNPDF30_AZNLO_ZH125J_Hyy_Zincl_MINLO.2to4lep.root"
+      },
+      {
+        "checksum": "adler32:b2df50bb",
+        "size": 4532023,
+        "uri": "root://eospublic.cern.ch//eos/opendata/atlas/rucio/opendata/ODEO_FEB2025_v0_2to4lep_mc_345320.PowhegPythia8EvtGen_NNPDF30_AZNLO_WmH125J_HZy_Wincl_MINLO.2to4lep.root"
+      },
+      {
+        "checksum": "adler32:5461f3f0",
+        "size": 4215945,
+        "uri": "root://eospublic.cern.ch//eos/opendata/atlas/rucio/opendata/ODEO_FEB2025_v0_2to4lep_mc_345321.PowhegPythia8EvtGen_NNPDF30_AZNLO_WpH125J_HZy_Wincl_MINLO.2to4lep.root"
+      },
+      {
+        "checksum": "adler32:ec1bea14",
+        "size": 8549452,
+        "uri": "root://eospublic.cern.ch//eos/opendata/atlas/rucio/opendata/ODEO_FEB2025_v0_2to4lep_mc_345322.PowhegPythia8EvtGen_NNPDF30_AZNLO_ZH125J_HZy_Zincl_MINLO.2to4lep.root"
+      },
+      {
+        "checksum": "adler32:7a129607",
+        "size": 32765973,
+        "uri": "root://eospublic.cern.ch//eos/opendata/atlas/rucio/opendata/ODEO_FEB2025_v0_2to4lep_mc_345324.PowhegPythia8EvtGen_NNLOPS_NN30_ggH125_WWlvlv_EF_15_5.2to4lep.root"
+      },
+      {
+        "checksum": "adler32:edece3b0",
+        "size": 14832481,
+        "uri": "root://eospublic.cern.ch//eos/opendata/atlas/rucio/opendata/ODEO_FEB2025_v0_2to4lep_mc_345325.PowhegPythia8EvtGen_NNPDF3_AZNLO_WpH125J_MINLO_qqWWlvlv.2to4lep.root"
+      },
+      {
+        "checksum": "adler32:17f2868f",
+        "size": 18690621,
+        "uri": "root://eospublic.cern.ch//eos/opendata/atlas/rucio/opendata/ODEO_FEB2025_v0_2to4lep_mc_345433.PowhegPythia8EvtGen_NNPDF3_AZNLO_WmH125J_MINLO_qqWWlvlv.2to4lep.root"
+      },
+      {
+        "checksum": "adler32:c704efa4",
+        "size": 5580171,
+        "uri": "root://eospublic.cern.ch//eos/opendata/atlas/rucio/opendata/ODEO_FEB2025_v0_2to4lep_mc_345445.PowhegPythia8EvtGen_NNPDF3_AZNLO_ZH125J_MINLO_vvWWlvlv.2to4lep.root"
+      },
+      {
+        "checksum": "adler32:0e454b64",
+        "size": 798942,
+        "uri": "root://eospublic.cern.ch//eos/opendata/atlas/rucio/opendata/ODEO_FEB2025_v0_2to4lep_mc_345596.PowhegPythia8EvtGen_NNPDF3_AZNLO_ggZH125_Zinc_HZZinv.2to4lep.root"
+      },
+      {
+        "checksum": "adler32:f5d59820",
+        "size": 42903377,
+        "uri": "root://eospublic.cern.ch//eos/opendata/atlas/rucio/opendata/ODEO_FEB2025_v0_2to4lep_mc_345697.MadGraphPythia8EvtGen_AZNLOCTEQ6L1_ggfhtautaullNp2.2to4lep.root"
+      },
+      {
+        "checksum": "adler32:5186bca4",
+        "size": 3551663,
+        "uri": "root://eospublic.cern.ch//eos/opendata/atlas/rucio/opendata/ODEO_FEB2025_v0_2to4lep_mc_345698.MadGraphPythia8EvtGen_AZNLOCTEQ6L1_ggfhtautaulhNp2.2to4lep.root"
+      },
+      {
+        "checksum": "adler32:9f7f059f",
+        "size": 409324,
+        "uri": "root://eospublic.cern.ch//eos/opendata/atlas/rucio/opendata/ODEO_FEB2025_v0_2to4lep_mc_345699.MadGraphPythia8EvtGen_AZNLOCTEQ6L1_ggfhtautauhhNp2.2to4lep.root"
+      },
+      {
+        "checksum": "adler32:196f206f",
+        "size": 60920831,
+        "uri": "root://eospublic.cern.ch//eos/opendata/atlas/rucio/opendata/ODEO_FEB2025_v0_2to4lep_mc_345833.PowhegPythia8EvtGen_NNPDF30_AZNLOCTEQ6L1_VBFH125_Zllgam.2to4lep.root"
+      },
+      {
+        "checksum": "adler32:d1fa24ad",
+        "size": 3436388,
+        "uri": "root://eospublic.cern.ch//eos/opendata/atlas/rucio/opendata/ODEO_FEB2025_v0_2to4lep_mc_345834.PowhegPythia8EvtGen_NNPDF30_AZNLOCTEQ6L1_VBFH125_gamstargam.2to4lep.root"
+      },
+      {
+        "checksum": "adler32:1b6b33a0",
+        "size": 12880387,
+        "uri": "root://eospublic.cern.ch//eos/opendata/atlas/rucio/opendata/ODEO_FEB2025_v0_2to4lep_mc_345876.PowhegPythia8EvtGen_NNPDF30_AZNLO_ZH125J_Hee__Zincl_MINLO.2to4lep.root"
+      },
+      {
+        "checksum": "adler32:cc6267ed",
+        "size": 7571053,
+        "uri": "root://eospublic.cern.ch//eos/opendata/atlas/rucio/opendata/ODEO_FEB2025_v0_2to4lep_mc_345877.PowhegPythia8EvtGen_NNPDF30_AZNLO_WpH125J_Hee_Wincl_MINLO.2to4lep.root"
+      },
+      {
+        "checksum": "adler32:1fe37865",
+        "size": 8306527,
+        "uri": "root://eospublic.cern.ch//eos/opendata/atlas/rucio/opendata/ODEO_FEB2025_v0_2to4lep_mc_345878.PowhegPythia8EvtGen_NNPDF30_AZNLO_WmH125J_Hee_Wincl_MINLO.2to4lep.root"
+      },
+      {
+        "checksum": "adler32:17484bf6",
+        "size": 887899,
+        "uri": "root://eospublic.cern.ch//eos/opendata/atlas/rucio/opendata/ODEO_FEB2025_v0_2to4lep_mc_345944.aMcAtNloPy8EG_A14NNPDF23LO_ppx0yy_FxFx_Np012_SM.2to4lep.root"
+      },
+      {
+        "checksum": "adler32:cd8a5ac9",
+        "size": 40593630,
+        "uri": "root://eospublic.cern.ch//eos/opendata/atlas/rucio/opendata/ODEO_FEB2025_v0_2to4lep_mc_345948.PowhegPy8EG_NNPDF30_AZNLOCTEQ6L1_VBFH125_WWlvlv.2to4lep.root"
+      },
+      {
+        "checksum": "adler32:35e42ef6",
+        "size": 298651,
+        "uri": "root://eospublic.cern.ch//eos/opendata/atlas/rucio/opendata/ODEO_FEB2025_v0_2to4lep_mc_345949.PowhegPythia8EvtGen_NNPDF30_AZNLOCTEQ6L1_VBFH125_bb.2to4lep.root"
+      },
+      {
+        "checksum": "adler32:e41af850",
+        "size": 7684764,
+        "uri": "root://eospublic.cern.ch//eos/opendata/atlas/rucio/opendata/ODEO_FEB2025_v0_2to4lep_mc_345961.PowhegPythia8EvtGen_NNLOPS_nnlo_30_ggH125_gamstargam.2to4lep.root"
+      },
+      {
+        "checksum": "adler32:77f66c58",
+        "size": 2474770,
+        "uri": "root://eospublic.cern.ch//eos/opendata/atlas/rucio/opendata/ODEO_FEB2025_v0_2to4lep_mc_345963.PowhegPythia8EvtGen_NNPDF30_AZNLO_WmH125J_Hgamstargam_MINLO.2to4lep.root"
+      },
+      {
+        "checksum": "adler32:679448ae",
+        "size": 2371227,
+        "uri": "root://eospublic.cern.ch//eos/opendata/atlas/rucio/opendata/ODEO_FEB2025_v0_2to4lep_mc_345964.PowhegPythia8EvtGen_NNPDF30_AZNLO_WpH125J_Hgamstargam_MINLO.2to4lep.root"
+      },
+      {
+        "checksum": "adler32:c9baf17b",
+        "size": 4247517,
+        "uri": "root://eospublic.cern.ch//eos/opendata/atlas/rucio/opendata/ODEO_FEB2025_v0_2to4lep_mc_345965.PowhegPythia8EvtGen_NNPDF30_AZNLO_ZH125J_Hgamstargam_MINLO.2to4lep.root"
+      },
+      {
+        "checksum": "adler32:9fed8aec",
+        "size": 979978,
+        "uri": "root://eospublic.cern.ch//eos/opendata/atlas/rucio/opendata/ODEO_FEB2025_v0_2to4lep_mc_346188.aMcAtNloPythia8EvtGen_tHjb125_4fl_gamgam.2to4lep.root"
+      },
+      {
+        "checksum": "adler32:bb382519",
+        "size": 3634308,
+        "uri": "root://eospublic.cern.ch//eos/opendata/atlas/rucio/opendata/ODEO_FEB2025_v0_2to4lep_mc_346189.aMcAtNloPythia8EvtGen_ttH_gamgam.2to4lep.root"
+      },
+      {
+        "checksum": "adler32:f3760218",
+        "size": 29267224,
+        "uri": "root://eospublic.cern.ch//eos/opendata/atlas/rucio/opendata/ODEO_FEB2025_v0_2to4lep_mc_346190.PowhegPy8EG_NNPDF30_AZNLOCTEQ6L1_VBFH125_tautaul13l7.2to4lep.root"
+      },
+      {
+        "checksum": "adler32:f8e30bbf",
+        "size": 1015135,
+        "uri": "root://eospublic.cern.ch//eos/opendata/atlas/rucio/opendata/ODEO_FEB2025_v0_2to4lep_mc_346191.PowhegPy8EG_NNPDF30_AZNLOCTEQ6L1_VBFH125_tautaulm15hp20.2to4lep.root"
+      },
+      {
+        "checksum": "adler32:87eb9b19",
+        "size": 976296,
+        "uri": "root://eospublic.cern.ch//eos/opendata/atlas/rucio/opendata/ODEO_FEB2025_v0_2to4lep_mc_346192.PowhegPy8EG_NNPDF30_AZNLOCTEQ6L1_VBFH125_tautaulp15hm20.2to4lep.root"
+      },
+      {
+        "checksum": "adler32:9826e5b7",
+        "size": 141881,
+        "uri": "root://eospublic.cern.ch//eos/opendata/atlas/rucio/opendata/ODEO_FEB2025_v0_2to4lep_mc_346193.PowhegPy8EG_NNPDF30_AZNLOCTEQ6L1_VBFH125_tautauh30h20.2to4lep.root"
+      },
+      {
+        "checksum": "adler32:8641cef6",
+        "size": 23639954,
+        "uri": "root://eospublic.cern.ch//eos/opendata/atlas/rucio/opendata/ODEO_FEB2025_v0_2to4lep_mc_346194.PowhegPy8EG_NNPDF30_AZNLOCTEQ6L1_VBFH125_etau_filt.2to4lep.root"
+      },
+      {
+        "checksum": "adler32:779542ca",
+        "size": 20950323,
+        "uri": "root://eospublic.cern.ch//eos/opendata/atlas/rucio/opendata/ODEO_FEB2025_v0_2to4lep_mc_346195.PowhegPy8EG_NNPDF30_AZNLOCTEQ6L1_VBFH125_mutau_filt.2to4lep.root"
+      },
+      {
+        "checksum": "adler32:b7d42541",
+        "size": 34093510,
+        "uri": "root://eospublic.cern.ch//eos/opendata/atlas/rucio/opendata/ODEO_FEB2025_v0_2to4lep_mc_346198.PhPy8EG_A14NNPDF23_NNPDF30ME_ttH125_Zgam.2to4lep.root"
+      },
+      {
+        "checksum": "adler32:0dc51e0f",
+        "size": 385777,
+        "uri": "root://eospublic.cern.ch//eos/opendata/atlas/rucio/opendata/ODEO_FEB2025_v0_2to4lep_mc_346214.PowhegPy8EG_NNPDF30_AZNLOCTEQ6L1_VBFH125_gamgam.2to4lep.root"
+      },
+      {
+        "checksum": "adler32:d6a190af",
+        "size": 121570695,
+        "uri": "root://eospublic.cern.ch//eos/opendata/atlas/rucio/opendata/ODEO_FEB2025_v0_2to4lep_mc_346228.PowhegPy8EG_NNPDF30_AZNLOCTEQ6L1_VBFH125_ZZ4lep_notau.2to4lep.root"
+      },
+      {
+        "checksum": "adler32:d16358d6",
+        "size": 2058913,
+        "uri": "root://eospublic.cern.ch//eos/opendata/atlas/rucio/opendata/ODEO_FEB2025_v0_2to4lep_mc_346310.PowhegPythia8EvtGen_NNPDF30_AZNLO_ZH125J_Zincl_H_incl_MINLO.2to4lep.root"
+      },
+      {
+        "checksum": "adler32:22f43b17",
+        "size": 799260,
+        "uri": "root://eospublic.cern.ch//eos/opendata/atlas/rucio/opendata/ODEO_FEB2025_v0_2to4lep_mc_346311.PowhegPythia8EvtGen_NNPDF30_AZNLO_WpH125J_Wincl_H_incl_MINLO.2to4lep.root"
+      },
+      {
+        "checksum": "adler32:c3af6e77",
+        "size": 641013,
+        "uri": "root://eospublic.cern.ch//eos/opendata/atlas/rucio/opendata/ODEO_FEB2025_v0_2to4lep_mc_346312.PowhegPythia8EvtGen_NNPDF30_AZNLO_WmH125J_Wincl_H_incl_MINLO.2to4lep.root"
+      },
+      {
+        "checksum": "adler32:40512635",
+        "size": 1900469,
+        "uri": "root://eospublic.cern.ch//eos/opendata/atlas/rucio/opendata/ODEO_FEB2025_v0_2to4lep_mc_346317.PowhegPy8EG_NNPDF30_AZNLOCTEQ6L1_VBFH125_incl.2to4lep.root"
+      },
+      {
+        "checksum": "adler32:493a1c61",
+        "size": 18210634,
+        "uri": "root://eospublic.cern.ch//eos/opendata/atlas/rucio/opendata/ODEO_FEB2025_v0_2to4lep_mc_346340.PowhegPy8EG_A14NNPDF23_NNPDF30ME_ttH125_ZZ4l_allhad.2to4lep.root"
+      },
+      {
+        "checksum": "adler32:89f8ba38",
+        "size": 15558644,
+        "uri": "root://eospublic.cern.ch//eos/opendata/atlas/rucio/opendata/ODEO_FEB2025_v0_2to4lep_mc_346341.PowhegPy8EG_A14NNPDF23_NNPDF30ME_ttH125_ZZ4l_semilep.2to4lep.root"
+      },
+      {
+        "checksum": "adler32:84fdc47c",
+        "size": 11106948,
+        "uri": "root://eospublic.cern.ch//eos/opendata/atlas/rucio/opendata/ODEO_FEB2025_v0_2to4lep_mc_346342.PowhegPy8EG_A14NNPDF23_NNPDF30ME_ttH125_ZZ4l_dilep.2to4lep.root"
+      },
+      {
+        "checksum": "adler32:6f4fa5f6",
+        "size": 2461890,
+        "uri": "root://eospublic.cern.ch//eos/opendata/atlas/rucio/opendata/ODEO_FEB2025_v0_2to4lep_mc_346343.PhPy8EG_A14NNPDF23_NNPDF30ME_ttH125_allhad.2to4lep.root"
+      },
+      {
+        "checksum": "adler32:b114d215",
+        "size": 7276367,
+        "uri": "root://eospublic.cern.ch//eos/opendata/atlas/rucio/opendata/ODEO_FEB2025_v0_2to4lep_mc_346344.PhPy8EG_A14NNPDF23_NNPDF30ME_ttH125_semilep.2to4lep.root"
+      },
+      {
+        "checksum": "adler32:2a09468c",
+        "size": 46273263,
+        "uri": "root://eospublic.cern.ch//eos/opendata/atlas/rucio/opendata/ODEO_FEB2025_v0_2to4lep_mc_346345.PhPy8EG_A14NNPDF23_NNPDF30ME_ttH125_dilep.2to4lep.root"
+      },
+      {
+        "checksum": "adler32:b7601ccc",
+        "size": 190890,
+        "uri": "root://eospublic.cern.ch//eos/opendata/atlas/rucio/opendata/ODEO_FEB2025_v0_2to4lep_mc_346398.PowhegHerwig7EvtGen_NNPDF3_AZNLO_ZH125J_MINLO_vvbb_VpT.2to4lep.root"
+      },
+      {
+        "checksum": "adler32:8b652e7b",
+        "size": 214457,
+        "uri": "root://eospublic.cern.ch//eos/opendata/atlas/rucio/opendata/ODEO_FEB2025_v0_2to4lep_mc_346400.PowhegHerwig7EvtGen_NNPDF3_AZNLO_ggZH125J_vvbb.2to4lep.root"
+      },
+      {
+        "checksum": "adler32:c28c4633",
+        "size": 11807425,
+        "uri": "root://eospublic.cern.ch//eos/opendata/atlas/rucio/opendata/ODEO_FEB2025_v0_2to4lep_mc_346414.aMcAtNloPythia8EvtGen_tHjb125_4fl_ZZ4l.2to4lep.root"
+      },
+      {
+        "checksum": "adler32:5b26904d",
+        "size": 362361641,
+        "uri": "root://eospublic.cern.ch//eos/opendata/atlas/rucio/opendata/ODEO_FEB2025_v0_2to4lep_mc_346446.PhH7EG_H7UE_NNLOPS_nnlo_30_ggH125_ZZ4l_noTau.2to4lep.root"
+      },
+      {
+        "checksum": "adler32:a814c6f4",
+        "size": 123135090,
+        "uri": "root://eospublic.cern.ch//eos/opendata/atlas/rucio/opendata/ODEO_FEB2025_v0_2to4lep_mc_346447.PhH7EG_H7UE_NNPDF30_VBFH125_ZZ4lep_noTau.2to4lep.root"
+      },
+      {
+        "checksum": "adler32:1b895aba",
+        "size": 30766123,
+        "uri": "root://eospublic.cern.ch//eos/opendata/atlas/rucio/opendata/ODEO_FEB2025_v0_2to4lep_mc_346448.PhH7EG_H7UE_NNPDF30_ZH125J_Zincl_MINLO.2to4lep.root"
+      },
+      {
+        "checksum": "adler32:e2d36186",
+        "size": 24134223,
+        "uri": "root://eospublic.cern.ch//eos/opendata/atlas/rucio/opendata/ODEO_FEB2025_v0_2to4lep_mc_346449.PhH7EG_H7UE_NNPDF30_WpH125J_Wincl_MINLO.2to4lep.root"
+      },
+      {
+        "checksum": "adler32:1cc851ef",
+        "size": 12665964,
+        "uri": "root://eospublic.cern.ch//eos/opendata/atlas/rucio/opendata/ODEO_FEB2025_v0_2to4lep_mc_346450.PhH7EG_H7UE_NNPDF30_WmH125J_Wincl_MINLO.2to4lep.root"
+      },
+      {
+        "checksum": "adler32:b1ca35ae",
+        "size": 15040469,
+        "uri": "root://eospublic.cern.ch//eos/opendata/atlas/rucio/opendata/ODEO_FEB2025_v0_2to4lep_mc_346451.PhH7EG_H7UE_NNPDF3_ggZH125_ZZ4lepZinc.2to4lep.root"
+      },
+      {
+        "checksum": "adler32:d8e379a9",
+        "size": 18230167,
+        "uri": "root://eospublic.cern.ch//eos/opendata/atlas/rucio/opendata/ODEO_FEB2025_v0_2to4lep_mc_346452.PhH7EG_H7UE_NNPDF30ME_ttH125_ZZ4l_allhad_noTau.2to4lep.root"
+      },
+      {
+        "checksum": "adler32:8f5264d2",
+        "size": 15740031,
+        "uri": "root://eospublic.cern.ch//eos/opendata/atlas/rucio/opendata/ODEO_FEB2025_v0_2to4lep_mc_346453.PhH7EG_H7UE_NNPDF30ME_ttH125_ZZ4l_semilep_noTau.2to4lep.root"
+      },
+      {
+        "checksum": "adler32:e90ced42",
+        "size": 11188095,
+        "uri": "root://eospublic.cern.ch//eos/opendata/atlas/rucio/opendata/ODEO_FEB2025_v0_2to4lep_mc_346454.PhH7EG_H7UE_NNPDF30ME_ttH125_ZZ4l_dilep_noTau.2to4lep.root"
+      },
+      {
+        "checksum": "adler32:6132f50e",
+        "size": 1861848,
+        "uri": "root://eospublic.cern.ch//eos/opendata/atlas/rucio/opendata/ODEO_FEB2025_v0_2to4lep_mc_346486.aMcAtNloPythia8EvtGen_tWH125_yy.2to4lep.root"
+      },
+      {
+        "checksum": "adler32:9e9f70e9",
+        "size": 13910448,
+        "uri": "root://eospublic.cern.ch//eos/opendata/atlas/rucio/opendata/ODEO_FEB2025_v0_2to4lep_mc_346511.aMcAtNloPythia8EvtGen_tWH125_ZZ4l.2to4lep.root"
+      },
+      {
+        "checksum": "adler32:5da06a3d",
+        "size": 7223769,
+        "uri": "root://eospublic.cern.ch//eos/opendata/atlas/rucio/opendata/ODEO_FEB2025_v0_2to4lep_mc_346524.PowhegPythia8EvtGen_NNPDF3_AZNLO_ggZH125J_MINLO_ZinclWWlvlv.2to4lep.root"
+      },
+      {
+        "checksum": "adler32:c3e9a4e5",
+        "size": 7881070,
+        "uri": "root://eospublic.cern.ch//eos/opendata/atlas/rucio/opendata/ODEO_FEB2025_v0_2to4lep_mc_346525.PowhegPythia8EvtGen_A14NNPDF23_NNPDF30ME_ttH125_gamgam.2to4lep.root"
+      },
+      {
+        "checksum": "adler32:20c3c33f",
+        "size": 7896843,
+        "uri": "root://eospublic.cern.ch//eos/opendata/atlas/rucio/opendata/ODEO_FEB2025_v0_2to4lep_mc_346526.PowhegHerwig7EvtGen_H7UE_NNPDF30ME_ttH125_gamgam.2to4lep.root"
+      },
+      {
+        "checksum": "adler32:27562b98",
+        "size": 98049,
+        "uri": "root://eospublic.cern.ch//eos/opendata/atlas/rucio/opendata/ODEO_FEB2025_v0_2to4lep_mc_346588.PowhegPythia8EvtGen_NNLOPS_nnlo_30_ggH125_ZZ4nu_MET75.2to4lep.root"
+      },
+      {
+        "checksum": "adler32:4b405618",
+        "size": 5516097,
+        "uri": "root://eospublic.cern.ch//eos/opendata/atlas/rucio/opendata/ODEO_FEB2025_v0_2to4lep_mc_346601.aMcAtNloHerwig7EvtGen_MEN30NLO_ttH125_gamgam.2to4lep.root"
+      },
+      {
+        "checksum": "adler32:eca637f7",
+        "size": 742449,
+        "uri": "root://eospublic.cern.ch//eos/opendata/atlas/rucio/opendata/ODEO_FEB2025_v0_2to4lep_mc_346602.aMcAtNloHerwig7EvtGen_MEN30NLO_tHjb125_gamgam.2to4lep.root"
+      },
+      {
+        "checksum": "adler32:2090adc7",
+        "size": 165681,
+        "uri": "root://eospublic.cern.ch//eos/opendata/atlas/rucio/opendata/ODEO_FEB2025_v0_2to4lep_mc_346605.PowhegPythia8EvtGen_NNPDF30_AZNLO_WpH125J_WinclHinv_MET75.2to4lep.root"
+      },
+      {
+        "checksum": "adler32:99bf4215",
+        "size": 157731,
+        "uri": "root://eospublic.cern.ch//eos/opendata/atlas/rucio/opendata/ODEO_FEB2025_v0_2to4lep_mc_346606.PowhegPythia8EvtGen_NNPDF30_AZNLO_WmH125J_WinclHinv_MET75.2to4lep.root"
+      },
+      {
+        "checksum": "adler32:c252542f",
+        "size": 2632287,
+        "uri": "root://eospublic.cern.ch//eos/opendata/atlas/rucio/opendata/ODEO_FEB2025_v0_2to4lep_mc_346607.PowhegPythia8EvtGen_NNPDF30_AZNLO_ZH125J_ZinclHinv_MET75.2to4lep.root"
+      },
+      {
+        "checksum": "adler32:4ce27859",
+        "size": 4908530,
+        "uri": "root://eospublic.cern.ch//eos/opendata/atlas/rucio/opendata/ODEO_FEB2025_v0_2to4lep_mc_346632.PowhegPy8EG_A14NNPDF23_NNPDF30ME_ttH125_ZZ4nu_semilep.2to4lep.root"
+      },
+      {
+        "checksum": "adler32:d8e96306",
+        "size": 672178,
+        "uri": "root://eospublic.cern.ch//eos/opendata/atlas/rucio/opendata/ODEO_FEB2025_v0_2to4lep_mc_346633.PowhegPy8EG_A14NNPDF23_NNPDF30ME_ttH125_ZZ4nu_allhad.2to4lep.root"
+      },
+      {
+        "checksum": "adler32:9b22daeb",
+        "size": 7958495,
+        "uri": "root://eospublic.cern.ch//eos/opendata/atlas/rucio/opendata/ODEO_FEB2025_v0_2to4lep_mc_346634.PowhegPy8EG_A14NNPDF23_NNPDF30ME_ttH125_ZZ4nu_dilep.2to4lep.root"
+      },
+      {
+        "checksum": "adler32:a41aa639",
+        "size": 43644192,
+        "uri": "root://eospublic.cern.ch//eos/opendata/atlas/rucio/opendata/ODEO_FEB2025_v0_2to4lep_mc_346645.PowhegPythia8EvtGen_NNPDF30_AZNLO_ZH125J_Zincl_MINLO_shw.2to4lep.root"
+      },
+      {
+        "checksum": "adler32:efce6d10",
+        "size": 24645729,
+        "uri": "root://eospublic.cern.ch//eos/opendata/atlas/rucio/opendata/ODEO_FEB2025_v0_2to4lep_mc_346646.PowhegPythia8EvtGen_NNPDF30_AZNLO_WpH125J_Wincl_MINLO_shw.2to4lep.root"
+      },
+      {
+        "checksum": "adler32:dee933f6",
+        "size": 13081016,
+        "uri": "root://eospublic.cern.ch//eos/opendata/atlas/rucio/opendata/ODEO_FEB2025_v0_2to4lep_mc_346647.PowhegPythia8EvtGen_NNPDF30_AZNLO_WmH125J_Wincl_MINLO_shw.2to4lep.root"
+      },
+      {
+        "checksum": "adler32:395a398a",
+        "size": 291259,
+        "uri": "root://eospublic.cern.ch//eos/opendata/atlas/rucio/opendata/ODEO_FEB2025_v0_2to4lep_mc_346726.PowhegHerwig7EvtGen_NNPDF3_AZNLO_ZH125J_MINLO_vvcc_VpT.2to4lep.root"
+      },
+      {
+        "checksum": "adler32:99ce9c5a",
+        "size": 75347,
+        "uri": "root://eospublic.cern.ch//eos/opendata/atlas/rucio/opendata/ODEO_FEB2025_v0_2to4lep_mc_346728.PowhegHerwig7EvtGen_NNPDF3_AZNLO_ggZH125J_vvcc.2to4lep.root"
+      },
+      {
+        "checksum": "adler32:a486be32",
+        "size": 5245343,
+        "uri": "root://eospublic.cern.ch//eos/opendata/atlas/rucio/opendata/ODEO_FEB2025_v0_2to4lep_mc_346797.PhH7EG_H7UE_NNLOPS_nnlo_30_ggH125_gamgam.2to4lep.root"
+      },
+      {
+        "checksum": "adler32:79bcd52e",
+        "size": 209331764,
+        "uri": "root://eospublic.cern.ch//eos/opendata/atlas/rucio/opendata/ODEO_FEB2025_v0_2to4lep_mc_346802.PhH7EG_NNLOPS_nnlo_30_ggH125_WWlvlv_noTau.2to4lep.root"
+      },
+      {
+        "checksum": "adler32:44655541",
+        "size": 33925198,
+        "uri": "root://eospublic.cern.ch//eos/opendata/atlas/rucio/opendata/ODEO_FEB2025_v0_2to4lep_mc_346877.PhH7EG_NNPDF30_VBFH125_WWlvlv.2to4lep.root"
+      },
+      {
+        "checksum": "adler32:c9469398",
+        "size": 966682,
+        "uri": "root://eospublic.cern.ch//eos/opendata/atlas/rucio/opendata/ODEO_FEB2025_v0_2to4lep_mc_346878.PhH7EG_H7UE_NNPDF30_VBF125_gammagamma.2to4lep.root"
+      },
+      {
+        "checksum": "adler32:da7ad217",
+        "size": 2289079,
+        "uri": "root://eospublic.cern.ch//eos/opendata/atlas/rucio/opendata/ODEO_FEB2025_v0_2to4lep_mc_346879.PhH7EG_H7UE_NNPDF30_ZH125J_Zincl_MINLO_gammagamma.2to4lep.root"
+      },
+      {
+        "checksum": "adler32:3ffab023",
+        "size": 448026,
+        "uri": "root://eospublic.cern.ch//eos/opendata/atlas/rucio/opendata/ODEO_FEB2025_v0_2to4lep_mc_346880.PhH7EG_H7UE_NNPDF30_WmH125J_Wincl_MINLO_gammagamma.2to4lep.root"
+      },
+      {
+        "checksum": "adler32:fb45d59e",
+        "size": 993298,
+        "uri": "root://eospublic.cern.ch//eos/opendata/atlas/rucio/opendata/ODEO_FEB2025_v0_2to4lep_mc_346881.PhH7EG_H7UE_NNPDF30_WpH125J_Wincl_MINLO_gammagamma.2to4lep.root"
+      },
+      {
+        "checksum": "adler32:bb602ce0",
+        "size": 1205266,
+        "uri": "root://eospublic.cern.ch//eos/opendata/atlas/rucio/opendata/ODEO_FEB2025_v0_2to4lep_mc_346882.PhH7EG_H7UE_NNPDF30_ggZH125_gammagamma.2to4lep.root"
+      },
+      {
+        "checksum": "adler32:93022b89",
+        "size": 6615315,
+        "uri": "root://eospublic.cern.ch//eos/opendata/atlas/rucio/opendata/ODEO_FEB2025_v0_2to4lep_mc_346919.PhPy8EG_A14NNPDF23_NNPDF30ME_ttH125_allhad_tautau_unpol.2to4lep.root"
+      },
+      {
+        "checksum": "adler32:1298d9b5",
+        "size": 19397637,
+        "uri": "root://eospublic.cern.ch//eos/opendata/atlas/rucio/opendata/ODEO_FEB2025_v0_2to4lep_mc_346923.PhPy8EG_A14NNPDF23_NNPDF30ME_ttH125_semilep_tautau_unpol.2to4lep.root"
+      },
+      {
+        "checksum": "adler32:081d96e3",
+        "size": 26309112,
+        "uri": "root://eospublic.cern.ch//eos/opendata/atlas/rucio/opendata/ODEO_FEB2025_v0_2to4lep_mc_346927.PhPy8EG_A14NNPDF23_NNPDF30ME_ttH125_dilep_tautau_unpol.2to4lep.root"
+      },
+      {
+        "checksum": "adler32:04cbd38c",
+        "size": 43978960,
+        "uri": "root://eospublic.cern.ch//eos/opendata/atlas/rucio/opendata/ODEO_FEB2025_v0_2to4lep_mc_364242.Sherpa_222_NNPDF30NNLO_WWW_3l3v_EW6.2to4lep.root"
+      },
+      {
+        "checksum": "adler32:f36e79af",
+        "size": 18992165,
+        "uri": "root://eospublic.cern.ch//eos/opendata/atlas/rucio/opendata/ODEO_FEB2025_v0_2to4lep_mc_364243.Sherpa_222_NNPDF30NNLO_WWZ_4l2v_EW6.2to4lep.root"
+      },
+      {
+        "checksum": "adler32:71dc89b2",
+        "size": 6840771,
+        "uri": "root://eospublic.cern.ch//eos/opendata/atlas/rucio/opendata/ODEO_FEB2025_v0_2to4lep_mc_364244.Sherpa_222_NNPDF30NNLO_WWZ_2l4v_EW6.2to4lep.root"
+      },
+      {
+        "checksum": "adler32:04ddfced",
+        "size": 15920016,
+        "uri": "root://eospublic.cern.ch//eos/opendata/atlas/rucio/opendata/ODEO_FEB2025_v0_2to4lep_mc_364245.Sherpa_222_NNPDF30NNLO_WZZ_5l1v_EW6.2to4lep.root"
+      },
+      {
+        "checksum": "adler32:7c9682c3",
+        "size": 13571672,
+        "uri": "root://eospublic.cern.ch//eos/opendata/atlas/rucio/opendata/ODEO_FEB2025_v0_2to4lep_mc_364246.Sherpa_222_NNPDF30NNLO_WZZ_3l3v_EW6.2to4lep.root"
+      },
+      {
+        "checksum": "adler32:04fda396",
+        "size": 10635601,
+        "uri": "root://eospublic.cern.ch//eos/opendata/atlas/rucio/opendata/ODEO_FEB2025_v0_2to4lep_mc_364247.Sherpa_222_NNPDF30NNLO_ZZZ_6l0v_EW6.2to4lep.root"
+      },
+      {
+        "checksum": "adler32:06639a1b",
+        "size": 3583960,
+        "uri": "root://eospublic.cern.ch//eos/opendata/atlas/rucio/opendata/ODEO_FEB2025_v0_2to4lep_mc_364248.Sherpa_222_NNPDF30NNLO_ZZZ_4l2v_EW6.2to4lep.root"
+      },
+      {
+        "checksum": "adler32:4ea037f8",
+        "size": 4707277,
+        "uri": "root://eospublic.cern.ch//eos/opendata/atlas/rucio/opendata/ODEO_FEB2025_v0_2to4lep_mc_364249.Sherpa_222_NNPDF30NNLO_ZZZ_2l4v_EW6.2to4lep.root"
+      },
+      {
+        "checksum": "adler32:8ec3ce88",
+        "size": 11797740,
+        "uri": "root://eospublic.cern.ch//eos/opendata/atlas/rucio/opendata/ODEO_FEB2025_v0_2to4lep_mc_364336.Sherpa_222_NNPDF30NNLO_WpWpWn_sslvlvjj_EW6.2to4lep.root"
+      },
+      {
+        "checksum": "adler32:92852432",
+        "size": 8997796,
+        "uri": "root://eospublic.cern.ch//eos/opendata/atlas/rucio/opendata/ODEO_FEB2025_v0_2to4lep_mc_364337.Sherpa_222_NNPDF30NNLO_WnWnWp_sslvlvjj_EW6.2to4lep.root"
+      },
+      {
+        "checksum": "adler32:c2327d5c",
+        "size": 4486383,
+        "uri": "root://eospublic.cern.ch//eos/opendata/atlas/rucio/opendata/ODEO_FEB2025_v0_2to4lep_mc_364338.Sherpa_222_NNPDF30NNLO_WpWpWn_oslvlvjj_EW6.2to4lep.root"
+      },
+      {
+        "checksum": "adler32:f9fc2fbe",
+        "size": 1550264,
+        "uri": "root://eospublic.cern.ch//eos/opendata/atlas/rucio/opendata/ODEO_FEB2025_v0_2to4lep_mc_364339.Sherpa_222_NNPDF30NNLO_WnWnWp_oslvlvjj_EW6.2to4lep.root"
+      },
+      {
+        "checksum": "adler32:4503f5a6",
+        "size": 4756031,
+        "uri": "root://eospublic.cern.ch//eos/opendata/atlas/rucio/opendata/ODEO_FEB2025_v0_2to4lep_mc_364350.Sherpa_224_NNPDF30NNLO_Diphoton_myy_0_50.2to4lep.root"
+      },
+      {
+        "checksum": "adler32:7f0510ae",
+        "size": 46806671,
+        "uri": "root://eospublic.cern.ch//eos/opendata/atlas/rucio/opendata/ODEO_FEB2025_v0_2to4lep_mc_364351.Sherpa_224_NNPDF30NNLO_Diphoton_myy_50_90.2to4lep.root"
+      },
+      {
+        "checksum": "adler32:4873dad7",
+        "size": 13566467,
+        "uri": "root://eospublic.cern.ch//eos/opendata/atlas/rucio/opendata/ODEO_FEB2025_v0_2to4lep_mc_364352.Sherpa_224_NNPDF30NNLO_Diphoton_myy_90_175.2to4lep.root"
+      },
+      {
+        "checksum": "adler32:52839147",
+        "size": 2427398,
+        "uri": "root://eospublic.cern.ch//eos/opendata/atlas/rucio/opendata/ODEO_FEB2025_v0_2to4lep_mc_364353.Sherpa_224_NNPDF30NNLO_Diphoton_myy_175_2000.2to4lep.root"
+      },
+      {
+        "checksum": "adler32:c1ad741d",
+        "size": 229777,
+        "uri": "root://eospublic.cern.ch//eos/opendata/atlas/rucio/opendata/ODEO_FEB2025_v0_2to4lep_mc_364354.Sherpa_224_NNPDF30NNLO_Diphoton_myy_2000_E_CMS.2to4lep.root"
+      },
+      {
+        "checksum": "adler32:23eee66d",
+        "size": 15566500,
+        "uri": "root://eospublic.cern.ch//eos/opendata/atlas/rucio/opendata/ODEO_FEB2025_v0_2to4lep_mc_364541.Sherpa_222_NNPDF30NNLO_SinglePhoton_pty_17_35.2to4lep.root"
+      },
+      {
+        "checksum": "adler32:486755bb",
+        "size": 14561934,
+        "uri": "root://eospublic.cern.ch//eos/opendata/atlas/rucio/opendata/ODEO_FEB2025_v0_2to4lep_mc_364542.Sherpa_222_NNPDF30NNLO_SinglePhoton_pty_35_70.2to4lep.root"
+      },
+      {
+        "checksum": "adler32:9bfd498e",
+        "size": 9495919,
+        "uri": "root://eospublic.cern.ch//eos/opendata/atlas/rucio/opendata/ODEO_FEB2025_v0_2to4lep_mc_364543.Sherpa_222_NNPDF30NNLO_SinglePhoton_pty_70_140.2to4lep.root"
+      },
+      {
+        "checksum": "adler32:77dbfa16",
+        "size": 14117196,
+        "uri": "root://eospublic.cern.ch//eos/opendata/atlas/rucio/opendata/ODEO_FEB2025_v0_2to4lep_mc_364544.Sherpa_222_NNPDF30NNLO_SinglePhoton_pty_140_280.2to4lep.root"
+      },
+      {
+        "checksum": "adler32:1a712b5e",
+        "size": 4269452,
+        "uri": "root://eospublic.cern.ch//eos/opendata/atlas/rucio/opendata/ODEO_FEB2025_v0_2to4lep_mc_364545.Sherpa_222_NNPDF30NNLO_SinglePhoton_pty_280_500.2to4lep.root"
+      },
+      {
+        "checksum": "adler32:4f6327bc",
+        "size": 525612,
+        "uri": "root://eospublic.cern.ch//eos/opendata/atlas/rucio/opendata/ODEO_FEB2025_v0_2to4lep_mc_364546.Sherpa_222_NNPDF30NNLO_SinglePhoton_pty_500_1000.2to4lep.root"
+      },
+      {
+        "checksum": "adler32:d496fd7a",
+        "size": 1035390,
+        "uri": "root://eospublic.cern.ch//eos/opendata/atlas/rucio/opendata/ODEO_FEB2025_v0_2to4lep_mc_364547.Sherpa_222_NNPDF30NNLO_SinglePhoton_pty_1000_E_CMS.2to4lep.root"
+      },
+      {
+        "checksum": "adler32:8d7f9ed2",
+        "size": 3063916,
+        "uri": "root://eospublic.cern.ch//eos/opendata/atlas/rucio/opendata/ODEO_FEB2025_v0_2to4lep_mc_364700.Pythia8EvtGen_A14NNPDF23LO_jetjet_JZ0WithSW.2to4lep.root"
+      },
+      {
+        "checksum": "adler32:80c20f23",
+        "size": 5000108,
+        "uri": "root://eospublic.cern.ch//eos/opendata/atlas/rucio/opendata/ODEO_FEB2025_v0_2to4lep_mc_364701.Pythia8EvtGen_A14NNPDF23LO_jetjet_JZ1WithSW.2to4lep.root"
+      },
+      {
+        "checksum": "adler32:be3961e6",
+        "size": 26405734,
+        "uri": "root://eospublic.cern.ch//eos/opendata/atlas/rucio/opendata/ODEO_FEB2025_v0_2to4lep_mc_364702.Pythia8EvtGen_A14NNPDF23LO_jetjet_JZ2WithSW.2to4lep.root"
+      },
+      {
+        "checksum": "adler32:43a7ea85",
+        "size": 102700652,
+        "uri": "root://eospublic.cern.ch//eos/opendata/atlas/rucio/opendata/ODEO_FEB2025_v0_2to4lep_mc_364703.Pythia8EvtGen_A14NNPDF23LO_jetjet_JZ3WithSW.2to4lep.root"
+      },
+      {
+        "checksum": "adler32:cd64f38a",
+        "size": 293220594,
+        "uri": "root://eospublic.cern.ch//eos/opendata/atlas/rucio/opendata/ODEO_FEB2025_v0_2to4lep_mc_364704.Pythia8EvtGen_A14NNPDF23LO_jetjet_JZ4WithSW.2to4lep.root"
+      },
+      {
+        "checksum": "adler32:04dc460b",
+        "size": 61772708,
+        "uri": "root://eospublic.cern.ch//eos/opendata/atlas/rucio/opendata/ODEO_FEB2025_v0_2to4lep_mc_364705.Pythia8EvtGen_A14NNPDF23LO_jetjet_JZ5WithSW.2to4lep.root"
+      },
+      {
+        "checksum": "adler32:62e6da1b",
+        "size": 4128074,
+        "uri": "root://eospublic.cern.ch//eos/opendata/atlas/rucio/opendata/ODEO_FEB2025_v0_2to4lep_mc_364706.Pythia8EvtGen_A14NNPDF23LO_jetjet_JZ6WithSW.2to4lep.root"
+      },
+      {
+        "checksum": "adler32:90e8f8f3",
+        "size": 3106708,
+        "uri": "root://eospublic.cern.ch//eos/opendata/atlas/rucio/opendata/ODEO_FEB2025_v0_2to4lep_mc_364707.Pythia8EvtGen_A14NNPDF23LO_jetjet_JZ7WithSW.2to4lep.root"
+      },
+      {
+        "checksum": "adler32:9c69be0c",
+        "size": 7658092,
+        "uri": "root://eospublic.cern.ch//eos/opendata/atlas/rucio/opendata/ODEO_FEB2025_v0_2to4lep_mc_364708.Pythia8EvtGen_A14NNPDF23LO_jetjet_JZ8WithSW.2to4lep.root"
+      },
+      {
+        "checksum": "adler32:72dfdc46",
+        "size": 3986689,
+        "uri": "root://eospublic.cern.ch//eos/opendata/atlas/rucio/opendata/ODEO_FEB2025_v0_2to4lep_mc_364709.Pythia8EvtGen_A14NNPDF23LO_jetjet_JZ9WithSW.2to4lep.root"
+      },
+      {
+        "checksum": "adler32:78b784be",
+        "size": 14791981,
+        "uri": "root://eospublic.cern.ch//eos/opendata/atlas/rucio/opendata/ODEO_FEB2025_v0_2to4lep_mc_364710.Pythia8EvtGen_A14NNPDF23LO_jetjet_JZ10WithSW.2to4lep.root"
+      },
+      {
+        "checksum": "adler32:b59e14d8",
+        "size": 8035407,
+        "uri": "root://eospublic.cern.ch//eos/opendata/atlas/rucio/opendata/ODEO_FEB2025_v0_2to4lep_mc_364711.Pythia8EvtGen_A14NNPDF23LO_jetjet_JZ11WithSW.2to4lep.root"
+      },
+      {
+        "checksum": "adler32:bcf8eb66",
+        "size": 11704509,
+        "uri": "root://eospublic.cern.ch//eos/opendata/atlas/rucio/opendata/ODEO_FEB2025_v0_2to4lep_mc_364712.Pythia8EvtGen_A14NNPDF23LO_jetjet_JZ12WithSW.2to4lep.root"
+      },
+      {
+        "checksum": "adler32:437aca40",
+        "size": 1794140,
+        "uri": "root://eospublic.cern.ch//eos/opendata/atlas/rucio/opendata/ODEO_FEB2025_v0_2to4lep_mc_375884.MGPy8EG_A14N_GG_ttn1_2000_5000_200.2to4lep.root"
+      },
+      {
+        "checksum": "adler32:37407c66",
+        "size": 147124,
+        "uri": "root://eospublic.cern.ch//eos/opendata/atlas/rucio/opendata/ODEO_FEB2025_v0_2to4lep_mc_376359.MGPy8EG_A14N23LO_SS_onestepCC_1600_900_200.2to4lep.root"
+      },
+      {
+        "checksum": "adler32:286bd5ba",
+        "size": 81560,
+        "uri": "root://eospublic.cern.ch//eos/opendata/atlas/rucio/opendata/ODEO_FEB2025_v0_2to4lep_mc_376518.MadGraphPythia8EvtGen_A14NNPDF23LO_GG_direct_2400_200.2to4lep.root"
+      },
+      {
+        "checksum": "adler32:8a4a9eee",
+        "size": 3850323,
+        "uri": "root://eospublic.cern.ch//eos/opendata/atlas/rucio/opendata/ODEO_FEB2025_v0_2to4lep_mc_392202.MGPy8EG_A14N23LO_C1N2_WZ_500p0_100p0_3L_2L7.2to4lep.root"
+      },
+      {
+        "checksum": "adler32:3232be62",
+        "size": 240887,
+        "uri": "root://eospublic.cern.ch//eos/opendata/atlas/rucio/opendata/ODEO_FEB2025_v0_2to4lep_mc_394997.MGPy8EG_A14N23LO_SM_N2C1p_105_100_2L2MET75_MadSpin.2to4lep.root"
+      },
+      {
+        "checksum": "adler32:1f270dd0",
+        "size": 1685293,
+        "uri": "root://eospublic.cern.ch//eos/opendata/atlas/rucio/opendata/ODEO_FEB2025_v0_2to4lep_mc_398384.MGPy8EG_A14N23LO_C1N2N1_GGMHinoZh50_800_noFilter.2to4lep.root"
+      },
+      {
+        "checksum": "adler32:f68b2c5c",
+        "size": 4016068,
+        "uri": "root://eospublic.cern.ch//eos/opendata/atlas/rucio/opendata/ODEO_FEB2025_v0_2to4lep_mc_410081.MadGraphPythia8EvtGen_A14NNPDF23_ttbarWW.2to4lep.root"
+      },
+      {
+        "checksum": "adler32:909421da",
+        "size": 29135325,
+        "uri": "root://eospublic.cern.ch//eos/opendata/atlas/rucio/opendata/ODEO_FEB2025_v0_2to4lep_mc_410082.MadGraphPythia8EvtGen_A14NNPDF23LO_ttgamma_noallhad.2to4lep.root"
+      },
+      {
+        "checksum": "adler32:4348cece",
+        "size": 1961307,
+        "uri": "root://eospublic.cern.ch//eos/opendata/atlas/rucio/opendata/ODEO_FEB2025_v0_2to4lep_mc_410087.MadGraphPythia8EvtGen_A14NNPDF23LO_ttgamma_allhad.2to4lep.root"
+      },
+      {
+        "checksum": "adler32:4706883a",
+        "size": 7480623,
+        "uri": "root://eospublic.cern.ch//eos/opendata/atlas/rucio/opendata/ODEO_FEB2025_v0_2to4lep_mc_410155.aMcAtNloPythia8EvtGen_MEN30NLO_A14N23LO_ttW.2to4lep.root"
+      },
+      {
+        "checksum": "adler32:f9f792fd",
+        "size": 4144736,
+        "uri": "root://eospublic.cern.ch//eos/opendata/atlas/rucio/opendata/ODEO_FEB2025_v0_2to4lep_mc_410156.aMcAtNloPythia8EvtGen_MEN30NLO_A14N23LO_ttZnunu.2to4lep.root"
+      },
+      {
+        "checksum": "adler32:665d5d79",
+        "size": 6921924,
+        "uri": "root://eospublic.cern.ch//eos/opendata/atlas/rucio/opendata/ODEO_FEB2025_v0_2to4lep_mc_410157.aMcAtNloPythia8EvtGen_MEN30NLO_A14N23LO_ttZqq.2to4lep.root"
+      },
+      {
+        "checksum": "adler32:3ec74019",
+        "size": 31483415,
+        "uri": "root://eospublic.cern.ch//eos/opendata/atlas/rucio/opendata/ODEO_FEB2025_v0_2to4lep_mc_410218.aMcAtNloPythia8EvtGen_MEN30NLO_A14N23LO_ttee.2to4lep.root"
+      },
+      {
+        "checksum": "adler32:80e6fb27",
+        "size": 49627108,
+        "uri": "root://eospublic.cern.ch//eos/opendata/atlas/rucio/opendata/ODEO_FEB2025_v0_2to4lep_mc_410219.aMcAtNloPythia8EvtGen_MEN30NLO_A14N23LO_ttmumu.2to4lep.root"
+      },
+      {
+        "checksum": "adler32:2d09fdf0",
+        "size": 16997620,
+        "uri": "root://eospublic.cern.ch//eos/opendata/atlas/rucio/opendata/ODEO_FEB2025_v0_2to4lep_mc_410220.aMcAtNloPythia8EvtGen_MEN30NLO_A14N23LO_tttautau.2to4lep.root"
+      },
+      {
+        "checksum": "adler32:8038a79d",
+        "size": 40758103,
+        "uri": "root://eospublic.cern.ch//eos/opendata/atlas/rucio/opendata/ODEO_FEB2025_v0_2to4lep_mc_410389.MadGraphPythia8EvtGen_A14NNPDF23_ttgamma_nonallhadronic.2to4lep.root"
+      },
+      {
+        "checksum": "adler32:a7659038",
+        "size": 35567212,
+        "uri": "root://eospublic.cern.ch//eos/opendata/atlas/rucio/opendata/ODEO_FEB2025_v0_2to4lep_mc_410395.MGH7EG_H7UE_ttgamma_nonallhadronic.2to4lep.root"
+      },
+      {
+        "checksum": "adler32:1166fd2a",
+        "size": 2220720,
+        "uri": "root://eospublic.cern.ch//eos/opendata/atlas/rucio/opendata/ODEO_FEB2025_v0_2to4lep_mc_410396.MGH7EG_H7UE_ttgamma_allhadronic.2to4lep.root"
+      },
+      {
+        "checksum": "adler32:7a127575",
+        "size": 10573310,
+        "uri": "root://eospublic.cern.ch//eos/opendata/atlas/rucio/opendata/ODEO_FEB2025_v0_2to4lep_mc_410408.aMcAtNloPythia8EvtGen_tWZ_Ztoll_minDR1.2to4lep.root"
+      },
+      {
+        "checksum": "adler32:1bd100c2",
+        "size": 1894938514,
+        "uri": "root://eospublic.cern.ch//eos/opendata/atlas/rucio/opendata/ODEO_FEB2025_v0_2to4lep_mc_410470.PhPy8EG_A14_ttbar_hdamp258p75_nonallhad.2to4lep.root"
+      },
+      {
+        "checksum": "adler32:ca9445c8",
+        "size": 68881622,
+        "uri": "root://eospublic.cern.ch//eos/opendata/atlas/rucio/opendata/ODEO_FEB2025_v0_2to4lep_mc_410471.PhPy8EG_A14_ttbar_hdamp258p75_allhad.2to4lep.root"
+      },
+      {
+        "checksum": "adler32:6a7c358e",
+        "size": 10966645,
+        "uri": "root://eospublic.cern.ch//eos/opendata/atlas/rucio/opendata/ODEO_FEB2025_v0_2to4lep_mc_410560.MadGraphPythia8EvtGen_A14_tZ_4fl_tchan_noAllHad.2to4lep.root"
+      },
+      {
+        "checksum": "adler32:ba3f192b",
+        "size": 2827726,
+        "uri": "root://eospublic.cern.ch//eos/opendata/atlas/rucio/opendata/ODEO_FEB2025_v0_2to4lep_mc_410644.PowhegPythia8EvtGen_A14_singletop_schan_lept_top.2to4lep.root"
+      },
+      {
+        "checksum": "adler32:dfe0ba2a",
+        "size": 1969395,
+        "uri": "root://eospublic.cern.ch//eos/opendata/atlas/rucio/opendata/ODEO_FEB2025_v0_2to4lep_mc_410645.PowhegPythia8EvtGen_A14_singletop_schan_lept_antitop.2to4lep.root"
+      },
+      {
+        "checksum": "adler32:869daf4e",
+        "size": 45062100,
+        "uri": "root://eospublic.cern.ch//eos/opendata/atlas/rucio/opendata/ODEO_FEB2025_v0_2to4lep_mc_410658.PhPy8EG_A14_tchan_BW50_lept_top.2to4lep.root"
+      },
+      {
+        "checksum": "adler32:ea0431ec",
+        "size": 27377498,
+        "uri": "root://eospublic.cern.ch//eos/opendata/atlas/rucio/opendata/ODEO_FEB2025_v0_2to4lep_mc_410659.PhPy8EG_A14_tchan_BW50_lept_antitop.2to4lep.root"
+      },
+      {
+        "checksum": "adler32:778f8255",
+        "size": 167669446,
+        "uri": "root://eospublic.cern.ch//eos/opendata/atlas/rucio/opendata/ODEO_FEB2025_v0_2to4lep_mc_411233.PowhegHerwig7EvtGen_tt_hdamp258p75_713_SingleLep.2to4lep.root"
+      },
+      {
+        "checksum": "adler32:411bea6c",
+        "size": 608897595,
+        "uri": "root://eospublic.cern.ch//eos/opendata/atlas/rucio/opendata/ODEO_FEB2025_v0_2to4lep_mc_411234.PowhegHerwig7EvtGen_tt_hdamp258p75_713_dil.2to4lep.root"
+      },
+      {
+        "checksum": "adler32:fc751868",
+        "size": 90611840,
+        "uri": "root://eospublic.cern.ch//eos/opendata/atlas/rucio/opendata/ODEO_FEB2025_v0_2to4lep_mc_411316.PowhegHerwig7EvtGen_tt_hdamp258p75_713_allhad.2to4lep.root"
+      },
+      {
+        "checksum": "adler32:a1f93dfe",
+        "size": 27035715,
+        "uri": "root://eospublic.cern.ch//eos/opendata/atlas/rucio/opendata/ODEO_FEB2025_v0_2to4lep_mc_412043.aMcAtNloPythia8EvtGen_A14NNPDF31_SM4topsNLO.2to4lep.root"
+      },
+      {
+        "checksum": "adler32:28ef4a63",
+        "size": 26325902,
+        "uri": "root://eospublic.cern.ch//eos/opendata/atlas/rucio/opendata/ODEO_FEB2025_v0_2to4lep_mc_412044.aMcAtNloHerwig7EvtGen_H7UE_SM4topsNLO.2to4lep.root"
+      },
+      {
+        "checksum": "adler32:3ecbf9aa",
+        "size": 737234,
+        "uri": "root://eospublic.cern.ch//eos/opendata/atlas/rucio/opendata/ODEO_FEB2025_v0_2to4lep_mc_423099.Pythia8EvtGen_A14NNPDF23LO_gammajet_DP8_17.2to4lep.root"
+      },
+      {
+        "checksum": "adler32:3975ff8f",
+        "size": 3772767,
+        "uri": "root://eospublic.cern.ch//eos/opendata/atlas/rucio/opendata/ODEO_FEB2025_v0_2to4lep_mc_423100.Pythia8EvtGen_A14NNPDF23LO_gammajet_DP17_35.2to4lep.root"
+      },
+      {
+        "checksum": "adler32:adb1091e",
+        "size": 3704949,
+        "uri": "root://eospublic.cern.ch//eos/opendata/atlas/rucio/opendata/ODEO_FEB2025_v0_2to4lep_mc_423101.Pythia8EvtGen_A14NNPDF23LO_gammajet_DP35_50.2to4lep.root"
+      },
+      {
+        "checksum": "adler32:12b0d827",
+        "size": 3279095,
+        "uri": "root://eospublic.cern.ch//eos/opendata/atlas/rucio/opendata/ODEO_FEB2025_v0_2to4lep_mc_423102.Pythia8EvtGen_A14NNPDF23LO_gammajet_DP50_70.2to4lep.root"
+      },
+      {
+        "checksum": "adler32:401fa696",
+        "size": 2189151,
+        "uri": "root://eospublic.cern.ch//eos/opendata/atlas/rucio/opendata/ODEO_FEB2025_v0_2to4lep_mc_423103.Pythia8EvtGen_A14NNPDF23LO_gammajet_DP70_140.2to4lep.root"
+      },
+      {
+        "checksum": "adler32:3838452e",
+        "size": 3267034,
+        "uri": "root://eospublic.cern.ch//eos/opendata/atlas/rucio/opendata/ODEO_FEB2025_v0_2to4lep_mc_423104.Pythia8EvtGen_A14NNPDF23LO_gammajet_DP140_280.2to4lep.root"
+      },
+      {
+        "checksum": "adler32:67babb4f",
+        "size": 4015855,
+        "uri": "root://eospublic.cern.ch//eos/opendata/atlas/rucio/opendata/ODEO_FEB2025_v0_2to4lep_mc_423105.Pythia8EvtGen_A14NNPDF23LO_gammajet_DP280_500.2to4lep.root"
+      },
+      {
+        "checksum": "adler32:0496a66d",
+        "size": 707603,
+        "uri": "root://eospublic.cern.ch//eos/opendata/atlas/rucio/opendata/ODEO_FEB2025_v0_2to4lep_mc_423106.Pythia8EvtGen_A14NNPDF23LO_gammajet_DP500_800.2to4lep.root"
+      },
+      {
+        "checksum": "adler32:1139efd6",
+        "size": 566612,
+        "uri": "root://eospublic.cern.ch//eos/opendata/atlas/rucio/opendata/ODEO_FEB2025_v0_2to4lep_mc_423107.Pythia8EvtGen_A14NNPDF23LO_gammajet_DP800_1000.2to4lep.root"
+      },
+      {
+        "checksum": "adler32:c9b23734",
+        "size": 887397,
+        "uri": "root://eospublic.cern.ch//eos/opendata/atlas/rucio/opendata/ODEO_FEB2025_v0_2to4lep_mc_423108.Pythia8EvtGen_A14NNPDF23LO_gammajet_DP1000_1500.2to4lep.root"
+      },
+      {
+        "checksum": "adler32:8d81fcc1",
+        "size": 452743,
+        "uri": "root://eospublic.cern.ch//eos/opendata/atlas/rucio/opendata/ODEO_FEB2025_v0_2to4lep_mc_423109.Pythia8EvtGen_A14NNPDF23LO_gammajet_DP1500_2000.2to4lep.root"
+      },
+      {
+        "checksum": "adler32:64e6b0fe",
+        "size": 386345,
+        "uri": "root://eospublic.cern.ch//eos/opendata/atlas/rucio/opendata/ODEO_FEB2025_v0_2to4lep_mc_423110.Pythia8EvtGen_A14NNPDF23LO_gammajet_DP2000_2500.2to4lep.root"
+      },
+      {
+        "checksum": "adler32:449b2e3b",
+        "size": 707732,
+        "uri": "root://eospublic.cern.ch//eos/opendata/atlas/rucio/opendata/ODEO_FEB2025_v0_2to4lep_mc_423111.Pythia8EvtGen_A14NNPDF23LO_gammajet_DP2500_3000.2to4lep.root"
+      },
+      {
+        "checksum": "adler32:774917ae",
+        "size": 604972,
+        "uri": "root://eospublic.cern.ch//eos/opendata/atlas/rucio/opendata/ODEO_FEB2025_v0_2to4lep_mc_423112.Pythia8EvtGen_A14NNPDF23LO_gammajet_DP3000_inf.2to4lep.root"
+      },
+      {
+        "checksum": "adler32:95ceebb1",
+        "size": 1278117,
+        "uri": "root://eospublic.cern.ch//eos/opendata/atlas/rucio/opendata/ODEO_FEB2025_v0_2to4lep_mc_448624.MGPy8EG_A14N23LO_TT_higgsinoRPV_1075_700.2to4lep.root"
+      },
+      {
+        "checksum": "adler32:cd0482c7",
+        "size": 3485430,
+        "uri": "root://eospublic.cern.ch//eos/opendata/atlas/rucio/opendata/ODEO_FEB2025_v0_2to4lep_mc_449595.MGPy8EG_A14N23LO_TT_RPVdirectBL_1400.2to4lep.root"
+      },
+      {
+        "checksum": "adler32:5491c327",
+        "size": 10388010,
+        "uri": "root://eospublic.cern.ch//eos/opendata/atlas/rucio/opendata/ODEO_FEB2025_v0_2to4lep_mc_450576.PowhegPythia8EvtGen_NNLOPS_nnlo_30_VBFH125_ZZllbb.2to4lep.root"
+      },
+      {
+        "checksum": "adler32:692d36a5",
+        "size": 34231080,
+        "uri": "root://eospublic.cern.ch//eos/opendata/atlas/rucio/opendata/ODEO_FEB2025_v0_2to4lep_mc_500335.MGH7EG_VBFHWWlvlv.2to4lep.root"
+      },
+      {
+        "checksum": "adler32:649be930",
+        "size": 3639170,
+        "uri": "root://eospublic.cern.ch//eos/opendata/atlas/rucio/opendata/ODEO_FEB2025_v0_2to4lep_mc_500553.aMCPy8EG_ZH_FxFx_Hyy.2to4lep.root"
+      },
+      {
+        "checksum": "adler32:42d4d993",
+        "size": 1150420,
+        "uri": "root://eospublic.cern.ch//eos/opendata/atlas/rucio/opendata/ODEO_FEB2025_v0_2to4lep_mc_500554.aMCPy8EG_WH_FxFx_Hyy.2to4lep.root"
+      },
+      {
+        "checksum": "adler32:e4ab4734",
+        "size": 3632821,
+        "uri": "root://eospublic.cern.ch//eos/opendata/atlas/rucio/opendata/ODEO_FEB2025_v0_2to4lep_mc_500555.aMCPy8EG_ggZH_Hyy.2to4lep.root"
+      },
+      {
+        "checksum": "adler32:9075ac85",
+        "size": 1308307,
+        "uri": "root://eospublic.cern.ch//eos/opendata/atlas/rucio/opendata/ODEO_FEB2025_v0_2to4lep_mc_501058.MGPy8EG_StauStauDirect_200p0_1p0_TFilt.2to4lep.root"
+      },
+      {
+        "checksum": "adler32:eb7cfbe9",
+        "size": 3243367,
+        "uri": "root://eospublic.cern.ch//eos/opendata/atlas/rucio/opendata/ODEO_FEB2025_v0_2to4lep_mc_506098.aMCPy8EG_WpH_FxFx_Htautau.2to4lep.root"
+      },
+      {
+        "checksum": "adler32:77ab2635",
+        "size": 2470270,
+        "uri": "root://eospublic.cern.ch//eos/opendata/atlas/rucio/opendata/ODEO_FEB2025_v0_2to4lep_mc_506099.aMCPy8EG_ZH_FxFx_Htautau.2to4lep.root"
+      },
+      {
+        "checksum": "adler32:0406a895",
+        "size": 205210,
+        "uri": "root://eospublic.cern.ch//eos/opendata/atlas/rucio/opendata/ODEO_FEB2025_v0_2to4lep_mc_506101.aMCH7EG_VBF_Htautauh30h20.2to4lep.root"
+      },
+      {
+        "checksum": "adler32:a0d2ea88",
+        "size": 34213755,
+        "uri": "root://eospublic.cern.ch//eos/opendata/atlas/rucio/opendata/ODEO_FEB2025_v0_2to4lep_mc_506102.aMCH7EG_VBF_Htautaul13l7.2to4lep.root"
+      },
+      {
+        "checksum": "adler32:b461a0a9",
+        "size": 1266654,
+        "uri": "root://eospublic.cern.ch//eos/opendata/atlas/rucio/opendata/ODEO_FEB2025_v0_2to4lep_mc_506103.aMCH7EG_VBF_Htautaulp15hm20.2to4lep.root"
+      },
+      {
+        "checksum": "adler32:6917f313",
+        "size": 2091932,
+        "uri": "root://eospublic.cern.ch//eos/opendata/atlas/rucio/opendata/ODEO_FEB2025_v0_2to4lep_mc_506104.aMCH7EG_VBF_Htautaulm15hp20.2to4lep.root"
+      },
+      {
+        "checksum": "adler32:b5dfd360",
+        "size": 427523,
+        "uri": "root://eospublic.cern.ch//eos/opendata/atlas/rucio/opendata/ODEO_FEB2025_v0_2to4lep_mc_506811.aMCH7EG_VBF_HC_Hyy.2to4lep.root"
+      },
+      {
+        "checksum": "adler32:ffe97b67",
+        "size": 261938,
+        "uri": "root://eospublic.cern.ch//eos/opendata/atlas/rucio/opendata/ODEO_FEB2025_v0_2to4lep_mc_506813.aMCPy8EG_ZH_had_FxFx_Hyy.2to4lep.root"
+      },
+      {
+        "checksum": "adler32:4a30dc98",
+        "size": 276817,
+        "uri": "root://eospublic.cern.ch//eos/opendata/atlas/rucio/opendata/ODEO_FEB2025_v0_2to4lep_mc_506814.aMCPy8EG_ggZH_Zhad_Hyy.2to4lep.root"
+      },
+      {
+        "checksum": "adler32:6b75655e",
+        "size": 357316,
+        "uri": "root://eospublic.cern.ch//eos/opendata/atlas/rucio/opendata/ODEO_FEB2025_v0_2to4lep_mc_507366.MGPy8EG_A14NNPDF23LO_GGM_N1N2C1_950.2to4lep.root"
+      },
+      {
+        "checksum": "adler32:bfdb2a4c",
+        "size": 4357202,
+        "uri": "root://eospublic.cern.ch//eos/opendata/atlas/rucio/opendata/ODEO_FEB2025_v0_2to4lep_mc_510097.MGPy8EG_A14N23LO_DM_4topscalar_p1000_c1_nonallhad.2to4lep.root"
+      },
+      {
+        "checksum": "adler32:da0100fb",
+        "size": 495025,
+        "uri": "root://eospublic.cern.ch//eos/opendata/atlas/rucio/opendata/ODEO_FEB2025_v0_2to4lep_mc_523692.MGPy8EG_A14N23LO_TT_tN1_1200_200_MS.2to4lep.root"
+      },
+      {
+        "checksum": "adler32:799e34c4",
+        "size": 20492912,
+        "uri": "root://eospublic.cern.ch//eos/opendata/atlas/rucio/opendata/ODEO_FEB2025_v0_2to4lep_mc_600017.PhH7EG_H7UE_716_tchan_lept_antitop.2to4lep.root"
+      },
+      {
+        "checksum": "adler32:fbfa2169",
+        "size": 34451500,
+        "uri": "root://eospublic.cern.ch//eos/opendata/atlas/rucio/opendata/ODEO_FEB2025_v0_2to4lep_mc_600018.PhH7EG_H7UE_716_tchan_lept_top.2to4lep.root"
+      },
+      {
+        "checksum": "adler32:9a7ff49d",
+        "size": 2112792,
+        "uri": "root://eospublic.cern.ch//eos/opendata/atlas/rucio/opendata/ODEO_FEB2025_v0_2to4lep_mc_600019.PhH7EG_H7UE_716_schan_lept_antitop.2to4lep.root"
+      },
+      {
+        "checksum": "adler32:5e76d2de",
+        "size": 2385733,
+        "uri": "root://eospublic.cern.ch//eos/opendata/atlas/rucio/opendata/ODEO_FEB2025_v0_2to4lep_mc_600020.PhH7EG_H7UE_716_schan_lept_top.2to4lep.root"
+      },
+      {
+        "checksum": "adler32:1205b8b9",
+        "size": 649190,
+        "uri": "root://eospublic.cern.ch//eos/opendata/atlas/rucio/opendata/ODEO_FEB2025_v0_2to4lep_mc_600565.PhH7EG_ggH125_tautauh30h20_ShowerSys_fix.2to4lep.root"
+      },
+      {
+        "checksum": "adler32:f5726492",
+        "size": 130493227,
+        "uri": "root://eospublic.cern.ch//eos/opendata/atlas/rucio/opendata/ODEO_FEB2025_v0_2to4lep_mc_600566.PhH7EG_ggH125_tautaul13l7_ShowerSys_fix.2to4lep.root"
+      },
+      {
+        "checksum": "adler32:c9b2aefc",
+        "size": 2730545,
+        "uri": "root://eospublic.cern.ch//eos/opendata/atlas/rucio/opendata/ODEO_FEB2025_v0_2to4lep_mc_600567.PhH7EG_ggH125_ttlp15hm20_ShowerSys_fix.2to4lep.root"
+      },
+      {
+        "checksum": "adler32:558c60c6",
+        "size": 3171713,
+        "uri": "root://eospublic.cern.ch//eos/opendata/atlas/rucio/opendata/ODEO_FEB2025_v0_2to4lep_mc_600568.PhH7EG_ggH125_ttlm15hp20_ShowerSys_fix.2to4lep.root"
+      },
+      {
+        "checksum": "adler32:cc9d255f",
+        "size": 252281,
+        "uri": "root://eospublic.cern.ch//eos/opendata/atlas/rucio/opendata/ODEO_FEB2025_v0_2to4lep_mc_600569.PhH7EG_VBFH125_tautauh30h20_ShowerSys_fix.2to4lep.root"
+      },
+      {
+        "checksum": "adler32:f90695e9",
+        "size": 33434680,
+        "uri": "root://eospublic.cern.ch//eos/opendata/atlas/rucio/opendata/ODEO_FEB2025_v0_2to4lep_mc_600570.PhH7EG_VBFH125_tautaul13l7_ShowerSys_fix.2to4lep.root"
+      },
+      {
+        "checksum": "adler32:66338daf",
+        "size": 823941,
+        "uri": "root://eospublic.cern.ch//eos/opendata/atlas/rucio/opendata/ODEO_FEB2025_v0_2to4lep_mc_600571.PhH7EG_VBFH125_tautaulp15hm20_ShowerSys_fix.2to4lep.root"
+      },
+      {
+        "checksum": "adler32:30a8a380",
+        "size": 838699,
+        "uri": "root://eospublic.cern.ch//eos/opendata/atlas/rucio/opendata/ODEO_FEB2025_v0_2to4lep_mc_600572.PhH7EG_VBFH125_tautaulm15hp20_ShowerSys_fix.2to4lep.root"
+      },
+      {
+        "checksum": "adler32:55b89d7c",
+        "size": 1966393,
+        "uri": "root://eospublic.cern.ch//eos/opendata/atlas/rucio/opendata/ODEO_FEB2025_v0_2to4lep_mc_600573.PhH7EG_WmH125J_Winc_MINLO_tt_ShowerSys_fix.2to4lep.root"
+      },
+      {
+        "checksum": "adler32:30850f19",
+        "size": 3103086,
+        "uri": "root://eospublic.cern.ch//eos/opendata/atlas/rucio/opendata/ODEO_FEB2025_v0_2to4lep_mc_600574.PhH7EG_WpH125J_Winc_MINLO_tt_ShowerSys_fix.2to4lep.root"
+      },
+      {
+        "checksum": "adler32:440055f1",
+        "size": 3543866,
+        "uri": "root://eospublic.cern.ch//eos/opendata/atlas/rucio/opendata/ODEO_FEB2025_v0_2to4lep_mc_600575.PhH7EG_ZH125J_Zinc_MINLO_tautau_ShowerSys_fix.2to4lep.root"
+      },
+      {
+        "checksum": "adler32:99751213",
+        "size": 2095232,
+        "uri": "root://eospublic.cern.ch//eos/opendata/atlas/rucio/opendata/ODEO_FEB2025_v0_2to4lep_mc_600686.PhPy8EG_NNPDF3_AZNLO_ggZH125_Htautau_Zinc.2to4lep.root"
+      },
+      {
+        "checksum": "adler32:63912a7c",
+        "size": 73993053,
+        "uri": "root://eospublic.cern.ch//eos/opendata/atlas/rucio/opendata/ODEO_FEB2025_v0_2to4lep_mc_601352.PhPy8EG_tW_dyn_DR_incl_antitop.2to4lep.root"
+      },
+      {
+        "checksum": "adler32:fa21dbf0",
+        "size": 72779615,
+        "uri": "root://eospublic.cern.ch//eos/opendata/atlas/rucio/opendata/ODEO_FEB2025_v0_2to4lep_mc_601355.PhPy8EG_tW_dyn_DR_incl_top.2to4lep.root"
+      },
+      {
+        "checksum": "adler32:8e5b7b41",
+        "size": 23105739,
+        "uri": "root://eospublic.cern.ch//eos/opendata/atlas/rucio/opendata/ODEO_FEB2025_v0_2to4lep_mc_601487.PhPy8EG_A14_tchan_pThard1_lep_antitop.2to4lep.root"
+      },
+      {
+        "checksum": "adler32:e8d8ed61",
+        "size": 36395985,
+        "uri": "root://eospublic.cern.ch//eos/opendata/atlas/rucio/opendata/ODEO_FEB2025_v0_2to4lep_mc_601489.PhPy8EG_A14_tchan_pThard1_lep_top.2to4lep.root"
+      },
+      {
+        "checksum": "adler32:62e1919e",
+        "size": 1048851889,
+        "uri": "root://eospublic.cern.ch//eos/opendata/atlas/rucio/opendata/ODEO_FEB2025_v0_2to4lep_mc_601491.PhPy8EG_A14_ttbar_pThard1_dil.2to4lep.root"
+      },
+      {
+        "checksum": "adler32:5c8921d5",
+        "size": 714663,
+        "uri": "root://eospublic.cern.ch//eos/opendata/atlas/rucio/opendata/ODEO_FEB2025_v0_2to4lep_mc_601495.PhPy8EG_A14_ttbar_pThard1_allhad.2to4lep.root"
+      },
+      {
+        "checksum": "adler32:402a56b0",
+        "size": 620420638,
+        "uri": "root://eospublic.cern.ch//eos/opendata/atlas/rucio/opendata/ODEO_FEB2025_v0_2to4lep_mc_601497.PhPy8EG_A14_ttbar_pThard1_singlelep.2to4lep.root"
+      },
+      {
+        "checksum": "adler32:1e30bc4b",
+        "size": 52182540,
+        "uri": "root://eospublic.cern.ch//eos/opendata/atlas/rucio/opendata/ODEO_FEB2025_v0_2to4lep_mc_601624.PhPy8EG_tW_DS_dyn_dil_antitop.2to4lep.root"
+      },
+      {
+        "checksum": "adler32:788da49d",
+        "size": 71203133,
+        "uri": "root://eospublic.cern.ch//eos/opendata/atlas/rucio/opendata/ODEO_FEB2025_v0_2to4lep_mc_601627.PhPy8EG_tW_DS_dyn_incl_antitop.2to4lep.root"
+      },
+      {
+        "checksum": "adler32:a87ecd8b",
+        "size": 66550947,
+        "uri": "root://eospublic.cern.ch//eos/opendata/atlas/rucio/opendata/ODEO_FEB2025_v0_2to4lep_mc_601628.PhPy8EG_tW_DS_dyn_dil_top.2to4lep.root"
+      },
+      {
+        "checksum": "adler32:6d57e2d6",
+        "size": 69525451,
+        "uri": "root://eospublic.cern.ch//eos/opendata/atlas/rucio/opendata/ODEO_FEB2025_v0_2to4lep_mc_601631.PhPy8EG_tW_DS_dyn_incl_top.2to4lep.root"
+      },
+      {
+        "checksum": "adler32:eeeb2a0c",
+        "size": 74057871,
+        "uri": "root://eospublic.cern.ch//eos/opendata/atlas/rucio/opendata/ODEO_FEB2025_v0_2to4lep_mc_601761.PhPy8EG_tW_dyn_DR_pThard1_incl_top.2to4lep.root"
+      },
+      {
+        "checksum": "adler32:a5d8ed68",
+        "size": 73008444,
+        "uri": "root://eospublic.cern.ch//eos/opendata/atlas/rucio/opendata/ODEO_FEB2025_v0_2to4lep_mc_601762.PhPy8EG_tW_dyn_DR_pThard1_incl_antitop.2to4lep.root"
+      },
+      {
+        "checksum": "adler32:09e168cf",
+        "size": 67444906,
+        "uri": "root://eospublic.cern.ch//eos/opendata/atlas/rucio/opendata/ODEO_FEB2025_v0_2to4lep_mc_601763.PhPy8EG_tW_dyn_DR_pThard1_dil_top.2to4lep.root"
+      },
+      {
+        "checksum": "adler32:2b2e50bc",
+        "size": 67617257,
+        "uri": "root://eospublic.cern.ch//eos/opendata/atlas/rucio/opendata/ODEO_FEB2025_v0_2to4lep_mc_601764.PhPy8EG_tW_dyn_DR_pThard1_dil_antitop.2to4lep.root"
+      },
+      {
+        "checksum": "adler32:9ac8b5fa",
+        "size": 12410421,
+        "uri": "root://eospublic.cern.ch//eos/opendata/atlas/rucio/opendata/ODEO_FEB2025_v0_2to4lep_mc_700000.Sh_228_ttW.2to4lep.root"
+      },
+      {
+        "checksum": "adler32:f706f37e",
+        "size": 415232,
+        "uri": "root://eospublic.cern.ch//eos/opendata/atlas/rucio/opendata/ODEO_FEB2025_v0_2to4lep_mc_700007.Sh_228_yyy_01NLO.2to4lep.root"
+      },
+      {
+        "checksum": "adler32:ab6aa1b3",
+        "size": 21344848,
+        "uri": "root://eospublic.cern.ch//eos/opendata/atlas/rucio/opendata/ODEO_FEB2025_v0_2to4lep_mc_700195.Sh_2210_eegammagamma.2to4lep.root"
+      },
+      {
+        "checksum": "adler32:24670707",
+        "size": 33321801,
+        "uri": "root://eospublic.cern.ch//eos/opendata/atlas/rucio/opendata/ODEO_FEB2025_v0_2to4lep_mc_700196.Sh_2210_mumugammagamma.2to4lep.root"
+      },
+      {
+        "checksum": "adler32:4aec12d4",
+        "size": 1101309,
+        "uri": "root://eospublic.cern.ch//eos/opendata/atlas/rucio/opendata/ODEO_FEB2025_v0_2to4lep_mc_700197.Sh_2210_tautaugammagamma.2to4lep.root"
+      },
+      {
+        "checksum": "adler32:9410f506",
+        "size": 93801,
+        "uri": "root://eospublic.cern.ch//eos/opendata/atlas/rucio/opendata/ODEO_FEB2025_v0_2to4lep_mc_700198.Sh_2210_nunugammagamma.2to4lep.root"
+      },
+      {
+        "checksum": "adler32:d1495dcc",
+        "size": 2105407,
+        "uri": "root://eospublic.cern.ch//eos/opendata/atlas/rucio/opendata/ODEO_FEB2025_v0_2to4lep_mc_700199.Sh_2210_enugammagamma.2to4lep.root"
+      },
+      {
+        "checksum": "adler32:798dc458",
+        "size": 1784322,
+        "uri": "root://eospublic.cern.ch//eos/opendata/atlas/rucio/opendata/ODEO_FEB2025_v0_2to4lep_mc_700200.Sh_2210_munugammagamma.2to4lep.root"
+      },
+      {
+        "checksum": "adler32:060daedc",
+        "size": 581121,
+        "uri": "root://eospublic.cern.ch//eos/opendata/atlas/rucio/opendata/ODEO_FEB2025_v0_2to4lep_mc_700201.Sh_2210_taunugammagamma.2to4lep.root"
+      },
+      {
+        "checksum": "adler32:d56f542a",
+        "size": 1142689121,
+        "uri": "root://eospublic.cern.ch//eos/opendata/atlas/rucio/opendata/ODEO_FEB2025_v0_2to4lep_mc_700320.Sh_2211_Zee_maxHTpTV2_BFilter.2to4lep.root"
+      },
+      {
+        "checksum": "adler32:9a9b4f4c",
+        "size": 4867813819,
+        "uri": "root://eospublic.cern.ch//eos/opendata/atlas/rucio/opendata/ODEO_FEB2025_v0_2to4lep_mc_700321.Sh_2211_Zee_maxHTpTV2_CFilterBVeto.2to4lep.root"
+      },
+      {
+        "checksum": "adler32:6617bb1d",
+        "size": 16088210019,
+        "uri": "root://eospublic.cern.ch//eos/opendata/atlas/rucio/opendata/ODEO_FEB2025_v0_2to4lep_mc_700322.Sh_2211_Zee_maxHTpTV2_CVetoBVeto.2to4lep.root"
+      },
+      {
+        "checksum": "adler32:b61dc115",
+        "size": 1123795763,
+        "uri": "root://eospublic.cern.ch//eos/opendata/atlas/rucio/opendata/ODEO_FEB2025_v0_2to4lep_mc_700323.Sh_2211_Zmumu_maxHTpTV2_BFilter.2to4lep.root"
+      },
+      {
+        "checksum": "adler32:3ef07b5a",
+        "size": 5079230416,
+        "uri": "root://eospublic.cern.ch//eos/opendata/atlas/rucio/opendata/ODEO_FEB2025_v0_2to4lep_mc_700324.Sh_2211_Zmumu_maxHTpTV2_CFilterBVeto.2to4lep.root"
+      },
+      {
+        "checksum": "adler32:544bb77c",
+        "size": 17335909921,
+        "uri": "root://eospublic.cern.ch//eos/opendata/atlas/rucio/opendata/ODEO_FEB2025_v0_2to4lep_mc_700325.Sh_2211_Zmumu_maxHTpTV2_CVetoBVeto.2to4lep.root"
+      },
+      {
+        "checksum": "adler32:cfbbc290",
+        "size": 4194835,
+        "uri": "root://eospublic.cern.ch//eos/opendata/atlas/rucio/opendata/ODEO_FEB2025_v0_2to4lep_mc_700335.Sh_2211_Znunu_pTV2_BFilter.2to4lep.root"
+      },
+      {
+        "checksum": "adler32:dd9bf335",
+        "size": 5476662,
+        "uri": "root://eospublic.cern.ch//eos/opendata/atlas/rucio/opendata/ODEO_FEB2025_v0_2to4lep_mc_700336.Sh_2211_Znunu_pTV2_CFilterBVeto.2to4lep.root"
+      },
+      {
+        "checksum": "adler32:54547dd9",
+        "size": 10580584,
+        "uri": "root://eospublic.cern.ch//eos/opendata/atlas/rucio/opendata/ODEO_FEB2025_v0_2to4lep_mc_700337.Sh_2211_Znunu_pTV2_CVetoBVeto.2to4lep.root"
+      },
+      {
+        "checksum": "adler32:79f22297",
+        "size": 317204942,
+        "uri": "root://eospublic.cern.ch//eos/opendata/atlas/rucio/opendata/ODEO_FEB2025_v0_2to4lep_mc_700338.Sh_2211_Wenu_maxHTpTV2_BFilter.2to4lep.root"
+      },
+      {
+        "checksum": "adler32:cf392a79",
+        "size": 1342636430,
+        "uri": "root://eospublic.cern.ch//eos/opendata/atlas/rucio/opendata/ODEO_FEB2025_v0_2to4lep_mc_700339.Sh_2211_Wenu_maxHTpTV2_CFilterBVeto.2to4lep.root"
+      },
+      {
+        "checksum": "adler32:59b57c1d",
+        "size": 890024277,
+        "uri": "root://eospublic.cern.ch//eos/opendata/atlas/rucio/opendata/ODEO_FEB2025_v0_2to4lep_mc_700340.Sh_2211_Wenu_maxHTpTV2_CVetoBVeto.2to4lep.root"
+      },
+      {
+        "checksum": "adler32:4b599726",
+        "size": 337131777,
+        "uri": "root://eospublic.cern.ch//eos/opendata/atlas/rucio/opendata/ODEO_FEB2025_v0_2to4lep_mc_700341.Sh_2211_Wmunu_maxHTpTV2_BFilter.2to4lep.root"
+      },
+      {
+        "checksum": "adler32:bf3fa70e",
+        "size": 1245698854,
+        "uri": "root://eospublic.cern.ch//eos/opendata/atlas/rucio/opendata/ODEO_FEB2025_v0_2to4lep_mc_700342.Sh_2211_Wmunu_maxHTpTV2_CFilterBVeto.2to4lep.root"
+      },
+      {
+        "checksum": "adler32:4e509d4d",
+        "size": 794193627,
+        "uri": "root://eospublic.cern.ch//eos/opendata/atlas/rucio/opendata/ODEO_FEB2025_v0_2to4lep_mc_700343.Sh_2211_Wmunu_maxHTpTV2_CVetoBVeto.2to4lep.root"
+      },
+      {
+        "checksum": "adler32:3f4e5d72",
+        "size": 73282625,
+        "uri": "root://eospublic.cern.ch//eos/opendata/atlas/rucio/opendata/ODEO_FEB2025_v0_2to4lep_mc_700344.Sh_2211_Wtaunu_L_maxHTpTV2_BFilter.2to4lep.root"
+      },
+      {
+        "checksum": "adler32:072db8ba",
+        "size": 164310117,
+        "uri": "root://eospublic.cern.ch//eos/opendata/atlas/rucio/opendata/ODEO_FEB2025_v0_2to4lep_mc_700345.Sh_2211_Wtaunu_L_maxHTpTV2_CFilterBVeto.2to4lep.root"
+      },
+      {
+        "checksum": "adler32:92cdcff2",
+        "size": 189087243,
+        "uri": "root://eospublic.cern.ch//eos/opendata/atlas/rucio/opendata/ODEO_FEB2025_v0_2to4lep_mc_700346.Sh_2211_Wtaunu_L_maxHTpTV2_CVetoBVeto.2to4lep.root"
+      },
+      {
+        "checksum": "adler32:8e9bdfbc",
+        "size": 23539582,
+        "uri": "root://eospublic.cern.ch//eos/opendata/atlas/rucio/opendata/ODEO_FEB2025_v0_2to4lep_mc_700347.Sh_2211_Wtaunu_H_maxHTpTV2_BFilter.2to4lep.root"
+      },
+      {
+        "checksum": "adler32:3652d8a6",
+        "size": 11383744,
+        "uri": "root://eospublic.cern.ch//eos/opendata/atlas/rucio/opendata/ODEO_FEB2025_v0_2to4lep_mc_700348.Sh_2211_Wtaunu_H_maxHTpTV2_CFilterBVeto.2to4lep.root"
+      },
+      {
+        "checksum": "adler32:1e8f4daf",
+        "size": 39696213,
+        "uri": "root://eospublic.cern.ch//eos/opendata/atlas/rucio/opendata/ODEO_FEB2025_v0_2to4lep_mc_700349.Sh_2211_Wtaunu_H_maxHTpTV2_CVetoBVeto.2to4lep.root"
+      },
+      {
+        "checksum": "adler32:20001e28",
+        "size": 1245222,
+        "uri": "root://eospublic.cern.ch//eos/opendata/atlas/rucio/opendata/ODEO_FEB2025_v0_2to4lep_mc_700352.Sh_2211_pTZ100_Zqqgamma.2to4lep.root"
+      },
+      {
+        "checksum": "adler32:e701b654",
+        "size": 1179344,
+        "uri": "root://eospublic.cern.ch//eos/opendata/atlas/rucio/opendata/ODEO_FEB2025_v0_2to4lep_mc_700353.Sh_2211_pTZ100_Zbbgamma.2to4lep.root"
+      },
+      {
+        "checksum": "adler32:017f4864",
+        "size": 40842782,
+        "uri": "root://eospublic.cern.ch//eos/opendata/atlas/rucio/opendata/ODEO_FEB2025_v0_2to4lep_mc_700358.Sh_2211_Zee2jets_Min_N_TChannel.2to4lep.root"
+      },
+      {
+        "checksum": "adler32:f9455345",
+        "size": 36648822,
+        "uri": "root://eospublic.cern.ch//eos/opendata/atlas/rucio/opendata/ODEO_FEB2025_v0_2to4lep_mc_700359.Sh_2211_Zmm2jets_Min_N_TChannel.2to4lep.root"
+      },
+      {
+        "checksum": "adler32:08793829",
+        "size": 2119439,
+        "uri": "root://eospublic.cern.ch//eos/opendata/atlas/rucio/opendata/ODEO_FEB2025_v0_2to4lep_mc_700360.Sh_2211_Ztt2jets_Min_N_TChannel.2to4lep.root"
+      },
+      {
+        "checksum": "adler32:d9163c8a",
+        "size": 185025,
+        "uri": "root://eospublic.cern.ch//eos/opendata/atlas/rucio/opendata/ODEO_FEB2025_v0_2to4lep_mc_700361.Sh_2211_Znunu2jets_Min_N_TChannel.2to4lep.root"
+      },
+      {
+        "checksum": "adler32:bf455348",
+        "size": 4621199,
+        "uri": "root://eospublic.cern.ch//eos/opendata/atlas/rucio/opendata/ODEO_FEB2025_v0_2to4lep_mc_700362.Sh_2211_Wenu2jets_Min_N_TChannel.2to4lep.root"
+      },
+      {
+        "checksum": "adler32:227602c7",
+        "size": 5275957,
+        "uri": "root://eospublic.cern.ch//eos/opendata/atlas/rucio/opendata/ODEO_FEB2025_v0_2to4lep_mc_700363.Sh_2211_Wmunu2jets_Min_N_TChannel.2to4lep.root"
+      },
+      {
+        "checksum": "adler32:c48392f2",
+        "size": 1264218,
+        "uri": "root://eospublic.cern.ch//eos/opendata/atlas/rucio/opendata/ODEO_FEB2025_v0_2to4lep_mc_700364.Sh_2211_Wtaunu2jets_Min_N_TChannel.2to4lep.root"
+      },
+      {
+        "checksum": "adler32:ea21f032",
+        "size": 1354540367,
+        "uri": "root://eospublic.cern.ch//eos/opendata/atlas/rucio/opendata/ODEO_FEB2025_v0_2to4lep_mc_700398.Sh_2211_mumugamma.2to4lep.root"
+      },
+      {
+        "checksum": "adler32:54dd4f67",
+        "size": 1382935442,
+        "uri": "root://eospublic.cern.ch//eos/opendata/atlas/rucio/opendata/ODEO_FEB2025_v0_2to4lep_mc_700399.Sh_2211_eegamma.2to4lep.root"
+      },
+      {
+        "checksum": "adler32:1400a0aa",
+        "size": 100492802,
+        "uri": "root://eospublic.cern.ch//eos/opendata/atlas/rucio/opendata/ODEO_FEB2025_v0_2to4lep_mc_700400.Sh_2211_tautaugamma.2to4lep.root"
+      },
+      {
+        "checksum": "adler32:3bb01b87",
+        "size": 5318924,
+        "uri": "root://eospublic.cern.ch//eos/opendata/atlas/rucio/opendata/ODEO_FEB2025_v0_2to4lep_mc_700401.Sh_2211_nunugamma.2to4lep.root"
+      },
+      {
+        "checksum": "adler32:bb47d20b",
+        "size": 337459010,
+        "uri": "root://eospublic.cern.ch//eos/opendata/atlas/rucio/opendata/ODEO_FEB2025_v0_2to4lep_mc_700402.Sh_2211_munugamma.2to4lep.root"
+      },
+      {
+        "checksum": "adler32:cae07be9",
+        "size": 356428523,
+        "uri": "root://eospublic.cern.ch//eos/opendata/atlas/rucio/opendata/ODEO_FEB2025_v0_2to4lep_mc_700403.Sh_2211_enugamma.2to4lep.root"
+      },
+      {
+        "checksum": "adler32:86fb8ed8",
+        "size": 105565868,
+        "uri": "root://eospublic.cern.ch//eos/opendata/atlas/rucio/opendata/ODEO_FEB2025_v0_2to4lep_mc_700404.Sh_2211_taunugamma.2to4lep.root"
+      },
+      {
+        "checksum": "adler32:d53619eb",
+        "size": 201652,
+        "uri": "root://eospublic.cern.ch//eos/opendata/atlas/rucio/opendata/ODEO_FEB2025_v0_2to4lep_mc_700442.Sh_2211_gamma2jets_pTy140_Min_N_TChannel.2to4lep.root"
+      },
+      {
+        "checksum": "adler32:c391887a",
+        "size": 87546395,
+        "uri": "root://eospublic.cern.ch//eos/opendata/atlas/rucio/opendata/ODEO_FEB2025_v0_2to4lep_mc_700467.Sh_2211_Zee_maxHTpTV2_m10_40_pT5_BFilter.2to4lep.root"
+      },
+      {
+        "checksum": "adler32:39a088b9",
+        "size": 453204974,
+        "uri": "root://eospublic.cern.ch//eos/opendata/atlas/rucio/opendata/ODEO_FEB2025_v0_2to4lep_mc_700468.Sh_2211_Zee_maxHTpTV2_m10_40_pT5_CFilterBVeto.2to4lep.root"
+      },
+      {
+        "checksum": "adler32:d2644e2c",
+        "size": 2745753615,
+        "uri": "root://eospublic.cern.ch//eos/opendata/atlas/rucio/opendata/ODEO_FEB2025_v0_2to4lep_mc_700469.Sh_2211_Zee_maxHTpTV2_m10_40_pT5_CVetoBVeto.2to4lep.root"
+      },
+      {
+        "checksum": "adler32:0da0e161",
+        "size": 95965883,
+        "uri": "root://eospublic.cern.ch//eos/opendata/atlas/rucio/opendata/ODEO_FEB2025_v0_2to4lep_mc_700470.Sh_2211_Zmumu_maxHTpTV2_m10_40_pT5_BFilter.2to4lep.root"
+      },
+      {
+        "checksum": "adler32:fa102bc3",
+        "size": 474963407,
+        "uri": "root://eospublic.cern.ch//eos/opendata/atlas/rucio/opendata/ODEO_FEB2025_v0_2to4lep_mc_700471.Sh_2211_Zmumu_maxHTpTV2_m10_40_pT5_CFilterBVeto.2to4lep.root"
+      },
+      {
+        "checksum": "adler32:8a7017fb",
+        "size": 2959864945,
+        "uri": "root://eospublic.cern.ch//eos/opendata/atlas/rucio/opendata/ODEO_FEB2025_v0_2to4lep_mc_700472.Sh_2211_Zmumu_maxHTpTV2_m10_40_pT5_CVetoBVeto.2to4lep.root"
+      },
+      {
+        "checksum": "adler32:fdda6101",
+        "size": 22173338,
+        "uri": "root://eospublic.cern.ch//eos/opendata/atlas/rucio/opendata/ODEO_FEB2025_v0_2to4lep_mc_700488.Sh_2211_WlvWqq.2to4lep.root"
+      },
+      {
+        "checksum": "adler32:b1404e1e",
+        "size": 5128434,
+        "uri": "root://eospublic.cern.ch//eos/opendata/atlas/rucio/opendata/ODEO_FEB2025_v0_2to4lep_mc_700489.Sh_2211_WlvZqq.2to4lep.root"
+      },
+      {
+        "checksum": "adler32:e09c320c",
+        "size": 3596930,
+        "uri": "root://eospublic.cern.ch//eos/opendata/atlas/rucio/opendata/ODEO_FEB2025_v0_2to4lep_mc_700490.Sh_2211_WlvZbb.2to4lep.root"
+      },
+      {
+        "checksum": "adler32:486773bf",
+        "size": 494855,
+        "uri": "root://eospublic.cern.ch//eos/opendata/atlas/rucio/opendata/ODEO_FEB2025_v0_2to4lep_mc_700491.Sh_2211_WqqZvv.2to4lep.root"
+      },
+      {
+        "checksum": "adler32:daedd310",
+        "size": 44294500,
+        "uri": "root://eospublic.cern.ch//eos/opendata/atlas/rucio/opendata/ODEO_FEB2025_v0_2to4lep_mc_700492.Sh_2211_WqqZll.2to4lep.root"
+      },
+      {
+        "checksum": "adler32:e814794a",
+        "size": 35785320,
+        "uri": "root://eospublic.cern.ch//eos/opendata/atlas/rucio/opendata/ODEO_FEB2025_v0_2to4lep_mc_700493.Sh_2211_ZqqZll.2to4lep.root"
+      },
+      {
+        "checksum": "adler32:fdd36aec",
+        "size": 32124086,
+        "uri": "root://eospublic.cern.ch//eos/opendata/atlas/rucio/opendata/ODEO_FEB2025_v0_2to4lep_mc_700494.Sh_2211_ZbbZll.2to4lep.root"
+      },
+      {
+        "checksum": "adler32:0921c34b",
+        "size": 218793,
+        "uri": "root://eospublic.cern.ch//eos/opendata/atlas/rucio/opendata/ODEO_FEB2025_v0_2to4lep_mc_700495.Sh_2211_ZqqZvv.2to4lep.root"
+      },
+      {
+        "checksum": "adler32:cc8a7182",
+        "size": 176700,
+        "uri": "root://eospublic.cern.ch//eos/opendata/atlas/rucio/opendata/ODEO_FEB2025_v0_2to4lep_mc_700496.Sh_2211_ZbbZvv.2to4lep.root"
+      },
+      {
+        "checksum": "adler32:7c11278f",
+        "size": 565445,
+        "uri": "root://eospublic.cern.ch//eos/opendata/atlas/rucio/opendata/ODEO_FEB2025_v0_2to4lep_mc_700507.Sh_2211_pTW140_Wqqgamma.2to4lep.root"
+      },
+      {
+        "checksum": "adler32:0d9ac3a6",
+        "size": 22558384,
+        "uri": "root://eospublic.cern.ch//eos/opendata/atlas/rucio/opendata/ODEO_FEB2025_v0_2to4lep_mc_700587.Sh_2212_lllljj.2to4lep.root"
+      },
+      {
+        "checksum": "adler32:faafb639",
+        "size": 8405646,
+        "uri": "root://eospublic.cern.ch//eos/opendata/atlas/rucio/opendata/ODEO_FEB2025_v0_2to4lep_mc_700588.Sh_2212_lllvjj.2to4lep.root"
+      },
+      {
+        "checksum": "adler32:4464636c",
+        "size": 7394001,
+        "uri": "root://eospublic.cern.ch//eos/opendata/atlas/rucio/opendata/ODEO_FEB2025_v0_2to4lep_mc_700589.Sh_2212_llvvjj_os.2to4lep.root"
+      },
+      {
+        "checksum": "adler32:72aae836",
+        "size": 15296379,
+        "uri": "root://eospublic.cern.ch//eos/opendata/atlas/rucio/opendata/ODEO_FEB2025_v0_2to4lep_mc_700590.Sh_2212_llvvjj_ss.2to4lep.root"
+      },
+      {
+        "checksum": "adler32:a833179c",
+        "size": 2747118,
+        "uri": "root://eospublic.cern.ch//eos/opendata/atlas/rucio/opendata/ODEO_FEB2025_v0_2to4lep_mc_700591.Sh_2212_lllljj_Int.2to4lep.root"
+      },
+      {
+        "checksum": "adler32:184822d1",
+        "size": 3305328,
+        "uri": "root://eospublic.cern.ch//eos/opendata/atlas/rucio/opendata/ODEO_FEB2025_v0_2to4lep_mc_700592.Sh_2212_lllvjj_Int.2to4lep.root"
+      },
+      {
+        "checksum": "adler32:ec07d8b1",
+        "size": 3201055,
+        "uri": "root://eospublic.cern.ch//eos/opendata/atlas/rucio/opendata/ODEO_FEB2025_v0_2to4lep_mc_700593.Sh_2212_llvvjj_os_Int.2to4lep.root"
+      },
+      {
+        "checksum": "adler32:5446a4ca",
+        "size": 3263721,
+        "uri": "root://eospublic.cern.ch//eos/opendata/atlas/rucio/opendata/ODEO_FEB2025_v0_2to4lep_mc_700594.Sh_2212_llvvjj_ss_Int.2to4lep.root"
+      },
+      {
+        "checksum": "adler32:6bc6a829",
+        "size": 46694016,
+        "uri": "root://eospublic.cern.ch//eos/opendata/atlas/rucio/opendata/ODEO_FEB2025_v0_2to4lep_mc_700600.Sh_2212_llll.2to4lep.root"
+      },
+      {
+        "checksum": "adler32:1608c06e",
+        "size": 76354993,
+        "uri": "root://eospublic.cern.ch//eos/opendata/atlas/rucio/opendata/ODEO_FEB2025_v0_2to4lep_mc_700601.Sh_2212_lllv.2to4lep.root"
+      },
+      {
+        "checksum": "adler32:d2d294e2",
+        "size": 114769933,
+        "uri": "root://eospublic.cern.ch//eos/opendata/atlas/rucio/opendata/ODEO_FEB2025_v0_2to4lep_mc_700602.Sh_2212_llvv_os.2to4lep.root"
+      },
+      {
+        "checksum": "adler32:8c9d2473",
+        "size": 17674012,
+        "uri": "root://eospublic.cern.ch//eos/opendata/atlas/rucio/opendata/ODEO_FEB2025_v0_2to4lep_mc_700603.Sh_2212_llvv_ss.2to4lep.root"
+      },
+      {
+        "checksum": "adler32:f1ecf3f0",
+        "size": 1467605,
+        "uri": "root://eospublic.cern.ch//eos/opendata/atlas/rucio/opendata/ODEO_FEB2025_v0_2to4lep_mc_700604.Sh_2212_lvvv.2to4lep.root"
+      },
+      {
+        "checksum": "adler32:0ec88f3c",
+        "size": 78196,
+        "uri": "root://eospublic.cern.ch//eos/opendata/atlas/rucio/opendata/ODEO_FEB2025_v0_2to4lep_mc_700605.Sh_2212_vvvv.2to4lep.root"
+      },
+      {
+        "checksum": "adler32:12096363",
+        "size": 1858441,
+        "uri": "root://eospublic.cern.ch//eos/opendata/atlas/rucio/opendata/ODEO_FEB2025_v0_2to4lep_mc_700709.Sh_2212_lvgammajj.2to4lep.root"
+      },
+      {
+        "checksum": "adler32:a7becaaa",
+        "size": 36881230,
+        "uri": "root://eospublic.cern.ch//eos/opendata/atlas/rucio/opendata/ODEO_FEB2025_v0_2to4lep_mc_700710.Sh_2212_llgammajj.2to4lep.root"
+      },
+      {
+        "checksum": "adler32:c06e97e6",
+        "size": 93983153,
+        "uri": "root://eospublic.cern.ch//eos/opendata/atlas/rucio/opendata/ODEO_FEB2025_v0_2to4lep_mc_700792.Sh_2214_Ztautau_maxHTpTV2_BFilter.2to4lep.root"
+      },
+      {
+        "checksum": "adler32:1741c307",
+        "size": 343641580,
+        "uri": "root://eospublic.cern.ch//eos/opendata/atlas/rucio/opendata/ODEO_FEB2025_v0_2to4lep_mc_700793.Sh_2214_Ztautau_maxHTpTV2_CFilterBVeto.2to4lep.root"
+      },
+      {
+        "checksum": "adler32:d808c865",
+        "size": 610141106,
+        "uri": "root://eospublic.cern.ch//eos/opendata/atlas/rucio/opendata/ODEO_FEB2025_v0_2to4lep_mc_700794.Sh_2214_Ztautau_maxHTpTV2_CVetoBVeto.2to4lep.root"
+      },
+      {
+        "checksum": "adler32:de103ff4",
+        "size": 32483467,
+        "uri": "root://eospublic.cern.ch//eos/opendata/atlas/rucio/opendata/ODEO_FEB2025_v0_2to4lep_mc_700843.Sh_2214_Wqq_ptW_200_ECMS.2to4lep.root"
+      },
+      {
+        "checksum": "adler32:428af426",
+        "size": 11384227,
+        "uri": "root://eospublic.cern.ch//eos/opendata/atlas/rucio/opendata/ODEO_FEB2025_v0_2to4lep_mc_700849.Sh_2214_Zqq_ptZ_200_ECMS.2to4lep.root"
+      },
+      {
+        "checksum": "adler32:e90065ea",
+        "size": 7707697,
+        "uri": "root://eospublic.cern.ch//eos/opendata/atlas/rucio/opendata/ODEO_FEB2025_v0_2to4lep_mc_700855.Sh_2214_Zbb_ptZ_200_ECMS.2to4lep.root"
+      },
+      {
+        "checksum": "adler32:d90ab94b",
+        "size": 10092630,
+        "uri": "root://eospublic.cern.ch//eos/opendata/atlas/rucio/opendata/ODEO_FEB2025_v0_2to4lep_mc_700901.Sh_2214_Ztt_maxHTpTV2_Mll10_40_BFilter.2to4lep.root"
+      },
+      {
+        "checksum": "adler32:8bae5420",
+        "size": 43043372,
+        "uri": "root://eospublic.cern.ch//eos/opendata/atlas/rucio/opendata/ODEO_FEB2025_v0_2to4lep_mc_700902.Sh_2214_Ztt_maxHTpTV2_Mll10_40_CFilterBVeto.2to4lep.root"
+      },
+      {
+        "checksum": "adler32:71ab82c0",
+        "size": 64333194,
+        "uri": "root://eospublic.cern.ch//eos/opendata/atlas/rucio/opendata/ODEO_FEB2025_v0_2to4lep_mc_700903.Sh_2214_Ztt_maxHTpTV2_Mll10_40_CVetoBVeto.2to4lep.root"
+      },
+      {
+        "checksum": "adler32:46404367",
+        "size": 2715595,
+        "uri": "root://eospublic.cern.ch//eos/opendata/atlas/rucio/opendata/ODEO_FEB2025_v0_2to4lep_mc_801976.Py8EG_A14NNPDF23LO_Zprime_NoInt_tautau_SSM3000.2to4lep.root"
+      },
+      {
+        "checksum": "adler32:a1d4d846",
+        "size": 83874,
+        "uri": "root://eospublic.cern.ch//eos/opendata/atlas/rucio/opendata/ODEO_FEB2025_v0_2to4lep_mc_801978.Py8EG_A14NNPDF23LO_Wprime_taunu_SSM3000.2to4lep.root"
+      }
+    ],
+    "license": {
+      "attribution": "CC0-1.0"
+    },
+    "methodology": {
+      "description": "<p>These data were created during LS2 as part of a major reprocessing campaign of the Run 2 data. All data were reprocessed using Athena Release 22, and new corresponding MC simulation samples were produced. These data and MC simulation datasets were processed into ROOT ntuple files from the DAOD_PHYSLITE format that is released as open data for research. For the files in this record, the following skimming selection was applied: Two to four leptons with at least 7 GeV of p<sub>T</sub> each"
+    },
+    "publisher": "CERN Open Data Portal",
+    "recid": "93923",
+    "relations": [
+      {
+        "description": "For citing all the Open Data for Education and Outreach from this release, and to find other related datasets, please see",
+        "doi": "10.7483/OPENDATA.ATLAS.B5M9.44TN",
+        "recid": "93910",
+        "title": "ROOT ntuple format 2015-2016 proton-proton Open Data for Education and Outreach from the ATLAS experiment",
+        "type": "isChildOf"
+      }
+    ],
+    "run_period": [
+      "2015",
+      "2016"
+    ],
+    "title": "ATLAS ROOT ntuple format MC simulation, 2015+2016 proton-proton collisions beta release, 2to4lep skim",
+    "type": {
+      "primary": "Dataset",
+      "secondary": [
+        "Simulated"
+      ]
+    },
+    "usage": {
+      "description": "<p> The data and MC simulation provided by the ATLAS experiment in root ntuple format is released under a CC0 license; citation of the data and acknowledgement of the collaboration is requested. This format can be used directly using ROOT or uproot for simple studies and is primarily intended for educational and outreach purposes. <p>Extensive instructions for interacting with the data, as well as documentation of the dataset naming conventions and their contents, are provided on the ATLAS Open Data website linked below. For those interested in implementing a research-quality data analysis, the open data designed for research (also linked below) may be a better starting point. Please be sure to cite the Open Data that you use, in line with the policy below.",
+      "links": [
+        {
+          "description": "ATLAS Open Data Website",
+          "url": "http://opendata.atlas.cern"
+        },
+        {
+          "description": "Resources to understand and use the open data for education and outreach",
+          "url": "https://opendata.atlas.cern/docs/category/13-tev-tutorials-for-education"
+        },
+        {
+          "description": "More about this ntuple format",
+          "url": "https://opendata.atlas.cern/docs/data/for_education/13TeV25_details"
+        },
+        {
+          "description": "Ntuple making framework",
+          "url": "http://gitlab.cern.ch/atlas-outreach-data-tools/physlitetoopendata"
+        },
+        {
+          "description": "Citation policy",
+          "url": "https://opendata.atlas.cern/docs/documentation/ethical_legal/citation_policy"
+        }
+      ]
+    }
+  }
+]

--- a/data/records/atlas-odeo-FEB2025-3j1lmet30-data.json
+++ b/data/records/atlas-odeo-FEB2025-3j1lmet30-data.json
@@ -1,0 +1,174 @@
+[
+  {
+    "abstract": {
+      "description": "Run 2 2015+2016 proton-proton collision data beta release, 3J1LMET30 skim from the ATLAS experiment"
+    },
+    "accelerator": "CERN-LHC",
+    "categories": {
+      "source": "ATLAS Collaboration"
+    },
+    "collaboration": {
+      "name": "ATLAS collaboration"
+    },
+    "collections": [
+      "ATLAS-Primary-Datasets"
+    ],
+    "collision_information": {
+      "energy": "13TeV",
+      "type": "pp"
+    },
+    "date_created": [
+      "2015",
+      "2016"
+    ],
+    "date_published": "2025",
+    "date_reprocessed": "2020",
+    "distribution": {
+      "formats": [
+        "root"
+      ],
+      "number_events": 16385953,
+      "number_files": 16,
+      "size": 5364976812
+    },
+    "doi": "10.7483/OPENDATA.ATLAS.CIU5.U5YX",
+    "experiment": [
+      "ATLAS"
+    ],
+    "files": [
+      {
+        "checksum": "adler32:5ff04070",
+        "size": 14258260,
+        "uri": "root://eospublic.cern.ch//eos/opendata/atlas/rucio/opendata/ODEO_FEB2025_v0_3J1LMET30_data15_periodD.3J1LMET30.root"
+      },
+      {
+        "checksum": "adler32:78f6d13d",
+        "size": 97601421,
+        "uri": "root://eospublic.cern.ch//eos/opendata/atlas/rucio/opendata/ODEO_FEB2025_v0_3J1LMET30_data15_periodE.3J1LMET30.root"
+      },
+      {
+        "checksum": "adler32:4b1b1c19",
+        "size": 62055939,
+        "uri": "root://eospublic.cern.ch//eos/opendata/atlas/rucio/opendata/ODEO_FEB2025_v0_3J1LMET30_data15_periodF.3J1LMET30.root"
+      },
+      {
+        "checksum": "adler32:7a7a1e12",
+        "size": 142408801,
+        "uri": "root://eospublic.cern.ch//eos/opendata/atlas/rucio/opendata/ODEO_FEB2025_v0_3J1LMET30_data15_periodG.3J1LMET30.root"
+      },
+      {
+        "checksum": "adler32:8bf5d2e5",
+        "size": 47227066,
+        "uri": "root://eospublic.cern.ch//eos/opendata/atlas/rucio/opendata/ODEO_FEB2025_v0_3J1LMET30_data15_periodH.3J1LMET30.root"
+      },
+      {
+        "checksum": "adler32:859a31ea",
+        "size": 262513482,
+        "uri": "root://eospublic.cern.ch//eos/opendata/atlas/rucio/opendata/ODEO_FEB2025_v0_3J1LMET30_data15_periodJ.3J1LMET30.root"
+      },
+      {
+        "checksum": "adler32:3b489942",
+        "size": 104908527,
+        "uri": "root://eospublic.cern.ch//eos/opendata/atlas/rucio/opendata/ODEO_FEB2025_v0_3J1LMET30_data16_periodA.3J1LMET30.root"
+      },
+      {
+        "checksum": "adler32:ad1f56d8",
+        "size": 272588172,
+        "uri": "root://eospublic.cern.ch//eos/opendata/atlas/rucio/opendata/ODEO_FEB2025_v0_3J1LMET30_data16_periodB.3J1LMET30.root"
+      },
+      {
+        "checksum": "adler32:abc3f037",
+        "size": 350634363,
+        "uri": "root://eospublic.cern.ch//eos/opendata/atlas/rucio/opendata/ODEO_FEB2025_v0_3J1LMET30_data16_periodC.3J1LMET30.root"
+      },
+      {
+        "checksum": "adler32:653d346b",
+        "size": 704300938,
+        "uri": "root://eospublic.cern.ch//eos/opendata/atlas/rucio/opendata/ODEO_FEB2025_v0_3J1LMET30_data16_periodD.3J1LMET30.root"
+      },
+      {
+        "checksum": "adler32:586fd41d",
+        "size": 212089053,
+        "uri": "root://eospublic.cern.ch//eos/opendata/atlas/rucio/opendata/ODEO_FEB2025_v0_3J1LMET30_data16_periodE.3J1LMET30.root"
+      },
+      {
+        "checksum": "adler32:f0e42b30",
+        "size": 485975701,
+        "uri": "root://eospublic.cern.ch//eos/opendata/atlas/rucio/opendata/ODEO_FEB2025_v0_3J1LMET30_data16_periodF.3J1LMET30.root"
+      },
+      {
+        "checksum": "adler32:323dcfa5",
+        "size": 535662213,
+        "uri": "root://eospublic.cern.ch//eos/opendata/atlas/rucio/opendata/ODEO_FEB2025_v0_3J1LMET30_data16_periodG.3J1LMET30.root"
+      },
+      {
+        "checksum": "adler32:8474747e",
+        "size": 808038641,
+        "uri": "root://eospublic.cern.ch//eos/opendata/atlas/rucio/opendata/ODEO_FEB2025_v0_3J1LMET30_data16_periodI.3J1LMET30.root"
+      },
+      {
+        "checksum": "adler32:736e9939",
+        "size": 320589422,
+        "uri": "root://eospublic.cern.ch//eos/opendata/atlas/rucio/opendata/ODEO_FEB2025_v0_3J1LMET30_data16_periodK.3J1LMET30.root"
+      },
+      {
+        "checksum": "adler32:6c1c86db",
+        "size": 944124813,
+        "uri": "root://eospublic.cern.ch//eos/opendata/atlas/rucio/opendata/ODEO_FEB2025_v0_3J1LMET30_data16_periodL.3J1LMET30.root"
+      }
+    ],
+    "license": {
+      "attribution": "CC0-1.0"
+    },
+    "methodology": {
+      "description": "<p>These data were created during LS2 as part of a major reprocessing campaign of the Run 2 data. All data were reprocessed using Athena Release 22, and new corresponding MC simulation samples were produced. These data and MC simulation datasets were processed into ROOT ntuple files from the DAOD_PHYSLITE format that is released as open data for research. For the files in this record, the following skimming selection was applied: At least three jets with at least 20 GeV of p<sub>T</sub>, at least one lepton passing tight identification requirements with at least 7 GeV of p<sub>T</sub>, and 30 GeV of missing transverse momentum (i.e. a semi-leptonic top-quark enhanced selection)"
+    },
+    "publisher": "CERN Open Data Portal",
+    "recid": "93926",
+    "relations": [
+      {
+        "description": "For citing all the Open Data for Education and Outreach from this release, and to find other related datasets, please see",
+        "doi": "10.7483/OPENDATA.ATLAS.B5M9.44TN",
+        "recid": "93910",
+        "title": "ROOT ntuple format 2015-2016 proton-proton Open Data for Education and Outreach from the ATLAS experiment",
+        "type": "isChildOf"
+      }
+    ],
+    "run_period": [
+      "2015",
+      "2016"
+    ],
+    "title": "ATLAS ROOT ntuple format Run 2 2015+2016 proton-proton collision data beta release, 3J1LMET30 skim",
+    "type": {
+      "primary": "Dataset",
+      "secondary": [
+        "Collision"
+      ]
+    },
+    "usage": {
+      "description": "<p> The data and MC simulation provided by the ATLAS experiment in root ntuple format is released under a CC0 license; citation of the data and acknowledgement of the collaboration is requested. This format can be used directly using ROOT or uproot for simple studies and is primarily intended for educational and outreach purposes. <p>Extensive instructions for interacting with the data, as well as documentation of the dataset naming conventions and their contents, are provided on the ATLAS Open Data website linked below. For those interested in implementing a research-quality data analysis, the open data designed for research (also linked below) may be a better starting point. Please be sure to cite the Open Data that you use, in line with the policy below.",
+      "links": [
+        {
+          "description": "ATLAS Open Data Website",
+          "url": "http://opendata.atlas.cern"
+        },
+        {
+          "description": "Resources to understand and use the open data for education and outreach",
+          "url": "https://opendata.atlas.cern/docs/category/13-tev-tutorials-for-education"
+        },
+        {
+          "description": "More about this ntuple format",
+          "url": "https://opendata.atlas.cern/docs/data/for_education/13TeV25_details"
+        },
+        {
+          "description": "Ntuple making framework",
+          "url": "http://gitlab.cern.ch/atlas-outreach-data-tools/physlitetoopendata"
+        },
+        {
+          "description": "Citation policy",
+          "url": "https://opendata.atlas.cern/docs/documentation/ethical_legal/citation_policy"
+        }
+      ]
+    }
+  }
+]

--- a/data/records/atlas-odeo-FEB2025-3j1lmet30-data.json
+++ b/data/records/atlas-odeo-FEB2025-3j1lmet30-data.json
@@ -154,15 +154,15 @@
         },
         {
           "description": "Resources to understand and use the open data for education and outreach",
-          "url": "https://opendata.atlas.cern/docs/category/13-tev-tutorials-for-education"
+          "url": "https://opendata.atlas.cern/docs/category/13-tev-2025-beta-release"
         },
         {
           "description": "More about this ntuple format",
-          "url": "https://opendata.atlas.cern/docs/data/for_education/13TeV25_details"
+          "url": "https://opendata.atlas.cern/docs/data/for_education/13TeV25_details#variable-list"
         },
         {
-          "description": "Ntuple making framework",
-          "url": "http://gitlab.cern.ch/atlas-outreach-data-tools/physlitetoopendata"
+          "description": "Ntuple making framework (PhysLiteToOpenData)",
+          "url": "https://doi.org/10.5281/zenodo.15791091"
         },
         {
           "description": "Citation policy",

--- a/data/records/atlas-odeo-FEB2025-3j1lmet30-mc.json
+++ b/data/records/atlas-odeo-FEB2025-3j1lmet30-mc.json
@@ -1939,15 +1939,15 @@
         },
         {
           "description": "Resources to understand and use the open data for education and outreach",
-          "url": "https://opendata.atlas.cern/docs/category/13-tev-tutorials-for-education"
+          "url": "https://opendata.atlas.cern/docs/category/13-tev-2025-beta-release"
         },
         {
           "description": "More about this ntuple format",
-          "url": "https://opendata.atlas.cern/docs/data/for_education/13TeV25_details"
+          "url": "https://opendata.atlas.cern/docs/data/for_education/13TeV25_details#variable-list"
         },
         {
-          "description": "Ntuple making framework",
-          "url": "http://gitlab.cern.ch/atlas-outreach-data-tools/physlitetoopendata"
+          "description": "Ntuple making framework (PhysLiteToOpenData)",
+          "url": "https://doi.org/10.5281/zenodo.15791091"
         },
         {
           "description": "Citation policy",

--- a/data/records/atlas-odeo-FEB2025-3j1lmet30-mc.json
+++ b/data/records/atlas-odeo-FEB2025-3j1lmet30-mc.json
@@ -1,0 +1,1959 @@
+[
+  {
+    "abstract": {
+      "description": "MC simulation, 2015+2016 proton-proton collisions beta release, 3J1LMET30 skim from the ATLAS experiment"
+    },
+    "accelerator": "CERN-LHC",
+    "categories": {
+      "source": "ATLAS Collaboration"
+    },
+    "collaboration": {
+      "name": "ATLAS collaboration"
+    },
+    "collections": [
+      "ATLAS-Primary-Datasets"
+    ],
+    "collision_information": {
+      "energy": "13TeV",
+      "type": "pp"
+    },
+    "date_created": [
+      "2015",
+      "2016"
+    ],
+    "date_published": "2025",
+    "date_reprocessed": "2020",
+    "distribution": {
+      "formats": [
+        "root"
+      ],
+      "number_events": 76407431,
+      "number_files": 373,
+      "size": 39247728015
+    },
+    "doi": "10.7483/OPENDATA.ATLAS.IBFR.R9L3",
+    "experiment": [
+      "ATLAS"
+    ],
+    "files": [
+      {
+        "checksum": "adler32:c0a706b1",
+        "size": 197762,
+        "uri": "root://eospublic.cern.ch//eos/opendata/atlas/rucio/opendata/ODEO_FEB2025_v0_3J1LMET30_mc_301204.Pythia8EvtGen_A14MSTW2008LO_Zprime_NoInt_ee_SSM3000.3J1LMET30.root"
+      },
+      {
+        "checksum": "adler32:306e25c4",
+        "size": 355042,
+        "uri": "root://eospublic.cern.ch//eos/opendata/atlas/rucio/opendata/ODEO_FEB2025_v0_3J1LMET30_mc_301209.Pythia8EvtGen_A14MSTW2008LO_Zprime_NoInt_mumu_SSM3000.3J1LMET30.root"
+      },
+      {
+        "checksum": "adler32:83737ba9",
+        "size": 114032,
+        "uri": "root://eospublic.cern.ch//eos/opendata/atlas/rucio/opendata/ODEO_FEB2025_v0_3J1LMET30_mc_301243.Pythia8EvtGen_A14NNPDF23LO_Wprime_enu_SSM3000.3J1LMET30.root"
+      },
+      {
+        "checksum": "adler32:00fa8849",
+        "size": 262657,
+        "uri": "root://eospublic.cern.ch//eos/opendata/atlas/rucio/opendata/ODEO_FEB2025_v0_3J1LMET30_mc_301247.Pythia8EvtGen_A14NNPDF23LO_Wprime_munu_SSM3000.3J1LMET30.root"
+      },
+      {
+        "checksum": "adler32:5e85396d",
+        "size": 993689,
+        "uri": "root://eospublic.cern.ch//eos/opendata/atlas/rucio/opendata/ODEO_FEB2025_v0_3J1LMET30_mc_301333.Pythia8EvtGen_A14NNPDF23LO_zprime3000_tt.3J1LMET30.root"
+      },
+      {
+        "checksum": "adler32:d7911d44",
+        "size": 84227,
+        "uri": "root://eospublic.cern.ch//eos/opendata/atlas/rucio/opendata/ODEO_FEB2025_v0_3J1LMET30_mc_301826.Pythia8EvtGen_A14NNPDF23LO_Wprime_qq_3000.3J1LMET30.root"
+      },
+      {
+        "checksum": "adler32:2ccd60e8",
+        "size": 30811,
+        "uri": "root://eospublic.cern.ch//eos/opendata/atlas/rucio/opendata/ODEO_FEB2025_v0_3J1LMET30_mc_301928.Pythia8EvtGen_A14NNPDF23LO_Zprimebb3000.3J1LMET30.root"
+      },
+      {
+        "checksum": "adler32:cbda11df",
+        "size": 372760,
+        "uri": "root://eospublic.cern.ch//eos/opendata/atlas/rucio/opendata/ODEO_FEB2025_v0_3J1LMET30_mc_302520.Pythia8EvtGen_A14NNPDF23LO_2DP20_Mass_55_100.3J1LMET30.root"
+      },
+      {
+        "checksum": "adler32:44276014",
+        "size": 100501,
+        "uri": "root://eospublic.cern.ch//eos/opendata/atlas/rucio/opendata/ODEO_FEB2025_v0_3J1LMET30_mc_302521.Pythia8EvtGen_A14NNPDF23LO_2DP20_Mass_100_160.3J1LMET30.root"
+      },
+      {
+        "checksum": "adler32:e54edd7a",
+        "size": 42499,
+        "uri": "root://eospublic.cern.ch//eos/opendata/atlas/rucio/opendata/ODEO_FEB2025_v0_3J1LMET30_mc_302522.Pythia8EvtGen_A14NNPDF23LO_2DP20_Mass_160_250.3J1LMET30.root"
+      },
+      {
+        "checksum": "adler32:907ce91e",
+        "size": 39744,
+        "uri": "root://eospublic.cern.ch//eos/opendata/atlas/rucio/opendata/ODEO_FEB2025_v0_3J1LMET30_mc_302523.Pythia8EvtGen_A14NNPDF23LO_2DP20_Mass_250_400.3J1LMET30.root"
+      },
+      {
+        "checksum": "adler32:8e8b7e5d",
+        "size": 57216,
+        "uri": "root://eospublic.cern.ch//eos/opendata/atlas/rucio/opendata/ODEO_FEB2025_v0_3J1LMET30_mc_302524.Pythia8EvtGen_A14NNPDF23LO_2DP20_Mass_400_650.3J1LMET30.root"
+      },
+      {
+        "checksum": "adler32:761bd4e0",
+        "size": 34334,
+        "uri": "root://eospublic.cern.ch//eos/opendata/atlas/rucio/opendata/ODEO_FEB2025_v0_3J1LMET30_mc_302525.Pythia8EvtGen_A14NNPDF23LO_2DP20_Mass_650_1000.3J1LMET30.root"
+      },
+      {
+        "checksum": "adler32:a390a46a",
+        "size": 64110,
+        "uri": "root://eospublic.cern.ch//eos/opendata/atlas/rucio/opendata/ODEO_FEB2025_v0_3J1LMET30_mc_302526.Pythia8EvtGen_A14NNPDF23LO_2DP20_Mass_1000_1500.3J1LMET30.root"
+      },
+      {
+        "checksum": "adler32:6c021a34",
+        "size": 74417,
+        "uri": "root://eospublic.cern.ch//eos/opendata/atlas/rucio/opendata/ODEO_FEB2025_v0_3J1LMET30_mc_302527.Pythia8EvtGen_A14NNPDF23LO_2DP20_Mass_1500_2000.3J1LMET30.root"
+      },
+      {
+        "checksum": "adler32:8c8bf82c",
+        "size": 110022,
+        "uri": "root://eospublic.cern.ch//eos/opendata/atlas/rucio/opendata/ODEO_FEB2025_v0_3J1LMET30_mc_302528.Pythia8EvtGen_A14NNPDF23LO_2DP20_Mass_2000_2500.3J1LMET30.root"
+      },
+      {
+        "checksum": "adler32:a6d5d096",
+        "size": 80446,
+        "uri": "root://eospublic.cern.ch//eos/opendata/atlas/rucio/opendata/ODEO_FEB2025_v0_3J1LMET30_mc_302529.Pythia8EvtGen_A14NNPDF23LO_2DP20_Mass_2500_3000.3J1LMET30.root"
+      },
+      {
+        "checksum": "adler32:bc0db36d",
+        "size": 133508,
+        "uri": "root://eospublic.cern.ch//eos/opendata/atlas/rucio/opendata/ODEO_FEB2025_v0_3J1LMET30_mc_302530.Pythia8EvtGen_A14NNPDF23LO_2DP20_Mass_3000_3500.3J1LMET30.root"
+      },
+      {
+        "checksum": "adler32:af988a01",
+        "size": 77369,
+        "uri": "root://eospublic.cern.ch//eos/opendata/atlas/rucio/opendata/ODEO_FEB2025_v0_3J1LMET30_mc_302531.Pythia8EvtGen_A14NNPDF23LO_2DP20_Mass_3500_4000.3J1LMET30.root"
+      },
+      {
+        "checksum": "adler32:084ad130",
+        "size": 117001,
+        "uri": "root://eospublic.cern.ch//eos/opendata/atlas/rucio/opendata/ODEO_FEB2025_v0_3J1LMET30_mc_302532.Pythia8EvtGen_A14NNPDF23LO_2DP20_Mass_4000_4500.3J1LMET30.root"
+      },
+      {
+        "checksum": "adler32:e5c90e0b",
+        "size": 54289,
+        "uri": "root://eospublic.cern.ch//eos/opendata/atlas/rucio/opendata/ODEO_FEB2025_v0_3J1LMET30_mc_302533.Pythia8EvtGen_A14NNPDF23LO_2DP20_Mass_4500_5000.3J1LMET30.root"
+      },
+      {
+        "checksum": "adler32:21ee4818",
+        "size": 128044,
+        "uri": "root://eospublic.cern.ch//eos/opendata/atlas/rucio/opendata/ODEO_FEB2025_v0_3J1LMET30_mc_302534.Pythia8EvtGen_A14NNPDF23LO_2DP20_Mass_5000_inf.3J1LMET30.root"
+      },
+      {
+        "checksum": "adler32:effa8c86",
+        "size": 1596495,
+        "uri": "root://eospublic.cern.ch//eos/opendata/atlas/rucio/opendata/ODEO_FEB2025_v0_3J1LMET30_mc_302733.MadGraphPythia8EvtGen_A14NNPDF23LO_WpL_tblep_M3000.3J1LMET30.root"
+      },
+      {
+        "checksum": "adler32:851c4e16",
+        "size": 7509013,
+        "uri": "root://eospublic.cern.ch//eos/opendata/atlas/rucio/opendata/ODEO_FEB2025_v0_3J1LMET30_mc_304014.MadGraphPythia8EvtGen_A14NNPDF23_3top_SM.3J1LMET30.root"
+      },
+      {
+        "checksum": "adler32:a3f53dd7",
+        "size": 60256,
+        "uri": "root://eospublic.cern.ch//eos/opendata/atlas/rucio/opendata/ODEO_FEB2025_v0_3J1LMET30_mc_306149.MadGraphPythia8EvtGen_A14NNPDF23LO_WpL_tbhad_M3000.3J1LMET30.root"
+      },
+      {
+        "checksum": "adler32:889c62da",
+        "size": 33412,
+        "uri": "root://eospublic.cern.ch//eos/opendata/atlas/rucio/opendata/ODEO_FEB2025_v0_3J1LMET30_mc_311490.PowhegPy8EG_A14N23LO_DMA_500_700_gq0p25.3J1LMET30.root"
+      },
+      {
+        "checksum": "adler32:586bca9e",
+        "size": 7542830,
+        "uri": "root://eospublic.cern.ch//eos/opendata/atlas/rucio/opendata/ODEO_FEB2025_v0_3J1LMET30_mc_312613.aMcAtNloPy8EG_A14N30NLO_LQd_gstML_0p3_nonallhad_M1000.3J1LMET30.root"
+      },
+      {
+        "checksum": "adler32:24aa074b",
+        "size": 336248,
+        "uri": "root://eospublic.cern.ch//eos/opendata/atlas/rucio/opendata/ODEO_FEB2025_v0_3J1LMET30_mc_341456.PowhegPythia8EvtGen_CT10_AZNLO_ZH125J_MINLO_veveWWlvqq_VpT.3J1LMET30.root"
+      },
+      {
+        "checksum": "adler32:fa5fbf1c",
+        "size": 726052,
+        "uri": "root://eospublic.cern.ch//eos/opendata/atlas/rucio/opendata/ODEO_FEB2025_v0_3J1LMET30_mc_341458.PowhegPythia8EvtGen_CT10_AZNLO_ZH125J_MINLO_vmuvmuWWlvqq_VpT.3J1LMET30.root"
+      },
+      {
+        "checksum": "adler32:5cc58dfe",
+        "size": 733292,
+        "uri": "root://eospublic.cern.ch//eos/opendata/atlas/rucio/opendata/ODEO_FEB2025_v0_3J1LMET30_mc_341460.PowhegPy8EG_CT10_AZNLO_ZH125J_MINLO_vtauvtauWWlvqq_VpT.3J1LMET30.root"
+      },
+      {
+        "checksum": "adler32:baa9accb",
+        "size": 94312,
+        "uri": "root://eospublic.cern.ch//eos/opendata/atlas/rucio/opendata/ODEO_FEB2025_v0_3J1LMET30_mc_343981.PowhegPythia8EvtGen_NNLOPS_nnlo_30_ggH125_gamgam.3J1LMET30.root"
+      },
+      {
+        "checksum": "adler32:634b2883",
+        "size": 1412545,
+        "uri": "root://eospublic.cern.ch//eos/opendata/atlas/rucio/opendata/ODEO_FEB2025_v0_3J1LMET30_mc_344158.aMcAtNloPythia8EvtGen_A14NNPDF23LO_ppx0_FxFx_Np012_SM.3J1LMET30.root"
+      },
+      {
+        "checksum": "adler32:a04e29e6",
+        "size": 108829,
+        "uri": "root://eospublic.cern.ch//eos/opendata/atlas/rucio/opendata/ODEO_FEB2025_v0_3J1LMET30_mc_345056.PowhegPythia8EvtGen_NNPDF3_AZNLO_ZH125J_MINLO_vvbb_VpT.3J1LMET30.root"
+      },
+      {
+        "checksum": "adler32:fdfba2e4",
+        "size": 133843,
+        "uri": "root://eospublic.cern.ch//eos/opendata/atlas/rucio/opendata/ODEO_FEB2025_v0_3J1LMET30_mc_345058.PowhegPythia8EvtGen_NNPDF3_AZNLO_ggZH125_vvbb.3J1LMET30.root"
+      },
+      {
+        "checksum": "adler32:dc7614ca",
+        "size": 12834481,
+        "uri": "root://eospublic.cern.ch//eos/opendata/atlas/rucio/opendata/ODEO_FEB2025_v0_3J1LMET30_mc_345060.PowhegPythia8EvtGen_NNLOPS_nnlo_30_ggH125_ZZ4l.3J1LMET30.root"
+      },
+      {
+        "checksum": "adler32:cc29351c",
+        "size": 137941,
+        "uri": "root://eospublic.cern.ch//eos/opendata/atlas/rucio/opendata/ODEO_FEB2025_v0_3J1LMET30_mc_345061.PowhegPythia8EvtGen_NNPDF3_AZNLO_ggZH125_HgamgamZinc.3J1LMET30.root"
+      },
+      {
+        "checksum": "adler32:854b922f",
+        "size": 2423533,
+        "uri": "root://eospublic.cern.ch//eos/opendata/atlas/rucio/opendata/ODEO_FEB2025_v0_3J1LMET30_mc_345066.PowhegPythia8EvtGen_NNPDF3_AZNLO_ggZH125_ZZ4lepZinc.3J1LMET30.root"
+      },
+      {
+        "checksum": "adler32:5512848c",
+        "size": 1175086,
+        "uri": "root://eospublic.cern.ch//eos/opendata/atlas/rucio/opendata/ODEO_FEB2025_v0_3J1LMET30_mc_345097.PowhegPythia8EvtGen_NNLOPS_nnlo_30_ggH125_mumu.3J1LMET30.root"
+      },
+      {
+        "checksum": "adler32:1dbf88d7",
+        "size": 2235452,
+        "uri": "root://eospublic.cern.ch//eos/opendata/atlas/rucio/opendata/ODEO_FEB2025_v0_3J1LMET30_mc_345098.PowhegPythia8EvtGen_NNPDF3_AZNLO_ggZH125_Hmumu_Zinc.3J1LMET30.root"
+      },
+      {
+        "checksum": "adler32:3fd0a529",
+        "size": 1314824,
+        "uri": "root://eospublic.cern.ch//eos/opendata/atlas/rucio/opendata/ODEO_FEB2025_v0_3J1LMET30_mc_345103.PowhegPythia8EvtGen_NNPDF30_AZNLO_ZH125J_Hmumu_Zincl_MINLO.3J1LMET30.root"
+      },
+      {
+        "checksum": "adler32:e3b6fec3",
+        "size": 1233036,
+        "uri": "root://eospublic.cern.ch//eos/opendata/atlas/rucio/opendata/ODEO_FEB2025_v0_3J1LMET30_mc_345104.PowhegPythia8EvtGen_NNPDF30_AZNLO_WpH125J_Hmumu_Wincl_MINLO.3J1LMET30.root"
+      },
+      {
+        "checksum": "adler32:5d1093a1",
+        "size": 737153,
+        "uri": "root://eospublic.cern.ch//eos/opendata/atlas/rucio/opendata/ODEO_FEB2025_v0_3J1LMET30_mc_345105.PowhegPythia8EvtGen_NNPDF30_AZNLO_WmH125J_Hmumu_Wincl_MINLO.3J1LMET30.root"
+      },
+      {
+        "checksum": "adler32:07bf61e0",
+        "size": 1010659,
+        "uri": "root://eospublic.cern.ch//eos/opendata/atlas/rucio/opendata/ODEO_FEB2025_v0_3J1LMET30_mc_345106.PowhegPythia8EvtGen_NNPDF30_AZNLOCTEQ6L1_VBFH125_mumu.3J1LMET30.root"
+      },
+      {
+        "checksum": "adler32:ffb810ed",
+        "size": 74522,
+        "uri": "root://eospublic.cern.ch//eos/opendata/atlas/rucio/opendata/ODEO_FEB2025_v0_3J1LMET30_mc_345112.PowhegPythia8EvtGen_NNPDF3_AZNLO_ZH125J_MINLO_vvcc_VpT.3J1LMET30.root"
+      },
+      {
+        "checksum": "adler32:afa22d44",
+        "size": 75919,
+        "uri": "root://eospublic.cern.ch//eos/opendata/atlas/rucio/opendata/ODEO_FEB2025_v0_3J1LMET30_mc_345114.PowhegPythia8EvtGen_NNPDF3_AZNLO_ggZH125_vvcc.3J1LMET30.root"
+      },
+      {
+        "checksum": "adler32:92a482f0",
+        "size": 1556274,
+        "uri": "root://eospublic.cern.ch//eos/opendata/atlas/rucio/opendata/ODEO_FEB2025_v0_3J1LMET30_mc_345120.PowhegPy8EG_NNLOPS_nnlo_30_ggH125_tautaul13l7.3J1LMET30.root"
+      },
+      {
+        "checksum": "adler32:6d165c2c",
+        "size": 1026994,
+        "uri": "root://eospublic.cern.ch//eos/opendata/atlas/rucio/opendata/ODEO_FEB2025_v0_3J1LMET30_mc_345121.PowhegPy8EG_NNLOPS_nnlo_30_ggH125_tautaulm15hp20.3J1LMET30.root"
+      },
+      {
+        "checksum": "adler32:32e4eeb7",
+        "size": 1431682,
+        "uri": "root://eospublic.cern.ch//eos/opendata/atlas/rucio/opendata/ODEO_FEB2025_v0_3J1LMET30_mc_345122.PowhegPy8EG_NNLOPS_nnlo_30_ggH125_tautaulp15hm20.3J1LMET30.root"
+      },
+      {
+        "checksum": "adler32:b0fbde7a",
+        "size": 94860,
+        "uri": "root://eospublic.cern.ch//eos/opendata/atlas/rucio/opendata/ODEO_FEB2025_v0_3J1LMET30_mc_345123.PowhegPy8EG_NNLOPS_nnlo_30_ggH125_tautauh30h20.3J1LMET30.root"
+      },
+      {
+        "checksum": "adler32:fa453c97",
+        "size": 7894047,
+        "uri": "root://eospublic.cern.ch//eos/opendata/atlas/rucio/opendata/ODEO_FEB2025_v0_3J1LMET30_mc_345124.PowhegPy8EG_NNLOPS_nnlo_30_ggH125_etau_filt.3J1LMET30.root"
+      },
+      {
+        "checksum": "adler32:551c395b",
+        "size": 12180653,
+        "uri": "root://eospublic.cern.ch//eos/opendata/atlas/rucio/opendata/ODEO_FEB2025_v0_3J1LMET30_mc_345125.PowhegPy8EG_NNLOPS_nnlo_30_ggH125_mutau_filt.3J1LMET30.root"
+      },
+      {
+        "checksum": "adler32:51e89cea",
+        "size": 422382,
+        "uri": "root://eospublic.cern.ch//eos/opendata/atlas/rucio/opendata/ODEO_FEB2025_v0_3J1LMET30_mc_345211.PowhegPy8EG_NNPDF30_AZNLO_WmH125J_Winc_MINLO_tautau.3J1LMET30.root"
+      },
+      {
+        "checksum": "adler32:d5850dcd",
+        "size": 506271,
+        "uri": "root://eospublic.cern.ch//eos/opendata/atlas/rucio/opendata/ODEO_FEB2025_v0_3J1LMET30_mc_345212.PowhegPy8EG_NNPDF30_AZNLO_WpH125J_Winc_MINLO_tautau.3J1LMET30.root"
+      },
+      {
+        "checksum": "adler32:79807f5c",
+        "size": 840295,
+        "uri": "root://eospublic.cern.ch//eos/opendata/atlas/rucio/opendata/ODEO_FEB2025_v0_3J1LMET30_mc_345213.PowhegPy8EG_NNPDF30_AZNLO_WmH125J_Winc_MINLO_etau.3J1LMET30.root"
+      },
+      {
+        "checksum": "adler32:01cfdc25",
+        "size": 1507096,
+        "uri": "root://eospublic.cern.ch//eos/opendata/atlas/rucio/opendata/ODEO_FEB2025_v0_3J1LMET30_mc_345214.PowhegPy8EG_NNPDF30_AZNLO_WpH125J_Winc_MINLO_etau.3J1LMET30.root"
+      },
+      {
+        "checksum": "adler32:111841b2",
+        "size": 1309059,
+        "uri": "root://eospublic.cern.ch//eos/opendata/atlas/rucio/opendata/ODEO_FEB2025_v0_3J1LMET30_mc_345215.PowhegPy8EG_NNPDF30_AZNLO_WmH125J_Winc_MINLO_mutau.3J1LMET30.root"
+      },
+      {
+        "checksum": "adler32:1fca392b",
+        "size": 2261281,
+        "uri": "root://eospublic.cern.ch//eos/opendata/atlas/rucio/opendata/ODEO_FEB2025_v0_3J1LMET30_mc_345216.PowhegPy8EG_NNPDF30_AZNLO_WpH125J_Winc_MINLO_mutau.3J1LMET30.root"
+      },
+      {
+        "checksum": "adler32:414a8fe4",
+        "size": 770179,
+        "uri": "root://eospublic.cern.ch//eos/opendata/atlas/rucio/opendata/ODEO_FEB2025_v0_3J1LMET30_mc_345217.PowhegPy8EG_NNPDF30_AZNLO_ZH125J_Zinc_MINLO_tautau.3J1LMET30.root"
+      },
+      {
+        "checksum": "adler32:71704b29",
+        "size": 1594993,
+        "uri": "root://eospublic.cern.ch//eos/opendata/atlas/rucio/opendata/ODEO_FEB2025_v0_3J1LMET30_mc_345218.PowhegPy8EG_NNPDF30_AZNLO_ZH125J_Zinc_MINLO_etau.3J1LMET30.root"
+      },
+      {
+        "checksum": "adler32:ed37cd35",
+        "size": 1852539,
+        "uri": "root://eospublic.cern.ch//eos/opendata/atlas/rucio/opendata/ODEO_FEB2025_v0_3J1LMET30_mc_345219.PowhegPy8EG_NNPDF30_AZNLO_ZH125J_Zinc_MINLO_mutau.3J1LMET30.root"
+      },
+      {
+        "checksum": "adler32:3c07eaee",
+        "size": 4839487,
+        "uri": "root://eospublic.cern.ch//eos/opendata/atlas/rucio/opendata/ODEO_FEB2025_v0_3J1LMET30_mc_345316.PowhegPythia8EvtGen_NNLOPS_nnlo_30_ggH125_Zy_Zll.3J1LMET30.root"
+      },
+      {
+        "checksum": "adler32:09c865d8",
+        "size": 583521,
+        "uri": "root://eospublic.cern.ch//eos/opendata/atlas/rucio/opendata/ODEO_FEB2025_v0_3J1LMET30_mc_345317.PowhegPythia8EvtGen_NNPDF30_AZNLO_WmH125J_Hyy_Wincl_MINLO.3J1LMET30.root"
+      },
+      {
+        "checksum": "adler32:65996be5",
+        "size": 346802,
+        "uri": "root://eospublic.cern.ch//eos/opendata/atlas/rucio/opendata/ODEO_FEB2025_v0_3J1LMET30_mc_345318.PowhegPythia8EvtGen_NNPDF30_AZNLO_WpH125J_Hyy_Wincl_MINLO.3J1LMET30.root"
+      },
+      {
+        "checksum": "adler32:d5d27816",
+        "size": 158079,
+        "uri": "root://eospublic.cern.ch//eos/opendata/atlas/rucio/opendata/ODEO_FEB2025_v0_3J1LMET30_mc_345319.PowhegPythia8EvtGen_NNPDF30_AZNLO_ZH125J_Hyy_Zincl_MINLO.3J1LMET30.root"
+      },
+      {
+        "checksum": "adler32:8934440a",
+        "size": 504185,
+        "uri": "root://eospublic.cern.ch//eos/opendata/atlas/rucio/opendata/ODEO_FEB2025_v0_3J1LMET30_mc_345320.PowhegPythia8EvtGen_NNPDF30_AZNLO_WmH125J_HZy_Wincl_MINLO.3J1LMET30.root"
+      },
+      {
+        "checksum": "adler32:2b07dbe3",
+        "size": 497134,
+        "uri": "root://eospublic.cern.ch//eos/opendata/atlas/rucio/opendata/ODEO_FEB2025_v0_3J1LMET30_mc_345321.PowhegPythia8EvtGen_NNPDF30_AZNLO_WpH125J_HZy_Wincl_MINLO.3J1LMET30.root"
+      },
+      {
+        "checksum": "adler32:3b39ed7d",
+        "size": 1030035,
+        "uri": "root://eospublic.cern.ch//eos/opendata/atlas/rucio/opendata/ODEO_FEB2025_v0_3J1LMET30_mc_345322.PowhegPythia8EvtGen_NNPDF30_AZNLO_ZH125J_HZy_Zincl_MINLO.3J1LMET30.root"
+      },
+      {
+        "checksum": "adler32:e6d419e9",
+        "size": 1401979,
+        "uri": "root://eospublic.cern.ch//eos/opendata/atlas/rucio/opendata/ODEO_FEB2025_v0_3J1LMET30_mc_345324.PowhegPythia8EvtGen_NNLOPS_NN30_ggH125_WWlvlv_EF_15_5.3J1LMET30.root"
+      },
+      {
+        "checksum": "adler32:80dc3bf0",
+        "size": 2217354,
+        "uri": "root://eospublic.cern.ch//eos/opendata/atlas/rucio/opendata/ODEO_FEB2025_v0_3J1LMET30_mc_345325.PowhegPythia8EvtGen_NNPDF3_AZNLO_WpH125J_MINLO_qqWWlvlv.3J1LMET30.root"
+      },
+      {
+        "checksum": "adler32:6e108069",
+        "size": 2688865,
+        "uri": "root://eospublic.cern.ch//eos/opendata/atlas/rucio/opendata/ODEO_FEB2025_v0_3J1LMET30_mc_345433.PowhegPythia8EvtGen_NNPDF3_AZNLO_WmH125J_MINLO_qqWWlvlv.3J1LMET30.root"
+      },
+      {
+        "checksum": "adler32:8c562005",
+        "size": 509329,
+        "uri": "root://eospublic.cern.ch//eos/opendata/atlas/rucio/opendata/ODEO_FEB2025_v0_3J1LMET30_mc_345445.PowhegPythia8EvtGen_NNPDF3_AZNLO_ZH125J_MINLO_vvWWlvlv.3J1LMET30.root"
+      },
+      {
+        "checksum": "adler32:236baf0f",
+        "size": 85230,
+        "uri": "root://eospublic.cern.ch//eos/opendata/atlas/rucio/opendata/ODEO_FEB2025_v0_3J1LMET30_mc_345596.PowhegPythia8EvtGen_NNPDF3_AZNLO_ggZH125_Zinc_HZZinv.3J1LMET30.root"
+      },
+      {
+        "checksum": "adler32:bddc0622",
+        "size": 3361175,
+        "uri": "root://eospublic.cern.ch//eos/opendata/atlas/rucio/opendata/ODEO_FEB2025_v0_3J1LMET30_mc_345697.MadGraphPythia8EvtGen_AZNLOCTEQ6L1_ggfhtautaullNp2.3J1LMET30.root"
+      },
+      {
+        "checksum": "adler32:aba94bfd",
+        "size": 4758414,
+        "uri": "root://eospublic.cern.ch//eos/opendata/atlas/rucio/opendata/ODEO_FEB2025_v0_3J1LMET30_mc_345698.MadGraphPythia8EvtGen_AZNLOCTEQ6L1_ggfhtautaulhNp2.3J1LMET30.root"
+      },
+      {
+        "checksum": "adler32:264f4740",
+        "size": 185117,
+        "uri": "root://eospublic.cern.ch//eos/opendata/atlas/rucio/opendata/ODEO_FEB2025_v0_3J1LMET30_mc_345699.MadGraphPythia8EvtGen_AZNLOCTEQ6L1_ggfhtautauhhNp2.3J1LMET30.root"
+      },
+      {
+        "checksum": "adler32:3ae32d01",
+        "size": 2708733,
+        "uri": "root://eospublic.cern.ch//eos/opendata/atlas/rucio/opendata/ODEO_FEB2025_v0_3J1LMET30_mc_345833.PowhegPythia8EvtGen_NNPDF30_AZNLOCTEQ6L1_VBFH125_Zllgam.3J1LMET30.root"
+      },
+      {
+        "checksum": "adler32:6210e099",
+        "size": 167299,
+        "uri": "root://eospublic.cern.ch//eos/opendata/atlas/rucio/opendata/ODEO_FEB2025_v0_3J1LMET30_mc_345834.PowhegPythia8EvtGen_NNPDF30_AZNLOCTEQ6L1_VBFH125_gamstargam.3J1LMET30.root"
+      },
+      {
+        "checksum": "adler32:6390938f",
+        "size": 728626,
+        "uri": "root://eospublic.cern.ch//eos/opendata/atlas/rucio/opendata/ODEO_FEB2025_v0_3J1LMET30_mc_345876.PowhegPythia8EvtGen_NNPDF30_AZNLO_ZH125J_Hee__Zincl_MINLO.3J1LMET30.root"
+      },
+      {
+        "checksum": "adler32:805385f9",
+        "size": 383520,
+        "uri": "root://eospublic.cern.ch//eos/opendata/atlas/rucio/opendata/ODEO_FEB2025_v0_3J1LMET30_mc_345877.PowhegPythia8EvtGen_NNPDF30_AZNLO_WpH125J_Hee_Wincl_MINLO.3J1LMET30.root"
+      },
+      {
+        "checksum": "adler32:cf7b802f",
+        "size": 424103,
+        "uri": "root://eospublic.cern.ch//eos/opendata/atlas/rucio/opendata/ODEO_FEB2025_v0_3J1LMET30_mc_345878.PowhegPythia8EvtGen_NNPDF30_AZNLO_WmH125J_Hee_Wincl_MINLO.3J1LMET30.root"
+      },
+      {
+        "checksum": "adler32:97793abf",
+        "size": 120320,
+        "uri": "root://eospublic.cern.ch//eos/opendata/atlas/rucio/opendata/ODEO_FEB2025_v0_3J1LMET30_mc_345944.aMcAtNloPy8EG_A14NNPDF23LO_ppx0yy_FxFx_Np012_SM.3J1LMET30.root"
+      },
+      {
+        "checksum": "adler32:ef63b5e3",
+        "size": 1110573,
+        "uri": "root://eospublic.cern.ch//eos/opendata/atlas/rucio/opendata/ODEO_FEB2025_v0_3J1LMET30_mc_345948.PowhegPy8EG_NNPDF30_AZNLOCTEQ6L1_VBFH125_WWlvlv.3J1LMET30.root"
+      },
+      {
+        "checksum": "adler32:a44b9b0c",
+        "size": 95709,
+        "uri": "root://eospublic.cern.ch//eos/opendata/atlas/rucio/opendata/ODEO_FEB2025_v0_3J1LMET30_mc_345949.PowhegPythia8EvtGen_NNPDF30_AZNLOCTEQ6L1_VBFH125_bb.3J1LMET30.root"
+      },
+      {
+        "checksum": "adler32:acbbb8f4",
+        "size": 377711,
+        "uri": "root://eospublic.cern.ch//eos/opendata/atlas/rucio/opendata/ODEO_FEB2025_v0_3J1LMET30_mc_345961.PowhegPythia8EvtGen_NNLOPS_nnlo_30_ggH125_gamstargam.3J1LMET30.root"
+      },
+      {
+        "checksum": "adler32:3f16cf4f",
+        "size": 247263,
+        "uri": "root://eospublic.cern.ch//eos/opendata/atlas/rucio/opendata/ODEO_FEB2025_v0_3J1LMET30_mc_345963.PowhegPythia8EvtGen_NNPDF30_AZNLO_WmH125J_Hgamstargam_MINLO.3J1LMET30.root"
+      },
+      {
+        "checksum": "adler32:813cb35d",
+        "size": 249942,
+        "uri": "root://eospublic.cern.ch//eos/opendata/atlas/rucio/opendata/ODEO_FEB2025_v0_3J1LMET30_mc_345964.PowhegPythia8EvtGen_NNPDF30_AZNLO_WpH125J_Hgamstargam_MINLO.3J1LMET30.root"
+      },
+      {
+        "checksum": "adler32:becabc33",
+        "size": 475216,
+        "uri": "root://eospublic.cern.ch//eos/opendata/atlas/rucio/opendata/ODEO_FEB2025_v0_3J1LMET30_mc_345965.PowhegPythia8EvtGen_NNPDF30_AZNLO_ZH125J_Hgamstargam_MINLO.3J1LMET30.root"
+      },
+      {
+        "checksum": "adler32:e74bde0c",
+        "size": 739937,
+        "uri": "root://eospublic.cern.ch//eos/opendata/atlas/rucio/opendata/ODEO_FEB2025_v0_3J1LMET30_mc_346188.aMcAtNloPythia8EvtGen_tHjb125_4fl_gamgam.3J1LMET30.root"
+      },
+      {
+        "checksum": "adler32:6173aaf3",
+        "size": 4945066,
+        "uri": "root://eospublic.cern.ch//eos/opendata/atlas/rucio/opendata/ODEO_FEB2025_v0_3J1LMET30_mc_346189.aMcAtNloPythia8EvtGen_ttH_gamgam.3J1LMET30.root"
+      },
+      {
+        "checksum": "adler32:e984f9f3",
+        "size": 894801,
+        "uri": "root://eospublic.cern.ch//eos/opendata/atlas/rucio/opendata/ODEO_FEB2025_v0_3J1LMET30_mc_346190.PowhegPy8EG_NNPDF30_AZNLOCTEQ6L1_VBFH125_tautaul13l7.3J1LMET30.root"
+      },
+      {
+        "checksum": "adler32:9ae5419c",
+        "size": 513114,
+        "uri": "root://eospublic.cern.ch//eos/opendata/atlas/rucio/opendata/ODEO_FEB2025_v0_3J1LMET30_mc_346191.PowhegPy8EG_NNPDF30_AZNLOCTEQ6L1_VBFH125_tautaulm15hp20.3J1LMET30.root"
+      },
+      {
+        "checksum": "adler32:1de351f9",
+        "size": 504477,
+        "uri": "root://eospublic.cern.ch//eos/opendata/atlas/rucio/opendata/ODEO_FEB2025_v0_3J1LMET30_mc_346192.PowhegPy8EG_NNPDF30_AZNLOCTEQ6L1_VBFH125_tautaulp15hm20.3J1LMET30.root"
+      },
+      {
+        "checksum": "adler32:cf5337a0",
+        "size": 51785,
+        "uri": "root://eospublic.cern.ch//eos/opendata/atlas/rucio/opendata/ODEO_FEB2025_v0_3J1LMET30_mc_346193.PowhegPy8EG_NNPDF30_AZNLOCTEQ6L1_VBFH125_tautauh30h20.3J1LMET30.root"
+      },
+      {
+        "checksum": "adler32:56ddee9c",
+        "size": 1379322,
+        "uri": "root://eospublic.cern.ch//eos/opendata/atlas/rucio/opendata/ODEO_FEB2025_v0_3J1LMET30_mc_346194.PowhegPy8EG_NNPDF30_AZNLOCTEQ6L1_VBFH125_etau_filt.3J1LMET30.root"
+      },
+      {
+        "checksum": "adler32:6c6f9094",
+        "size": 1534936,
+        "uri": "root://eospublic.cern.ch//eos/opendata/atlas/rucio/opendata/ODEO_FEB2025_v0_3J1LMET30_mc_346195.PowhegPy8EG_NNPDF30_AZNLOCTEQ6L1_VBFH125_mutau_filt.3J1LMET30.root"
+      },
+      {
+        "checksum": "adler32:7bd2254a",
+        "size": 23064124,
+        "uri": "root://eospublic.cern.ch//eos/opendata/atlas/rucio/opendata/ODEO_FEB2025_v0_3J1LMET30_mc_346198.PhPy8EG_A14NNPDF23_NNPDF30ME_ttH125_Zgam.3J1LMET30.root"
+      },
+      {
+        "checksum": "adler32:bc5f4829",
+        "size": 36507,
+        "uri": "root://eospublic.cern.ch//eos/opendata/atlas/rucio/opendata/ODEO_FEB2025_v0_3J1LMET30_mc_346214.PowhegPy8EG_NNPDF30_AZNLOCTEQ6L1_VBFH125_gamgam.3J1LMET30.root"
+      },
+      {
+        "checksum": "adler32:e686335e",
+        "size": 1746286,
+        "uri": "root://eospublic.cern.ch//eos/opendata/atlas/rucio/opendata/ODEO_FEB2025_v0_3J1LMET30_mc_346228.PowhegPy8EG_NNPDF30_AZNLOCTEQ6L1_VBFH125_ZZ4lep_notau.3J1LMET30.root"
+      },
+      {
+        "checksum": "adler32:43499eca",
+        "size": 610523,
+        "uri": "root://eospublic.cern.ch//eos/opendata/atlas/rucio/opendata/ODEO_FEB2025_v0_3J1LMET30_mc_346310.PowhegPythia8EvtGen_NNPDF30_AZNLO_ZH125J_Zincl_H_incl_MINLO.3J1LMET30.root"
+      },
+      {
+        "checksum": "adler32:3e407914",
+        "size": 528472,
+        "uri": "root://eospublic.cern.ch//eos/opendata/atlas/rucio/opendata/ODEO_FEB2025_v0_3J1LMET30_mc_346311.PowhegPythia8EvtGen_NNPDF30_AZNLO_WpH125J_Wincl_H_incl_MINLO.3J1LMET30.root"
+      },
+      {
+        "checksum": "adler32:10793d71",
+        "size": 444123,
+        "uri": "root://eospublic.cern.ch//eos/opendata/atlas/rucio/opendata/ODEO_FEB2025_v0_3J1LMET30_mc_346312.PowhegPythia8EvtGen_NNPDF30_AZNLO_WmH125J_Wincl_H_incl_MINLO.3J1LMET30.root"
+      },
+      {
+        "checksum": "adler32:ede1756c",
+        "size": 520329,
+        "uri": "root://eospublic.cern.ch//eos/opendata/atlas/rucio/opendata/ODEO_FEB2025_v0_3J1LMET30_mc_346317.PowhegPy8EG_NNPDF30_AZNLOCTEQ6L1_VBFH125_incl.3J1LMET30.root"
+      },
+      {
+        "checksum": "adler32:2ccd592b",
+        "size": 10085849,
+        "uri": "root://eospublic.cern.ch//eos/opendata/atlas/rucio/opendata/ODEO_FEB2025_v0_3J1LMET30_mc_346340.PowhegPy8EG_A14NNPDF23_NNPDF30ME_ttH125_ZZ4l_allhad.3J1LMET30.root"
+      },
+      {
+        "checksum": "adler32:98a3a6e9",
+        "size": 9738349,
+        "uri": "root://eospublic.cern.ch//eos/opendata/atlas/rucio/opendata/ODEO_FEB2025_v0_3J1LMET30_mc_346341.PowhegPy8EG_A14NNPDF23_NNPDF30ME_ttH125_ZZ4l_semilep.3J1LMET30.root"
+      },
+      {
+        "checksum": "adler32:5f9b40d4",
+        "size": 5532017,
+        "uri": "root://eospublic.cern.ch//eos/opendata/atlas/rucio/opendata/ODEO_FEB2025_v0_3J1LMET30_mc_346342.PowhegPy8EG_A14NNPDF23_NNPDF30ME_ttH125_ZZ4l_dilep.3J1LMET30.root"
+      },
+      {
+        "checksum": "adler32:e4bf12b9",
+        "size": 4422378,
+        "uri": "root://eospublic.cern.ch//eos/opendata/atlas/rucio/opendata/ODEO_FEB2025_v0_3J1LMET30_mc_346343.PhPy8EG_A14NNPDF23_NNPDF30ME_ttH125_allhad.3J1LMET30.root"
+      },
+      {
+        "checksum": "adler32:f9ee5d8b",
+        "size": 18827270,
+        "uri": "root://eospublic.cern.ch//eos/opendata/atlas/rucio/opendata/ODEO_FEB2025_v0_3J1LMET30_mc_346344.PhPy8EG_A14NNPDF23_NNPDF30ME_ttH125_semilep.3J1LMET30.root"
+      },
+      {
+        "checksum": "adler32:62857b3b",
+        "size": 42782419,
+        "uri": "root://eospublic.cern.ch//eos/opendata/atlas/rucio/opendata/ODEO_FEB2025_v0_3J1LMET30_mc_346345.PhPy8EG_A14NNPDF23_NNPDF30ME_ttH125_dilep.3J1LMET30.root"
+      },
+      {
+        "checksum": "adler32:9e04ecf7",
+        "size": 68803,
+        "uri": "root://eospublic.cern.ch//eos/opendata/atlas/rucio/opendata/ODEO_FEB2025_v0_3J1LMET30_mc_346398.PowhegHerwig7EvtGen_NNPDF3_AZNLO_ZH125J_MINLO_vvbb_VpT.3J1LMET30.root"
+      },
+      {
+        "checksum": "adler32:b3ee838d",
+        "size": 119288,
+        "uri": "root://eospublic.cern.ch//eos/opendata/atlas/rucio/opendata/ODEO_FEB2025_v0_3J1LMET30_mc_346400.PowhegHerwig7EvtGen_NNPDF3_AZNLO_ggZH125J_vvbb.3J1LMET30.root"
+      },
+      {
+        "checksum": "adler32:6e27f871",
+        "size": 3993144,
+        "uri": "root://eospublic.cern.ch//eos/opendata/atlas/rucio/opendata/ODEO_FEB2025_v0_3J1LMET30_mc_346414.aMcAtNloPythia8EvtGen_tHjb125_4fl_ZZ4l.3J1LMET30.root"
+      },
+      {
+        "checksum": "adler32:e69f6fe9",
+        "size": 11338946,
+        "uri": "root://eospublic.cern.ch//eos/opendata/atlas/rucio/opendata/ODEO_FEB2025_v0_3J1LMET30_mc_346446.PhH7EG_H7UE_NNLOPS_nnlo_30_ggH125_ZZ4l_noTau.3J1LMET30.root"
+      },
+      {
+        "checksum": "adler32:65fad91d",
+        "size": 2245215,
+        "uri": "root://eospublic.cern.ch//eos/opendata/atlas/rucio/opendata/ODEO_FEB2025_v0_3J1LMET30_mc_346447.PhH7EG_H7UE_NNPDF30_VBFH125_ZZ4lep_noTau.3J1LMET30.root"
+      },
+      {
+        "checksum": "adler32:81b6c1be",
+        "size": 3433485,
+        "uri": "root://eospublic.cern.ch//eos/opendata/atlas/rucio/opendata/ODEO_FEB2025_v0_3J1LMET30_mc_346448.PhH7EG_H7UE_NNPDF30_ZH125J_Zincl_MINLO.3J1LMET30.root"
+      },
+      {
+        "checksum": "adler32:141df9a6",
+        "size": 2436599,
+        "uri": "root://eospublic.cern.ch//eos/opendata/atlas/rucio/opendata/ODEO_FEB2025_v0_3J1LMET30_mc_346449.PhH7EG_H7UE_NNPDF30_WpH125J_Wincl_MINLO.3J1LMET30.root"
+      },
+      {
+        "checksum": "adler32:ceb2dbfb",
+        "size": 1281891,
+        "uri": "root://eospublic.cern.ch//eos/opendata/atlas/rucio/opendata/ODEO_FEB2025_v0_3J1LMET30_mc_346450.PhH7EG_H7UE_NNPDF30_WmH125J_Wincl_MINLO.3J1LMET30.root"
+      },
+      {
+        "checksum": "adler32:9bf2f7f4",
+        "size": 2798517,
+        "uri": "root://eospublic.cern.ch//eos/opendata/atlas/rucio/opendata/ODEO_FEB2025_v0_3J1LMET30_mc_346451.PhH7EG_H7UE_NNPDF3_ggZH125_ZZ4lepZinc.3J1LMET30.root"
+      },
+      {
+        "checksum": "adler32:d9a19fd1",
+        "size": 10642605,
+        "uri": "root://eospublic.cern.ch//eos/opendata/atlas/rucio/opendata/ODEO_FEB2025_v0_3J1LMET30_mc_346452.PhH7EG_H7UE_NNPDF30ME_ttH125_ZZ4l_allhad_noTau.3J1LMET30.root"
+      },
+      {
+        "checksum": "adler32:912c0b9e",
+        "size": 10565756,
+        "uri": "root://eospublic.cern.ch//eos/opendata/atlas/rucio/opendata/ODEO_FEB2025_v0_3J1LMET30_mc_346453.PhH7EG_H7UE_NNPDF30ME_ttH125_ZZ4l_semilep_noTau.3J1LMET30.root"
+      },
+      {
+        "checksum": "adler32:dfe7ab68",
+        "size": 6454000,
+        "uri": "root://eospublic.cern.ch//eos/opendata/atlas/rucio/opendata/ODEO_FEB2025_v0_3J1LMET30_mc_346454.PhH7EG_H7UE_NNPDF30ME_ttH125_ZZ4l_dilep_noTau.3J1LMET30.root"
+      },
+      {
+        "checksum": "adler32:97617756",
+        "size": 2003881,
+        "uri": "root://eospublic.cern.ch//eos/opendata/atlas/rucio/opendata/ODEO_FEB2025_v0_3J1LMET30_mc_346486.aMcAtNloPythia8EvtGen_tWH125_yy.3J1LMET30.root"
+      },
+      {
+        "checksum": "adler32:75913032",
+        "size": 7346170,
+        "uri": "root://eospublic.cern.ch//eos/opendata/atlas/rucio/opendata/ODEO_FEB2025_v0_3J1LMET30_mc_346511.aMcAtNloPythia8EvtGen_tWH125_ZZ4l.3J1LMET30.root"
+      },
+      {
+        "checksum": "adler32:6b244cd9",
+        "size": 1977730,
+        "uri": "root://eospublic.cern.ch//eos/opendata/atlas/rucio/opendata/ODEO_FEB2025_v0_3J1LMET30_mc_346524.PowhegPythia8EvtGen_NNPDF3_AZNLO_ggZH125J_MINLO_ZinclWWlvlv.3J1LMET30.root"
+      },
+      {
+        "checksum": "adler32:57796cba",
+        "size": 9811028,
+        "uri": "root://eospublic.cern.ch//eos/opendata/atlas/rucio/opendata/ODEO_FEB2025_v0_3J1LMET30_mc_346525.PowhegPythia8EvtGen_A14NNPDF23_NNPDF30ME_ttH125_gamgam.3J1LMET30.root"
+      },
+      {
+        "checksum": "adler32:8ae796b7",
+        "size": 11317933,
+        "uri": "root://eospublic.cern.ch//eos/opendata/atlas/rucio/opendata/ODEO_FEB2025_v0_3J1LMET30_mc_346526.PowhegHerwig7EvtGen_H7UE_NNPDF30ME_ttH125_gamgam.3J1LMET30.root"
+      },
+      {
+        "checksum": "adler32:a4cb7fcf",
+        "size": 51348,
+        "uri": "root://eospublic.cern.ch//eos/opendata/atlas/rucio/opendata/ODEO_FEB2025_v0_3J1LMET30_mc_346588.PowhegPythia8EvtGen_NNLOPS_nnlo_30_ggH125_ZZ4nu_MET75.3J1LMET30.root"
+      },
+      {
+        "checksum": "adler32:777944e4",
+        "size": 7904721,
+        "uri": "root://eospublic.cern.ch//eos/opendata/atlas/rucio/opendata/ODEO_FEB2025_v0_3J1LMET30_mc_346601.aMcAtNloHerwig7EvtGen_MEN30NLO_ttH125_gamgam.3J1LMET30.root"
+      },
+      {
+        "checksum": "adler32:7f9f20b6",
+        "size": 476336,
+        "uri": "root://eospublic.cern.ch//eos/opendata/atlas/rucio/opendata/ODEO_FEB2025_v0_3J1LMET30_mc_346602.aMcAtNloHerwig7EvtGen_MEN30NLO_tHjb125_gamgam.3J1LMET30.root"
+      },
+      {
+        "checksum": "adler32:69138b65",
+        "size": 284123,
+        "uri": "root://eospublic.cern.ch//eos/opendata/atlas/rucio/opendata/ODEO_FEB2025_v0_3J1LMET30_mc_346605.PowhegPythia8EvtGen_NNPDF30_AZNLO_WpH125J_WinclHinv_MET75.3J1LMET30.root"
+      },
+      {
+        "checksum": "adler32:5694cb16",
+        "size": 271815,
+        "uri": "root://eospublic.cern.ch//eos/opendata/atlas/rucio/opendata/ODEO_FEB2025_v0_3J1LMET30_mc_346606.PowhegPythia8EvtGen_NNPDF30_AZNLO_WmH125J_WinclHinv_MET75.3J1LMET30.root"
+      },
+      {
+        "checksum": "adler32:35264b16",
+        "size": 225240,
+        "uri": "root://eospublic.cern.ch//eos/opendata/atlas/rucio/opendata/ODEO_FEB2025_v0_3J1LMET30_mc_346607.PowhegPythia8EvtGen_NNPDF30_AZNLO_ZH125J_ZinclHinv_MET75.3J1LMET30.root"
+      },
+      {
+        "checksum": "adler32:96c199cc",
+        "size": 21629623,
+        "uri": "root://eospublic.cern.ch//eos/opendata/atlas/rucio/opendata/ODEO_FEB2025_v0_3J1LMET30_mc_346632.PowhegPy8EG_A14NNPDF23_NNPDF30ME_ttH125_ZZ4nu_semilep.3J1LMET30.root"
+      },
+      {
+        "checksum": "adler32:e9eecc75",
+        "size": 723103,
+        "uri": "root://eospublic.cern.ch//eos/opendata/atlas/rucio/opendata/ODEO_FEB2025_v0_3J1LMET30_mc_346633.PowhegPy8EG_A14NNPDF23_NNPDF30ME_ttH125_ZZ4nu_allhad.3J1LMET30.root"
+      },
+      {
+        "checksum": "adler32:f3a309fb",
+        "size": 4175638,
+        "uri": "root://eospublic.cern.ch//eos/opendata/atlas/rucio/opendata/ODEO_FEB2025_v0_3J1LMET30_mc_346634.PowhegPy8EG_A14NNPDF23_NNPDF30ME_ttH125_ZZ4nu_dilep.3J1LMET30.root"
+      },
+      {
+        "checksum": "adler32:748d02cb",
+        "size": 4055130,
+        "uri": "root://eospublic.cern.ch//eos/opendata/atlas/rucio/opendata/ODEO_FEB2025_v0_3J1LMET30_mc_346645.PowhegPythia8EvtGen_NNPDF30_AZNLO_ZH125J_Zincl_MINLO_shw.3J1LMET30.root"
+      },
+      {
+        "checksum": "adler32:bd72075c",
+        "size": 2218755,
+        "uri": "root://eospublic.cern.ch//eos/opendata/atlas/rucio/opendata/ODEO_FEB2025_v0_3J1LMET30_mc_346646.PowhegPythia8EvtGen_NNPDF30_AZNLO_WpH125J_Wincl_MINLO_shw.3J1LMET30.root"
+      },
+      {
+        "checksum": "adler32:b4fd3135",
+        "size": 1125524,
+        "uri": "root://eospublic.cern.ch//eos/opendata/atlas/rucio/opendata/ODEO_FEB2025_v0_3J1LMET30_mc_346647.PowhegPythia8EvtGen_NNPDF30_AZNLO_WmH125J_Wincl_MINLO_shw.3J1LMET30.root"
+      },
+      {
+        "checksum": "adler32:9ba51346",
+        "size": 82324,
+        "uri": "root://eospublic.cern.ch//eos/opendata/atlas/rucio/opendata/ODEO_FEB2025_v0_3J1LMET30_mc_346726.PowhegHerwig7EvtGen_NNPDF3_AZNLO_ZH125J_MINLO_vvcc_VpT.3J1LMET30.root"
+      },
+      {
+        "checksum": "adler32:72cf3878",
+        "size": 44414,
+        "uri": "root://eospublic.cern.ch//eos/opendata/atlas/rucio/opendata/ODEO_FEB2025_v0_3J1LMET30_mc_346728.PowhegHerwig7EvtGen_NNPDF3_AZNLO_ggZH125J_vvcc.3J1LMET30.root"
+      },
+      {
+        "checksum": "adler32:b0e5e40e",
+        "size": 594717,
+        "uri": "root://eospublic.cern.ch//eos/opendata/atlas/rucio/opendata/ODEO_FEB2025_v0_3J1LMET30_mc_346797.PhH7EG_H7UE_NNLOPS_nnlo_30_ggH125_gamgam.3J1LMET30.root"
+      },
+      {
+        "checksum": "adler32:b21195ed",
+        "size": 13140815,
+        "uri": "root://eospublic.cern.ch//eos/opendata/atlas/rucio/opendata/ODEO_FEB2025_v0_3J1LMET30_mc_346802.PhH7EG_NNLOPS_nnlo_30_ggH125_WWlvlv_noTau.3J1LMET30.root"
+      },
+      {
+        "checksum": "adler32:a9a52a62",
+        "size": 1116481,
+        "uri": "root://eospublic.cern.ch//eos/opendata/atlas/rucio/opendata/ODEO_FEB2025_v0_3J1LMET30_mc_346877.PhH7EG_NNPDF30_VBFH125_WWlvlv.3J1LMET30.root"
+      },
+      {
+        "checksum": "adler32:4b046d93",
+        "size": 107176,
+        "uri": "root://eospublic.cern.ch//eos/opendata/atlas/rucio/opendata/ODEO_FEB2025_v0_3J1LMET30_mc_346878.PhH7EG_H7UE_NNPDF30_VBF125_gammagamma.3J1LMET30.root"
+      },
+      {
+        "checksum": "adler32:32a2bad6",
+        "size": 175340,
+        "uri": "root://eospublic.cern.ch//eos/opendata/atlas/rucio/opendata/ODEO_FEB2025_v0_3J1LMET30_mc_346879.PhH7EG_H7UE_NNPDF30_ZH125J_Zincl_MINLO_gammagamma.3J1LMET30.root"
+      },
+      {
+        "checksum": "adler32:98452ff9",
+        "size": 158461,
+        "uri": "root://eospublic.cern.ch//eos/opendata/atlas/rucio/opendata/ODEO_FEB2025_v0_3J1LMET30_mc_346880.PhH7EG_H7UE_NNPDF30_WmH125J_Wincl_MINLO_gammagamma.3J1LMET30.root"
+      },
+      {
+        "checksum": "adler32:b30a562b",
+        "size": 320628,
+        "uri": "root://eospublic.cern.ch//eos/opendata/atlas/rucio/opendata/ODEO_FEB2025_v0_3J1LMET30_mc_346881.PhH7EG_H7UE_NNPDF30_WpH125J_Wincl_MINLO_gammagamma.3J1LMET30.root"
+      },
+      {
+        "checksum": "adler32:da2bc230",
+        "size": 131147,
+        "uri": "root://eospublic.cern.ch//eos/opendata/atlas/rucio/opendata/ODEO_FEB2025_v0_3J1LMET30_mc_346882.PhH7EG_H7UE_NNPDF30_ggZH125_gammagamma.3J1LMET30.root"
+      },
+      {
+        "checksum": "adler32:c7dbbed5",
+        "size": 14901806,
+        "uri": "root://eospublic.cern.ch//eos/opendata/atlas/rucio/opendata/ODEO_FEB2025_v0_3J1LMET30_mc_346919.PhPy8EG_A14NNPDF23_NNPDF30ME_ttH125_allhad_tautau_unpol.3J1LMET30.root"
+      },
+      {
+        "checksum": "adler32:abf4d93c",
+        "size": 23638199,
+        "uri": "root://eospublic.cern.ch//eos/opendata/atlas/rucio/opendata/ODEO_FEB2025_v0_3J1LMET30_mc_346923.PhPy8EG_A14NNPDF23_NNPDF30ME_ttH125_semilep_tautau_unpol.3J1LMET30.root"
+      },
+      {
+        "checksum": "adler32:171a0276",
+        "size": 12299867,
+        "uri": "root://eospublic.cern.ch//eos/opendata/atlas/rucio/opendata/ODEO_FEB2025_v0_3J1LMET30_mc_346927.PhPy8EG_A14NNPDF23_NNPDF30ME_ttH125_dilep_tautau_unpol.3J1LMET30.root"
+      },
+      {
+        "checksum": "adler32:10ecab4c",
+        "size": 4140505,
+        "uri": "root://eospublic.cern.ch//eos/opendata/atlas/rucio/opendata/ODEO_FEB2025_v0_3J1LMET30_mc_364242.Sherpa_222_NNPDF30NNLO_WWW_3l3v_EW6.3J1LMET30.root"
+      },
+      {
+        "checksum": "adler32:bfb45cd3",
+        "size": 1797041,
+        "uri": "root://eospublic.cern.ch//eos/opendata/atlas/rucio/opendata/ODEO_FEB2025_v0_3J1LMET30_mc_364243.Sherpa_222_NNPDF30NNLO_WWZ_4l2v_EW6.3J1LMET30.root"
+      },
+      {
+        "checksum": "adler32:1aa8ba1a",
+        "size": 1092935,
+        "uri": "root://eospublic.cern.ch//eos/opendata/atlas/rucio/opendata/ODEO_FEB2025_v0_3J1LMET30_mc_364244.Sherpa_222_NNPDF30NNLO_WWZ_2l4v_EW6.3J1LMET30.root"
+      },
+      {
+        "checksum": "adler32:0dd2ab31",
+        "size": 1748860,
+        "uri": "root://eospublic.cern.ch//eos/opendata/atlas/rucio/opendata/ODEO_FEB2025_v0_3J1LMET30_mc_364245.Sherpa_222_NNPDF30NNLO_WZZ_5l1v_EW6.3J1LMET30.root"
+      },
+      {
+        "checksum": "adler32:a1f210bd",
+        "size": 1513754,
+        "uri": "root://eospublic.cern.ch//eos/opendata/atlas/rucio/opendata/ODEO_FEB2025_v0_3J1LMET30_mc_364246.Sherpa_222_NNPDF30NNLO_WZZ_3l3v_EW6.3J1LMET30.root"
+      },
+      {
+        "checksum": "adler32:32faf59e",
+        "size": 661304,
+        "uri": "root://eospublic.cern.ch//eos/opendata/atlas/rucio/opendata/ODEO_FEB2025_v0_3J1LMET30_mc_364247.Sherpa_222_NNPDF30NNLO_ZZZ_6l0v_EW6.3J1LMET30.root"
+      },
+      {
+        "checksum": "adler32:d50dee9b",
+        "size": 185925,
+        "uri": "root://eospublic.cern.ch//eos/opendata/atlas/rucio/opendata/ODEO_FEB2025_v0_3J1LMET30_mc_364248.Sherpa_222_NNPDF30NNLO_ZZZ_4l2v_EW6.3J1LMET30.root"
+      },
+      {
+        "checksum": "adler32:b9188cb4",
+        "size": 271846,
+        "uri": "root://eospublic.cern.ch//eos/opendata/atlas/rucio/opendata/ODEO_FEB2025_v0_3J1LMET30_mc_364249.Sherpa_222_NNPDF30NNLO_ZZZ_2l4v_EW6.3J1LMET30.root"
+      },
+      {
+        "checksum": "adler32:d84ac63f",
+        "size": 2887733,
+        "uri": "root://eospublic.cern.ch//eos/opendata/atlas/rucio/opendata/ODEO_FEB2025_v0_3J1LMET30_mc_364336.Sherpa_222_NNPDF30NNLO_WpWpWn_sslvlvjj_EW6.3J1LMET30.root"
+      },
+      {
+        "checksum": "adler32:eead1be5",
+        "size": 2311065,
+        "uri": "root://eospublic.cern.ch//eos/opendata/atlas/rucio/opendata/ODEO_FEB2025_v0_3J1LMET30_mc_364337.Sherpa_222_NNPDF30NNLO_WnWnWp_sslvlvjj_EW6.3J1LMET30.root"
+      },
+      {
+        "checksum": "adler32:0676792d",
+        "size": 999995,
+        "uri": "root://eospublic.cern.ch//eos/opendata/atlas/rucio/opendata/ODEO_FEB2025_v0_3J1LMET30_mc_364338.Sherpa_222_NNPDF30NNLO_WpWpWn_oslvlvjj_EW6.3J1LMET30.root"
+      },
+      {
+        "checksum": "adler32:e18387dc",
+        "size": 377650,
+        "uri": "root://eospublic.cern.ch//eos/opendata/atlas/rucio/opendata/ODEO_FEB2025_v0_3J1LMET30_mc_364339.Sherpa_222_NNPDF30NNLO_WnWnWp_oslvlvjj_EW6.3J1LMET30.root"
+      },
+      {
+        "checksum": "adler32:6bd9eb3e",
+        "size": 312235,
+        "uri": "root://eospublic.cern.ch//eos/opendata/atlas/rucio/opendata/ODEO_FEB2025_v0_3J1LMET30_mc_364350.Sherpa_224_NNPDF30NNLO_Diphoton_myy_0_50.3J1LMET30.root"
+      },
+      {
+        "checksum": "adler32:57b4b744",
+        "size": 2379886,
+        "uri": "root://eospublic.cern.ch//eos/opendata/atlas/rucio/opendata/ODEO_FEB2025_v0_3J1LMET30_mc_364351.Sherpa_224_NNPDF30NNLO_Diphoton_myy_50_90.3J1LMET30.root"
+      },
+      {
+        "checksum": "adler32:1163a0b5",
+        "size": 1084275,
+        "uri": "root://eospublic.cern.ch//eos/opendata/atlas/rucio/opendata/ODEO_FEB2025_v0_3J1LMET30_mc_364352.Sherpa_224_NNPDF30NNLO_Diphoton_myy_90_175.3J1LMET30.root"
+      },
+      {
+        "checksum": "adler32:2b3bf326",
+        "size": 390744,
+        "uri": "root://eospublic.cern.ch//eos/opendata/atlas/rucio/opendata/ODEO_FEB2025_v0_3J1LMET30_mc_364353.Sherpa_224_NNPDF30NNLO_Diphoton_myy_175_2000.3J1LMET30.root"
+      },
+      {
+        "checksum": "adler32:a666479b",
+        "size": 89211,
+        "uri": "root://eospublic.cern.ch//eos/opendata/atlas/rucio/opendata/ODEO_FEB2025_v0_3J1LMET30_mc_364354.Sherpa_224_NNPDF30NNLO_Diphoton_myy_2000_E_CMS.3J1LMET30.root"
+      },
+      {
+        "checksum": "adler32:6bdfb35a",
+        "size": 1332529,
+        "uri": "root://eospublic.cern.ch//eos/opendata/atlas/rucio/opendata/ODEO_FEB2025_v0_3J1LMET30_mc_364541.Sherpa_222_NNPDF30NNLO_SinglePhoton_pty_17_35.3J1LMET30.root"
+      },
+      {
+        "checksum": "adler32:17335410",
+        "size": 1835931,
+        "uri": "root://eospublic.cern.ch//eos/opendata/atlas/rucio/opendata/ODEO_FEB2025_v0_3J1LMET30_mc_364542.Sherpa_222_NNPDF30NNLO_SinglePhoton_pty_35_70.3J1LMET30.root"
+      },
+      {
+        "checksum": "adler32:fa5c3914",
+        "size": 2812420,
+        "uri": "root://eospublic.cern.ch//eos/opendata/atlas/rucio/opendata/ODEO_FEB2025_v0_3J1LMET30_mc_364543.Sherpa_222_NNPDF30NNLO_SinglePhoton_pty_70_140.3J1LMET30.root"
+      },
+      {
+        "checksum": "adler32:7b71fd9e",
+        "size": 4459464,
+        "uri": "root://eospublic.cern.ch//eos/opendata/atlas/rucio/opendata/ODEO_FEB2025_v0_3J1LMET30_mc_364544.Sherpa_222_NNPDF30NNLO_SinglePhoton_pty_140_280.3J1LMET30.root"
+      },
+      {
+        "checksum": "adler32:fb472168",
+        "size": 991652,
+        "uri": "root://eospublic.cern.ch//eos/opendata/atlas/rucio/opendata/ODEO_FEB2025_v0_3J1LMET30_mc_364545.Sherpa_222_NNPDF30NNLO_SinglePhoton_pty_280_500.3J1LMET30.root"
+      },
+      {
+        "checksum": "adler32:334292bc",
+        "size": 88074,
+        "uri": "root://eospublic.cern.ch//eos/opendata/atlas/rucio/opendata/ODEO_FEB2025_v0_3J1LMET30_mc_364546.Sherpa_222_NNPDF30NNLO_SinglePhoton_pty_500_1000.3J1LMET30.root"
+      },
+      {
+        "checksum": "adler32:05a484e0",
+        "size": 111143,
+        "uri": "root://eospublic.cern.ch//eos/opendata/atlas/rucio/opendata/ODEO_FEB2025_v0_3J1LMET30_mc_364547.Sherpa_222_NNPDF30NNLO_SinglePhoton_pty_1000_E_CMS.3J1LMET30.root"
+      },
+      {
+        "checksum": "adler32:6ad02dfb",
+        "size": 690496,
+        "uri": "root://eospublic.cern.ch//eos/opendata/atlas/rucio/opendata/ODEO_FEB2025_v0_3J1LMET30_mc_364700.Pythia8EvtGen_A14NNPDF23LO_jetjet_JZ0WithSW.3J1LMET30.root"
+      },
+      {
+        "checksum": "adler32:bfb5a3ed",
+        "size": 1632830,
+        "uri": "root://eospublic.cern.ch//eos/opendata/atlas/rucio/opendata/ODEO_FEB2025_v0_3J1LMET30_mc_364701.Pythia8EvtGen_A14NNPDF23LO_jetjet_JZ1WithSW.3J1LMET30.root"
+      },
+      {
+        "checksum": "adler32:3bae1d20",
+        "size": 11497517,
+        "uri": "root://eospublic.cern.ch//eos/opendata/atlas/rucio/opendata/ODEO_FEB2025_v0_3J1LMET30_mc_364702.Pythia8EvtGen_A14NNPDF23LO_jetjet_JZ2WithSW.3J1LMET30.root"
+      },
+      {
+        "checksum": "adler32:29075eb4",
+        "size": 20763330,
+        "uri": "root://eospublic.cern.ch//eos/opendata/atlas/rucio/opendata/ODEO_FEB2025_v0_3J1LMET30_mc_364703.Pythia8EvtGen_A14NNPDF23LO_jetjet_JZ3WithSW.3J1LMET30.root"
+      },
+      {
+        "checksum": "adler32:30030bb8",
+        "size": 27234002,
+        "uri": "root://eospublic.cern.ch//eos/opendata/atlas/rucio/opendata/ODEO_FEB2025_v0_3J1LMET30_mc_364704.Pythia8EvtGen_A14NNPDF23LO_jetjet_JZ4WithSW.3J1LMET30.root"
+      },
+      {
+        "checksum": "adler32:f96711f8",
+        "size": 3797803,
+        "uri": "root://eospublic.cern.ch//eos/opendata/atlas/rucio/opendata/ODEO_FEB2025_v0_3J1LMET30_mc_364705.Pythia8EvtGen_A14NNPDF23LO_jetjet_JZ5WithSW.3J1LMET30.root"
+      },
+      {
+        "checksum": "adler32:ded35416",
+        "size": 221496,
+        "uri": "root://eospublic.cern.ch//eos/opendata/atlas/rucio/opendata/ODEO_FEB2025_v0_3J1LMET30_mc_364706.Pythia8EvtGen_A14NNPDF23LO_jetjet_JZ6WithSW.3J1LMET30.root"
+      },
+      {
+        "checksum": "adler32:c3fbd5c4",
+        "size": 131573,
+        "uri": "root://eospublic.cern.ch//eos/opendata/atlas/rucio/opendata/ODEO_FEB2025_v0_3J1LMET30_mc_364707.Pythia8EvtGen_A14NNPDF23LO_jetjet_JZ7WithSW.3J1LMET30.root"
+      },
+      {
+        "checksum": "adler32:80ae5255",
+        "size": 249412,
+        "uri": "root://eospublic.cern.ch//eos/opendata/atlas/rucio/opendata/ODEO_FEB2025_v0_3J1LMET30_mc_364708.Pythia8EvtGen_A14NNPDF23LO_jetjet_JZ8WithSW.3J1LMET30.root"
+      },
+      {
+        "checksum": "adler32:b8353259",
+        "size": 158674,
+        "uri": "root://eospublic.cern.ch//eos/opendata/atlas/rucio/opendata/ODEO_FEB2025_v0_3J1LMET30_mc_364709.Pythia8EvtGen_A14NNPDF23LO_jetjet_JZ9WithSW.3J1LMET30.root"
+      },
+      {
+        "checksum": "adler32:328a015c",
+        "size": 402243,
+        "uri": "root://eospublic.cern.ch//eos/opendata/atlas/rucio/opendata/ODEO_FEB2025_v0_3J1LMET30_mc_364710.Pythia8EvtGen_A14NNPDF23LO_jetjet_JZ10WithSW.3J1LMET30.root"
+      },
+      {
+        "checksum": "adler32:9a18a8de",
+        "size": 150805,
+        "uri": "root://eospublic.cern.ch//eos/opendata/atlas/rucio/opendata/ODEO_FEB2025_v0_3J1LMET30_mc_364711.Pythia8EvtGen_A14NNPDF23LO_jetjet_JZ11WithSW.3J1LMET30.root"
+      },
+      {
+        "checksum": "adler32:b68e6e47",
+        "size": 152291,
+        "uri": "root://eospublic.cern.ch//eos/opendata/atlas/rucio/opendata/ODEO_FEB2025_v0_3J1LMET30_mc_364712.Pythia8EvtGen_A14NNPDF23LO_jetjet_JZ12WithSW.3J1LMET30.root"
+      },
+      {
+        "checksum": "adler32:2933c647",
+        "size": 1841584,
+        "uri": "root://eospublic.cern.ch//eos/opendata/atlas/rucio/opendata/ODEO_FEB2025_v0_3J1LMET30_mc_375884.MGPy8EG_A14N_GG_ttn1_2000_5000_200.3J1LMET30.root"
+      },
+      {
+        "checksum": "adler32:aea3897e",
+        "size": 153995,
+        "uri": "root://eospublic.cern.ch//eos/opendata/atlas/rucio/opendata/ODEO_FEB2025_v0_3J1LMET30_mc_376359.MGPy8EG_A14N23LO_SS_onestepCC_1600_900_200.3J1LMET30.root"
+      },
+      {
+        "checksum": "adler32:ee883886",
+        "size": 30890,
+        "uri": "root://eospublic.cern.ch//eos/opendata/atlas/rucio/opendata/ODEO_FEB2025_v0_3J1LMET30_mc_376518.MadGraphPythia8EvtGen_A14NNPDF23LO_GG_direct_2400_200.3J1LMET30.root"
+      },
+      {
+        "checksum": "adler32:182aa197",
+        "size": 171114,
+        "uri": "root://eospublic.cern.ch//eos/opendata/atlas/rucio/opendata/ODEO_FEB2025_v0_3J1LMET30_mc_392202.MGPy8EG_A14N23LO_C1N2_WZ_500p0_100p0_3L_2L7.3J1LMET30.root"
+      },
+      {
+        "checksum": "adler32:0e7cf759",
+        "size": 125616,
+        "uri": "root://eospublic.cern.ch//eos/opendata/atlas/rucio/opendata/ODEO_FEB2025_v0_3J1LMET30_mc_394997.MGPy8EG_A14N23LO_SM_N2C1p_105_100_2L2MET75_MadSpin.3J1LMET30.root"
+      },
+      {
+        "checksum": "adler32:1f7a81a5",
+        "size": 406450,
+        "uri": "root://eospublic.cern.ch//eos/opendata/atlas/rucio/opendata/ODEO_FEB2025_v0_3J1LMET30_mc_398384.MGPy8EG_A14N23LO_C1N2N1_GGMHinoZh50_800_noFilter.3J1LMET30.root"
+      },
+      {
+        "checksum": "adler32:091ecc2c",
+        "size": 6006768,
+        "uri": "root://eospublic.cern.ch//eos/opendata/atlas/rucio/opendata/ODEO_FEB2025_v0_3J1LMET30_mc_410081.MadGraphPythia8EvtGen_A14NNPDF23_ttbarWW.3J1LMET30.root"
+      },
+      {
+        "checksum": "adler32:1f0ef8a7",
+        "size": 42578805,
+        "uri": "root://eospublic.cern.ch//eos/opendata/atlas/rucio/opendata/ODEO_FEB2025_v0_3J1LMET30_mc_410082.MadGraphPythia8EvtGen_A14NNPDF23LO_ttgamma_noallhad.3J1LMET30.root"
+      },
+      {
+        "checksum": "adler32:bb6b1162",
+        "size": 1317234,
+        "uri": "root://eospublic.cern.ch//eos/opendata/atlas/rucio/opendata/ODEO_FEB2025_v0_3J1LMET30_mc_410087.MadGraphPythia8EvtGen_A14NNPDF23LO_ttgamma_allhad.3J1LMET30.root"
+      },
+      {
+        "checksum": "adler32:83ceb9c4",
+        "size": 12108021,
+        "uri": "root://eospublic.cern.ch//eos/opendata/atlas/rucio/opendata/ODEO_FEB2025_v0_3J1LMET30_mc_410155.aMcAtNloPythia8EvtGen_MEN30NLO_A14N23LO_ttW.3J1LMET30.root"
+      },
+      {
+        "checksum": "adler32:b13bee3a",
+        "size": 9285044,
+        "uri": "root://eospublic.cern.ch//eos/opendata/atlas/rucio/opendata/ODEO_FEB2025_v0_3J1LMET30_mc_410156.aMcAtNloPythia8EvtGen_MEN30NLO_A14N23LO_ttZnunu.3J1LMET30.root"
+      },
+      {
+        "checksum": "adler32:657efd6b",
+        "size": 17678789,
+        "uri": "root://eospublic.cern.ch//eos/opendata/atlas/rucio/opendata/ODEO_FEB2025_v0_3J1LMET30_mc_410157.aMcAtNloPythia8EvtGen_MEN30NLO_A14N23LO_ttZqq.3J1LMET30.root"
+      },
+      {
+        "checksum": "adler32:978e7141",
+        "size": 17879930,
+        "uri": "root://eospublic.cern.ch//eos/opendata/atlas/rucio/opendata/ODEO_FEB2025_v0_3J1LMET30_mc_410218.aMcAtNloPythia8EvtGen_MEN30NLO_A14N23LO_ttee.3J1LMET30.root"
+      },
+      {
+        "checksum": "adler32:f4f5b8ec",
+        "size": 35941401,
+        "uri": "root://eospublic.cern.ch//eos/opendata/atlas/rucio/opendata/ODEO_FEB2025_v0_3J1LMET30_mc_410219.aMcAtNloPythia8EvtGen_MEN30NLO_A14N23LO_ttmumu.3J1LMET30.root"
+      },
+      {
+        "checksum": "adler32:2a0e6d3a",
+        "size": 23386084,
+        "uri": "root://eospublic.cern.ch//eos/opendata/atlas/rucio/opendata/ODEO_FEB2025_v0_3J1LMET30_mc_410220.aMcAtNloPythia8EvtGen_MEN30NLO_A14N23LO_tttautau.3J1LMET30.root"
+      },
+      {
+        "checksum": "adler32:67637353",
+        "size": 55351043,
+        "uri": "root://eospublic.cern.ch//eos/opendata/atlas/rucio/opendata/ODEO_FEB2025_v0_3J1LMET30_mc_410389.MadGraphPythia8EvtGen_A14NNPDF23_ttgamma_nonallhadronic.3J1LMET30.root"
+      },
+      {
+        "checksum": "adler32:255e14c8",
+        "size": 56398939,
+        "uri": "root://eospublic.cern.ch//eos/opendata/atlas/rucio/opendata/ODEO_FEB2025_v0_3J1LMET30_mc_410395.MGH7EG_H7UE_ttgamma_nonallhadronic.3J1LMET30.root"
+      },
+      {
+        "checksum": "adler32:14dcc62b",
+        "size": 1532456,
+        "uri": "root://eospublic.cern.ch//eos/opendata/atlas/rucio/opendata/ODEO_FEB2025_v0_3J1LMET30_mc_410396.MGH7EG_H7UE_ttgamma_allhadronic.3J1LMET30.root"
+      },
+      {
+        "checksum": "adler32:9dd3ea2a",
+        "size": 5355574,
+        "uri": "root://eospublic.cern.ch//eos/opendata/atlas/rucio/opendata/ODEO_FEB2025_v0_3J1LMET30_mc_410408.aMcAtNloPythia8EvtGen_tWZ_Ztoll_minDR1.3J1LMET30.root"
+      },
+      {
+        "checksum": "adler32:ae1d8b8d",
+        "size": 3360688731,
+        "uri": "root://eospublic.cern.ch//eos/opendata/atlas/rucio/opendata/ODEO_FEB2025_v0_3J1LMET30_mc_410470.PhPy8EG_A14_ttbar_hdamp258p75_nonallhad.3J1LMET30.root"
+      },
+      {
+        "checksum": "adler32:cc961288",
+        "size": 65537816,
+        "uri": "root://eospublic.cern.ch//eos/opendata/atlas/rucio/opendata/ODEO_FEB2025_v0_3J1LMET30_mc_410471.PhPy8EG_A14_ttbar_hdamp258p75_allhad.3J1LMET30.root"
+      },
+      {
+        "checksum": "adler32:2da2f265",
+        "size": 9370976,
+        "uri": "root://eospublic.cern.ch//eos/opendata/atlas/rucio/opendata/ODEO_FEB2025_v0_3J1LMET30_mc_410560.MadGraphPythia8EvtGen_A14_tZ_4fl_tchan_noAllHad.3J1LMET30.root"
+      },
+      {
+        "checksum": "adler32:6712b66f",
+        "size": 3623630,
+        "uri": "root://eospublic.cern.ch//eos/opendata/atlas/rucio/opendata/ODEO_FEB2025_v0_3J1LMET30_mc_410644.PowhegPythia8EvtGen_A14_singletop_schan_lept_top.3J1LMET30.root"
+      },
+      {
+        "checksum": "adler32:b89a21be",
+        "size": 2422518,
+        "uri": "root://eospublic.cern.ch//eos/opendata/atlas/rucio/opendata/ODEO_FEB2025_v0_3J1LMET30_mc_410645.PowhegPythia8EvtGen_A14_singletop_schan_lept_antitop.3J1LMET30.root"
+      },
+      {
+        "checksum": "adler32:3ab5bbb1",
+        "size": 58227819,
+        "uri": "root://eospublic.cern.ch//eos/opendata/atlas/rucio/opendata/ODEO_FEB2025_v0_3J1LMET30_mc_410658.PhPy8EG_A14_tchan_BW50_lept_top.3J1LMET30.root"
+      },
+      {
+        "checksum": "adler32:6eb4435b",
+        "size": 34682927,
+        "uri": "root://eospublic.cern.ch//eos/opendata/atlas/rucio/opendata/ODEO_FEB2025_v0_3J1LMET30_mc_410659.PhPy8EG_A14_tchan_BW50_lept_antitop.3J1LMET30.root"
+      },
+      {
+        "checksum": "adler32:d7c1258e",
+        "size": 782138835,
+        "uri": "root://eospublic.cern.ch//eos/opendata/atlas/rucio/opendata/ODEO_FEB2025_v0_3J1LMET30_mc_411233.PowhegHerwig7EvtGen_tt_hdamp258p75_713_SingleLep.3J1LMET30.root"
+      },
+      {
+        "checksum": "adler32:f8309822",
+        "size": 316589154,
+        "uri": "root://eospublic.cern.ch//eos/opendata/atlas/rucio/opendata/ODEO_FEB2025_v0_3J1LMET30_mc_411234.PowhegHerwig7EvtGen_tt_hdamp258p75_713_dil.3J1LMET30.root"
+      },
+      {
+        "checksum": "adler32:180a6ac7",
+        "size": 90681054,
+        "uri": "root://eospublic.cern.ch//eos/opendata/atlas/rucio/opendata/ODEO_FEB2025_v0_3J1LMET30_mc_411316.PowhegHerwig7EvtGen_tt_hdamp258p75_713_allhad.3J1LMET30.root"
+      },
+      {
+        "checksum": "adler32:0e29f83e",
+        "size": 46351326,
+        "uri": "root://eospublic.cern.ch//eos/opendata/atlas/rucio/opendata/ODEO_FEB2025_v0_3J1LMET30_mc_412043.aMcAtNloPythia8EvtGen_A14NNPDF31_SM4topsNLO.3J1LMET30.root"
+      },
+      {
+        "checksum": "adler32:80c7de3e",
+        "size": 45233320,
+        "uri": "root://eospublic.cern.ch//eos/opendata/atlas/rucio/opendata/ODEO_FEB2025_v0_3J1LMET30_mc_412044.aMcAtNloHerwig7EvtGen_H7UE_SM4topsNLO.3J1LMET30.root"
+      },
+      {
+        "checksum": "adler32:e2963159",
+        "size": 256616,
+        "uri": "root://eospublic.cern.ch//eos/opendata/atlas/rucio/opendata/ODEO_FEB2025_v0_3J1LMET30_mc_423099.Pythia8EvtGen_A14NNPDF23LO_gammajet_DP8_17.3J1LMET30.root"
+      },
+      {
+        "checksum": "adler32:72143eaf",
+        "size": 369383,
+        "uri": "root://eospublic.cern.ch//eos/opendata/atlas/rucio/opendata/ODEO_FEB2025_v0_3J1LMET30_mc_423100.Pythia8EvtGen_A14NNPDF23LO_gammajet_DP17_35.3J1LMET30.root"
+      },
+      {
+        "checksum": "adler32:f216fe02",
+        "size": 476869,
+        "uri": "root://eospublic.cern.ch//eos/opendata/atlas/rucio/opendata/ODEO_FEB2025_v0_3J1LMET30_mc_423101.Pythia8EvtGen_A14NNPDF23LO_gammajet_DP35_50.3J1LMET30.root"
+      },
+      {
+        "checksum": "adler32:a9f40ca2",
+        "size": 764245,
+        "uri": "root://eospublic.cern.ch//eos/opendata/atlas/rucio/opendata/ODEO_FEB2025_v0_3J1LMET30_mc_423102.Pythia8EvtGen_A14NNPDF23LO_gammajet_DP50_70.3J1LMET30.root"
+      },
+      {
+        "checksum": "adler32:01f5494e",
+        "size": 688918,
+        "uri": "root://eospublic.cern.ch//eos/opendata/atlas/rucio/opendata/ODEO_FEB2025_v0_3J1LMET30_mc_423103.Pythia8EvtGen_A14NNPDF23LO_gammajet_DP70_140.3J1LMET30.root"
+      },
+      {
+        "checksum": "adler32:8a58646c",
+        "size": 1005594,
+        "uri": "root://eospublic.cern.ch//eos/opendata/atlas/rucio/opendata/ODEO_FEB2025_v0_3J1LMET30_mc_423104.Pythia8EvtGen_A14NNPDF23LO_gammajet_DP140_280.3J1LMET30.root"
+      },
+      {
+        "checksum": "adler32:d218a57b",
+        "size": 912772,
+        "uri": "root://eospublic.cern.ch//eos/opendata/atlas/rucio/opendata/ODEO_FEB2025_v0_3J1LMET30_mc_423105.Pythia8EvtGen_A14NNPDF23LO_gammajet_DP280_500.3J1LMET30.root"
+      },
+      {
+        "checksum": "adler32:b2a2b7a5",
+        "size": 139959,
+        "uri": "root://eospublic.cern.ch//eos/opendata/atlas/rucio/opendata/ODEO_FEB2025_v0_3J1LMET30_mc_423106.Pythia8EvtGen_A14NNPDF23LO_gammajet_DP500_800.3J1LMET30.root"
+      },
+      {
+        "checksum": "adler32:8273484e",
+        "size": 81198,
+        "uri": "root://eospublic.cern.ch//eos/opendata/atlas/rucio/opendata/ODEO_FEB2025_v0_3J1LMET30_mc_423107.Pythia8EvtGen_A14NNPDF23LO_gammajet_DP800_1000.3J1LMET30.root"
+      },
+      {
+        "checksum": "adler32:c1b421bb",
+        "size": 112469,
+        "uri": "root://eospublic.cern.ch//eos/opendata/atlas/rucio/opendata/ODEO_FEB2025_v0_3J1LMET30_mc_423108.Pythia8EvtGen_A14NNPDF23LO_gammajet_DP1000_1500.3J1LMET30.root"
+      },
+      {
+        "checksum": "adler32:8a40a9d2",
+        "size": 54365,
+        "uri": "root://eospublic.cern.ch//eos/opendata/atlas/rucio/opendata/ODEO_FEB2025_v0_3J1LMET30_mc_423109.Pythia8EvtGen_A14NNPDF23LO_gammajet_DP1500_2000.3J1LMET30.root"
+      },
+      {
+        "checksum": "adler32:c0158d36",
+        "size": 50801,
+        "uri": "root://eospublic.cern.ch//eos/opendata/atlas/rucio/opendata/ODEO_FEB2025_v0_3J1LMET30_mc_423110.Pythia8EvtGen_A14NNPDF23LO_gammajet_DP2000_2500.3J1LMET30.root"
+      },
+      {
+        "checksum": "adler32:f2270ed8",
+        "size": 65925,
+        "uri": "root://eospublic.cern.ch//eos/opendata/atlas/rucio/opendata/ODEO_FEB2025_v0_3J1LMET30_mc_423111.Pythia8EvtGen_A14NNPDF23LO_gammajet_DP2500_3000.3J1LMET30.root"
+      },
+      {
+        "checksum": "adler32:03a12674",
+        "size": 62339,
+        "uri": "root://eospublic.cern.ch//eos/opendata/atlas/rucio/opendata/ODEO_FEB2025_v0_3J1LMET30_mc_423112.Pythia8EvtGen_A14NNPDF23LO_gammajet_DP3000_inf.3J1LMET30.root"
+      },
+      {
+        "checksum": "adler32:7e4aa625",
+        "size": 1622914,
+        "uri": "root://eospublic.cern.ch//eos/opendata/atlas/rucio/opendata/ODEO_FEB2025_v0_3J1LMET30_mc_448624.MGPy8EG_A14N23LO_TT_higgsinoRPV_1075_700.3J1LMET30.root"
+      },
+      {
+        "checksum": "adler32:b2278d58",
+        "size": 1383878,
+        "uri": "root://eospublic.cern.ch//eos/opendata/atlas/rucio/opendata/ODEO_FEB2025_v0_3J1LMET30_mc_449595.MGPy8EG_A14N23LO_TT_RPVdirectBL_1400.3J1LMET30.root"
+      },
+      {
+        "checksum": "adler32:b14b5800",
+        "size": 823422,
+        "uri": "root://eospublic.cern.ch//eos/opendata/atlas/rucio/opendata/ODEO_FEB2025_v0_3J1LMET30_mc_450576.PowhegPythia8EvtGen_NNLOPS_nnlo_30_VBFH125_ZZllbb.3J1LMET30.root"
+      },
+      {
+        "checksum": "adler32:f36ccd21",
+        "size": 994095,
+        "uri": "root://eospublic.cern.ch//eos/opendata/atlas/rucio/opendata/ODEO_FEB2025_v0_3J1LMET30_mc_500335.MGH7EG_VBFHWWlvlv.3J1LMET30.root"
+      },
+      {
+        "checksum": "adler32:6eefd885",
+        "size": 168441,
+        "uri": "root://eospublic.cern.ch//eos/opendata/atlas/rucio/opendata/ODEO_FEB2025_v0_3J1LMET30_mc_500553.aMCPy8EG_ZH_FxFx_Hyy.3J1LMET30.root"
+      },
+      {
+        "checksum": "adler32:bc5187f8",
+        "size": 308483,
+        "uri": "root://eospublic.cern.ch//eos/opendata/atlas/rucio/opendata/ODEO_FEB2025_v0_3J1LMET30_mc_500554.aMCPy8EG_WH_FxFx_Hyy.3J1LMET30.root"
+      },
+      {
+        "checksum": "adler32:b165fd81",
+        "size": 307392,
+        "uri": "root://eospublic.cern.ch//eos/opendata/atlas/rucio/opendata/ODEO_FEB2025_v0_3J1LMET30_mc_500555.aMCPy8EG_ggZH_Hyy.3J1LMET30.root"
+      },
+      {
+        "checksum": "adler32:fbab880e",
+        "size": 168732,
+        "uri": "root://eospublic.cern.ch//eos/opendata/atlas/rucio/opendata/ODEO_FEB2025_v0_3J1LMET30_mc_501058.MGPy8EG_StauStauDirect_200p0_1p0_TFilt.3J1LMET30.root"
+      },
+      {
+        "checksum": "adler32:a4068ebb",
+        "size": 807276,
+        "uri": "root://eospublic.cern.ch//eos/opendata/atlas/rucio/opendata/ODEO_FEB2025_v0_3J1LMET30_mc_506098.aMCPy8EG_WpH_FxFx_Htautau.3J1LMET30.root"
+      },
+      {
+        "checksum": "adler32:56ab14d9",
+        "size": 651727,
+        "uri": "root://eospublic.cern.ch//eos/opendata/atlas/rucio/opendata/ODEO_FEB2025_v0_3J1LMET30_mc_506099.aMCPy8EG_ZH_FxFx_Htautau.3J1LMET30.root"
+      },
+      {
+        "checksum": "adler32:19c0b091",
+        "size": 67557,
+        "uri": "root://eospublic.cern.ch//eos/opendata/atlas/rucio/opendata/ODEO_FEB2025_v0_3J1LMET30_mc_506101.aMCH7EG_VBF_Htautauh30h20.3J1LMET30.root"
+      },
+      {
+        "checksum": "adler32:6cdfbad9",
+        "size": 975551,
+        "uri": "root://eospublic.cern.ch//eos/opendata/atlas/rucio/opendata/ODEO_FEB2025_v0_3J1LMET30_mc_506102.aMCH7EG_VBF_Htautaul13l7.3J1LMET30.root"
+      },
+      {
+        "checksum": "adler32:7dfd8075",
+        "size": 654180,
+        "uri": "root://eospublic.cern.ch//eos/opendata/atlas/rucio/opendata/ODEO_FEB2025_v0_3J1LMET30_mc_506103.aMCH7EG_VBF_Htautaulp15hm20.3J1LMET30.root"
+      },
+      {
+        "checksum": "adler32:b8a2a00f",
+        "size": 1081917,
+        "uri": "root://eospublic.cern.ch//eos/opendata/atlas/rucio/opendata/ODEO_FEB2025_v0_3J1LMET30_mc_506104.aMCH7EG_VBF_Htautaulm15hp20.3J1LMET30.root"
+      },
+      {
+        "checksum": "adler32:ffc4d0cf",
+        "size": 54133,
+        "uri": "root://eospublic.cern.ch//eos/opendata/atlas/rucio/opendata/ODEO_FEB2025_v0_3J1LMET30_mc_506811.aMCH7EG_VBF_HC_Hyy.3J1LMET30.root"
+      },
+      {
+        "checksum": "adler32:bac7245f",
+        "size": 68117,
+        "uri": "root://eospublic.cern.ch//eos/opendata/atlas/rucio/opendata/ODEO_FEB2025_v0_3J1LMET30_mc_506813.aMCPy8EG_ZH_had_FxFx_Hyy.3J1LMET30.root"
+      },
+      {
+        "checksum": "adler32:567bfe31",
+        "size": 111711,
+        "uri": "root://eospublic.cern.ch//eos/opendata/atlas/rucio/opendata/ODEO_FEB2025_v0_3J1LMET30_mc_506814.aMCPy8EG_ggZH_Zhad_Hyy.3J1LMET30.root"
+      },
+      {
+        "checksum": "adler32:4afa0d03",
+        "size": 96580,
+        "uri": "root://eospublic.cern.ch//eos/opendata/atlas/rucio/opendata/ODEO_FEB2025_v0_3J1LMET30_mc_507366.MGPy8EG_A14NNPDF23LO_GGM_N1N2C1_950.3J1LMET30.root"
+      },
+      {
+        "checksum": "adler32:2d258868",
+        "size": 6435451,
+        "uri": "root://eospublic.cern.ch//eos/opendata/atlas/rucio/opendata/ODEO_FEB2025_v0_3J1LMET30_mc_510097.MGPy8EG_A14N23LO_DM_4topscalar_p1000_c1_nonallhad.3J1LMET30.root"
+      },
+      {
+        "checksum": "adler32:ef194f37",
+        "size": 531084,
+        "uri": "root://eospublic.cern.ch//eos/opendata/atlas/rucio/opendata/ODEO_FEB2025_v0_3J1LMET30_mc_523692.MGPy8EG_A14N23LO_TT_tN1_1200_200_MS.3J1LMET30.root"
+      },
+      {
+        "checksum": "adler32:917454ac",
+        "size": 28441020,
+        "uri": "root://eospublic.cern.ch//eos/opendata/atlas/rucio/opendata/ODEO_FEB2025_v0_3J1LMET30_mc_600017.PhH7EG_H7UE_716_tchan_lept_antitop.3J1LMET30.root"
+      },
+      {
+        "checksum": "adler32:45dc4d8f",
+        "size": 48932972,
+        "uri": "root://eospublic.cern.ch//eos/opendata/atlas/rucio/opendata/ODEO_FEB2025_v0_3J1LMET30_mc_600018.PhH7EG_H7UE_716_tchan_lept_top.3J1LMET30.root"
+      },
+      {
+        "checksum": "adler32:54953cdf",
+        "size": 3573079,
+        "uri": "root://eospublic.cern.ch//eos/opendata/atlas/rucio/opendata/ODEO_FEB2025_v0_3J1LMET30_mc_600019.PhH7EG_H7UE_716_schan_lept_antitop.3J1LMET30.root"
+      },
+      {
+        "checksum": "adler32:f7ae9e50",
+        "size": 4052134,
+        "uri": "root://eospublic.cern.ch//eos/opendata/atlas/rucio/opendata/ODEO_FEB2025_v0_3J1LMET30_mc_600020.PhH7EG_H7UE_716_schan_lept_top.3J1LMET30.root"
+      },
+      {
+        "checksum": "adler32:3982790f",
+        "size": 274345,
+        "uri": "root://eospublic.cern.ch//eos/opendata/atlas/rucio/opendata/ODEO_FEB2025_v0_3J1LMET30_mc_600565.PhH7EG_ggH125_tautauh30h20_ShowerSys_fix.3J1LMET30.root"
+      },
+      {
+        "checksum": "adler32:f4bc2e48",
+        "size": 7736988,
+        "uri": "root://eospublic.cern.ch//eos/opendata/atlas/rucio/opendata/ODEO_FEB2025_v0_3J1LMET30_mc_600566.PhH7EG_ggH125_tautaul13l7_ShowerSys_fix.3J1LMET30.root"
+      },
+      {
+        "checksum": "adler32:faccae83",
+        "size": 3239093,
+        "uri": "root://eospublic.cern.ch//eos/opendata/atlas/rucio/opendata/ODEO_FEB2025_v0_3J1LMET30_mc_600567.PhH7EG_ggH125_ttlp15hm20_ShowerSys_fix.3J1LMET30.root"
+      },
+      {
+        "checksum": "adler32:cd80a4b1",
+        "size": 3700734,
+        "uri": "root://eospublic.cern.ch//eos/opendata/atlas/rucio/opendata/ODEO_FEB2025_v0_3J1LMET30_mc_600568.PhH7EG_ggH125_ttlm15hp20_ShowerSys_fix.3J1LMET30.root"
+      },
+      {
+        "checksum": "adler32:e1fbfa23",
+        "size": 89083,
+        "uri": "root://eospublic.cern.ch//eos/opendata/atlas/rucio/opendata/ODEO_FEB2025_v0_3J1LMET30_mc_600569.PhH7EG_VBFH125_tautauh30h20_ShowerSys_fix.3J1LMET30.root"
+      },
+      {
+        "checksum": "adler32:c9446a99",
+        "size": 1089484,
+        "uri": "root://eospublic.cern.ch//eos/opendata/atlas/rucio/opendata/ODEO_FEB2025_v0_3J1LMET30_mc_600570.PhH7EG_VBFH125_tautaul13l7_ShowerSys_fix.3J1LMET30.root"
+      },
+      {
+        "checksum": "adler32:aa5b6105",
+        "size": 519070,
+        "uri": "root://eospublic.cern.ch//eos/opendata/atlas/rucio/opendata/ODEO_FEB2025_v0_3J1LMET30_mc_600571.PhH7EG_VBFH125_tautaulp15hm20_ShowerSys_fix.3J1LMET30.root"
+      },
+      {
+        "checksum": "adler32:9d0d0eec",
+        "size": 524446,
+        "uri": "root://eospublic.cern.ch//eos/opendata/atlas/rucio/opendata/ODEO_FEB2025_v0_3J1LMET30_mc_600572.PhH7EG_VBFH125_tautaulm15hp20_ShowerSys_fix.3J1LMET30.root"
+      },
+      {
+        "checksum": "adler32:82b3bf32",
+        "size": 561611,
+        "uri": "root://eospublic.cern.ch//eos/opendata/atlas/rucio/opendata/ODEO_FEB2025_v0_3J1LMET30_mc_600573.PhH7EG_WmH125J_Winc_MINLO_tt_ShowerSys_fix.3J1LMET30.root"
+      },
+      {
+        "checksum": "adler32:0de23738",
+        "size": 883473,
+        "uri": "root://eospublic.cern.ch//eos/opendata/atlas/rucio/opendata/ODEO_FEB2025_v0_3J1LMET30_mc_600574.PhH7EG_WpH125J_Winc_MINLO_tt_ShowerSys_fix.3J1LMET30.root"
+      },
+      {
+        "checksum": "adler32:7c176a91",
+        "size": 988994,
+        "uri": "root://eospublic.cern.ch//eos/opendata/atlas/rucio/opendata/ODEO_FEB2025_v0_3J1LMET30_mc_600575.PhH7EG_ZH125J_Zinc_MINLO_tautau_ShowerSys_fix.3J1LMET30.root"
+      },
+      {
+        "checksum": "adler32:d2d6a415",
+        "size": 894509,
+        "uri": "root://eospublic.cern.ch//eos/opendata/atlas/rucio/opendata/ODEO_FEB2025_v0_3J1LMET30_mc_600686.PhPy8EG_NNPDF3_AZNLO_ggZH125_Htautau_Zinc.3J1LMET30.root"
+      },
+      {
+        "checksum": "adler32:a783bfdd",
+        "size": 81727983,
+        "uri": "root://eospublic.cern.ch//eos/opendata/atlas/rucio/opendata/ODEO_FEB2025_v0_3J1LMET30_mc_601352.PhPy8EG_tW_dyn_DR_incl_antitop.3J1LMET30.root"
+      },
+      {
+        "checksum": "adler32:0325dfef",
+        "size": 79774584,
+        "uri": "root://eospublic.cern.ch//eos/opendata/atlas/rucio/opendata/ODEO_FEB2025_v0_3J1LMET30_mc_601355.PhPy8EG_tW_dyn_DR_incl_top.3J1LMET30.root"
+      },
+      {
+        "checksum": "adler32:31e4fc82",
+        "size": 22748052,
+        "uri": "root://eospublic.cern.ch//eos/opendata/atlas/rucio/opendata/ODEO_FEB2025_v0_3J1LMET30_mc_601487.PhPy8EG_A14_tchan_pThard1_lep_antitop.3J1LMET30.root"
+      },
+      {
+        "checksum": "adler32:b69947fa",
+        "size": 37200445,
+        "uri": "root://eospublic.cern.ch//eos/opendata/atlas/rucio/opendata/ODEO_FEB2025_v0_3J1LMET30_mc_601489.PhPy8EG_A14_tchan_pThard1_lep_top.3J1LMET30.root"
+      },
+      {
+        "checksum": "adler32:9a17f5dc",
+        "size": 447197794,
+        "uri": "root://eospublic.cern.ch//eos/opendata/atlas/rucio/opendata/ODEO_FEB2025_v0_3J1LMET30_mc_601491.PhPy8EG_A14_ttbar_pThard1_dil.3J1LMET30.root"
+      },
+      {
+        "checksum": "adler32:83e9f72e",
+        "size": 698151,
+        "uri": "root://eospublic.cern.ch//eos/opendata/atlas/rucio/opendata/ODEO_FEB2025_v0_3J1LMET30_mc_601495.PhPy8EG_A14_ttbar_pThard1_allhad.3J1LMET30.root"
+      },
+      {
+        "checksum": "adler32:5fc19c42",
+        "size": 2496867267,
+        "uri": "root://eospublic.cern.ch//eos/opendata/atlas/rucio/opendata/ODEO_FEB2025_v0_3J1LMET30_mc_601497.PhPy8EG_A14_ttbar_pThard1_singlelep.3J1LMET30.root"
+      },
+      {
+        "checksum": "adler32:6b6eb238",
+        "size": 8692391,
+        "uri": "root://eospublic.cern.ch//eos/opendata/atlas/rucio/opendata/ODEO_FEB2025_v0_3J1LMET30_mc_601624.PhPy8EG_tW_DS_dyn_dil_antitop.3J1LMET30.root"
+      },
+      {
+        "checksum": "adler32:821ad740",
+        "size": 75051801,
+        "uri": "root://eospublic.cern.ch//eos/opendata/atlas/rucio/opendata/ODEO_FEB2025_v0_3J1LMET30_mc_601627.PhPy8EG_tW_DS_dyn_incl_antitop.3J1LMET30.root"
+      },
+      {
+        "checksum": "adler32:f90a6391",
+        "size": 10915106,
+        "uri": "root://eospublic.cern.ch//eos/opendata/atlas/rucio/opendata/ODEO_FEB2025_v0_3J1LMET30_mc_601628.PhPy8EG_tW_DS_dyn_dil_top.3J1LMET30.root"
+      },
+      {
+        "checksum": "adler32:1bbcb267",
+        "size": 73051989,
+        "uri": "root://eospublic.cern.ch//eos/opendata/atlas/rucio/opendata/ODEO_FEB2025_v0_3J1LMET30_mc_601631.PhPy8EG_tW_DS_dyn_incl_top.3J1LMET30.root"
+      },
+      {
+        "checksum": "adler32:22adee1d",
+        "size": 82431040,
+        "uri": "root://eospublic.cern.ch//eos/opendata/atlas/rucio/opendata/ODEO_FEB2025_v0_3J1LMET30_mc_601761.PhPy8EG_tW_dyn_DR_pThard1_incl_top.3J1LMET30.root"
+      },
+      {
+        "checksum": "adler32:5b50847b",
+        "size": 81324978,
+        "uri": "root://eospublic.cern.ch//eos/opendata/atlas/rucio/opendata/ODEO_FEB2025_v0_3J1LMET30_mc_601762.PhPy8EG_tW_dyn_DR_pThard1_incl_antitop.3J1LMET30.root"
+      },
+      {
+        "checksum": "adler32:363bf066",
+        "size": 12523120,
+        "uri": "root://eospublic.cern.ch//eos/opendata/atlas/rucio/opendata/ODEO_FEB2025_v0_3J1LMET30_mc_601763.PhPy8EG_tW_dyn_DR_pThard1_dil_top.3J1LMET30.root"
+      },
+      {
+        "checksum": "adler32:f6c858cd",
+        "size": 12712090,
+        "uri": "root://eospublic.cern.ch//eos/opendata/atlas/rucio/opendata/ODEO_FEB2025_v0_3J1LMET30_mc_601764.PhPy8EG_tW_dyn_DR_pThard1_dil_antitop.3J1LMET30.root"
+      },
+      {
+        "checksum": "adler32:5ef96548",
+        "size": 19369809,
+        "uri": "root://eospublic.cern.ch//eos/opendata/atlas/rucio/opendata/ODEO_FEB2025_v0_3J1LMET30_mc_700000.Sh_228_ttW.3J1LMET30.root"
+      },
+      {
+        "checksum": "adler32:77c6768c",
+        "size": 42977,
+        "uri": "root://eospublic.cern.ch//eos/opendata/atlas/rucio/opendata/ODEO_FEB2025_v0_3J1LMET30_mc_700007.Sh_228_yyy_01NLO.3J1LMET30.root"
+      },
+      {
+        "checksum": "adler32:e3b9ee14",
+        "size": 639137,
+        "uri": "root://eospublic.cern.ch//eos/opendata/atlas/rucio/opendata/ODEO_FEB2025_v0_3J1LMET30_mc_700195.Sh_2210_eegammagamma.3J1LMET30.root"
+      },
+      {
+        "checksum": "adler32:bdef4883",
+        "size": 1446505,
+        "uri": "root://eospublic.cern.ch//eos/opendata/atlas/rucio/opendata/ODEO_FEB2025_v0_3J1LMET30_mc_700196.Sh_2210_mumugammagamma.3J1LMET30.root"
+      },
+      {
+        "checksum": "adler32:7d8490ac",
+        "size": 194864,
+        "uri": "root://eospublic.cern.ch//eos/opendata/atlas/rucio/opendata/ODEO_FEB2025_v0_3J1LMET30_mc_700197.Sh_2210_tautaugammagamma.3J1LMET30.root"
+      },
+      {
+        "checksum": "adler32:c89e92e6",
+        "size": 33021,
+        "uri": "root://eospublic.cern.ch//eos/opendata/atlas/rucio/opendata/ODEO_FEB2025_v0_3J1LMET30_mc_700198.Sh_2210_nunugammagamma.3J1LMET30.root"
+      },
+      {
+        "checksum": "adler32:110b1a9a",
+        "size": 827487,
+        "uri": "root://eospublic.cern.ch//eos/opendata/atlas/rucio/opendata/ODEO_FEB2025_v0_3J1LMET30_mc_700199.Sh_2210_enugammagamma.3J1LMET30.root"
+      },
+      {
+        "checksum": "adler32:90c5d15f",
+        "size": 865033,
+        "uri": "root://eospublic.cern.ch//eos/opendata/atlas/rucio/opendata/ODEO_FEB2025_v0_3J1LMET30_mc_700200.Sh_2210_munugammagamma.3J1LMET30.root"
+      },
+      {
+        "checksum": "adler32:0ee8ea00",
+        "size": 224329,
+        "uri": "root://eospublic.cern.ch//eos/opendata/atlas/rucio/opendata/ODEO_FEB2025_v0_3J1LMET30_mc_700201.Sh_2210_taunugammagamma.3J1LMET30.root"
+      },
+      {
+        "checksum": "adler32:9ee497e1",
+        "size": 199290642,
+        "uri": "root://eospublic.cern.ch//eos/opendata/atlas/rucio/opendata/ODEO_FEB2025_v0_3J1LMET30_mc_700320.Sh_2211_Zee_maxHTpTV2_BFilter.3J1LMET30.root"
+      },
+      {
+        "checksum": "adler32:4c504358",
+        "size": 750578160,
+        "uri": "root://eospublic.cern.ch//eos/opendata/atlas/rucio/opendata/ODEO_FEB2025_v0_3J1LMET30_mc_700321.Sh_2211_Zee_maxHTpTV2_CFilterBVeto.3J1LMET30.root"
+      },
+      {
+        "checksum": "adler32:2cf976e0",
+        "size": 1607458440,
+        "uri": "root://eospublic.cern.ch//eos/opendata/atlas/rucio/opendata/ODEO_FEB2025_v0_3J1LMET30_mc_700322.Sh_2211_Zee_maxHTpTV2_CVetoBVeto.3J1LMET30.root"
+      },
+      {
+        "checksum": "adler32:bd5b9107",
+        "size": 277681107,
+        "uri": "root://eospublic.cern.ch//eos/opendata/atlas/rucio/opendata/ODEO_FEB2025_v0_3J1LMET30_mc_700323.Sh_2211_Zmumu_maxHTpTV2_BFilter.3J1LMET30.root"
+      },
+      {
+        "checksum": "adler32:b38400a6",
+        "size": 1151038551,
+        "uri": "root://eospublic.cern.ch//eos/opendata/atlas/rucio/opendata/ODEO_FEB2025_v0_3J1LMET30_mc_700324.Sh_2211_Zmumu_maxHTpTV2_CFilterBVeto.3J1LMET30.root"
+      },
+      {
+        "checksum": "adler32:80edd568",
+        "size": 2615310871,
+        "uri": "root://eospublic.cern.ch//eos/opendata/atlas/rucio/opendata/ODEO_FEB2025_v0_3J1LMET30_mc_700325.Sh_2211_Zmumu_maxHTpTV2_CVetoBVeto.3J1LMET30.root"
+      },
+      {
+        "checksum": "adler32:8e7768b8",
+        "size": 1702837,
+        "uri": "root://eospublic.cern.ch//eos/opendata/atlas/rucio/opendata/ODEO_FEB2025_v0_3J1LMET30_mc_700335.Sh_2211_Znunu_pTV2_BFilter.3J1LMET30.root"
+      },
+      {
+        "checksum": "adler32:70ce7162",
+        "size": 1936895,
+        "uri": "root://eospublic.cern.ch//eos/opendata/atlas/rucio/opendata/ODEO_FEB2025_v0_3J1LMET30_mc_700336.Sh_2211_Znunu_pTV2_CFilterBVeto.3J1LMET30.root"
+      },
+      {
+        "checksum": "adler32:b6f826a3",
+        "size": 3985796,
+        "uri": "root://eospublic.cern.ch//eos/opendata/atlas/rucio/opendata/ODEO_FEB2025_v0_3J1LMET30_mc_700337.Sh_2211_Znunu_pTV2_CVetoBVeto.3J1LMET30.root"
+      },
+      {
+        "checksum": "adler32:e8b8437f",
+        "size": 871570899,
+        "uri": "root://eospublic.cern.ch//eos/opendata/atlas/rucio/opendata/ODEO_FEB2025_v0_3J1LMET30_mc_700338.Sh_2211_Wenu_maxHTpTV2_BFilter.3J1LMET30.root"
+      },
+      {
+        "checksum": "adler32:32e1b09c",
+        "size": 4515448077,
+        "uri": "root://eospublic.cern.ch//eos/opendata/atlas/rucio/opendata/ODEO_FEB2025_v0_3J1LMET30_mc_700339.Sh_2211_Wenu_maxHTpTV2_CFilterBVeto.3J1LMET30.root"
+      },
+      {
+        "checksum": "adler32:29abc1b7",
+        "size": 3324318375,
+        "uri": "root://eospublic.cern.ch//eos/opendata/atlas/rucio/opendata/ODEO_FEB2025_v0_3J1LMET30_mc_700340.Sh_2211_Wenu_maxHTpTV2_CVetoBVeto.3J1LMET30.root"
+      },
+      {
+        "checksum": "adler32:7f5bf87c",
+        "size": 1098250940,
+        "uri": "root://eospublic.cern.ch//eos/opendata/atlas/rucio/opendata/ODEO_FEB2025_v0_3J1LMET30_mc_700341.Sh_2211_Wmunu_maxHTpTV2_BFilter.3J1LMET30.root"
+      },
+      {
+        "checksum": "adler32:49800297",
+        "size": 5134378684,
+        "uri": "root://eospublic.cern.ch//eos/opendata/atlas/rucio/opendata/ODEO_FEB2025_v0_3J1LMET30_mc_700342.Sh_2211_Wmunu_maxHTpTV2_CFilterBVeto.3J1LMET30.root"
+      },
+      {
+        "checksum": "adler32:91ffb3a2",
+        "size": 3684621508,
+        "uri": "root://eospublic.cern.ch//eos/opendata/atlas/rucio/opendata/ODEO_FEB2025_v0_3J1LMET30_mc_700343.Sh_2211_Wmunu_maxHTpTV2_CVetoBVeto.3J1LMET30.root"
+      },
+      {
+        "checksum": "adler32:a3d97108",
+        "size": 189225873,
+        "uri": "root://eospublic.cern.ch//eos/opendata/atlas/rucio/opendata/ODEO_FEB2025_v0_3J1LMET30_mc_700344.Sh_2211_Wtaunu_L_maxHTpTV2_BFilter.3J1LMET30.root"
+      },
+      {
+        "checksum": "adler32:d3672d37",
+        "size": 527150113,
+        "uri": "root://eospublic.cern.ch//eos/opendata/atlas/rucio/opendata/ODEO_FEB2025_v0_3J1LMET30_mc_700345.Sh_2211_Wtaunu_L_maxHTpTV2_CFilterBVeto.3J1LMET30.root"
+      },
+      {
+        "checksum": "adler32:217b3600",
+        "size": 684769441,
+        "uri": "root://eospublic.cern.ch//eos/opendata/atlas/rucio/opendata/ODEO_FEB2025_v0_3J1LMET30_mc_700346.Sh_2211_Wtaunu_L_maxHTpTV2_CVetoBVeto.3J1LMET30.root"
+      },
+      {
+        "checksum": "adler32:e99b7d0a",
+        "size": 16371754,
+        "uri": "root://eospublic.cern.ch//eos/opendata/atlas/rucio/opendata/ODEO_FEB2025_v0_3J1LMET30_mc_700347.Sh_2211_Wtaunu_H_maxHTpTV2_BFilter.3J1LMET30.root"
+      },
+      {
+        "checksum": "adler32:d88e6aec",
+        "size": 6791013,
+        "uri": "root://eospublic.cern.ch//eos/opendata/atlas/rucio/opendata/ODEO_FEB2025_v0_3J1LMET30_mc_700348.Sh_2211_Wtaunu_H_maxHTpTV2_CFilterBVeto.3J1LMET30.root"
+      },
+      {
+        "checksum": "adler32:c208f85c",
+        "size": 26092489,
+        "uri": "root://eospublic.cern.ch//eos/opendata/atlas/rucio/opendata/ODEO_FEB2025_v0_3J1LMET30_mc_700349.Sh_2211_Wtaunu_H_maxHTpTV2_CVetoBVeto.3J1LMET30.root"
+      },
+      {
+        "checksum": "adler32:b85ecf4d",
+        "size": 298177,
+        "uri": "root://eospublic.cern.ch//eos/opendata/atlas/rucio/opendata/ODEO_FEB2025_v0_3J1LMET30_mc_700352.Sh_2211_pTZ100_Zqqgamma.3J1LMET30.root"
+      },
+      {
+        "checksum": "adler32:b25f356d",
+        "size": 211317,
+        "uri": "root://eospublic.cern.ch//eos/opendata/atlas/rucio/opendata/ODEO_FEB2025_v0_3J1LMET30_mc_700353.Sh_2211_pTZ100_Zbbgamma.3J1LMET30.root"
+      },
+      {
+        "checksum": "adler32:d9ab6510",
+        "size": 1400786,
+        "uri": "root://eospublic.cern.ch//eos/opendata/atlas/rucio/opendata/ODEO_FEB2025_v0_3J1LMET30_mc_700358.Sh_2211_Zee2jets_Min_N_TChannel.3J1LMET30.root"
+      },
+      {
+        "checksum": "adler32:14fb7319",
+        "size": 2121140,
+        "uri": "root://eospublic.cern.ch//eos/opendata/atlas/rucio/opendata/ODEO_FEB2025_v0_3J1LMET30_mc_700359.Sh_2211_Zmm2jets_Min_N_TChannel.3J1LMET30.root"
+      },
+      {
+        "checksum": "adler32:a9cafb3e",
+        "size": 804703,
+        "uri": "root://eospublic.cern.ch//eos/opendata/atlas/rucio/opendata/ODEO_FEB2025_v0_3J1LMET30_mc_700360.Sh_2211_Ztt2jets_Min_N_TChannel.3J1LMET30.root"
+      },
+      {
+        "checksum": "adler32:a4fb5dad",
+        "size": 64693,
+        "uri": "root://eospublic.cern.ch//eos/opendata/atlas/rucio/opendata/ODEO_FEB2025_v0_3J1LMET30_mc_700361.Sh_2211_Znunu2jets_Min_N_TChannel.3J1LMET30.root"
+      },
+      {
+        "checksum": "adler32:209c2b10",
+        "size": 6988497,
+        "uri": "root://eospublic.cern.ch//eos/opendata/atlas/rucio/opendata/ODEO_FEB2025_v0_3J1LMET30_mc_700362.Sh_2211_Wenu2jets_Min_N_TChannel.3J1LMET30.root"
+      },
+      {
+        "checksum": "adler32:020e60d5",
+        "size": 9886481,
+        "uri": "root://eospublic.cern.ch//eos/opendata/atlas/rucio/opendata/ODEO_FEB2025_v0_3J1LMET30_mc_700363.Sh_2211_Wmunu2jets_Min_N_TChannel.3J1LMET30.root"
+      },
+      {
+        "checksum": "adler32:d436be6b",
+        "size": 1555693,
+        "uri": "root://eospublic.cern.ch//eos/opendata/atlas/rucio/opendata/ODEO_FEB2025_v0_3J1LMET30_mc_700364.Sh_2211_Wtaunu2jets_Min_N_TChannel.3J1LMET30.root"
+      },
+      {
+        "checksum": "adler32:f6d5dcdd",
+        "size": 131880828,
+        "uri": "root://eospublic.cern.ch//eos/opendata/atlas/rucio/opendata/ODEO_FEB2025_v0_3J1LMET30_mc_700398.Sh_2211_mumugamma.3J1LMET30.root"
+      },
+      {
+        "checksum": "adler32:c66ab35c",
+        "size": 84426557,
+        "uri": "root://eospublic.cern.ch//eos/opendata/atlas/rucio/opendata/ODEO_FEB2025_v0_3J1LMET30_mc_700399.Sh_2211_eegamma.3J1LMET30.root"
+      },
+      {
+        "checksum": "adler32:07442e8f",
+        "size": 46363457,
+        "uri": "root://eospublic.cern.ch//eos/opendata/atlas/rucio/opendata/ODEO_FEB2025_v0_3J1LMET30_mc_700400.Sh_2211_tautaugamma.3J1LMET30.root"
+      },
+      {
+        "checksum": "adler32:84b940e6",
+        "size": 1496202,
+        "uri": "root://eospublic.cern.ch//eos/opendata/atlas/rucio/opendata/ODEO_FEB2025_v0_3J1LMET30_mc_700401.Sh_2211_nunugamma.3J1LMET30.root"
+      },
+      {
+        "checksum": "adler32:8731dfa3",
+        "size": 441655563,
+        "uri": "root://eospublic.cern.ch//eos/opendata/atlas/rucio/opendata/ODEO_FEB2025_v0_3J1LMET30_mc_700402.Sh_2211_munugamma.3J1LMET30.root"
+      },
+      {
+        "checksum": "adler32:39f887f7",
+        "size": 400695394,
+        "uri": "root://eospublic.cern.ch//eos/opendata/atlas/rucio/opendata/ODEO_FEB2025_v0_3J1LMET30_mc_700403.Sh_2211_enugamma.3J1LMET30.root"
+      },
+      {
+        "checksum": "adler32:05269510",
+        "size": 103274179,
+        "uri": "root://eospublic.cern.ch//eos/opendata/atlas/rucio/opendata/ODEO_FEB2025_v0_3J1LMET30_mc_700404.Sh_2211_taunugamma.3J1LMET30.root"
+      },
+      {
+        "checksum": "adler32:ab3ff7de",
+        "size": 59813,
+        "uri": "root://eospublic.cern.ch//eos/opendata/atlas/rucio/opendata/ODEO_FEB2025_v0_3J1LMET30_mc_700442.Sh_2211_gamma2jets_pTy140_Min_N_TChannel.3J1LMET30.root"
+      },
+      {
+        "checksum": "adler32:c4db4e37",
+        "size": 18474850,
+        "uri": "root://eospublic.cern.ch//eos/opendata/atlas/rucio/opendata/ODEO_FEB2025_v0_3J1LMET30_mc_700467.Sh_2211_Zee_maxHTpTV2_m10_40_pT5_BFilter.3J1LMET30.root"
+      },
+      {
+        "checksum": "adler32:e69b01d8",
+        "size": 61132293,
+        "uri": "root://eospublic.cern.ch//eos/opendata/atlas/rucio/opendata/ODEO_FEB2025_v0_3J1LMET30_mc_700468.Sh_2211_Zee_maxHTpTV2_m10_40_pT5_CFilterBVeto.3J1LMET30.root"
+      },
+      {
+        "checksum": "adler32:1b6ba78c",
+        "size": 249333411,
+        "uri": "root://eospublic.cern.ch//eos/opendata/atlas/rucio/opendata/ODEO_FEB2025_v0_3J1LMET30_mc_700469.Sh_2211_Zee_maxHTpTV2_m10_40_pT5_CVetoBVeto.3J1LMET30.root"
+      },
+      {
+        "checksum": "adler32:e5ee387a",
+        "size": 25400169,
+        "uri": "root://eospublic.cern.ch//eos/opendata/atlas/rucio/opendata/ODEO_FEB2025_v0_3J1LMET30_mc_700470.Sh_2211_Zmumu_maxHTpTV2_m10_40_pT5_BFilter.3J1LMET30.root"
+      },
+      {
+        "checksum": "adler32:2a514928",
+        "size": 80655971,
+        "uri": "root://eospublic.cern.ch//eos/opendata/atlas/rucio/opendata/ODEO_FEB2025_v0_3J1LMET30_mc_700471.Sh_2211_Zmumu_maxHTpTV2_m10_40_pT5_CFilterBVeto.3J1LMET30.root"
+      },
+      {
+        "checksum": "adler32:293802d8",
+        "size": 335813911,
+        "uri": "root://eospublic.cern.ch//eos/opendata/atlas/rucio/opendata/ODEO_FEB2025_v0_3J1LMET30_mc_700472.Sh_2211_Zmumu_maxHTpTV2_m10_40_pT5_CVetoBVeto.3J1LMET30.root"
+      },
+      {
+        "checksum": "adler32:e979d1ff",
+        "size": 77879988,
+        "uri": "root://eospublic.cern.ch//eos/opendata/atlas/rucio/opendata/ODEO_FEB2025_v0_3J1LMET30_mc_700488.Sh_2211_WlvWqq.3J1LMET30.root"
+      },
+      {
+        "checksum": "adler32:52d87cff",
+        "size": 20920796,
+        "uri": "root://eospublic.cern.ch//eos/opendata/atlas/rucio/opendata/ODEO_FEB2025_v0_3J1LMET30_mc_700489.Sh_2211_WlvZqq.3J1LMET30.root"
+      },
+      {
+        "checksum": "adler32:712e2af4",
+        "size": 6324292,
+        "uri": "root://eospublic.cern.ch//eos/opendata/atlas/rucio/opendata/ODEO_FEB2025_v0_3J1LMET30_mc_700490.Sh_2211_WlvZbb.3J1LMET30.root"
+      },
+      {
+        "checksum": "adler32:e31ac5a3",
+        "size": 229712,
+        "uri": "root://eospublic.cern.ch//eos/opendata/atlas/rucio/opendata/ODEO_FEB2025_v0_3J1LMET30_mc_700491.Sh_2211_WqqZvv.3J1LMET30.root"
+      },
+      {
+        "checksum": "adler32:47b703e5",
+        "size": 8084912,
+        "uri": "root://eospublic.cern.ch//eos/opendata/atlas/rucio/opendata/ODEO_FEB2025_v0_3J1LMET30_mc_700492.Sh_2211_WqqZll.3J1LMET30.root"
+      },
+      {
+        "checksum": "adler32:aec3da2b",
+        "size": 4604192,
+        "uri": "root://eospublic.cern.ch//eos/opendata/atlas/rucio/opendata/ODEO_FEB2025_v0_3J1LMET30_mc_700493.Sh_2211_ZqqZll.3J1LMET30.root"
+      },
+      {
+        "checksum": "adler32:c1188cc6",
+        "size": 4158497,
+        "uri": "root://eospublic.cern.ch//eos/opendata/atlas/rucio/opendata/ODEO_FEB2025_v0_3J1LMET30_mc_700494.Sh_2211_ZbbZll.3J1LMET30.root"
+      },
+      {
+        "checksum": "adler32:35b7c07a",
+        "size": 107532,
+        "uri": "root://eospublic.cern.ch//eos/opendata/atlas/rucio/opendata/ODEO_FEB2025_v0_3J1LMET30_mc_700495.Sh_2211_ZqqZvv.3J1LMET30.root"
+      },
+      {
+        "checksum": "adler32:0fda00de",
+        "size": 89535,
+        "uri": "root://eospublic.cern.ch//eos/opendata/atlas/rucio/opendata/ODEO_FEB2025_v0_3J1LMET30_mc_700496.Sh_2211_ZbbZvv.3J1LMET30.root"
+      },
+      {
+        "checksum": "adler32:be9dbd9b",
+        "size": 133498,
+        "uri": "root://eospublic.cern.ch//eos/opendata/atlas/rucio/opendata/ODEO_FEB2025_v0_3J1LMET30_mc_700507.Sh_2211_pTW140_Wqqgamma.3J1LMET30.root"
+      },
+      {
+        "checksum": "adler32:4670b3f8",
+        "size": 1877799,
+        "uri": "root://eospublic.cern.ch//eos/opendata/atlas/rucio/opendata/ODEO_FEB2025_v0_3J1LMET30_mc_700587.Sh_2212_lllljj.3J1LMET30.root"
+      },
+      {
+        "checksum": "adler32:62e18c8c",
+        "size": 1272555,
+        "uri": "root://eospublic.cern.ch//eos/opendata/atlas/rucio/opendata/ODEO_FEB2025_v0_3J1LMET30_mc_700588.Sh_2212_lllvjj.3J1LMET30.root"
+      },
+      {
+        "checksum": "adler32:50c690b7",
+        "size": 1009683,
+        "uri": "root://eospublic.cern.ch//eos/opendata/atlas/rucio/opendata/ODEO_FEB2025_v0_3J1LMET30_mc_700589.Sh_2212_llvvjj_os.3J1LMET30.root"
+      },
+      {
+        "checksum": "adler32:fca910dc",
+        "size": 2898469,
+        "uri": "root://eospublic.cern.ch//eos/opendata/atlas/rucio/opendata/ODEO_FEB2025_v0_3J1LMET30_mc_700590.Sh_2212_llvvjj_ss.3J1LMET30.root"
+      },
+      {
+        "checksum": "adler32:e1322fea",
+        "size": 254029,
+        "uri": "root://eospublic.cern.ch//eos/opendata/atlas/rucio/opendata/ODEO_FEB2025_v0_3J1LMET30_mc_700591.Sh_2212_lllljj_Int.3J1LMET30.root"
+      },
+      {
+        "checksum": "adler32:f1496aa4",
+        "size": 543253,
+        "uri": "root://eospublic.cern.ch//eos/opendata/atlas/rucio/opendata/ODEO_FEB2025_v0_3J1LMET30_mc_700592.Sh_2212_lllvjj_Int.3J1LMET30.root"
+      },
+      {
+        "checksum": "adler32:b021482b",
+        "size": 697095,
+        "uri": "root://eospublic.cern.ch//eos/opendata/atlas/rucio/opendata/ODEO_FEB2025_v0_3J1LMET30_mc_700593.Sh_2212_llvvjj_os_Int.3J1LMET30.root"
+      },
+      {
+        "checksum": "adler32:80c28154",
+        "size": 880998,
+        "uri": "root://eospublic.cern.ch//eos/opendata/atlas/rucio/opendata/ODEO_FEB2025_v0_3J1LMET30_mc_700594.Sh_2212_llvvjj_ss_Int.3J1LMET30.root"
+      },
+      {
+        "checksum": "adler32:6f967833",
+        "size": 2823566,
+        "uri": "root://eospublic.cern.ch//eos/opendata/atlas/rucio/opendata/ODEO_FEB2025_v0_3J1LMET30_mc_700600.Sh_2212_llll.3J1LMET30.root"
+      },
+      {
+        "checksum": "adler32:ba0289ca",
+        "size": 10596027,
+        "uri": "root://eospublic.cern.ch//eos/opendata/atlas/rucio/opendata/ODEO_FEB2025_v0_3J1LMET30_mc_700601.Sh_2212_lllv.3J1LMET30.root"
+      },
+      {
+        "checksum": "adler32:c52a0d98",
+        "size": 20788096,
+        "uri": "root://eospublic.cern.ch//eos/opendata/atlas/rucio/opendata/ODEO_FEB2025_v0_3J1LMET30_mc_700602.Sh_2212_llvv_os.3J1LMET30.root"
+      },
+      {
+        "checksum": "adler32:8a04069e",
+        "size": 6645946,
+        "uri": "root://eospublic.cern.ch//eos/opendata/atlas/rucio/opendata/ODEO_FEB2025_v0_3J1LMET30_mc_700603.Sh_2212_llvv_ss.3J1LMET30.root"
+      },
+      {
+        "checksum": "adler32:df1bddcd",
+        "size": 5208979,
+        "uri": "root://eospublic.cern.ch//eos/opendata/atlas/rucio/opendata/ODEO_FEB2025_v0_3J1LMET30_mc_700604.Sh_2212_lvvv.3J1LMET30.root"
+      },
+      {
+        "checksum": "adler32:7536ec21",
+        "size": 44701,
+        "uri": "root://eospublic.cern.ch//eos/opendata/atlas/rucio/opendata/ODEO_FEB2025_v0_3J1LMET30_mc_700605.Sh_2212_vvvv.3J1LMET30.root"
+      },
+      {
+        "checksum": "adler32:6ca55138",
+        "size": 2194021,
+        "uri": "root://eospublic.cern.ch//eos/opendata/atlas/rucio/opendata/ODEO_FEB2025_v0_3J1LMET30_mc_700709.Sh_2212_lvgammajj.3J1LMET30.root"
+      },
+      {
+        "checksum": "adler32:5da0ff0d",
+        "size": 3923551,
+        "uri": "root://eospublic.cern.ch//eos/opendata/atlas/rucio/opendata/ODEO_FEB2025_v0_3J1LMET30_mc_700710.Sh_2212_llgammajj.3J1LMET30.root"
+      },
+      {
+        "checksum": "adler32:c15bf02b",
+        "size": 88571267,
+        "uri": "root://eospublic.cern.ch//eos/opendata/atlas/rucio/opendata/ODEO_FEB2025_v0_3J1LMET30_mc_700792.Sh_2214_Ztautau_maxHTpTV2_BFilter.3J1LMET30.root"
+      },
+      {
+        "checksum": "adler32:5849c18e",
+        "size": 356358742,
+        "uri": "root://eospublic.cern.ch//eos/opendata/atlas/rucio/opendata/ODEO_FEB2025_v0_3J1LMET30_mc_700793.Sh_2214_Ztautau_maxHTpTV2_CFilterBVeto.3J1LMET30.root"
+      },
+      {
+        "checksum": "adler32:b40223e0",
+        "size": 490359588,
+        "uri": "root://eospublic.cern.ch//eos/opendata/atlas/rucio/opendata/ODEO_FEB2025_v0_3J1LMET30_mc_700794.Sh_2214_Ztautau_maxHTpTV2_CVetoBVeto.3J1LMET30.root"
+      },
+      {
+        "checksum": "adler32:9df71e66",
+        "size": 4495744,
+        "uri": "root://eospublic.cern.ch//eos/opendata/atlas/rucio/opendata/ODEO_FEB2025_v0_3J1LMET30_mc_700843.Sh_2214_Wqq_ptW_200_ECMS.3J1LMET30.root"
+      },
+      {
+        "checksum": "adler32:5c1cc1f7",
+        "size": 1731068,
+        "uri": "root://eospublic.cern.ch//eos/opendata/atlas/rucio/opendata/ODEO_FEB2025_v0_3J1LMET30_mc_700849.Sh_2214_Zqq_ptZ_200_ECMS.3J1LMET30.root"
+      },
+      {
+        "checksum": "adler32:68a6c463",
+        "size": 864420,
+        "uri": "root://eospublic.cern.ch//eos/opendata/atlas/rucio/opendata/ODEO_FEB2025_v0_3J1LMET30_mc_700855.Sh_2214_Zbb_ptZ_200_ECMS.3J1LMET30.root"
+      },
+      {
+        "checksum": "adler32:997d226d",
+        "size": 9980955,
+        "uri": "root://eospublic.cern.ch//eos/opendata/atlas/rucio/opendata/ODEO_FEB2025_v0_3J1LMET30_mc_700901.Sh_2214_Ztt_maxHTpTV2_Mll10_40_BFilter.3J1LMET30.root"
+      },
+      {
+        "checksum": "adler32:8f546fe9",
+        "size": 42143084,
+        "uri": "root://eospublic.cern.ch//eos/opendata/atlas/rucio/opendata/ODEO_FEB2025_v0_3J1LMET30_mc_700902.Sh_2214_Ztt_maxHTpTV2_Mll10_40_CFilterBVeto.3J1LMET30.root"
+      },
+      {
+        "checksum": "adler32:bbb0d5ab",
+        "size": 58926056,
+        "uri": "root://eospublic.cern.ch//eos/opendata/atlas/rucio/opendata/ODEO_FEB2025_v0_3J1LMET30_mc_700903.Sh_2214_Ztt_maxHTpTV2_Mll10_40_CVetoBVeto.3J1LMET30.root"
+      },
+      {
+        "checksum": "adler32:50eaeb31",
+        "size": 397920,
+        "uri": "root://eospublic.cern.ch//eos/opendata/atlas/rucio/opendata/ODEO_FEB2025_v0_3J1LMET30_mc_801976.Py8EG_A14NNPDF23LO_Zprime_NoInt_tautau_SSM3000.3J1LMET30.root"
+      },
+      {
+        "checksum": "adler32:f3db326f",
+        "size": 110980,
+        "uri": "root://eospublic.cern.ch//eos/opendata/atlas/rucio/opendata/ODEO_FEB2025_v0_3J1LMET30_mc_801978.Py8EG_A14NNPDF23LO_Wprime_taunu_SSM3000.3J1LMET30.root"
+      }
+    ],
+    "license": {
+      "attribution": "CC0-1.0"
+    },
+    "methodology": {
+      "description": "<p>These data were created during LS2 as part of a major reprocessing campaign of the Run 2 data. All data were reprocessed using Athena Release 22, and new corresponding MC simulation samples were produced. These data and MC simulation datasets were processed into ROOT ntuple files from the DAOD_PHYSLITE format that is released as open data for research. For the files in this record, the following skimming selection was applied: At least three jets with at least 20 GeV of p<sub>T</sub>, at least one lepton passing tight identification requirements with at least 7 GeV of p<sub>T</sub>, and 30 GeV of missing transverse momentum (i.e. a semi-leptonic top-quark enhanced selection)"
+    },
+    "publisher": "CERN Open Data Portal",
+    "recid": "93916",
+    "relations": [
+      {
+        "description": "For citing all the Open Data for Education and Outreach from this release, and to find other related datasets, please see",
+        "doi": "10.7483/OPENDATA.ATLAS.B5M9.44TN",
+        "recid": "93910",
+        "title": "ROOT ntuple format 2015-2016 proton-proton Open Data for Education and Outreach from the ATLAS experiment",
+        "type": "isChildOf"
+      }
+    ],
+    "run_period": [
+      "2015",
+      "2016"
+    ],
+    "title": "ATLAS ROOT ntuple format MC simulation, 2015+2016 proton-proton collisions beta release, 3J1LMET30 skim",
+    "type": {
+      "primary": "Dataset",
+      "secondary": [
+        "Simulated"
+      ]
+    },
+    "usage": {
+      "description": "<p> The data and MC simulation provided by the ATLAS experiment in root ntuple format is released under a CC0 license; citation of the data and acknowledgement of the collaboration is requested. This format can be used directly using ROOT or uproot for simple studies and is primarily intended for educational and outreach purposes. <p>Extensive instructions for interacting with the data, as well as documentation of the dataset naming conventions and their contents, are provided on the ATLAS Open Data website linked below. For those interested in implementing a research-quality data analysis, the open data designed for research (also linked below) may be a better starting point. Please be sure to cite the Open Data that you use, in line with the policy below.",
+      "links": [
+        {
+          "description": "ATLAS Open Data Website",
+          "url": "http://opendata.atlas.cern"
+        },
+        {
+          "description": "Resources to understand and use the open data for education and outreach",
+          "url": "https://opendata.atlas.cern/docs/category/13-tev-tutorials-for-education"
+        },
+        {
+          "description": "More about this ntuple format",
+          "url": "https://opendata.atlas.cern/docs/data/for_education/13TeV25_details"
+        },
+        {
+          "description": "Ntuple making framework",
+          "url": "http://gitlab.cern.ch/atlas-outreach-data-tools/physlitetoopendata"
+        },
+        {
+          "description": "Citation policy",
+          "url": "https://opendata.atlas.cern/docs/documentation/ethical_legal/citation_policy"
+        }
+      ]
+    }
+  }
+]

--- a/data/records/atlas-odeo-FEB2025-3lep-data.json
+++ b/data/records/atlas-odeo-FEB2025-3lep-data.json
@@ -154,15 +154,15 @@
         },
         {
           "description": "Resources to understand and use the open data for education and outreach",
-          "url": "https://opendata.atlas.cern/docs/category/13-tev-tutorials-for-education"
+          "url": "https://opendata.atlas.cern/docs/category/13-tev-2025-beta-release"
         },
         {
           "description": "More about this ntuple format",
-          "url": "https://opendata.atlas.cern/docs/data/for_education/13TeV25_details"
+          "url": "https://opendata.atlas.cern/docs/data/for_education/13TeV25_details#variable-list"
         },
         {
-          "description": "Ntuple making framework",
-          "url": "http://gitlab.cern.ch/atlas-outreach-data-tools/physlitetoopendata"
+          "description": "Ntuple making framework (PhysLiteToOpenData)",
+          "url": "https://doi.org/10.5281/zenodo.15791091"
         },
         {
           "description": "Citation policy",

--- a/data/records/atlas-odeo-FEB2025-3lep-data.json
+++ b/data/records/atlas-odeo-FEB2025-3lep-data.json
@@ -1,0 +1,174 @@
+[
+  {
+    "abstract": {
+      "description": "Run 2 2015+2016 proton-proton collision data beta release, 3lep skim from the ATLAS experiment"
+    },
+    "accelerator": "CERN-LHC",
+    "categories": {
+      "source": "ATLAS Collaboration"
+    },
+    "collaboration": {
+      "name": "ATLAS collaboration"
+    },
+    "collections": [
+      "ATLAS-Primary-Datasets"
+    ],
+    "collision_information": {
+      "energy": "13TeV",
+      "type": "pp"
+    },
+    "date_created": [
+      "2015",
+      "2016"
+    ],
+    "date_published": "2025",
+    "date_reprocessed": "2020",
+    "distribution": {
+      "formats": [
+        "root"
+      ],
+      "number_events": 17193618,
+      "number_files": 16,
+      "size": 5895545592
+    },
+    "doi": "10.7483/OPENDATA.ATLAS.CMHX.9D8M",
+    "experiment": [
+      "ATLAS"
+    ],
+    "files": [
+      {
+        "checksum": "adler32:579b4d60",
+        "size": 18056533,
+        "uri": "root://eospublic.cern.ch//eos/opendata/atlas/rucio/opendata/ODEO_FEB2025_v0_3lep_data15_periodD.3lep.root"
+      },
+      {
+        "checksum": "adler32:9ad95780",
+        "size": 126926532,
+        "uri": "root://eospublic.cern.ch//eos/opendata/atlas/rucio/opendata/ODEO_FEB2025_v0_3lep_data15_periodE.3lep.root"
+      },
+      {
+        "checksum": "adler32:05fb0270",
+        "size": 81172382,
+        "uri": "root://eospublic.cern.ch//eos/opendata/atlas/rucio/opendata/ODEO_FEB2025_v0_3lep_data15_periodF.3lep.root"
+      },
+      {
+        "checksum": "adler32:f14a08a5",
+        "size": 181013001,
+        "uri": "root://eospublic.cern.ch//eos/opendata/atlas/rucio/opendata/ODEO_FEB2025_v0_3lep_data15_periodG.3lep.root"
+      },
+      {
+        "checksum": "adler32:5692fa34",
+        "size": 56455952,
+        "uri": "root://eospublic.cern.ch//eos/opendata/atlas/rucio/opendata/ODEO_FEB2025_v0_3lep_data15_periodH.3lep.root"
+      },
+      {
+        "checksum": "adler32:e126b4fc",
+        "size": 318204886,
+        "uri": "root://eospublic.cern.ch//eos/opendata/atlas/rucio/opendata/ODEO_FEB2025_v0_3lep_data15_periodJ.3lep.root"
+      },
+      {
+        "checksum": "adler32:b10ce125",
+        "size": 141206798,
+        "uri": "root://eospublic.cern.ch//eos/opendata/atlas/rucio/opendata/ODEO_FEB2025_v0_3lep_data16_periodA.3lep.root"
+      },
+      {
+        "checksum": "adler32:c66880e6",
+        "size": 316239180,
+        "uri": "root://eospublic.cern.ch//eos/opendata/atlas/rucio/opendata/ODEO_FEB2025_v0_3lep_data16_periodB.3lep.root"
+      },
+      {
+        "checksum": "adler32:e83cfea3",
+        "size": 403444208,
+        "uri": "root://eospublic.cern.ch//eos/opendata/atlas/rucio/opendata/ODEO_FEB2025_v0_3lep_data16_periodC.3lep.root"
+      },
+      {
+        "checksum": "adler32:98e63118",
+        "size": 754434310,
+        "uri": "root://eospublic.cern.ch//eos/opendata/atlas/rucio/opendata/ODEO_FEB2025_v0_3lep_data16_periodD.3lep.root"
+      },
+      {
+        "checksum": "adler32:46eb2b37",
+        "size": 233763348,
+        "uri": "root://eospublic.cern.ch//eos/opendata/atlas/rucio/opendata/ODEO_FEB2025_v0_3lep_data16_periodE.3lep.root"
+      },
+      {
+        "checksum": "adler32:f7295b40",
+        "size": 498712502,
+        "uri": "root://eospublic.cern.ch//eos/opendata/atlas/rucio/opendata/ODEO_FEB2025_v0_3lep_data16_periodF.3lep.root"
+      },
+      {
+        "checksum": "adler32:3c654942",
+        "size": 566546904,
+        "uri": "root://eospublic.cern.ch//eos/opendata/atlas/rucio/opendata/ODEO_FEB2025_v0_3lep_data16_periodG.3lep.root"
+      },
+      {
+        "checksum": "adler32:782660ed",
+        "size": 864893674,
+        "uri": "root://eospublic.cern.ch//eos/opendata/atlas/rucio/opendata/ODEO_FEB2025_v0_3lep_data16_periodI.3lep.root"
+      },
+      {
+        "checksum": "adler32:b061d6b1",
+        "size": 350735839,
+        "uri": "root://eospublic.cern.ch//eos/opendata/atlas/rucio/opendata/ODEO_FEB2025_v0_3lep_data16_periodK.3lep.root"
+      },
+      {
+        "checksum": "adler32:d7aa435c",
+        "size": 983739543,
+        "uri": "root://eospublic.cern.ch//eos/opendata/atlas/rucio/opendata/ODEO_FEB2025_v0_3lep_data16_periodL.3lep.root"
+      }
+    ],
+    "license": {
+      "attribution": "CC0-1.0"
+    },
+    "methodology": {
+      "description": "<p>These data were created during LS2 as part of a major reprocessing campaign of the Run 2 data. All data were reprocessed using Athena Release 22, and new corresponding MC simulation samples were produced. These data and MC simulation datasets were processed into ROOT ntuple files from the DAOD_PHYSLITE format that is released as open data for research. For the files in this record, the following skimming selection was applied: At least three leptons with at least 7 GeV of p<sub>T</sub> each"
+    },
+    "publisher": "CERN Open Data Portal",
+    "recid": "93912",
+    "relations": [
+      {
+        "description": "For citing all the Open Data for Education and Outreach from this release, and to find other related datasets, please see",
+        "doi": "10.7483/OPENDATA.ATLAS.B5M9.44TN",
+        "recid": "93910",
+        "title": "ROOT ntuple format 2015-2016 proton-proton Open Data for Education and Outreach from the ATLAS experiment",
+        "type": "isChildOf"
+      }
+    ],
+    "run_period": [
+      "2015",
+      "2016"
+    ],
+    "title": "ATLAS ROOT ntuple format Run 2 2015+2016 proton-proton collision data beta release, 3lep skim",
+    "type": {
+      "primary": "Dataset",
+      "secondary": [
+        "Collision"
+      ]
+    },
+    "usage": {
+      "description": "<p> The data and MC simulation provided by the ATLAS experiment in root ntuple format is released under a CC0 license; citation of the data and acknowledgement of the collaboration is requested. This format can be used directly using ROOT or uproot for simple studies and is primarily intended for educational and outreach purposes. <p>Extensive instructions for interacting with the data, as well as documentation of the dataset naming conventions and their contents, are provided on the ATLAS Open Data website linked below. For those interested in implementing a research-quality data analysis, the open data designed for research (also linked below) may be a better starting point. Please be sure to cite the Open Data that you use, in line with the policy below.",
+      "links": [
+        {
+          "description": "ATLAS Open Data Website",
+          "url": "http://opendata.atlas.cern"
+        },
+        {
+          "description": "Resources to understand and use the open data for education and outreach",
+          "url": "https://opendata.atlas.cern/docs/category/13-tev-tutorials-for-education"
+        },
+        {
+          "description": "More about this ntuple format",
+          "url": "https://opendata.atlas.cern/docs/data/for_education/13TeV25_details"
+        },
+        {
+          "description": "Ntuple making framework",
+          "url": "http://gitlab.cern.ch/atlas-outreach-data-tools/physlitetoopendata"
+        },
+        {
+          "description": "Citation policy",
+          "url": "https://opendata.atlas.cern/docs/documentation/ethical_legal/citation_policy"
+        }
+      ]
+    }
+  }
+]

--- a/data/records/atlas-odeo-FEB2025-3lep-mc.json
+++ b/data/records/atlas-odeo-FEB2025-3lep-mc.json
@@ -1,0 +1,1959 @@
+[
+  {
+    "abstract": {
+      "description": "MC simulation, 2015+2016 proton-proton collisions beta release, 3lep skim from the ATLAS experiment"
+    },
+    "accelerator": "CERN-LHC",
+    "categories": {
+      "source": "ATLAS Collaboration"
+    },
+    "collaboration": {
+      "name": "ATLAS collaboration"
+    },
+    "collections": [
+      "ATLAS-Primary-Datasets"
+    ],
+    "collision_information": {
+      "energy": "13TeV",
+      "type": "pp"
+    },
+    "date_created": [
+      "2015",
+      "2016"
+    ],
+    "date_published": "2025",
+    "date_reprocessed": "2020",
+    "distribution": {
+      "formats": [
+        "root"
+      ],
+      "number_events": 8310255,
+      "number_files": 373,
+      "size": 4392947574
+    },
+    "doi": "10.7483/OPENDATA.ATLAS.211Z.76E7",
+    "experiment": [
+      "ATLAS"
+    ],
+    "files": [
+      {
+        "checksum": "adler32:918b5d12",
+        "size": 173688,
+        "uri": "root://eospublic.cern.ch//eos/opendata/atlas/rucio/opendata/ODEO_FEB2025_v0_3lep_mc_301204.Pythia8EvtGen_A14MSTW2008LO_Zprime_NoInt_ee_SSM3000.3lep.root"
+      },
+      {
+        "checksum": "adler32:f9dc90c4",
+        "size": 221431,
+        "uri": "root://eospublic.cern.ch//eos/opendata/atlas/rucio/opendata/ODEO_FEB2025_v0_3lep_mc_301209.Pythia8EvtGen_A14MSTW2008LO_Zprime_NoInt_mumu_SSM3000.3lep.root"
+      },
+      {
+        "checksum": "adler32:9d02284d",
+        "size": 28535,
+        "uri": "root://eospublic.cern.ch//eos/opendata/atlas/rucio/opendata/ODEO_FEB2025_v0_3lep_mc_301243.Pythia8EvtGen_A14NNPDF23LO_Wprime_enu_SSM3000.3lep.root"
+      },
+      {
+        "checksum": "adler32:21865dc4",
+        "size": 39196,
+        "uri": "root://eospublic.cern.ch//eos/opendata/atlas/rucio/opendata/ODEO_FEB2025_v0_3lep_mc_301247.Pythia8EvtGen_A14NNPDF23LO_Wprime_munu_SSM3000.3lep.root"
+      },
+      {
+        "checksum": "adler32:a1e4ef34",
+        "size": 325708,
+        "uri": "root://eospublic.cern.ch//eos/opendata/atlas/rucio/opendata/ODEO_FEB2025_v0_3lep_mc_301333.Pythia8EvtGen_A14NNPDF23LO_zprime3000_tt.3lep.root"
+      },
+      {
+        "checksum": "adler32:40dd2d1f",
+        "size": 64225,
+        "uri": "root://eospublic.cern.ch//eos/opendata/atlas/rucio/opendata/ODEO_FEB2025_v0_3lep_mc_301826.Pythia8EvtGen_A14NNPDF23LO_Wprime_qq_3000.3lep.root"
+      },
+      {
+        "checksum": "adler32:608aac51",
+        "size": 65275,
+        "uri": "root://eospublic.cern.ch//eos/opendata/atlas/rucio/opendata/ODEO_FEB2025_v0_3lep_mc_301928.Pythia8EvtGen_A14NNPDF23LO_Zprimebb3000.3lep.root"
+      },
+      {
+        "checksum": "adler32:6c05c08d",
+        "size": 896788,
+        "uri": "root://eospublic.cern.ch//eos/opendata/atlas/rucio/opendata/ODEO_FEB2025_v0_3lep_mc_302520.Pythia8EvtGen_A14NNPDF23LO_2DP20_Mass_55_100.3lep.root"
+      },
+      {
+        "checksum": "adler32:6de28983",
+        "size": 192138,
+        "uri": "root://eospublic.cern.ch//eos/opendata/atlas/rucio/opendata/ODEO_FEB2025_v0_3lep_mc_302521.Pythia8EvtGen_A14NNPDF23LO_2DP20_Mass_100_160.3lep.root"
+      },
+      {
+        "checksum": "adler32:7b8d67f3",
+        "size": 66644,
+        "uri": "root://eospublic.cern.ch//eos/opendata/atlas/rucio/opendata/ODEO_FEB2025_v0_3lep_mc_302522.Pythia8EvtGen_A14NNPDF23LO_2DP20_Mass_160_250.3lep.root"
+      },
+      {
+        "checksum": "adler32:a2ac15c6",
+        "size": 29506,
+        "uri": "root://eospublic.cern.ch//eos/opendata/atlas/rucio/opendata/ODEO_FEB2025_v0_3lep_mc_302523.Pythia8EvtGen_A14NNPDF23LO_2DP20_Mass_250_400.3lep.root"
+      },
+      {
+        "checksum": "adler32:cad88b81",
+        "size": 45664,
+        "uri": "root://eospublic.cern.ch//eos/opendata/atlas/rucio/opendata/ODEO_FEB2025_v0_3lep_mc_302524.Pythia8EvtGen_A14NNPDF23LO_2DP20_Mass_400_650.3lep.root"
+      },
+      {
+        "checksum": "adler32:4279ecdc",
+        "size": 29979,
+        "uri": "root://eospublic.cern.ch//eos/opendata/atlas/rucio/opendata/ODEO_FEB2025_v0_3lep_mc_302525.Pythia8EvtGen_A14NNPDF23LO_2DP20_Mass_650_1000.3lep.root"
+      },
+      {
+        "checksum": "adler32:3fb01343",
+        "size": 49574,
+        "uri": "root://eospublic.cern.ch//eos/opendata/atlas/rucio/opendata/ODEO_FEB2025_v0_3lep_mc_302526.Pythia8EvtGen_A14NNPDF23LO_2DP20_Mass_1000_1500.3lep.root"
+      },
+      {
+        "checksum": "adler32:a72b684a",
+        "size": 52600,
+        "uri": "root://eospublic.cern.ch//eos/opendata/atlas/rucio/opendata/ODEO_FEB2025_v0_3lep_mc_302527.Pythia8EvtGen_A14NNPDF23LO_2DP20_Mass_1500_2000.3lep.root"
+      },
+      {
+        "checksum": "adler32:0349f237",
+        "size": 67646,
+        "uri": "root://eospublic.cern.ch//eos/opendata/atlas/rucio/opendata/ODEO_FEB2025_v0_3lep_mc_302528.Pythia8EvtGen_A14NNPDF23LO_2DP20_Mass_2000_2500.3lep.root"
+      },
+      {
+        "checksum": "adler32:7a923128",
+        "size": 53114,
+        "uri": "root://eospublic.cern.ch//eos/opendata/atlas/rucio/opendata/ODEO_FEB2025_v0_3lep_mc_302529.Pythia8EvtGen_A14NNPDF23LO_2DP20_Mass_2500_3000.3lep.root"
+      },
+      {
+        "checksum": "adler32:c00a3c58",
+        "size": 76971,
+        "uri": "root://eospublic.cern.ch//eos/opendata/atlas/rucio/opendata/ODEO_FEB2025_v0_3lep_mc_302530.Pythia8EvtGen_A14NNPDF23LO_2DP20_Mass_3000_3500.3lep.root"
+      },
+      {
+        "checksum": "adler32:6e82e91b",
+        "size": 50927,
+        "uri": "root://eospublic.cern.ch//eos/opendata/atlas/rucio/opendata/ODEO_FEB2025_v0_3lep_mc_302531.Pythia8EvtGen_A14NNPDF23LO_2DP20_Mass_3500_4000.3lep.root"
+      },
+      {
+        "checksum": "adler32:4a8c9bd5",
+        "size": 74509,
+        "uri": "root://eospublic.cern.ch//eos/opendata/atlas/rucio/opendata/ODEO_FEB2025_v0_3lep_mc_302532.Pythia8EvtGen_A14NNPDF23LO_2DP20_Mass_4000_4500.3lep.root"
+      },
+      {
+        "checksum": "adler32:e7547926",
+        "size": 37305,
+        "uri": "root://eospublic.cern.ch//eos/opendata/atlas/rucio/opendata/ODEO_FEB2025_v0_3lep_mc_302533.Pythia8EvtGen_A14NNPDF23LO_2DP20_Mass_4500_5000.3lep.root"
+      },
+      {
+        "checksum": "adler32:410c8153",
+        "size": 66486,
+        "uri": "root://eospublic.cern.ch//eos/opendata/atlas/rucio/opendata/ODEO_FEB2025_v0_3lep_mc_302534.Pythia8EvtGen_A14NNPDF23LO_2DP20_Mass_5000_inf.3lep.root"
+      },
+      {
+        "checksum": "adler32:0e0647c8",
+        "size": 350008,
+        "uri": "root://eospublic.cern.ch//eos/opendata/atlas/rucio/opendata/ODEO_FEB2025_v0_3lep_mc_302733.MadGraphPythia8EvtGen_A14NNPDF23LO_WpL_tblep_M3000.3lep.root"
+      },
+      {
+        "checksum": "adler32:cad6d805",
+        "size": 1067335,
+        "uri": "root://eospublic.cern.ch//eos/opendata/atlas/rucio/opendata/ODEO_FEB2025_v0_3lep_mc_304014.MadGraphPythia8EvtGen_A14NNPDF23_3top_SM.3lep.root"
+      },
+      {
+        "checksum": "adler32:4438cdb4",
+        "size": 165664,
+        "uri": "root://eospublic.cern.ch//eos/opendata/atlas/rucio/opendata/ODEO_FEB2025_v0_3lep_mc_306149.MadGraphPythia8EvtGen_A14NNPDF23LO_WpL_tbhad_M3000.3lep.root"
+      },
+      {
+        "checksum": "adler32:8d0914d1",
+        "size": 34592,
+        "uri": "root://eospublic.cern.ch//eos/opendata/atlas/rucio/opendata/ODEO_FEB2025_v0_3lep_mc_311490.PowhegPy8EG_A14N23LO_DMA_500_700_gq0p25.3lep.root"
+      },
+      {
+        "checksum": "adler32:b69c57b0",
+        "size": 9011827,
+        "uri": "root://eospublic.cern.ch//eos/opendata/atlas/rucio/opendata/ODEO_FEB2025_v0_3lep_mc_312613.aMcAtNloPy8EG_A14N30NLO_LQd_gstML_0p3_nonallhad_M1000.3lep.root"
+      },
+      {
+        "checksum": "adler32:7c4ab4df",
+        "size": 28346,
+        "uri": "root://eospublic.cern.ch//eos/opendata/atlas/rucio/opendata/ODEO_FEB2025_v0_3lep_mc_341456.PowhegPythia8EvtGen_CT10_AZNLO_ZH125J_MINLO_veveWWlvqq_VpT.3lep.root"
+      },
+      {
+        "checksum": "adler32:78de3d7d",
+        "size": 41331,
+        "uri": "root://eospublic.cern.ch//eos/opendata/atlas/rucio/opendata/ODEO_FEB2025_v0_3lep_mc_341458.PowhegPythia8EvtGen_CT10_AZNLO_ZH125J_MINLO_vmuvmuWWlvqq_VpT.3lep.root"
+      },
+      {
+        "checksum": "adler32:6aae13a9",
+        "size": 38386,
+        "uri": "root://eospublic.cern.ch//eos/opendata/atlas/rucio/opendata/ODEO_FEB2025_v0_3lep_mc_341460.PowhegPy8EG_CT10_AZNLO_ZH125J_MINLO_vtauvtauWWlvqq_VpT.3lep.root"
+      },
+      {
+        "checksum": "adler32:8d29c772",
+        "size": 99144,
+        "uri": "root://eospublic.cern.ch//eos/opendata/atlas/rucio/opendata/ODEO_FEB2025_v0_3lep_mc_343981.PowhegPythia8EvtGen_NNLOPS_nnlo_30_ggH125_gamgam.3lep.root"
+      },
+      {
+        "checksum": "adler32:eb9bacce",
+        "size": 29203063,
+        "uri": "root://eospublic.cern.ch//eos/opendata/atlas/rucio/opendata/ODEO_FEB2025_v0_3lep_mc_344158.aMcAtNloPythia8EvtGen_A14NNPDF23LO_ppx0_FxFx_Np012_SM.3lep.root"
+      },
+      {
+        "checksum": "adler32:987ec2dc",
+        "size": 58793,
+        "uri": "root://eospublic.cern.ch//eos/opendata/atlas/rucio/opendata/ODEO_FEB2025_v0_3lep_mc_345056.PowhegPythia8EvtGen_NNPDF3_AZNLO_ZH125J_MINLO_vvbb_VpT.3lep.root"
+      },
+      {
+        "checksum": "adler32:c3f2a10c",
+        "size": 52459,
+        "uri": "root://eospublic.cern.ch//eos/opendata/atlas/rucio/opendata/ODEO_FEB2025_v0_3lep_mc_345058.PowhegPythia8EvtGen_NNPDF3_AZNLO_ggZH125_vvbb.3lep.root"
+      },
+      {
+        "checksum": "adler32:e5f9eab3",
+        "size": 448312250,
+        "uri": "root://eospublic.cern.ch//eos/opendata/atlas/rucio/opendata/ODEO_FEB2025_v0_3lep_mc_345060.PowhegPythia8EvtGen_NNLOPS_nnlo_30_ggH125_ZZ4l.3lep.root"
+      },
+      {
+        "checksum": "adler32:736a8dea",
+        "size": 161553,
+        "uri": "root://eospublic.cern.ch//eos/opendata/atlas/rucio/opendata/ODEO_FEB2025_v0_3lep_mc_345061.PowhegPythia8EvtGen_NNPDF3_AZNLO_ggZH125_HgamgamZinc.3lep.root"
+      },
+      {
+        "checksum": "adler32:2f6494fc",
+        "size": 9521112,
+        "uri": "root://eospublic.cern.ch//eos/opendata/atlas/rucio/opendata/ODEO_FEB2025_v0_3lep_mc_345066.PowhegPythia8EvtGen_NNPDF3_AZNLO_ggZH125_ZZ4lepZinc.3lep.root"
+      },
+      {
+        "checksum": "adler32:e75c61fa",
+        "size": 493055,
+        "uri": "root://eospublic.cern.ch//eos/opendata/atlas/rucio/opendata/ODEO_FEB2025_v0_3lep_mc_345097.PowhegPythia8EvtGen_NNLOPS_nnlo_30_ggH125_mumu.3lep.root"
+      },
+      {
+        "checksum": "adler32:326e36ed",
+        "size": 1718320,
+        "uri": "root://eospublic.cern.ch//eos/opendata/atlas/rucio/opendata/ODEO_FEB2025_v0_3lep_mc_345098.PowhegPythia8EvtGen_NNPDF3_AZNLO_ggZH125_Hmumu_Zinc.3lep.root"
+      },
+      {
+        "checksum": "adler32:4bbac201",
+        "size": 1715664,
+        "uri": "root://eospublic.cern.ch//eos/opendata/atlas/rucio/opendata/ODEO_FEB2025_v0_3lep_mc_345103.PowhegPythia8EvtGen_NNPDF30_AZNLO_ZH125J_Hmumu_Zincl_MINLO.3lep.root"
+      },
+      {
+        "checksum": "adler32:b0e75429",
+        "size": 2620727,
+        "uri": "root://eospublic.cern.ch//eos/opendata/atlas/rucio/opendata/ODEO_FEB2025_v0_3lep_mc_345104.PowhegPythia8EvtGen_NNPDF30_AZNLO_WpH125J_Hmumu_Wincl_MINLO.3lep.root"
+      },
+      {
+        "checksum": "adler32:0d1f8e48",
+        "size": 1626093,
+        "uri": "root://eospublic.cern.ch//eos/opendata/atlas/rucio/opendata/ODEO_FEB2025_v0_3lep_mc_345105.PowhegPythia8EvtGen_NNPDF30_AZNLO_WmH125J_Hmumu_Wincl_MINLO.3lep.root"
+      },
+      {
+        "checksum": "adler32:aed127a7",
+        "size": 627909,
+        "uri": "root://eospublic.cern.ch//eos/opendata/atlas/rucio/opendata/ODEO_FEB2025_v0_3lep_mc_345106.PowhegPythia8EvtGen_NNPDF30_AZNLOCTEQ6L1_VBFH125_mumu.3lep.root"
+      },
+      {
+        "checksum": "adler32:244cf175",
+        "size": 57430,
+        "uri": "root://eospublic.cern.ch//eos/opendata/atlas/rucio/opendata/ODEO_FEB2025_v0_3lep_mc_345112.PowhegPythia8EvtGen_NNPDF3_AZNLO_ZH125J_MINLO_vvcc_VpT.3lep.root"
+      },
+      {
+        "checksum": "adler32:82666fc6",
+        "size": 52542,
+        "uri": "root://eospublic.cern.ch//eos/opendata/atlas/rucio/opendata/ODEO_FEB2025_v0_3lep_mc_345114.PowhegPythia8EvtGen_NNPDF3_AZNLO_ggZH125_vvcc.3lep.root"
+      },
+      {
+        "checksum": "adler32:41ca6b2b",
+        "size": 468063,
+        "uri": "root://eospublic.cern.ch//eos/opendata/atlas/rucio/opendata/ODEO_FEB2025_v0_3lep_mc_345120.PowhegPy8EG_NNLOPS_nnlo_30_ggH125_tautaul13l7.3lep.root"
+      },
+      {
+        "checksum": "adler32:189aa527",
+        "size": 76696,
+        "uri": "root://eospublic.cern.ch//eos/opendata/atlas/rucio/opendata/ODEO_FEB2025_v0_3lep_mc_345121.PowhegPy8EG_NNLOPS_nnlo_30_ggH125_tautaulm15hp20.3lep.root"
+      },
+      {
+        "checksum": "adler32:3c658070",
+        "size": 106014,
+        "uri": "root://eospublic.cern.ch//eos/opendata/atlas/rucio/opendata/ODEO_FEB2025_v0_3lep_mc_345122.PowhegPy8EG_NNLOPS_nnlo_30_ggH125_tautaulp15hm20.3lep.root"
+      },
+      {
+        "checksum": "adler32:6d03d83e",
+        "size": 59269,
+        "uri": "root://eospublic.cern.ch//eos/opendata/atlas/rucio/opendata/ODEO_FEB2025_v0_3lep_mc_345123.PowhegPy8EG_NNLOPS_nnlo_30_ggH125_tautauh30h20.3lep.root"
+      },
+      {
+        "checksum": "adler32:d68c132e",
+        "size": 1639856,
+        "uri": "root://eospublic.cern.ch//eos/opendata/atlas/rucio/opendata/ODEO_FEB2025_v0_3lep_mc_345124.PowhegPy8EG_NNLOPS_nnlo_30_ggH125_etau_filt.3lep.root"
+      },
+      {
+        "checksum": "adler32:2c253912",
+        "size": 1757738,
+        "uri": "root://eospublic.cern.ch//eos/opendata/atlas/rucio/opendata/ODEO_FEB2025_v0_3lep_mc_345125.PowhegPy8EG_NNLOPS_nnlo_30_ggH125_mutau_filt.3lep.root"
+      },
+      {
+        "checksum": "adler32:253c6faf",
+        "size": 161870,
+        "uri": "root://eospublic.cern.ch//eos/opendata/atlas/rucio/opendata/ODEO_FEB2025_v0_3lep_mc_345211.PowhegPy8EG_NNPDF30_AZNLO_WmH125J_Winc_MINLO_tautau.3lep.root"
+      },
+      {
+        "checksum": "adler32:1b2509fb",
+        "size": 193742,
+        "uri": "root://eospublic.cern.ch//eos/opendata/atlas/rucio/opendata/ODEO_FEB2025_v0_3lep_mc_345212.PowhegPy8EG_NNPDF30_AZNLO_WpH125J_Winc_MINLO_tautau.3lep.root"
+      },
+      {
+        "checksum": "adler32:d2f927d1",
+        "size": 605912,
+        "uri": "root://eospublic.cern.ch//eos/opendata/atlas/rucio/opendata/ODEO_FEB2025_v0_3lep_mc_345213.PowhegPy8EG_NNPDF30_AZNLO_WmH125J_Winc_MINLO_etau.3lep.root"
+      },
+      {
+        "checksum": "adler32:e7718d4c",
+        "size": 1021475,
+        "uri": "root://eospublic.cern.ch//eos/opendata/atlas/rucio/opendata/ODEO_FEB2025_v0_3lep_mc_345214.PowhegPy8EG_NNPDF30_AZNLO_WpH125J_Winc_MINLO_etau.3lep.root"
+      },
+      {
+        "checksum": "adler32:dbe9f793",
+        "size": 708830,
+        "uri": "root://eospublic.cern.ch//eos/opendata/atlas/rucio/opendata/ODEO_FEB2025_v0_3lep_mc_345215.PowhegPy8EG_NNPDF30_AZNLO_WmH125J_Winc_MINLO_mutau.3lep.root"
+      },
+      {
+        "checksum": "adler32:829f7ccd",
+        "size": 1232056,
+        "uri": "root://eospublic.cern.ch//eos/opendata/atlas/rucio/opendata/ODEO_FEB2025_v0_3lep_mc_345216.PowhegPy8EG_NNPDF30_AZNLO_WpH125J_Winc_MINLO_mutau.3lep.root"
+      },
+      {
+        "checksum": "adler32:c4a58d20",
+        "size": 586294,
+        "uri": "root://eospublic.cern.ch//eos/opendata/atlas/rucio/opendata/ODEO_FEB2025_v0_3lep_mc_345217.PowhegPy8EG_NNPDF30_AZNLO_ZH125J_Zinc_MINLO_tautau.3lep.root"
+      },
+      {
+        "checksum": "adler32:53328be7",
+        "size": 1647376,
+        "uri": "root://eospublic.cern.ch//eos/opendata/atlas/rucio/opendata/ODEO_FEB2025_v0_3lep_mc_345218.PowhegPy8EG_NNPDF30_AZNLO_ZH125J_Zinc_MINLO_etau.3lep.root"
+      },
+      {
+        "checksum": "adler32:a57353f3",
+        "size": 1416651,
+        "uri": "root://eospublic.cern.ch//eos/opendata/atlas/rucio/opendata/ODEO_FEB2025_v0_3lep_mc_345219.PowhegPy8EG_NNPDF30_AZNLO_ZH125J_Zinc_MINLO_mutau.3lep.root"
+      },
+      {
+        "checksum": "adler32:9ad9b4a0",
+        "size": 7137019,
+        "uri": "root://eospublic.cern.ch//eos/opendata/atlas/rucio/opendata/ODEO_FEB2025_v0_3lep_mc_345316.PowhegPythia8EvtGen_NNLOPS_nnlo_30_ggH125_Zy_Zll.3lep.root"
+      },
+      {
+        "checksum": "adler32:b4b8bda5",
+        "size": 292329,
+        "uri": "root://eospublic.cern.ch//eos/opendata/atlas/rucio/opendata/ODEO_FEB2025_v0_3lep_mc_345317.PowhegPythia8EvtGen_NNPDF30_AZNLO_WmH125J_Hyy_Wincl_MINLO.3lep.root"
+      },
+      {
+        "checksum": "adler32:701cc235",
+        "size": 173780,
+        "uri": "root://eospublic.cern.ch//eos/opendata/atlas/rucio/opendata/ODEO_FEB2025_v0_3lep_mc_345318.PowhegPythia8EvtGen_NNPDF30_AZNLO_WpH125J_Hyy_Wincl_MINLO.3lep.root"
+      },
+      {
+        "checksum": "adler32:97aba55a",
+        "size": 229736,
+        "uri": "root://eospublic.cern.ch//eos/opendata/atlas/rucio/opendata/ODEO_FEB2025_v0_3lep_mc_345319.PowhegPythia8EvtGen_NNPDF30_AZNLO_ZH125J_Hyy_Zincl_MINLO.3lep.root"
+      },
+      {
+        "checksum": "adler32:8da5ba23",
+        "size": 995400,
+        "uri": "root://eospublic.cern.ch//eos/opendata/atlas/rucio/opendata/ODEO_FEB2025_v0_3lep_mc_345320.PowhegPythia8EvtGen_NNPDF30_AZNLO_WmH125J_HZy_Wincl_MINLO.3lep.root"
+      },
+      {
+        "checksum": "adler32:f954de77",
+        "size": 995633,
+        "uri": "root://eospublic.cern.ch//eos/opendata/atlas/rucio/opendata/ODEO_FEB2025_v0_3lep_mc_345321.PowhegPythia8EvtGen_NNPDF30_AZNLO_WpH125J_HZy_Wincl_MINLO.3lep.root"
+      },
+      {
+        "checksum": "adler32:f057347c",
+        "size": 1440141,
+        "uri": "root://eospublic.cern.ch//eos/opendata/atlas/rucio/opendata/ODEO_FEB2025_v0_3lep_mc_345322.PowhegPythia8EvtGen_NNPDF30_AZNLO_ZH125J_HZy_Zincl_MINLO.3lep.root"
+      },
+      {
+        "checksum": "adler32:edc91a67",
+        "size": 437443,
+        "uri": "root://eospublic.cern.ch//eos/opendata/atlas/rucio/opendata/ODEO_FEB2025_v0_3lep_mc_345324.PowhegPythia8EvtGen_NNLOPS_NN30_ggH125_WWlvlv_EF_15_5.3lep.root"
+      },
+      {
+        "checksum": "adler32:b462ea8b",
+        "size": 2387331,
+        "uri": "root://eospublic.cern.ch//eos/opendata/atlas/rucio/opendata/ODEO_FEB2025_v0_3lep_mc_345325.PowhegPythia8EvtGen_NNPDF3_AZNLO_WpH125J_MINLO_qqWWlvlv.3lep.root"
+      },
+      {
+        "checksum": "adler32:717c63a1",
+        "size": 2945292,
+        "uri": "root://eospublic.cern.ch//eos/opendata/atlas/rucio/opendata/ODEO_FEB2025_v0_3lep_mc_345433.PowhegPythia8EvtGen_NNPDF3_AZNLO_WmH125J_MINLO_qqWWlvlv.3lep.root"
+      },
+      {
+        "checksum": "adler32:0fd8d5d9",
+        "size": 113442,
+        "uri": "root://eospublic.cern.ch//eos/opendata/atlas/rucio/opendata/ODEO_FEB2025_v0_3lep_mc_345445.PowhegPythia8EvtGen_NNPDF3_AZNLO_ZH125J_MINLO_vvWWlvlv.3lep.root"
+      },
+      {
+        "checksum": "adler32:65714793",
+        "size": 45628,
+        "uri": "root://eospublic.cern.ch//eos/opendata/atlas/rucio/opendata/ODEO_FEB2025_v0_3lep_mc_345596.PowhegPythia8EvtGen_NNPDF3_AZNLO_ggZH125_Zinc_HZZinv.3lep.root"
+      },
+      {
+        "checksum": "adler32:28e46858",
+        "size": 683359,
+        "uri": "root://eospublic.cern.ch//eos/opendata/atlas/rucio/opendata/ODEO_FEB2025_v0_3lep_mc_345697.MadGraphPythia8EvtGen_AZNLOCTEQ6L1_ggfhtautaullNp2.3lep.root"
+      },
+      {
+        "checksum": "adler32:1500bc36",
+        "size": 226990,
+        "uri": "root://eospublic.cern.ch//eos/opendata/atlas/rucio/opendata/ODEO_FEB2025_v0_3lep_mc_345698.MadGraphPythia8EvtGen_AZNLOCTEQ6L1_ggfhtautaulhNp2.3lep.root"
+      },
+      {
+        "checksum": "adler32:dd1da9f0",
+        "size": 108042,
+        "uri": "root://eospublic.cern.ch//eos/opendata/atlas/rucio/opendata/ODEO_FEB2025_v0_3lep_mc_345699.MadGraphPythia8EvtGen_AZNLOCTEQ6L1_ggfhtautauhhNp2.3lep.root"
+      },
+      {
+        "checksum": "adler32:b3f35c1b",
+        "size": 4353870,
+        "uri": "root://eospublic.cern.ch//eos/opendata/atlas/rucio/opendata/ODEO_FEB2025_v0_3lep_mc_345833.PowhegPythia8EvtGen_NNPDF30_AZNLOCTEQ6L1_VBFH125_Zllgam.3lep.root"
+      },
+      {
+        "checksum": "adler32:59c17f45",
+        "size": 241603,
+        "uri": "root://eospublic.cern.ch//eos/opendata/atlas/rucio/opendata/ODEO_FEB2025_v0_3lep_mc_345834.PowhegPythia8EvtGen_NNPDF30_AZNLOCTEQ6L1_VBFH125_gamstargam.3lep.root"
+      },
+      {
+        "checksum": "adler32:40b63162",
+        "size": 1669068,
+        "uri": "root://eospublic.cern.ch//eos/opendata/atlas/rucio/opendata/ODEO_FEB2025_v0_3lep_mc_345876.PowhegPythia8EvtGen_NNPDF30_AZNLO_ZH125J_Hee__Zincl_MINLO.3lep.root"
+      },
+      {
+        "checksum": "adler32:23a8643b",
+        "size": 1458894,
+        "uri": "root://eospublic.cern.ch//eos/opendata/atlas/rucio/opendata/ODEO_FEB2025_v0_3lep_mc_345877.PowhegPythia8EvtGen_NNPDF30_AZNLO_WpH125J_Hee_Wincl_MINLO.3lep.root"
+      },
+      {
+        "checksum": "adler32:082eec11",
+        "size": 1574681,
+        "uri": "root://eospublic.cern.ch//eos/opendata/atlas/rucio/opendata/ODEO_FEB2025_v0_3lep_mc_345878.PowhegPythia8EvtGen_NNPDF30_AZNLO_WmH125J_Hee_Wincl_MINLO.3lep.root"
+      },
+      {
+        "checksum": "adler32:63c86546",
+        "size": 96511,
+        "uri": "root://eospublic.cern.ch//eos/opendata/atlas/rucio/opendata/ODEO_FEB2025_v0_3lep_mc_345944.aMcAtNloPy8EG_A14NNPDF23LO_ppx0yy_FxFx_Np012_SM.3lep.root"
+      },
+      {
+        "checksum": "adler32:ade26d08",
+        "size": 746069,
+        "uri": "root://eospublic.cern.ch//eos/opendata/atlas/rucio/opendata/ODEO_FEB2025_v0_3lep_mc_345948.PowhegPy8EG_NNPDF30_AZNLOCTEQ6L1_VBFH125_WWlvlv.3lep.root"
+      },
+      {
+        "checksum": "adler32:a8c027ff",
+        "size": 59016,
+        "uri": "root://eospublic.cern.ch//eos/opendata/atlas/rucio/opendata/ODEO_FEB2025_v0_3lep_mc_345949.PowhegPythia8EvtGen_NNPDF30_AZNLOCTEQ6L1_VBFH125_bb.3lep.root"
+      },
+      {
+        "checksum": "adler32:e8ca1d83",
+        "size": 466768,
+        "uri": "root://eospublic.cern.ch//eos/opendata/atlas/rucio/opendata/ODEO_FEB2025_v0_3lep_mc_345961.PowhegPythia8EvtGen_NNLOPS_nnlo_30_ggH125_gamstargam.3lep.root"
+      },
+      {
+        "checksum": "adler32:7987f171",
+        "size": 442180,
+        "uri": "root://eospublic.cern.ch//eos/opendata/atlas/rucio/opendata/ODEO_FEB2025_v0_3lep_mc_345963.PowhegPythia8EvtGen_NNPDF30_AZNLO_WmH125J_Hgamstargam_MINLO.3lep.root"
+      },
+      {
+        "checksum": "adler32:53457186",
+        "size": 405377,
+        "uri": "root://eospublic.cern.ch//eos/opendata/atlas/rucio/opendata/ODEO_FEB2025_v0_3lep_mc_345964.PowhegPythia8EvtGen_NNPDF30_AZNLO_WpH125J_Hgamstargam_MINLO.3lep.root"
+      },
+      {
+        "checksum": "adler32:620bdc75",
+        "size": 848628,
+        "uri": "root://eospublic.cern.ch//eos/opendata/atlas/rucio/opendata/ODEO_FEB2025_v0_3lep_mc_345965.PowhegPythia8EvtGen_NNPDF30_AZNLO_ZH125J_Hgamstargam_MINLO.3lep.root"
+      },
+      {
+        "checksum": "adler32:a27a9041",
+        "size": 123934,
+        "uri": "root://eospublic.cern.ch//eos/opendata/atlas/rucio/opendata/ODEO_FEB2025_v0_3lep_mc_346188.aMcAtNloPythia8EvtGen_tHjb125_4fl_gamgam.3lep.root"
+      },
+      {
+        "checksum": "adler32:3d75f9bf",
+        "size": 537009,
+        "uri": "root://eospublic.cern.ch//eos/opendata/atlas/rucio/opendata/ODEO_FEB2025_v0_3lep_mc_346189.aMcAtNloPythia8EvtGen_ttH_gamgam.3lep.root"
+      },
+      {
+        "checksum": "adler32:bc2db1d6",
+        "size": 582337,
+        "uri": "root://eospublic.cern.ch//eos/opendata/atlas/rucio/opendata/ODEO_FEB2025_v0_3lep_mc_346190.PowhegPy8EG_NNPDF30_AZNLOCTEQ6L1_VBFH125_tautaul13l7.3lep.root"
+      },
+      {
+        "checksum": "adler32:c53634e0",
+        "size": 80558,
+        "uri": "root://eospublic.cern.ch//eos/opendata/atlas/rucio/opendata/ODEO_FEB2025_v0_3lep_mc_346191.PowhegPy8EG_NNPDF30_AZNLOCTEQ6L1_VBFH125_tautaulm15hp20.3lep.root"
+      },
+      {
+        "checksum": "adler32:1ed809f3",
+        "size": 84041,
+        "uri": "root://eospublic.cern.ch//eos/opendata/atlas/rucio/opendata/ODEO_FEB2025_v0_3lep_mc_346192.PowhegPy8EG_NNPDF30_AZNLOCTEQ6L1_VBFH125_tautaulp15hm20.3lep.root"
+      },
+      {
+        "checksum": "adler32:6c261a9c",
+        "size": 48189,
+        "uri": "root://eospublic.cern.ch//eos/opendata/atlas/rucio/opendata/ODEO_FEB2025_v0_3lep_mc_346193.PowhegPy8EG_NNPDF30_AZNLOCTEQ6L1_VBFH125_tautauh30h20.3lep.root"
+      },
+      {
+        "checksum": "adler32:fe65386d",
+        "size": 558338,
+        "uri": "root://eospublic.cern.ch//eos/opendata/atlas/rucio/opendata/ODEO_FEB2025_v0_3lep_mc_346194.PowhegPy8EG_NNPDF30_AZNLOCTEQ6L1_VBFH125_etau_filt.3lep.root"
+      },
+      {
+        "checksum": "adler32:7e661bb7",
+        "size": 521345,
+        "uri": "root://eospublic.cern.ch//eos/opendata/atlas/rucio/opendata/ODEO_FEB2025_v0_3lep_mc_346195.PowhegPy8EG_NNPDF30_AZNLOCTEQ6L1_VBFH125_mutau_filt.3lep.root"
+      },
+      {
+        "checksum": "adler32:78e70fd1",
+        "size": 13012116,
+        "uri": "root://eospublic.cern.ch//eos/opendata/atlas/rucio/opendata/ODEO_FEB2025_v0_3lep_mc_346198.PhPy8EG_A14NNPDF23_NNPDF30ME_ttH125_Zgam.3lep.root"
+      },
+      {
+        "checksum": "adler32:b61455bd",
+        "size": 62226,
+        "uri": "root://eospublic.cern.ch//eos/opendata/atlas/rucio/opendata/ODEO_FEB2025_v0_3lep_mc_346214.PowhegPy8EG_NNPDF30_AZNLOCTEQ6L1_VBFH125_gamgam.3lep.root"
+      },
+      {
+        "checksum": "adler32:46fc6475",
+        "size": 94555873,
+        "uri": "root://eospublic.cern.ch//eos/opendata/atlas/rucio/opendata/ODEO_FEB2025_v0_3lep_mc_346228.PowhegPy8EG_NNPDF30_AZNLOCTEQ6L1_VBFH125_ZZ4lep_notau.3lep.root"
+      },
+      {
+        "checksum": "adler32:312cb649",
+        "size": 283460,
+        "uri": "root://eospublic.cern.ch//eos/opendata/atlas/rucio/opendata/ODEO_FEB2025_v0_3lep_mc_346310.PowhegPythia8EvtGen_NNPDF30_AZNLO_ZH125J_Zincl_H_incl_MINLO.3lep.root"
+      },
+      {
+        "checksum": "adler32:05616a29",
+        "size": 95519,
+        "uri": "root://eospublic.cern.ch//eos/opendata/atlas/rucio/opendata/ODEO_FEB2025_v0_3lep_mc_346311.PowhegPythia8EvtGen_NNPDF30_AZNLO_WpH125J_Wincl_H_incl_MINLO.3lep.root"
+      },
+      {
+        "checksum": "adler32:b5f13ec4",
+        "size": 78524,
+        "uri": "root://eospublic.cern.ch//eos/opendata/atlas/rucio/opendata/ODEO_FEB2025_v0_3lep_mc_346312.PowhegPythia8EvtGen_NNPDF30_AZNLO_WmH125J_Wincl_H_incl_MINLO.3lep.root"
+      },
+      {
+        "checksum": "adler32:efed0588",
+        "size": 148027,
+        "uri": "root://eospublic.cern.ch//eos/opendata/atlas/rucio/opendata/ODEO_FEB2025_v0_3lep_mc_346317.PowhegPy8EG_NNPDF30_AZNLOCTEQ6L1_VBFH125_incl.3lep.root"
+      },
+      {
+        "checksum": "adler32:97662c82",
+        "size": 13619205,
+        "uri": "root://eospublic.cern.ch//eos/opendata/atlas/rucio/opendata/ODEO_FEB2025_v0_3lep_mc_346340.PowhegPy8EG_A14NNPDF23_NNPDF30ME_ttH125_ZZ4l_allhad.3lep.root"
+      },
+      {
+        "checksum": "adler32:ed4afd94",
+        "size": 16713624,
+        "uri": "root://eospublic.cern.ch//eos/opendata/atlas/rucio/opendata/ODEO_FEB2025_v0_3lep_mc_346341.PowhegPy8EG_A14NNPDF23_NNPDF30ME_ttH125_ZZ4l_semilep.3lep.root"
+      },
+      {
+        "checksum": "adler32:5e9cfd75",
+        "size": 17913595,
+        "uri": "root://eospublic.cern.ch//eos/opendata/atlas/rucio/opendata/ODEO_FEB2025_v0_3lep_mc_346342.PowhegPy8EG_A14NNPDF23_NNPDF30ME_ttH125_ZZ4l_dilep.3lep.root"
+      },
+      {
+        "checksum": "adler32:0639a1ac",
+        "size": 304438,
+        "uri": "root://eospublic.cern.ch//eos/opendata/atlas/rucio/opendata/ODEO_FEB2025_v0_3lep_mc_346343.PhPy8EG_A14NNPDF23_NNPDF30ME_ttH125_allhad.3lep.root"
+      },
+      {
+        "checksum": "adler32:7aebe718",
+        "size": 1073782,
+        "uri": "root://eospublic.cern.ch//eos/opendata/atlas/rucio/opendata/ODEO_FEB2025_v0_3lep_mc_346344.PhPy8EG_A14NNPDF23_NNPDF30ME_ttH125_semilep.3lep.root"
+      },
+      {
+        "checksum": "adler32:c7fc2265",
+        "size": 8886716,
+        "uri": "root://eospublic.cern.ch//eos/opendata/atlas/rucio/opendata/ODEO_FEB2025_v0_3lep_mc_346345.PhPy8EG_A14NNPDF23_NNPDF30ME_ttH125_dilep.3lep.root"
+      },
+      {
+        "checksum": "adler32:5ad2cea3",
+        "size": 43461,
+        "uri": "root://eospublic.cern.ch//eos/opendata/atlas/rucio/opendata/ODEO_FEB2025_v0_3lep_mc_346398.PowhegHerwig7EvtGen_NNPDF3_AZNLO_ZH125J_MINLO_vvbb_VpT.3lep.root"
+      },
+      {
+        "checksum": "adler32:8adb48fe",
+        "size": 46998,
+        "uri": "root://eospublic.cern.ch//eos/opendata/atlas/rucio/opendata/ODEO_FEB2025_v0_3lep_mc_346400.PowhegHerwig7EvtGen_NNPDF3_AZNLO_ggZH125J_vvbb.3lep.root"
+      },
+      {
+        "checksum": "adler32:d58b4968",
+        "size": 7465693,
+        "uri": "root://eospublic.cern.ch//eos/opendata/atlas/rucio/opendata/ODEO_FEB2025_v0_3lep_mc_346414.aMcAtNloPythia8EvtGen_tHjb125_4fl_ZZ4l.3lep.root"
+      },
+      {
+        "checksum": "adler32:732dc021",
+        "size": 271878870,
+        "uri": "root://eospublic.cern.ch//eos/opendata/atlas/rucio/opendata/ODEO_FEB2025_v0_3lep_mc_346446.PhH7EG_H7UE_NNLOPS_nnlo_30_ggH125_ZZ4l_noTau.3lep.root"
+      },
+      {
+        "checksum": "adler32:c4e608f4",
+        "size": 95276645,
+        "uri": "root://eospublic.cern.ch//eos/opendata/atlas/rucio/opendata/ODEO_FEB2025_v0_3lep_mc_346447.PhH7EG_H7UE_NNPDF30_VBFH125_ZZ4lep_noTau.3lep.root"
+      },
+      {
+        "checksum": "adler32:8bdd29b2",
+        "size": 17601062,
+        "uri": "root://eospublic.cern.ch//eos/opendata/atlas/rucio/opendata/ODEO_FEB2025_v0_3lep_mc_346448.PhH7EG_H7UE_NNPDF30_ZH125J_Zincl_MINLO.3lep.root"
+      },
+      {
+        "checksum": "adler32:53e137df",
+        "size": 14246649,
+        "uri": "root://eospublic.cern.ch//eos/opendata/atlas/rucio/opendata/ODEO_FEB2025_v0_3lep_mc_346449.PhH7EG_H7UE_NNPDF30_WpH125J_Wincl_MINLO.3lep.root"
+      },
+      {
+        "checksum": "adler32:03e5035e",
+        "size": 7525636,
+        "uri": "root://eospublic.cern.ch//eos/opendata/atlas/rucio/opendata/ODEO_FEB2025_v0_3lep_mc_346450.PhH7EG_H7UE_NNPDF30_WmH125J_Wincl_MINLO.3lep.root"
+      },
+      {
+        "checksum": "adler32:ab8df2eb",
+        "size": 9280555,
+        "uri": "root://eospublic.cern.ch//eos/opendata/atlas/rucio/opendata/ODEO_FEB2025_v0_3lep_mc_346451.PhH7EG_H7UE_NNPDF3_ggZH125_ZZ4lepZinc.3lep.root"
+      },
+      {
+        "checksum": "adler32:80c7fdba",
+        "size": 13618723,
+        "uri": "root://eospublic.cern.ch//eos/opendata/atlas/rucio/opendata/ODEO_FEB2025_v0_3lep_mc_346452.PhH7EG_H7UE_NNPDF30ME_ttH125_ZZ4l_allhad_noTau.3lep.root"
+      },
+      {
+        "checksum": "adler32:b0634b91",
+        "size": 16686757,
+        "uri": "root://eospublic.cern.ch//eos/opendata/atlas/rucio/opendata/ODEO_FEB2025_v0_3lep_mc_346453.PhH7EG_H7UE_NNPDF30ME_ttH125_ZZ4l_semilep_noTau.3lep.root"
+      },
+      {
+        "checksum": "adler32:024178ff",
+        "size": 17949365,
+        "uri": "root://eospublic.cern.ch//eos/opendata/atlas/rucio/opendata/ODEO_FEB2025_v0_3lep_mc_346454.PhH7EG_H7UE_NNPDF30ME_ttH125_ZZ4l_dilep_noTau.3lep.root"
+      },
+      {
+        "checksum": "adler32:f3a78a9d",
+        "size": 278483,
+        "uri": "root://eospublic.cern.ch//eos/opendata/atlas/rucio/opendata/ODEO_FEB2025_v0_3lep_mc_346486.aMcAtNloPythia8EvtGen_tWH125_yy.3lep.root"
+      },
+      {
+        "checksum": "adler32:3f3deb0e",
+        "size": 10142501,
+        "uri": "root://eospublic.cern.ch//eos/opendata/atlas/rucio/opendata/ODEO_FEB2025_v0_3lep_mc_346511.aMcAtNloPythia8EvtGen_tWH125_ZZ4l.3lep.root"
+      },
+      {
+        "checksum": "adler32:37c0439d",
+        "size": 1162429,
+        "uri": "root://eospublic.cern.ch//eos/opendata/atlas/rucio/opendata/ODEO_FEB2025_v0_3lep_mc_346524.PowhegPythia8EvtGen_NNPDF3_AZNLO_ggZH125J_MINLO_ZinclWWlvlv.3lep.root"
+      },
+      {
+        "checksum": "adler32:3b758707",
+        "size": 1088880,
+        "uri": "root://eospublic.cern.ch//eos/opendata/atlas/rucio/opendata/ODEO_FEB2025_v0_3lep_mc_346525.PowhegPythia8EvtGen_A14NNPDF23_NNPDF30ME_ttH125_gamgam.3lep.root"
+      },
+      {
+        "checksum": "adler32:0363f767",
+        "size": 997114,
+        "uri": "root://eospublic.cern.ch//eos/opendata/atlas/rucio/opendata/ODEO_FEB2025_v0_3lep_mc_346526.PowhegHerwig7EvtGen_H7UE_NNPDF30ME_ttH125_gamgam.3lep.root"
+      },
+      {
+        "checksum": "adler32:6b47e37f",
+        "size": 40338,
+        "uri": "root://eospublic.cern.ch//eos/opendata/atlas/rucio/opendata/ODEO_FEB2025_v0_3lep_mc_346588.PowhegPythia8EvtGen_NNLOPS_nnlo_30_ggH125_ZZ4nu_MET75.3lep.root"
+      },
+      {
+        "checksum": "adler32:1fe5800a",
+        "size": 674798,
+        "uri": "root://eospublic.cern.ch//eos/opendata/atlas/rucio/opendata/ODEO_FEB2025_v0_3lep_mc_346601.aMcAtNloHerwig7EvtGen_MEN30NLO_ttH125_gamgam.3lep.root"
+      },
+      {
+        "checksum": "adler32:e5d79290",
+        "size": 91695,
+        "uri": "root://eospublic.cern.ch//eos/opendata/atlas/rucio/opendata/ODEO_FEB2025_v0_3lep_mc_346602.aMcAtNloHerwig7EvtGen_MEN30NLO_tHjb125_gamgam.3lep.root"
+      },
+      {
+        "checksum": "adler32:7dd309f2",
+        "size": 51553,
+        "uri": "root://eospublic.cern.ch//eos/opendata/atlas/rucio/opendata/ODEO_FEB2025_v0_3lep_mc_346605.PowhegPythia8EvtGen_NNPDF30_AZNLO_WpH125J_WinclHinv_MET75.3lep.root"
+      },
+      {
+        "checksum": "adler32:a11040cf",
+        "size": 44529,
+        "uri": "root://eospublic.cern.ch//eos/opendata/atlas/rucio/opendata/ODEO_FEB2025_v0_3lep_mc_346606.PowhegPythia8EvtGen_NNPDF30_AZNLO_WmH125J_WinclHinv_MET75.3lep.root"
+      },
+      {
+        "checksum": "adler32:e325fef6",
+        "size": 86301,
+        "uri": "root://eospublic.cern.ch//eos/opendata/atlas/rucio/opendata/ODEO_FEB2025_v0_3lep_mc_346607.PowhegPythia8EvtGen_NNPDF30_AZNLO_ZH125J_ZinclHinv_MET75.3lep.root"
+      },
+      {
+        "checksum": "adler32:90cbf43c",
+        "size": 457108,
+        "uri": "root://eospublic.cern.ch//eos/opendata/atlas/rucio/opendata/ODEO_FEB2025_v0_3lep_mc_346632.PowhegPy8EG_A14NNPDF23_NNPDF30ME_ttH125_ZZ4nu_semilep.3lep.root"
+      },
+      {
+        "checksum": "adler32:42ae57f5",
+        "size": 103220,
+        "uri": "root://eospublic.cern.ch//eos/opendata/atlas/rucio/opendata/ODEO_FEB2025_v0_3lep_mc_346633.PowhegPy8EG_A14NNPDF23_NNPDF30ME_ttH125_ZZ4nu_allhad.3lep.root"
+      },
+      {
+        "checksum": "adler32:bd81d2d0",
+        "size": 697020,
+        "uri": "root://eospublic.cern.ch//eos/opendata/atlas/rucio/opendata/ODEO_FEB2025_v0_3lep_mc_346634.PowhegPy8EG_A14NNPDF23_NNPDF30ME_ttH125_ZZ4nu_dilep.3lep.root"
+      },
+      {
+        "checksum": "adler32:7a9c0afc",
+        "size": 25622957,
+        "uri": "root://eospublic.cern.ch//eos/opendata/atlas/rucio/opendata/ODEO_FEB2025_v0_3lep_mc_346645.PowhegPythia8EvtGen_NNPDF30_AZNLO_ZH125J_Zincl_MINLO_shw.3lep.root"
+      },
+      {
+        "checksum": "adler32:88d280c7",
+        "size": 14779107,
+        "uri": "root://eospublic.cern.ch//eos/opendata/atlas/rucio/opendata/ODEO_FEB2025_v0_3lep_mc_346646.PowhegPythia8EvtGen_NNPDF30_AZNLO_WpH125J_Wincl_MINLO_shw.3lep.root"
+      },
+      {
+        "checksum": "adler32:46600af8",
+        "size": 7972972,
+        "uri": "root://eospublic.cern.ch//eos/opendata/atlas/rucio/opendata/ODEO_FEB2025_v0_3lep_mc_346647.PowhegPythia8EvtGen_NNPDF30_AZNLO_WmH125J_Wincl_MINLO_shw.3lep.root"
+      },
+      {
+        "checksum": "adler32:66152630",
+        "size": 62895,
+        "uri": "root://eospublic.cern.ch//eos/opendata/atlas/rucio/opendata/ODEO_FEB2025_v0_3lep_mc_346726.PowhegHerwig7EvtGen_NNPDF3_AZNLO_ZH125J_MINLO_vvcc_VpT.3lep.root"
+      },
+      {
+        "checksum": "adler32:a533f2e6",
+        "size": 29388,
+        "uri": "root://eospublic.cern.ch//eos/opendata/atlas/rucio/opendata/ODEO_FEB2025_v0_3lep_mc_346728.PowhegHerwig7EvtGen_NNPDF3_AZNLO_ggZH125J_vvcc.3lep.root"
+      },
+      {
+        "checksum": "adler32:bd00546e",
+        "size": 578869,
+        "uri": "root://eospublic.cern.ch//eos/opendata/atlas/rucio/opendata/ODEO_FEB2025_v0_3lep_mc_346797.PhH7EG_H7UE_NNLOPS_nnlo_30_ggH125_gamgam.3lep.root"
+      },
+      {
+        "checksum": "adler32:1f289bd4",
+        "size": 2929402,
+        "uri": "root://eospublic.cern.ch//eos/opendata/atlas/rucio/opendata/ODEO_FEB2025_v0_3lep_mc_346802.PhH7EG_NNLOPS_nnlo_30_ggH125_WWlvlv_noTau.3lep.root"
+      },
+      {
+        "checksum": "adler32:e89b8eb6",
+        "size": 579206,
+        "uri": "root://eospublic.cern.ch//eos/opendata/atlas/rucio/opendata/ODEO_FEB2025_v0_3lep_mc_346877.PhH7EG_NNPDF30_VBFH125_WWlvlv.3lep.root"
+      },
+      {
+        "checksum": "adler32:c9d2c9ff",
+        "size": 125306,
+        "uri": "root://eospublic.cern.ch//eos/opendata/atlas/rucio/opendata/ODEO_FEB2025_v0_3lep_mc_346878.PhH7EG_H7UE_NNPDF30_VBF125_gammagamma.3lep.root"
+      },
+      {
+        "checksum": "adler32:774bdd9f",
+        "size": 224747,
+        "uri": "root://eospublic.cern.ch//eos/opendata/atlas/rucio/opendata/ODEO_FEB2025_v0_3lep_mc_346879.PhH7EG_H7UE_NNPDF30_ZH125J_Zincl_MINLO_gammagamma.3lep.root"
+      },
+      {
+        "checksum": "adler32:2b158055",
+        "size": 58303,
+        "uri": "root://eospublic.cern.ch//eos/opendata/atlas/rucio/opendata/ODEO_FEB2025_v0_3lep_mc_346880.PhH7EG_H7UE_NNPDF30_WmH125J_Wincl_MINLO_gammagamma.3lep.root"
+      },
+      {
+        "checksum": "adler32:1e7b5b68",
+        "size": 103566,
+        "uri": "root://eospublic.cern.ch//eos/opendata/atlas/rucio/opendata/ODEO_FEB2025_v0_3lep_mc_346881.PhH7EG_H7UE_NNPDF30_WpH125J_Wincl_MINLO_gammagamma.3lep.root"
+      },
+      {
+        "checksum": "adler32:5168c460",
+        "size": 145791,
+        "uri": "root://eospublic.cern.ch//eos/opendata/atlas/rucio/opendata/ODEO_FEB2025_v0_3lep_mc_346882.PhH7EG_H7UE_NNPDF30_ggZH125_gammagamma.3lep.root"
+      },
+      {
+        "checksum": "adler32:60ff6edb",
+        "size": 710035,
+        "uri": "root://eospublic.cern.ch//eos/opendata/atlas/rucio/opendata/ODEO_FEB2025_v0_3lep_mc_346919.PhPy8EG_A14NNPDF23_NNPDF30ME_ttH125_allhad_tautau_unpol.3lep.root"
+      },
+      {
+        "checksum": "adler32:b1affd10",
+        "size": 3245565,
+        "uri": "root://eospublic.cern.ch//eos/opendata/atlas/rucio/opendata/ODEO_FEB2025_v0_3lep_mc_346923.PhPy8EG_A14NNPDF23_NNPDF30ME_ttH125_semilep_tautau_unpol.3lep.root"
+      },
+      {
+        "checksum": "adler32:768d8b52",
+        "size": 8381766,
+        "uri": "root://eospublic.cern.ch//eos/opendata/atlas/rucio/opendata/ODEO_FEB2025_v0_3lep_mc_346927.PhPy8EG_A14NNPDF23_NNPDF30ME_ttH125_dilep_tautau_unpol.3lep.root"
+      },
+      {
+        "checksum": "adler32:16cacbc5",
+        "size": 14108625,
+        "uri": "root://eospublic.cern.ch//eos/opendata/atlas/rucio/opendata/ODEO_FEB2025_v0_3lep_mc_364242.Sherpa_222_NNPDF30NNLO_WWW_3l3v_EW6.3lep.root"
+      },
+      {
+        "checksum": "adler32:a88e0506",
+        "size": 11558565,
+        "uri": "root://eospublic.cern.ch//eos/opendata/atlas/rucio/opendata/ODEO_FEB2025_v0_3lep_mc_364243.Sherpa_222_NNPDF30NNLO_WWZ_4l2v_EW6.3lep.root"
+      },
+      {
+        "checksum": "adler32:77285c12",
+        "size": 156443,
+        "uri": "root://eospublic.cern.ch//eos/opendata/atlas/rucio/opendata/ODEO_FEB2025_v0_3lep_mc_364244.Sherpa_222_NNPDF30NNLO_WWZ_2l4v_EW6.3lep.root"
+      },
+      {
+        "checksum": "adler32:0ceba7cc",
+        "size": 13671105,
+        "uri": "root://eospublic.cern.ch//eos/opendata/atlas/rucio/opendata/ODEO_FEB2025_v0_3lep_mc_364245.Sherpa_222_NNPDF30NNLO_WZZ_5l1v_EW6.3lep.root"
+      },
+      {
+        "checksum": "adler32:20216b1e",
+        "size": 5709131,
+        "uri": "root://eospublic.cern.ch//eos/opendata/atlas/rucio/opendata/ODEO_FEB2025_v0_3lep_mc_364246.Sherpa_222_NNPDF30NNLO_WZZ_3l3v_EW6.3lep.root"
+      },
+      {
+        "checksum": "adler32:b17e4caf",
+        "size": 12187063,
+        "uri": "root://eospublic.cern.ch//eos/opendata/atlas/rucio/opendata/ODEO_FEB2025_v0_3lep_mc_364247.Sherpa_222_NNPDF30NNLO_ZZZ_6l0v_EW6.3lep.root"
+      },
+      {
+        "checksum": "adler32:dc3e8d8f",
+        "size": 2132437,
+        "uri": "root://eospublic.cern.ch//eos/opendata/atlas/rucio/opendata/ODEO_FEB2025_v0_3lep_mc_364248.Sherpa_222_NNPDF30NNLO_ZZZ_4l2v_EW6.3lep.root"
+      },
+      {
+        "checksum": "adler32:c8e44251",
+        "size": 101225,
+        "uri": "root://eospublic.cern.ch//eos/opendata/atlas/rucio/opendata/ODEO_FEB2025_v0_3lep_mc_364249.Sherpa_222_NNPDF30NNLO_ZZZ_2l4v_EW6.3lep.root"
+      },
+      {
+        "checksum": "adler32:050ab5b3",
+        "size": 390544,
+        "uri": "root://eospublic.cern.ch//eos/opendata/atlas/rucio/opendata/ODEO_FEB2025_v0_3lep_mc_364336.Sherpa_222_NNPDF30NNLO_WpWpWn_sslvlvjj_EW6.3lep.root"
+      },
+      {
+        "checksum": "adler32:4e331d5b",
+        "size": 306646,
+        "uri": "root://eospublic.cern.ch//eos/opendata/atlas/rucio/opendata/ODEO_FEB2025_v0_3lep_mc_364337.Sherpa_222_NNPDF30NNLO_WnWnWp_sslvlvjj_EW6.3lep.root"
+      },
+      {
+        "checksum": "adler32:ab7b1e8b",
+        "size": 554162,
+        "uri": "root://eospublic.cern.ch//eos/opendata/atlas/rucio/opendata/ODEO_FEB2025_v0_3lep_mc_364338.Sherpa_222_NNPDF30NNLO_WpWpWn_oslvlvjj_EW6.3lep.root"
+      },
+      {
+        "checksum": "adler32:4edafdeb",
+        "size": 196030,
+        "uri": "root://eospublic.cern.ch//eos/opendata/atlas/rucio/opendata/ODEO_FEB2025_v0_3lep_mc_364339.Sherpa_222_NNPDF30NNLO_WnWnWp_oslvlvjj_EW6.3lep.root"
+      },
+      {
+        "checksum": "adler32:ca7da35b",
+        "size": 405112,
+        "uri": "root://eospublic.cern.ch//eos/opendata/atlas/rucio/opendata/ODEO_FEB2025_v0_3lep_mc_364350.Sherpa_224_NNPDF30NNLO_Diphoton_myy_0_50.3lep.root"
+      },
+      {
+        "checksum": "adler32:364dd394",
+        "size": 3835800,
+        "uri": "root://eospublic.cern.ch//eos/opendata/atlas/rucio/opendata/ODEO_FEB2025_v0_3lep_mc_364351.Sherpa_224_NNPDF30NNLO_Diphoton_myy_50_90.3lep.root"
+      },
+      {
+        "checksum": "adler32:d9184b86",
+        "size": 1338692,
+        "uri": "root://eospublic.cern.ch//eos/opendata/atlas/rucio/opendata/ODEO_FEB2025_v0_3lep_mc_364352.Sherpa_224_NNPDF30NNLO_Diphoton_myy_90_175.3lep.root"
+      },
+      {
+        "checksum": "adler32:710bbe05",
+        "size": 299323,
+        "uri": "root://eospublic.cern.ch//eos/opendata/atlas/rucio/opendata/ODEO_FEB2025_v0_3lep_mc_364353.Sherpa_224_NNPDF30NNLO_Diphoton_myy_175_2000.3lep.root"
+      },
+      {
+        "checksum": "adler32:7661dc63",
+        "size": 44221,
+        "uri": "root://eospublic.cern.ch//eos/opendata/atlas/rucio/opendata/ODEO_FEB2025_v0_3lep_mc_364354.Sherpa_224_NNPDF30NNLO_Diphoton_myy_2000_E_CMS.3lep.root"
+      },
+      {
+        "checksum": "adler32:5f4f07e6",
+        "size": 1373935,
+        "uri": "root://eospublic.cern.ch//eos/opendata/atlas/rucio/opendata/ODEO_FEB2025_v0_3lep_mc_364541.Sherpa_222_NNPDF30NNLO_SinglePhoton_pty_17_35.3lep.root"
+      },
+      {
+        "checksum": "adler32:53bdeac6",
+        "size": 1621533,
+        "uri": "root://eospublic.cern.ch//eos/opendata/atlas/rucio/opendata/ODEO_FEB2025_v0_3lep_mc_364542.Sherpa_222_NNPDF30NNLO_SinglePhoton_pty_35_70.3lep.root"
+      },
+      {
+        "checksum": "adler32:d52b7f22",
+        "size": 1896678,
+        "uri": "root://eospublic.cern.ch//eos/opendata/atlas/rucio/opendata/ODEO_FEB2025_v0_3lep_mc_364543.Sherpa_222_NNPDF30NNLO_SinglePhoton_pty_70_140.3lep.root"
+      },
+      {
+        "checksum": "adler32:88e7851c",
+        "size": 2668643,
+        "uri": "root://eospublic.cern.ch//eos/opendata/atlas/rucio/opendata/ODEO_FEB2025_v0_3lep_mc_364544.Sherpa_222_NNPDF30NNLO_SinglePhoton_pty_140_280.3lep.root"
+      },
+      {
+        "checksum": "adler32:6b1757cc",
+        "size": 763623,
+        "uri": "root://eospublic.cern.ch//eos/opendata/atlas/rucio/opendata/ODEO_FEB2025_v0_3lep_mc_364545.Sherpa_222_NNPDF30NNLO_SinglePhoton_pty_280_500.3lep.root"
+      },
+      {
+        "checksum": "adler32:19d060a6",
+        "size": 102347,
+        "uri": "root://eospublic.cern.ch//eos/opendata/atlas/rucio/opendata/ODEO_FEB2025_v0_3lep_mc_364546.Sherpa_222_NNPDF30NNLO_SinglePhoton_pty_500_1000.3lep.root"
+      },
+      {
+        "checksum": "adler32:d8859359",
+        "size": 179912,
+        "uri": "root://eospublic.cern.ch//eos/opendata/atlas/rucio/opendata/ODEO_FEB2025_v0_3lep_mc_364547.Sherpa_222_NNPDF30NNLO_SinglePhoton_pty_1000_E_CMS.3lep.root"
+      },
+      {
+        "checksum": "adler32:f60d0570",
+        "size": 51233,
+        "uri": "root://eospublic.cern.ch//eos/opendata/atlas/rucio/opendata/ODEO_FEB2025_v0_3lep_mc_364700.Pythia8EvtGen_A14NNPDF23LO_jetjet_JZ0WithSW.3lep.root"
+      },
+      {
+        "checksum": "adler32:2675db68",
+        "size": 158528,
+        "uri": "root://eospublic.cern.ch//eos/opendata/atlas/rucio/opendata/ODEO_FEB2025_v0_3lep_mc_364701.Pythia8EvtGen_A14NNPDF23LO_jetjet_JZ1WithSW.3lep.root"
+      },
+      {
+        "checksum": "adler32:1fb5f4a4",
+        "size": 7490491,
+        "uri": "root://eospublic.cern.ch//eos/opendata/atlas/rucio/opendata/ODEO_FEB2025_v0_3lep_mc_364702.Pythia8EvtGen_A14NNPDF23LO_jetjet_JZ2WithSW.3lep.root"
+      },
+      {
+        "checksum": "adler32:eed101af",
+        "size": 17916542,
+        "uri": "root://eospublic.cern.ch//eos/opendata/atlas/rucio/opendata/ODEO_FEB2025_v0_3lep_mc_364703.Pythia8EvtGen_A14NNPDF23LO_jetjet_JZ3WithSW.3lep.root"
+      },
+      {
+        "checksum": "adler32:4a3e3df0",
+        "size": 45035628,
+        "uri": "root://eospublic.cern.ch//eos/opendata/atlas/rucio/opendata/ODEO_FEB2025_v0_3lep_mc_364704.Pythia8EvtGen_A14NNPDF23LO_jetjet_JZ4WithSW.3lep.root"
+      },
+      {
+        "checksum": "adler32:7ec15a3a",
+        "size": 10451000,
+        "uri": "root://eospublic.cern.ch//eos/opendata/atlas/rucio/opendata/ODEO_FEB2025_v0_3lep_mc_364705.Pythia8EvtGen_A14NNPDF23LO_jetjet_JZ5WithSW.3lep.root"
+      },
+      {
+        "checksum": "adler32:2765c662",
+        "size": 780091,
+        "uri": "root://eospublic.cern.ch//eos/opendata/atlas/rucio/opendata/ODEO_FEB2025_v0_3lep_mc_364706.Pythia8EvtGen_A14NNPDF23LO_jetjet_JZ6WithSW.3lep.root"
+      },
+      {
+        "checksum": "adler32:c255fa62",
+        "size": 617391,
+        "uri": "root://eospublic.cern.ch//eos/opendata/atlas/rucio/opendata/ODEO_FEB2025_v0_3lep_mc_364707.Pythia8EvtGen_A14NNPDF23LO_jetjet_JZ7WithSW.3lep.root"
+      },
+      {
+        "checksum": "adler32:08434b58",
+        "size": 1587501,
+        "uri": "root://eospublic.cern.ch//eos/opendata/atlas/rucio/opendata/ODEO_FEB2025_v0_3lep_mc_364708.Pythia8EvtGen_A14NNPDF23LO_jetjet_JZ8WithSW.3lep.root"
+      },
+      {
+        "checksum": "adler32:f31ea5cf",
+        "size": 906189,
+        "uri": "root://eospublic.cern.ch//eos/opendata/atlas/rucio/opendata/ODEO_FEB2025_v0_3lep_mc_364709.Pythia8EvtGen_A14NNPDF23LO_jetjet_JZ9WithSW.3lep.root"
+      },
+      {
+        "checksum": "adler32:9337ee1d",
+        "size": 3526685,
+        "uri": "root://eospublic.cern.ch//eos/opendata/atlas/rucio/opendata/ODEO_FEB2025_v0_3lep_mc_364710.Pythia8EvtGen_A14NNPDF23LO_jetjet_JZ10WithSW.3lep.root"
+      },
+      {
+        "checksum": "adler32:b24265a6",
+        "size": 2060482,
+        "uri": "root://eospublic.cern.ch//eos/opendata/atlas/rucio/opendata/ODEO_FEB2025_v0_3lep_mc_364711.Pythia8EvtGen_A14NNPDF23LO_jetjet_JZ11WithSW.3lep.root"
+      },
+      {
+        "checksum": "adler32:e3fadba9",
+        "size": 3209819,
+        "uri": "root://eospublic.cern.ch//eos/opendata/atlas/rucio/opendata/ODEO_FEB2025_v0_3lep_mc_364712.Pythia8EvtGen_A14NNPDF23LO_jetjet_JZ12WithSW.3lep.root"
+      },
+      {
+        "checksum": "adler32:8f5310f6",
+        "size": 491951,
+        "uri": "root://eospublic.cern.ch//eos/opendata/atlas/rucio/opendata/ODEO_FEB2025_v0_3lep_mc_375884.MGPy8EG_A14N_GG_ttn1_2000_5000_200.3lep.root"
+      },
+      {
+        "checksum": "adler32:41a27fc5",
+        "size": 42487,
+        "uri": "root://eospublic.cern.ch//eos/opendata/atlas/rucio/opendata/ODEO_FEB2025_v0_3lep_mc_376359.MGPy8EG_A14N23LO_SS_onestepCC_1600_900_200.3lep.root"
+      },
+      {
+        "checksum": "adler32:eff67aff",
+        "size": 32096,
+        "uri": "root://eospublic.cern.ch//eos/opendata/atlas/rucio/opendata/ODEO_FEB2025_v0_3lep_mc_376518.MadGraphPythia8EvtGen_A14NNPDF23LO_GG_direct_2400_200.3lep.root"
+      },
+      {
+        "checksum": "adler32:a1bfb289",
+        "size": 1952395,
+        "uri": "root://eospublic.cern.ch//eos/opendata/atlas/rucio/opendata/ODEO_FEB2025_v0_3lep_mc_392202.MGPy8EG_A14N23LO_C1N2_WZ_500p0_100p0_3L_2L7.3lep.root"
+      },
+      {
+        "checksum": "adler32:dbb44551",
+        "size": 44856,
+        "uri": "root://eospublic.cern.ch//eos/opendata/atlas/rucio/opendata/ODEO_FEB2025_v0_3lep_mc_394997.MGPy8EG_A14N23LO_SM_N2C1p_105_100_2L2MET75_MadSpin.3lep.root"
+      },
+      {
+        "checksum": "adler32:c71ff315",
+        "size": 250300,
+        "uri": "root://eospublic.cern.ch//eos/opendata/atlas/rucio/opendata/ODEO_FEB2025_v0_3lep_mc_398384.MGPy8EG_A14N23LO_C1N2N1_GGMHinoZh50_800_noFilter.3lep.root"
+      },
+      {
+        "checksum": "adler32:20fa0504",
+        "size": 827371,
+        "uri": "root://eospublic.cern.ch//eos/opendata/atlas/rucio/opendata/ODEO_FEB2025_v0_3lep_mc_410081.MadGraphPythia8EvtGen_A14NNPDF23_ttbarWW.3lep.root"
+      },
+      {
+        "checksum": "adler32:7d1eb9cf",
+        "size": 3519257,
+        "uri": "root://eospublic.cern.ch//eos/opendata/atlas/rucio/opendata/ODEO_FEB2025_v0_3lep_mc_410082.MadGraphPythia8EvtGen_A14NNPDF23LO_ttgamma_noallhad.3lep.root"
+      },
+      {
+        "checksum": "adler32:f718c6ac",
+        "size": 230444,
+        "uri": "root://eospublic.cern.ch//eos/opendata/atlas/rucio/opendata/ODEO_FEB2025_v0_3lep_mc_410087.MadGraphPythia8EvtGen_A14NNPDF23LO_ttgamma_allhad.3lep.root"
+      },
+      {
+        "checksum": "adler32:5061761f",
+        "size": 1021936,
+        "uri": "root://eospublic.cern.ch//eos/opendata/atlas/rucio/opendata/ODEO_FEB2025_v0_3lep_mc_410155.aMcAtNloPythia8EvtGen_MEN30NLO_A14N23LO_ttW.3lep.root"
+      },
+      {
+        "checksum": "adler32:4df65539",
+        "size": 377517,
+        "uri": "root://eospublic.cern.ch//eos/opendata/atlas/rucio/opendata/ODEO_FEB2025_v0_3lep_mc_410156.aMcAtNloPythia8EvtGen_MEN30NLO_A14N23LO_ttZnunu.3lep.root"
+      },
+      {
+        "checksum": "adler32:b72bb29d",
+        "size": 749574,
+        "uri": "root://eospublic.cern.ch//eos/opendata/atlas/rucio/opendata/ODEO_FEB2025_v0_3lep_mc_410157.aMcAtNloPythia8EvtGen_MEN30NLO_A14N23LO_ttZqq.3lep.root"
+      },
+      {
+        "checksum": "adler32:f22acad3",
+        "size": 11618213,
+        "uri": "root://eospublic.cern.ch//eos/opendata/atlas/rucio/opendata/ODEO_FEB2025_v0_3lep_mc_410218.aMcAtNloPythia8EvtGen_MEN30NLO_A14N23LO_ttee.3lep.root"
+      },
+      {
+        "checksum": "adler32:c589306e",
+        "size": 18135345,
+        "uri": "root://eospublic.cern.ch//eos/opendata/atlas/rucio/opendata/ODEO_FEB2025_v0_3lep_mc_410219.aMcAtNloPythia8EvtGen_MEN30NLO_A14N23LO_ttmumu.3lep.root"
+      },
+      {
+        "checksum": "adler32:cb9f5089",
+        "size": 3178252,
+        "uri": "root://eospublic.cern.ch//eos/opendata/atlas/rucio/opendata/ODEO_FEB2025_v0_3lep_mc_410220.aMcAtNloPythia8EvtGen_MEN30NLO_A14N23LO_tttautau.3lep.root"
+      },
+      {
+        "checksum": "adler32:80dcb341",
+        "size": 4763031,
+        "uri": "root://eospublic.cern.ch//eos/opendata/atlas/rucio/opendata/ODEO_FEB2025_v0_3lep_mc_410389.MadGraphPythia8EvtGen_A14NNPDF23_ttgamma_nonallhadronic.3lep.root"
+      },
+      {
+        "checksum": "adler32:cc84837d",
+        "size": 3781219,
+        "uri": "root://eospublic.cern.ch//eos/opendata/atlas/rucio/opendata/ODEO_FEB2025_v0_3lep_mc_410395.MGH7EG_H7UE_ttgamma_nonallhadronic.3lep.root"
+      },
+      {
+        "checksum": "adler32:6fae9093",
+        "size": 266008,
+        "uri": "root://eospublic.cern.ch//eos/opendata/atlas/rucio/opendata/ODEO_FEB2025_v0_3lep_mc_410396.MGH7EG_H7UE_ttgamma_allhadronic.3lep.root"
+      },
+      {
+        "checksum": "adler32:38d835d2",
+        "size": 3775178,
+        "uri": "root://eospublic.cern.ch//eos/opendata/atlas/rucio/opendata/ODEO_FEB2025_v0_3lep_mc_410408.aMcAtNloPythia8EvtGen_tWZ_Ztoll_minDR1.3lep.root"
+      },
+      {
+        "checksum": "adler32:373a70bb",
+        "size": 144393511,
+        "uri": "root://eospublic.cern.ch//eos/opendata/atlas/rucio/opendata/ODEO_FEB2025_v0_3lep_mc_410470.PhPy8EG_A14_ttbar_hdamp258p75_nonallhad.3lep.root"
+      },
+      {
+        "checksum": "adler32:99464176",
+        "size": 8995059,
+        "uri": "root://eospublic.cern.ch//eos/opendata/atlas/rucio/opendata/ODEO_FEB2025_v0_3lep_mc_410471.PhPy8EG_A14_ttbar_hdamp258p75_allhad.3lep.root"
+      },
+      {
+        "checksum": "adler32:fc1a8828",
+        "size": 2182432,
+        "uri": "root://eospublic.cern.ch//eos/opendata/atlas/rucio/opendata/ODEO_FEB2025_v0_3lep_mc_410560.MadGraphPythia8EvtGen_A14_tZ_4fl_tchan_noAllHad.3lep.root"
+      },
+      {
+        "checksum": "adler32:85884a6d",
+        "size": 219243,
+        "uri": "root://eospublic.cern.ch//eos/opendata/atlas/rucio/opendata/ODEO_FEB2025_v0_3lep_mc_410644.PowhegPythia8EvtGen_A14_singletop_schan_lept_top.3lep.root"
+      },
+      {
+        "checksum": "adler32:1e535f2b",
+        "size": 153090,
+        "uri": "root://eospublic.cern.ch//eos/opendata/atlas/rucio/opendata/ODEO_FEB2025_v0_3lep_mc_410645.PowhegPythia8EvtGen_A14_singletop_schan_lept_antitop.3lep.root"
+      },
+      {
+        "checksum": "adler32:315f5301",
+        "size": 2887550,
+        "uri": "root://eospublic.cern.ch//eos/opendata/atlas/rucio/opendata/ODEO_FEB2025_v0_3lep_mc_410658.PhPy8EG_A14_tchan_BW50_lept_top.3lep.root"
+      },
+      {
+        "checksum": "adler32:a5c9614d",
+        "size": 1740324,
+        "uri": "root://eospublic.cern.ch//eos/opendata/atlas/rucio/opendata/ODEO_FEB2025_v0_3lep_mc_410659.PhPy8EG_A14_tchan_BW50_lept_antitop.3lep.root"
+      },
+      {
+        "checksum": "adler32:ccad1f9d",
+        "size": 13157272,
+        "uri": "root://eospublic.cern.ch//eos/opendata/atlas/rucio/opendata/ODEO_FEB2025_v0_3lep_mc_411233.PowhegHerwig7EvtGen_tt_hdamp258p75_713_SingleLep.3lep.root"
+      },
+      {
+        "checksum": "adler32:f33d1165",
+        "size": 44344900,
+        "uri": "root://eospublic.cern.ch//eos/opendata/atlas/rucio/opendata/ODEO_FEB2025_v0_3lep_mc_411234.PowhegHerwig7EvtGen_tt_hdamp258p75_713_dil.3lep.root"
+      },
+      {
+        "checksum": "adler32:5d4d9176",
+        "size": 10898766,
+        "uri": "root://eospublic.cern.ch//eos/opendata/atlas/rucio/opendata/ODEO_FEB2025_v0_3lep_mc_411316.PowhegHerwig7EvtGen_tt_hdamp258p75_713_allhad.3lep.root"
+      },
+      {
+        "checksum": "adler32:c622620a",
+        "size": 6357710,
+        "uri": "root://eospublic.cern.ch//eos/opendata/atlas/rucio/opendata/ODEO_FEB2025_v0_3lep_mc_412043.aMcAtNloPythia8EvtGen_A14NNPDF31_SM4topsNLO.3lep.root"
+      },
+      {
+        "checksum": "adler32:f7d6e6df",
+        "size": 6050150,
+        "uri": "root://eospublic.cern.ch//eos/opendata/atlas/rucio/opendata/ODEO_FEB2025_v0_3lep_mc_412044.aMcAtNloHerwig7EvtGen_H7UE_SM4topsNLO.3lep.root"
+      },
+      {
+        "checksum": "adler32:0d4f3ad6",
+        "size": 122291,
+        "uri": "root://eospublic.cern.ch//eos/opendata/atlas/rucio/opendata/ODEO_FEB2025_v0_3lep_mc_423099.Pythia8EvtGen_A14NNPDF23LO_gammajet_DP8_17.3lep.root"
+      },
+      {
+        "checksum": "adler32:bbcf75a6",
+        "size": 322134,
+        "uri": "root://eospublic.cern.ch//eos/opendata/atlas/rucio/opendata/ODEO_FEB2025_v0_3lep_mc_423100.Pythia8EvtGen_A14NNPDF23LO_gammajet_DP17_35.3lep.root"
+      },
+      {
+        "checksum": "adler32:6ac8258b",
+        "size": 419148,
+        "uri": "root://eospublic.cern.ch//eos/opendata/atlas/rucio/opendata/ODEO_FEB2025_v0_3lep_mc_423101.Pythia8EvtGen_A14NNPDF23LO_gammajet_DP35_50.3lep.root"
+      },
+      {
+        "checksum": "adler32:8c34d498",
+        "size": 527617,
+        "uri": "root://eospublic.cern.ch//eos/opendata/atlas/rucio/opendata/ODEO_FEB2025_v0_3lep_mc_423102.Pythia8EvtGen_A14NNPDF23LO_gammajet_DP50_70.3lep.root"
+      },
+      {
+        "checksum": "adler32:0d629722",
+        "size": 409272,
+        "uri": "root://eospublic.cern.ch//eos/opendata/atlas/rucio/opendata/ODEO_FEB2025_v0_3lep_mc_423103.Pythia8EvtGen_A14NNPDF23LO_gammajet_DP70_140.3lep.root"
+      },
+      {
+        "checksum": "adler32:7c4de5ef",
+        "size": 595164,
+        "uri": "root://eospublic.cern.ch//eos/opendata/atlas/rucio/opendata/ODEO_FEB2025_v0_3lep_mc_423104.Pythia8EvtGen_A14NNPDF23LO_gammajet_DP140_280.3lep.root"
+      },
+      {
+        "checksum": "adler32:5e2981e9",
+        "size": 718182,
+        "uri": "root://eospublic.cern.ch//eos/opendata/atlas/rucio/opendata/ODEO_FEB2025_v0_3lep_mc_423105.Pythia8EvtGen_A14NNPDF23LO_gammajet_DP280_500.3lep.root"
+      },
+      {
+        "checksum": "adler32:b8a49591",
+        "size": 130784,
+        "uri": "root://eospublic.cern.ch//eos/opendata/atlas/rucio/opendata/ODEO_FEB2025_v0_3lep_mc_423106.Pythia8EvtGen_A14NNPDF23LO_gammajet_DP500_800.3lep.root"
+      },
+      {
+        "checksum": "adler32:c0f7a203",
+        "size": 106066,
+        "uri": "root://eospublic.cern.ch//eos/opendata/atlas/rucio/opendata/ODEO_FEB2025_v0_3lep_mc_423107.Pythia8EvtGen_A14NNPDF23LO_gammajet_DP800_1000.3lep.root"
+      },
+      {
+        "checksum": "adler32:776610c8",
+        "size": 159983,
+        "uri": "root://eospublic.cern.ch//eos/opendata/atlas/rucio/opendata/ODEO_FEB2025_v0_3lep_mc_423108.Pythia8EvtGen_A14NNPDF23LO_gammajet_DP1000_1500.3lep.root"
+      },
+      {
+        "checksum": "adler32:4c2c0577",
+        "size": 85713,
+        "uri": "root://eospublic.cern.ch//eos/opendata/atlas/rucio/opendata/ODEO_FEB2025_v0_3lep_mc_423109.Pythia8EvtGen_A14NNPDF23LO_gammajet_DP1500_2000.3lep.root"
+      },
+      {
+        "checksum": "adler32:be14bc2b",
+        "size": 75258,
+        "uri": "root://eospublic.cern.ch//eos/opendata/atlas/rucio/opendata/ODEO_FEB2025_v0_3lep_mc_423110.Pythia8EvtGen_A14NNPDF23LO_gammajet_DP2000_2500.3lep.root"
+      },
+      {
+        "checksum": "adler32:a1ea4be6",
+        "size": 150926,
+        "uri": "root://eospublic.cern.ch//eos/opendata/atlas/rucio/opendata/ODEO_FEB2025_v0_3lep_mc_423111.Pythia8EvtGen_A14NNPDF23LO_gammajet_DP2500_3000.3lep.root"
+      },
+      {
+        "checksum": "adler32:9ac9d62a",
+        "size": 133106,
+        "uri": "root://eospublic.cern.ch//eos/opendata/atlas/rucio/opendata/ODEO_FEB2025_v0_3lep_mc_423112.Pythia8EvtGen_A14NNPDF23LO_gammajet_DP3000_inf.3lep.root"
+      },
+      {
+        "checksum": "adler32:f55c387d",
+        "size": 322935,
+        "uri": "root://eospublic.cern.ch//eos/opendata/atlas/rucio/opendata/ODEO_FEB2025_v0_3lep_mc_448624.MGPy8EG_A14N23LO_TT_higgsinoRPV_1075_700.3lep.root"
+      },
+      {
+        "checksum": "adler32:4e5b4435",
+        "size": 699198,
+        "uri": "root://eospublic.cern.ch//eos/opendata/atlas/rucio/opendata/ODEO_FEB2025_v0_3lep_mc_449595.MGPy8EG_A14N23LO_TT_RPVdirectBL_1400.3lep.root"
+      },
+      {
+        "checksum": "adler32:6a056505",
+        "size": 660070,
+        "uri": "root://eospublic.cern.ch//eos/opendata/atlas/rucio/opendata/ODEO_FEB2025_v0_3lep_mc_450576.PowhegPythia8EvtGen_NNLOPS_nnlo_30_VBFH125_ZZllbb.3lep.root"
+      },
+      {
+        "checksum": "adler32:5927006e",
+        "size": 648135,
+        "uri": "root://eospublic.cern.ch//eos/opendata/atlas/rucio/opendata/ODEO_FEB2025_v0_3lep_mc_500335.MGH7EG_VBFHWWlvlv.3lep.root"
+      },
+      {
+        "checksum": "adler32:c9862f4e",
+        "size": 383787,
+        "uri": "root://eospublic.cern.ch//eos/opendata/atlas/rucio/opendata/ODEO_FEB2025_v0_3lep_mc_500553.aMCPy8EG_ZH_FxFx_Hyy.3lep.root"
+      },
+      {
+        "checksum": "adler32:71329726",
+        "size": 114452,
+        "uri": "root://eospublic.cern.ch//eos/opendata/atlas/rucio/opendata/ODEO_FEB2025_v0_3lep_mc_500554.aMCPy8EG_WH_FxFx_Hyy.3lep.root"
+      },
+      {
+        "checksum": "adler32:46bcd412",
+        "size": 407340,
+        "uri": "root://eospublic.cern.ch//eos/opendata/atlas/rucio/opendata/ODEO_FEB2025_v0_3lep_mc_500555.aMCPy8EG_ggZH_Hyy.3lep.root"
+      },
+      {
+        "checksum": "adler32:ef0783ed",
+        "size": 57073,
+        "uri": "root://eospublic.cern.ch//eos/opendata/atlas/rucio/opendata/ODEO_FEB2025_v0_3lep_mc_501058.MGPy8EG_StauStauDirect_200p0_1p0_TFilt.3lep.root"
+      },
+      {
+        "checksum": "adler32:ccb0726e",
+        "size": 322113,
+        "uri": "root://eospublic.cern.ch//eos/opendata/atlas/rucio/opendata/ODEO_FEB2025_v0_3lep_mc_506098.aMCPy8EG_WpH_FxFx_Htautau.3lep.root"
+      },
+      {
+        "checksum": "adler32:e31bcaa2",
+        "size": 486586,
+        "uri": "root://eospublic.cern.ch//eos/opendata/atlas/rucio/opendata/ODEO_FEB2025_v0_3lep_mc_506099.aMCPy8EG_ZH_FxFx_Htautau.3lep.root"
+      },
+      {
+        "checksum": "adler32:4db00f77",
+        "size": 59952,
+        "uri": "root://eospublic.cern.ch//eos/opendata/atlas/rucio/opendata/ODEO_FEB2025_v0_3lep_mc_506101.aMCH7EG_VBF_Htautauh30h20.3lep.root"
+      },
+      {
+        "checksum": "adler32:0c055117",
+        "size": 681055,
+        "uri": "root://eospublic.cern.ch//eos/opendata/atlas/rucio/opendata/ODEO_FEB2025_v0_3lep_mc_506102.aMCH7EG_VBF_Htautaul13l7.3lep.root"
+      },
+      {
+        "checksum": "adler32:768ffef8",
+        "size": 95818,
+        "uri": "root://eospublic.cern.ch//eos/opendata/atlas/rucio/opendata/ODEO_FEB2025_v0_3lep_mc_506103.aMCH7EG_VBF_Htautaulp15hm20.3lep.root"
+      },
+      {
+        "checksum": "adler32:bcf4529b",
+        "size": 143181,
+        "uri": "root://eospublic.cern.ch//eos/opendata/atlas/rucio/opendata/ODEO_FEB2025_v0_3lep_mc_506104.aMCH7EG_VBF_Htautaulm15hp20.3lep.root"
+      },
+      {
+        "checksum": "adler32:2c3b4af6",
+        "size": 63739,
+        "uri": "root://eospublic.cern.ch//eos/opendata/atlas/rucio/opendata/ODEO_FEB2025_v0_3lep_mc_506811.aMCH7EG_VBF_HC_Hyy.3lep.root"
+      },
+      {
+        "checksum": "adler32:f4d88db1",
+        "size": 40484,
+        "uri": "root://eospublic.cern.ch//eos/opendata/atlas/rucio/opendata/ODEO_FEB2025_v0_3lep_mc_506813.aMCPy8EG_ZH_had_FxFx_Hyy.3lep.root"
+      },
+      {
+        "checksum": "adler32:9be39879",
+        "size": 46733,
+        "uri": "root://eospublic.cern.ch//eos/opendata/atlas/rucio/opendata/ODEO_FEB2025_v0_3lep_mc_506814.aMCPy8EG_ggZH_Zhad_Hyy.3lep.root"
+      },
+      {
+        "checksum": "adler32:bae5ee7d",
+        "size": 84202,
+        "uri": "root://eospublic.cern.ch//eos/opendata/atlas/rucio/opendata/ODEO_FEB2025_v0_3lep_mc_507366.MGPy8EG_A14NNPDF23LO_GGM_N1N2C1_950.3lep.root"
+      },
+      {
+        "checksum": "adler32:0b4c4dff",
+        "size": 1095305,
+        "uri": "root://eospublic.cern.ch//eos/opendata/atlas/rucio/opendata/ODEO_FEB2025_v0_3lep_mc_510097.MGPy8EG_A14N23LO_DM_4topscalar_p1000_c1_nonallhad.3lep.root"
+      },
+      {
+        "checksum": "adler32:c6d7bb19",
+        "size": 94407,
+        "uri": "root://eospublic.cern.ch//eos/opendata/atlas/rucio/opendata/ODEO_FEB2025_v0_3lep_mc_523692.MGPy8EG_A14N23LO_TT_tN1_1200_200_MS.3lep.root"
+      },
+      {
+        "checksum": "adler32:ccb5f8d8",
+        "size": 1279092,
+        "uri": "root://eospublic.cern.ch//eos/opendata/atlas/rucio/opendata/ODEO_FEB2025_v0_3lep_mc_600017.PhH7EG_H7UE_716_tchan_lept_antitop.3lep.root"
+      },
+      {
+        "checksum": "adler32:2959ae05",
+        "size": 2158499,
+        "uri": "root://eospublic.cern.ch//eos/opendata/atlas/rucio/opendata/ODEO_FEB2025_v0_3lep_mc_600018.PhH7EG_H7UE_716_tchan_lept_top.3lep.root"
+      },
+      {
+        "checksum": "adler32:6dbb3ea5",
+        "size": 170096,
+        "uri": "root://eospublic.cern.ch//eos/opendata/atlas/rucio/opendata/ODEO_FEB2025_v0_3lep_mc_600019.PhH7EG_H7UE_716_schan_lept_antitop.3lep.root"
+      },
+      {
+        "checksum": "adler32:d35df6b0",
+        "size": 205216,
+        "uri": "root://eospublic.cern.ch//eos/opendata/atlas/rucio/opendata/ODEO_FEB2025_v0_3lep_mc_600020.PhH7EG_H7UE_716_schan_lept_top.3lep.root"
+      },
+      {
+        "checksum": "adler32:26480633",
+        "size": 152166,
+        "uri": "root://eospublic.cern.ch//eos/opendata/atlas/rucio/opendata/ODEO_FEB2025_v0_3lep_mc_600565.PhH7EG_ggH125_tautauh30h20_ShowerSys_fix.3lep.root"
+      },
+      {
+        "checksum": "adler32:f0a8d4bf",
+        "size": 1744122,
+        "uri": "root://eospublic.cern.ch//eos/opendata/atlas/rucio/opendata/ODEO_FEB2025_v0_3lep_mc_600566.PhH7EG_ggH125_tautaul13l7_ShowerSys_fix.3lep.root"
+      },
+      {
+        "checksum": "adler32:3b8301d0",
+        "size": 167613,
+        "uri": "root://eospublic.cern.ch//eos/opendata/atlas/rucio/opendata/ODEO_FEB2025_v0_3lep_mc_600567.PhH7EG_ggH125_ttlp15hm20_ShowerSys_fix.3lep.root"
+      },
+      {
+        "checksum": "adler32:ae478a63",
+        "size": 199192,
+        "uri": "root://eospublic.cern.ch//eos/opendata/atlas/rucio/opendata/ODEO_FEB2025_v0_3lep_mc_600568.PhH7EG_ggH125_ttlm15hp20_ShowerSys_fix.3lep.root"
+      },
+      {
+        "checksum": "adler32:c704c5c7",
+        "size": 62323,
+        "uri": "root://eospublic.cern.ch//eos/opendata/atlas/rucio/opendata/ODEO_FEB2025_v0_3lep_mc_600569.PhH7EG_VBFH125_tautauh30h20_ShowerSys_fix.3lep.root"
+      },
+      {
+        "checksum": "adler32:5d081546",
+        "size": 625255,
+        "uri": "root://eospublic.cern.ch//eos/opendata/atlas/rucio/opendata/ODEO_FEB2025_v0_3lep_mc_600570.PhH7EG_VBFH125_tautaul13l7_ShowerSys_fix.3lep.root"
+      },
+      {
+        "checksum": "adler32:2e22d621",
+        "size": 75348,
+        "uri": "root://eospublic.cern.ch//eos/opendata/atlas/rucio/opendata/ODEO_FEB2025_v0_3lep_mc_600571.PhH7EG_VBFH125_tautaulp15hm20_ShowerSys_fix.3lep.root"
+      },
+      {
+        "checksum": "adler32:502f6387",
+        "size": 78287,
+        "uri": "root://eospublic.cern.ch//eos/opendata/atlas/rucio/opendata/ODEO_FEB2025_v0_3lep_mc_600572.PhH7EG_VBFH125_tautaulm15hp20_ShowerSys_fix.3lep.root"
+      },
+      {
+        "checksum": "adler32:65ce0fe9",
+        "size": 198789,
+        "uri": "root://eospublic.cern.ch//eos/opendata/atlas/rucio/opendata/ODEO_FEB2025_v0_3lep_mc_600573.PhH7EG_WmH125J_Winc_MINLO_tt_ShowerSys_fix.3lep.root"
+      },
+      {
+        "checksum": "adler32:1382e9b9",
+        "size": 297915,
+        "uri": "root://eospublic.cern.ch//eos/opendata/atlas/rucio/opendata/ODEO_FEB2025_v0_3lep_mc_600574.PhH7EG_WpH125J_Winc_MINLO_tt_ShowerSys_fix.3lep.root"
+      },
+      {
+        "checksum": "adler32:7f7af892",
+        "size": 693135,
+        "uri": "root://eospublic.cern.ch//eos/opendata/atlas/rucio/opendata/ODEO_FEB2025_v0_3lep_mc_600575.PhH7EG_ZH125J_Zinc_MINLO_tautau_ShowerSys_fix.3lep.root"
+      },
+      {
+        "checksum": "adler32:038818fa",
+        "size": 416365,
+        "uri": "root://eospublic.cern.ch//eos/opendata/atlas/rucio/opendata/ODEO_FEB2025_v0_3lep_mc_600686.PhPy8EG_NNPDF3_AZNLO_ggZH125_Htautau_Zinc.3lep.root"
+      },
+      {
+        "checksum": "adler32:1acfbb34",
+        "size": 4872699,
+        "uri": "root://eospublic.cern.ch//eos/opendata/atlas/rucio/opendata/ODEO_FEB2025_v0_3lep_mc_601352.PhPy8EG_tW_dyn_DR_incl_antitop.3lep.root"
+      },
+      {
+        "checksum": "adler32:a351baef",
+        "size": 4768812,
+        "uri": "root://eospublic.cern.ch//eos/opendata/atlas/rucio/opendata/ODEO_FEB2025_v0_3lep_mc_601355.PhPy8EG_tW_dyn_DR_incl_top.3lep.root"
+      },
+      {
+        "checksum": "adler32:bd7e273c",
+        "size": 1449623,
+        "uri": "root://eospublic.cern.ch//eos/opendata/atlas/rucio/opendata/ODEO_FEB2025_v0_3lep_mc_601487.PhPy8EG_A14_tchan_pThard1_lep_antitop.3lep.root"
+      },
+      {
+        "checksum": "adler32:abfe5eba",
+        "size": 2353161,
+        "uri": "root://eospublic.cern.ch//eos/opendata/atlas/rucio/opendata/ODEO_FEB2025_v0_3lep_mc_601489.PhPy8EG_A14_tchan_pThard1_lep_top.3lep.root"
+      },
+      {
+        "checksum": "adler32:d544aae4",
+        "size": 79716459,
+        "uri": "root://eospublic.cern.ch//eos/opendata/atlas/rucio/opendata/ODEO_FEB2025_v0_3lep_mc_601491.PhPy8EG_A14_ttbar_pThard1_dil.3lep.root"
+      },
+      {
+        "checksum": "adler32:558cd70b",
+        "size": 108104,
+        "uri": "root://eospublic.cern.ch//eos/opendata/atlas/rucio/opendata/ODEO_FEB2025_v0_3lep_mc_601495.PhPy8EG_A14_ttbar_pThard1_allhad.3lep.root"
+      },
+      {
+        "checksum": "adler32:ab64dad4",
+        "size": 48395879,
+        "uri": "root://eospublic.cern.ch//eos/opendata/atlas/rucio/opendata/ODEO_FEB2025_v0_3lep_mc_601497.PhPy8EG_A14_ttbar_pThard1_singlelep.3lep.root"
+      },
+      {
+        "checksum": "adler32:9ae197e7",
+        "size": 2989154,
+        "uri": "root://eospublic.cern.ch//eos/opendata/atlas/rucio/opendata/ODEO_FEB2025_v0_3lep_mc_601624.PhPy8EG_tW_DS_dyn_dil_antitop.3lep.root"
+      },
+      {
+        "checksum": "adler32:45eb7461",
+        "size": 4558618,
+        "uri": "root://eospublic.cern.ch//eos/opendata/atlas/rucio/opendata/ODEO_FEB2025_v0_3lep_mc_601627.PhPy8EG_tW_DS_dyn_incl_antitop.3lep.root"
+      },
+      {
+        "checksum": "adler32:0655dd42",
+        "size": 3720869,
+        "uri": "root://eospublic.cern.ch//eos/opendata/atlas/rucio/opendata/ODEO_FEB2025_v0_3lep_mc_601628.PhPy8EG_tW_DS_dyn_dil_top.3lep.root"
+      },
+      {
+        "checksum": "adler32:1f59f3ca",
+        "size": 4414282,
+        "uri": "root://eospublic.cern.ch//eos/opendata/atlas/rucio/opendata/ODEO_FEB2025_v0_3lep_mc_601631.PhPy8EG_tW_DS_dyn_incl_top.3lep.root"
+      },
+      {
+        "checksum": "adler32:3dd3e270",
+        "size": 4780747,
+        "uri": "root://eospublic.cern.ch//eos/opendata/atlas/rucio/opendata/ODEO_FEB2025_v0_3lep_mc_601761.PhPy8EG_tW_dyn_DR_pThard1_incl_top.3lep.root"
+      },
+      {
+        "checksum": "adler32:6de7ca05",
+        "size": 4837573,
+        "uri": "root://eospublic.cern.ch//eos/opendata/atlas/rucio/opendata/ODEO_FEB2025_v0_3lep_mc_601762.PhPy8EG_tW_dyn_DR_pThard1_incl_antitop.3lep.root"
+      },
+      {
+        "checksum": "adler32:fcf01979",
+        "size": 3828039,
+        "uri": "root://eospublic.cern.ch//eos/opendata/atlas/rucio/opendata/ODEO_FEB2025_v0_3lep_mc_601763.PhPy8EG_tW_dyn_DR_pThard1_dil_top.3lep.root"
+      },
+      {
+        "checksum": "adler32:30f07710",
+        "size": 3889171,
+        "uri": "root://eospublic.cern.ch//eos/opendata/atlas/rucio/opendata/ODEO_FEB2025_v0_3lep_mc_601764.PhPy8EG_tW_dyn_DR_pThard1_dil_antitop.3lep.root"
+      },
+      {
+        "checksum": "adler32:1d7d718c",
+        "size": 1703660,
+        "uri": "root://eospublic.cern.ch//eos/opendata/atlas/rucio/opendata/ODEO_FEB2025_v0_3lep_mc_700000.Sh_228_ttW.3lep.root"
+      },
+      {
+        "checksum": "adler32:c180cad8",
+        "size": 59235,
+        "uri": "root://eospublic.cern.ch//eos/opendata/atlas/rucio/opendata/ODEO_FEB2025_v0_3lep_mc_700007.Sh_228_yyy_01NLO.3lep.root"
+      },
+      {
+        "checksum": "adler32:518169f5",
+        "size": 1699431,
+        "uri": "root://eospublic.cern.ch//eos/opendata/atlas/rucio/opendata/ODEO_FEB2025_v0_3lep_mc_700195.Sh_2210_eegammagamma.3lep.root"
+      },
+      {
+        "checksum": "adler32:d532bef8",
+        "size": 2480564,
+        "uri": "root://eospublic.cern.ch//eos/opendata/atlas/rucio/opendata/ODEO_FEB2025_v0_3lep_mc_700196.Sh_2210_mumugammagamma.3lep.root"
+      },
+      {
+        "checksum": "adler32:445f0670",
+        "size": 119397,
+        "uri": "root://eospublic.cern.ch//eos/opendata/atlas/rucio/opendata/ODEO_FEB2025_v0_3lep_mc_700197.Sh_2210_tautaugammagamma.3lep.root"
+      },
+      {
+        "checksum": "adler32:0fb3436f",
+        "size": 27573,
+        "uri": "root://eospublic.cern.ch//eos/opendata/atlas/rucio/opendata/ODEO_FEB2025_v0_3lep_mc_700198.Sh_2210_nunugammagamma.3lep.root"
+      },
+      {
+        "checksum": "adler32:86588538",
+        "size": 159952,
+        "uri": "root://eospublic.cern.ch//eos/opendata/atlas/rucio/opendata/ODEO_FEB2025_v0_3lep_mc_700199.Sh_2210_enugammagamma.3lep.root"
+      },
+      {
+        "checksum": "adler32:792fd451",
+        "size": 159201,
+        "uri": "root://eospublic.cern.ch//eos/opendata/atlas/rucio/opendata/ODEO_FEB2025_v0_3lep_mc_700200.Sh_2210_munugammagamma.3lep.root"
+      },
+      {
+        "checksum": "adler32:7be3ccc0",
+        "size": 70419,
+        "uri": "root://eospublic.cern.ch//eos/opendata/atlas/rucio/opendata/ODEO_FEB2025_v0_3lep_mc_700201.Sh_2210_taunugammagamma.3lep.root"
+      },
+      {
+        "checksum": "adler32:0f2c3e29",
+        "size": 78833425,
+        "uri": "root://eospublic.cern.ch//eos/opendata/atlas/rucio/opendata/ODEO_FEB2025_v0_3lep_mc_700320.Sh_2211_Zee_maxHTpTV2_BFilter.3lep.root"
+      },
+      {
+        "checksum": "adler32:b9682260",
+        "size": 203438419,
+        "uri": "root://eospublic.cern.ch//eos/opendata/atlas/rucio/opendata/ODEO_FEB2025_v0_3lep_mc_700321.Sh_2211_Zee_maxHTpTV2_CFilterBVeto.3lep.root"
+      },
+      {
+        "checksum": "adler32:34f9caca",
+        "size": 417008956,
+        "uri": "root://eospublic.cern.ch//eos/opendata/atlas/rucio/opendata/ODEO_FEB2025_v0_3lep_mc_700322.Sh_2211_Zee_maxHTpTV2_CVetoBVeto.3lep.root"
+      },
+      {
+        "checksum": "adler32:821e14c4",
+        "size": 76086970,
+        "uri": "root://eospublic.cern.ch//eos/opendata/atlas/rucio/opendata/ODEO_FEB2025_v0_3lep_mc_700323.Sh_2211_Zmumu_maxHTpTV2_BFilter.3lep.root"
+      },
+      {
+        "checksum": "adler32:4dae13c2",
+        "size": 203893858,
+        "uri": "root://eospublic.cern.ch//eos/opendata/atlas/rucio/opendata/ODEO_FEB2025_v0_3lep_mc_700324.Sh_2211_Zmumu_maxHTpTV2_CFilterBVeto.3lep.root"
+      },
+      {
+        "checksum": "adler32:314ba0df",
+        "size": 422648713,
+        "uri": "root://eospublic.cern.ch//eos/opendata/atlas/rucio/opendata/ODEO_FEB2025_v0_3lep_mc_700325.Sh_2211_Zmumu_maxHTpTV2_CVetoBVeto.3lep.root"
+      },
+      {
+        "checksum": "adler32:48e216d6",
+        "size": 705800,
+        "uri": "root://eospublic.cern.ch//eos/opendata/atlas/rucio/opendata/ODEO_FEB2025_v0_3lep_mc_700335.Sh_2211_Znunu_pTV2_BFilter.3lep.root"
+      },
+      {
+        "checksum": "adler32:5739ba94",
+        "size": 1297026,
+        "uri": "root://eospublic.cern.ch//eos/opendata/atlas/rucio/opendata/ODEO_FEB2025_v0_3lep_mc_700336.Sh_2211_Znunu_pTV2_CFilterBVeto.3lep.root"
+      },
+      {
+        "checksum": "adler32:56c0cbf5",
+        "size": 3463827,
+        "uri": "root://eospublic.cern.ch//eos/opendata/atlas/rucio/opendata/ODEO_FEB2025_v0_3lep_mc_700337.Sh_2211_Znunu_pTV2_CVetoBVeto.3lep.root"
+      },
+      {
+        "checksum": "adler32:2be2906c",
+        "size": 32263726,
+        "uri": "root://eospublic.cern.ch//eos/opendata/atlas/rucio/opendata/ODEO_FEB2025_v0_3lep_mc_700338.Sh_2211_Wenu_maxHTpTV2_BFilter.3lep.root"
+      },
+      {
+        "checksum": "adler32:c16efb7b",
+        "size": 113697023,
+        "uri": "root://eospublic.cern.ch//eos/opendata/atlas/rucio/opendata/ODEO_FEB2025_v0_3lep_mc_700339.Sh_2211_Wenu_maxHTpTV2_CFilterBVeto.3lep.root"
+      },
+      {
+        "checksum": "adler32:324bcf89",
+        "size": 69049798,
+        "uri": "root://eospublic.cern.ch//eos/opendata/atlas/rucio/opendata/ODEO_FEB2025_v0_3lep_mc_700340.Sh_2211_Wenu_maxHTpTV2_CVetoBVeto.3lep.root"
+      },
+      {
+        "checksum": "adler32:e77f2fa3",
+        "size": 33470108,
+        "uri": "root://eospublic.cern.ch//eos/opendata/atlas/rucio/opendata/ODEO_FEB2025_v0_3lep_mc_700341.Sh_2211_Wmunu_maxHTpTV2_BFilter.3lep.root"
+      },
+      {
+        "checksum": "adler32:e94bfb51",
+        "size": 105650205,
+        "uri": "root://eospublic.cern.ch//eos/opendata/atlas/rucio/opendata/ODEO_FEB2025_v0_3lep_mc_700342.Sh_2211_Wmunu_maxHTpTV2_CFilterBVeto.3lep.root"
+      },
+      {
+        "checksum": "adler32:a69c0ed8",
+        "size": 62888601,
+        "uri": "root://eospublic.cern.ch//eos/opendata/atlas/rucio/opendata/ODEO_FEB2025_v0_3lep_mc_700343.Sh_2211_Wmunu_maxHTpTV2_CVetoBVeto.3lep.root"
+      },
+      {
+        "checksum": "adler32:7f15273a",
+        "size": 7978530,
+        "uri": "root://eospublic.cern.ch//eos/opendata/atlas/rucio/opendata/ODEO_FEB2025_v0_3lep_mc_700344.Sh_2211_Wtaunu_L_maxHTpTV2_BFilter.3lep.root"
+      },
+      {
+        "checksum": "adler32:a1e46f17",
+        "size": 18435008,
+        "uri": "root://eospublic.cern.ch//eos/opendata/atlas/rucio/opendata/ODEO_FEB2025_v0_3lep_mc_700345.Sh_2211_Wtaunu_L_maxHTpTV2_CFilterBVeto.3lep.root"
+      },
+      {
+        "checksum": "adler32:685b8f0a",
+        "size": 21061676,
+        "uri": "root://eospublic.cern.ch//eos/opendata/atlas/rucio/opendata/ODEO_FEB2025_v0_3lep_mc_700346.Sh_2211_Wtaunu_L_maxHTpTV2_CVetoBVeto.3lep.root"
+      },
+      {
+        "checksum": "adler32:178c5989",
+        "size": 3811073,
+        "uri": "root://eospublic.cern.ch//eos/opendata/atlas/rucio/opendata/ODEO_FEB2025_v0_3lep_mc_700347.Sh_2211_Wtaunu_H_maxHTpTV2_BFilter.3lep.root"
+      },
+      {
+        "checksum": "adler32:a286dc3a",
+        "size": 2377294,
+        "uri": "root://eospublic.cern.ch//eos/opendata/atlas/rucio/opendata/ODEO_FEB2025_v0_3lep_mc_700348.Sh_2211_Wtaunu_H_maxHTpTV2_CFilterBVeto.3lep.root"
+      },
+      {
+        "checksum": "adler32:3144b813",
+        "size": 9202639,
+        "uri": "root://eospublic.cern.ch//eos/opendata/atlas/rucio/opendata/ODEO_FEB2025_v0_3lep_mc_700349.Sh_2211_Wtaunu_H_maxHTpTV2_CVetoBVeto.3lep.root"
+      },
+      {
+        "checksum": "adler32:34f44316",
+        "size": 205355,
+        "uri": "root://eospublic.cern.ch//eos/opendata/atlas/rucio/opendata/ODEO_FEB2025_v0_3lep_mc_700352.Sh_2211_pTZ100_Zqqgamma.3lep.root"
+      },
+      {
+        "checksum": "adler32:ec672dfb",
+        "size": 183473,
+        "uri": "root://eospublic.cern.ch//eos/opendata/atlas/rucio/opendata/ODEO_FEB2025_v0_3lep_mc_700353.Sh_2211_pTZ100_Zbbgamma.3lep.root"
+      },
+      {
+        "checksum": "adler32:e06e2f4b",
+        "size": 1098361,
+        "uri": "root://eospublic.cern.ch//eos/opendata/atlas/rucio/opendata/ODEO_FEB2025_v0_3lep_mc_700358.Sh_2211_Zee2jets_Min_N_TChannel.3lep.root"
+      },
+      {
+        "checksum": "adler32:20db0ebb",
+        "size": 941059,
+        "uri": "root://eospublic.cern.ch//eos/opendata/atlas/rucio/opendata/ODEO_FEB2025_v0_3lep_mc_700359.Sh_2211_Zmm2jets_Min_N_TChannel.3lep.root"
+      },
+      {
+        "checksum": "adler32:bf0ec84e",
+        "size": 114610,
+        "uri": "root://eospublic.cern.ch//eos/opendata/atlas/rucio/opendata/ODEO_FEB2025_v0_3lep_mc_700360.Sh_2211_Ztt2jets_Min_N_TChannel.3lep.root"
+      },
+      {
+        "checksum": "adler32:5d752b6b",
+        "size": 59532,
+        "uri": "root://eospublic.cern.ch//eos/opendata/atlas/rucio/opendata/ODEO_FEB2025_v0_3lep_mc_700361.Sh_2211_Znunu2jets_Min_N_TChannel.3lep.root"
+      },
+      {
+        "checksum": "adler32:8a106605",
+        "size": 420537,
+        "uri": "root://eospublic.cern.ch//eos/opendata/atlas/rucio/opendata/ODEO_FEB2025_v0_3lep_mc_700362.Sh_2211_Wenu2jets_Min_N_TChannel.3lep.root"
+      },
+      {
+        "checksum": "adler32:9095cd10",
+        "size": 495273,
+        "uri": "root://eospublic.cern.ch//eos/opendata/atlas/rucio/opendata/ODEO_FEB2025_v0_3lep_mc_700363.Sh_2211_Wmunu2jets_Min_N_TChannel.3lep.root"
+      },
+      {
+        "checksum": "adler32:927507ac",
+        "size": 200362,
+        "uri": "root://eospublic.cern.ch//eos/opendata/atlas/rucio/opendata/ODEO_FEB2025_v0_3lep_mc_700364.Sh_2211_Wtaunu2jets_Min_N_TChannel.3lep.root"
+      },
+      {
+        "checksum": "adler32:bab5265b",
+        "size": 79293543,
+        "uri": "root://eospublic.cern.ch//eos/opendata/atlas/rucio/opendata/ODEO_FEB2025_v0_3lep_mc_700398.Sh_2211_mumugamma.3lep.root"
+      },
+      {
+        "checksum": "adler32:cdead307",
+        "size": 82331883,
+        "uri": "root://eospublic.cern.ch//eos/opendata/atlas/rucio/opendata/ODEO_FEB2025_v0_3lep_mc_700399.Sh_2211_eegamma.3lep.root"
+      },
+      {
+        "checksum": "adler32:a2c29daf",
+        "size": 7656847,
+        "uri": "root://eospublic.cern.ch//eos/opendata/atlas/rucio/opendata/ODEO_FEB2025_v0_3lep_mc_700400.Sh_2211_tautaugamma.3lep.root"
+      },
+      {
+        "checksum": "adler32:8b415e61",
+        "size": 921598,
+        "uri": "root://eospublic.cern.ch//eos/opendata/atlas/rucio/opendata/ODEO_FEB2025_v0_3lep_mc_700401.Sh_2211_nunugamma.3lep.root"
+      },
+      {
+        "checksum": "adler32:598f9816",
+        "size": 27540240,
+        "uri": "root://eospublic.cern.ch//eos/opendata/atlas/rucio/opendata/ODEO_FEB2025_v0_3lep_mc_700402.Sh_2211_munugamma.3lep.root"
+      },
+      {
+        "checksum": "adler32:b78483c5",
+        "size": 29563340,
+        "uri": "root://eospublic.cern.ch//eos/opendata/atlas/rucio/opendata/ODEO_FEB2025_v0_3lep_mc_700403.Sh_2211_enugamma.3lep.root"
+      },
+      {
+        "checksum": "adler32:f9b7b058",
+        "size": 11575373,
+        "uri": "root://eospublic.cern.ch//eos/opendata/atlas/rucio/opendata/ODEO_FEB2025_v0_3lep_mc_700404.Sh_2211_taunugamma.3lep.root"
+      },
+      {
+        "checksum": "adler32:0a301116",
+        "size": 52371,
+        "uri": "root://eospublic.cern.ch//eos/opendata/atlas/rucio/opendata/ODEO_FEB2025_v0_3lep_mc_700442.Sh_2211_gamma2jets_pTy140_Min_N_TChannel.3lep.root"
+      },
+      {
+        "checksum": "adler32:30355606",
+        "size": 5856098,
+        "uri": "root://eospublic.cern.ch//eos/opendata/atlas/rucio/opendata/ODEO_FEB2025_v0_3lep_mc_700467.Sh_2211_Zee_maxHTpTV2_m10_40_pT5_BFilter.3lep.root"
+      },
+      {
+        "checksum": "adler32:7a2b7911",
+        "size": 16724114,
+        "uri": "root://eospublic.cern.ch//eos/opendata/atlas/rucio/opendata/ODEO_FEB2025_v0_3lep_mc_700468.Sh_2211_Zee_maxHTpTV2_m10_40_pT5_CFilterBVeto.3lep.root"
+      },
+      {
+        "checksum": "adler32:99ebfc55",
+        "size": 60430420,
+        "uri": "root://eospublic.cern.ch//eos/opendata/atlas/rucio/opendata/ODEO_FEB2025_v0_3lep_mc_700469.Sh_2211_Zee_maxHTpTV2_m10_40_pT5_CVetoBVeto.3lep.root"
+      },
+      {
+        "checksum": "adler32:9c1dc97a",
+        "size": 6207012,
+        "uri": "root://eospublic.cern.ch//eos/opendata/atlas/rucio/opendata/ODEO_FEB2025_v0_3lep_mc_700470.Sh_2211_Zmumu_maxHTpTV2_m10_40_pT5_BFilter.3lep.root"
+      },
+      {
+        "checksum": "adler32:6db708e5",
+        "size": 16206450,
+        "uri": "root://eospublic.cern.ch//eos/opendata/atlas/rucio/opendata/ODEO_FEB2025_v0_3lep_mc_700471.Sh_2211_Zmumu_maxHTpTV2_m10_40_pT5_CFilterBVeto.3lep.root"
+      },
+      {
+        "checksum": "adler32:c29c8d33",
+        "size": 58869323,
+        "uri": "root://eospublic.cern.ch//eos/opendata/atlas/rucio/opendata/ODEO_FEB2025_v0_3lep_mc_700472.Sh_2211_Zmumu_maxHTpTV2_m10_40_pT5_CVetoBVeto.3lep.root"
+      },
+      {
+        "checksum": "adler32:5b3f2505",
+        "size": 1987840,
+        "uri": "root://eospublic.cern.ch//eos/opendata/atlas/rucio/opendata/ODEO_FEB2025_v0_3lep_mc_700488.Sh_2211_WlvWqq.3lep.root"
+      },
+      {
+        "checksum": "adler32:7ab2f7be",
+        "size": 491994,
+        "uri": "root://eospublic.cern.ch//eos/opendata/atlas/rucio/opendata/ODEO_FEB2025_v0_3lep_mc_700489.Sh_2211_WlvZqq.3lep.root"
+      },
+      {
+        "checksum": "adler32:4d79dab7",
+        "size": 317436,
+        "uri": "root://eospublic.cern.ch//eos/opendata/atlas/rucio/opendata/ODEO_FEB2025_v0_3lep_mc_700490.Sh_2211_WlvZbb.3lep.root"
+      },
+      {
+        "checksum": "adler32:5e4c9404",
+        "size": 133847,
+        "uri": "root://eospublic.cern.ch//eos/opendata/atlas/rucio/opendata/ODEO_FEB2025_v0_3lep_mc_700491.Sh_2211_WqqZvv.3lep.root"
+      },
+      {
+        "checksum": "adler32:bf344ed0",
+        "size": 1624986,
+        "uri": "root://eospublic.cern.ch//eos/opendata/atlas/rucio/opendata/ODEO_FEB2025_v0_3lep_mc_700492.Sh_2211_WqqZll.3lep.root"
+      },
+      {
+        "checksum": "adler32:d835e44d",
+        "size": 1130740,
+        "uri": "root://eospublic.cern.ch//eos/opendata/atlas/rucio/opendata/ODEO_FEB2025_v0_3lep_mc_700493.Sh_2211_ZqqZll.3lep.root"
+      },
+      {
+        "checksum": "adler32:6d20d187",
+        "size": 2325027,
+        "uri": "root://eospublic.cern.ch//eos/opendata/atlas/rucio/opendata/ODEO_FEB2025_v0_3lep_mc_700494.Sh_2211_ZbbZll.3lep.root"
+      },
+      {
+        "checksum": "adler32:7121d4bb",
+        "size": 79748,
+        "uri": "root://eospublic.cern.ch//eos/opendata/atlas/rucio/opendata/ODEO_FEB2025_v0_3lep_mc_700495.Sh_2211_ZqqZvv.3lep.root"
+      },
+      {
+        "checksum": "adler32:0bcdc082",
+        "size": 47325,
+        "uri": "root://eospublic.cern.ch//eos/opendata/atlas/rucio/opendata/ODEO_FEB2025_v0_3lep_mc_700496.Sh_2211_ZbbZvv.3lep.root"
+      },
+      {
+        "checksum": "adler32:1aa4220a",
+        "size": 102110,
+        "uri": "root://eospublic.cern.ch//eos/opendata/atlas/rucio/opendata/ODEO_FEB2025_v0_3lep_mc_700507.Sh_2211_pTW140_Wqqgamma.3lep.root"
+      },
+      {
+        "checksum": "adler32:7004f18e",
+        "size": 8771972,
+        "uri": "root://eospublic.cern.ch//eos/opendata/atlas/rucio/opendata/ODEO_FEB2025_v0_3lep_mc_700587.Sh_2212_lllljj.3lep.root"
+      },
+      {
+        "checksum": "adler32:a585fea4",
+        "size": 3005385,
+        "uri": "root://eospublic.cern.ch//eos/opendata/atlas/rucio/opendata/ODEO_FEB2025_v0_3lep_mc_700588.Sh_2212_lllvjj.3lep.root"
+      },
+      {
+        "checksum": "adler32:99c7920a",
+        "size": 195576,
+        "uri": "root://eospublic.cern.ch//eos/opendata/atlas/rucio/opendata/ODEO_FEB2025_v0_3lep_mc_700589.Sh_2212_llvvjj_os.3lep.root"
+      },
+      {
+        "checksum": "adler32:08f9b46a",
+        "size": 466474,
+        "uri": "root://eospublic.cern.ch//eos/opendata/atlas/rucio/opendata/ODEO_FEB2025_v0_3lep_mc_700590.Sh_2212_llvvjj_ss.3lep.root"
+      },
+      {
+        "checksum": "adler32:8f637e18",
+        "size": 739552,
+        "uri": "root://eospublic.cern.ch//eos/opendata/atlas/rucio/opendata/ODEO_FEB2025_v0_3lep_mc_700591.Sh_2212_lllljj_Int.3lep.root"
+      },
+      {
+        "checksum": "adler32:07541596",
+        "size": 1059609,
+        "uri": "root://eospublic.cern.ch//eos/opendata/atlas/rucio/opendata/ODEO_FEB2025_v0_3lep_mc_700592.Sh_2212_lllvjj_Int.3lep.root"
+      },
+      {
+        "checksum": "adler32:cdbf339c",
+        "size": 128746,
+        "uri": "root://eospublic.cern.ch//eos/opendata/atlas/rucio/opendata/ODEO_FEB2025_v0_3lep_mc_700593.Sh_2212_llvvjj_os_Int.3lep.root"
+      },
+      {
+        "checksum": "adler32:9376fb88",
+        "size": 151516,
+        "uri": "root://eospublic.cern.ch//eos/opendata/atlas/rucio/opendata/ODEO_FEB2025_v0_3lep_mc_700594.Sh_2212_llvvjj_ss_Int.3lep.root"
+      },
+      {
+        "checksum": "adler32:63301beb",
+        "size": 19299224,
+        "uri": "root://eospublic.cern.ch//eos/opendata/atlas/rucio/opendata/ODEO_FEB2025_v0_3lep_mc_700600.Sh_2212_llll.3lep.root"
+      },
+      {
+        "checksum": "adler32:513aa56a",
+        "size": 26632359,
+        "uri": "root://eospublic.cern.ch//eos/opendata/atlas/rucio/opendata/ODEO_FEB2025_v0_3lep_mc_700601.Sh_2212_lllv.3lep.root"
+      },
+      {
+        "checksum": "adler32:e4dd8164",
+        "size": 2438221,
+        "uri": "root://eospublic.cern.ch//eos/opendata/atlas/rucio/opendata/ODEO_FEB2025_v0_3lep_mc_700602.Sh_2212_llvv_os.3lep.root"
+      },
+      {
+        "checksum": "adler32:31b5e0d9",
+        "size": 733215,
+        "uri": "root://eospublic.cern.ch//eos/opendata/atlas/rucio/opendata/ODEO_FEB2025_v0_3lep_mc_700603.Sh_2212_llvv_ss.3lep.root"
+      },
+      {
+        "checksum": "adler32:7e75552a",
+        "size": 156669,
+        "uri": "root://eospublic.cern.ch//eos/opendata/atlas/rucio/opendata/ODEO_FEB2025_v0_3lep_mc_700604.Sh_2212_lvvv.3lep.root"
+      },
+      {
+        "checksum": "adler32:760807c7",
+        "size": 41130,
+        "uri": "root://eospublic.cern.ch//eos/opendata/atlas/rucio/opendata/ODEO_FEB2025_v0_3lep_mc_700605.Sh_2212_vvvv.3lep.root"
+      },
+      {
+        "checksum": "adler32:a1c10b47",
+        "size": 170779,
+        "uri": "root://eospublic.cern.ch//eos/opendata/atlas/rucio/opendata/ODEO_FEB2025_v0_3lep_mc_700709.Sh_2212_lvgammajj.3lep.root"
+      },
+      {
+        "checksum": "adler32:87e9c09e",
+        "size": 2227477,
+        "uri": "root://eospublic.cern.ch//eos/opendata/atlas/rucio/opendata/ODEO_FEB2025_v0_3lep_mc_700710.Sh_2212_llgammajj.3lep.root"
+      },
+      {
+        "checksum": "adler32:0bcd991e",
+        "size": 8168342,
+        "uri": "root://eospublic.cern.ch//eos/opendata/atlas/rucio/opendata/ODEO_FEB2025_v0_3lep_mc_700792.Sh_2214_Ztautau_maxHTpTV2_BFilter.3lep.root"
+      },
+      {
+        "checksum": "adler32:44f59ff4",
+        "size": 23314176,
+        "uri": "root://eospublic.cern.ch//eos/opendata/atlas/rucio/opendata/ODEO_FEB2025_v0_3lep_mc_700793.Sh_2214_Ztautau_maxHTpTV2_CFilterBVeto.3lep.root"
+      },
+      {
+        "checksum": "adler32:68df50df",
+        "size": 30821615,
+        "uri": "root://eospublic.cern.ch//eos/opendata/atlas/rucio/opendata/ODEO_FEB2025_v0_3lep_mc_700794.Sh_2214_Ztautau_maxHTpTV2_CVetoBVeto.3lep.root"
+      },
+      {
+        "checksum": "adler32:bdd65ffa",
+        "size": 5453190,
+        "uri": "root://eospublic.cern.ch//eos/opendata/atlas/rucio/opendata/ODEO_FEB2025_v0_3lep_mc_700843.Sh_2214_Wqq_ptW_200_ECMS.3lep.root"
+      },
+      {
+        "checksum": "adler32:9e9689bf",
+        "size": 1952690,
+        "uri": "root://eospublic.cern.ch//eos/opendata/atlas/rucio/opendata/ODEO_FEB2025_v0_3lep_mc_700849.Sh_2214_Zqq_ptZ_200_ECMS.3lep.root"
+      },
+      {
+        "checksum": "adler32:1d1ea972",
+        "size": 1100433,
+        "uri": "root://eospublic.cern.ch//eos/opendata/atlas/rucio/opendata/ODEO_FEB2025_v0_3lep_mc_700855.Sh_2214_Zbb_ptZ_200_ECMS.3lep.root"
+      },
+      {
+        "checksum": "adler32:41d64b82",
+        "size": 1075862,
+        "uri": "root://eospublic.cern.ch//eos/opendata/atlas/rucio/opendata/ODEO_FEB2025_v0_3lep_mc_700901.Sh_2214_Ztt_maxHTpTV2_Mll10_40_BFilter.3lep.root"
+      },
+      {
+        "checksum": "adler32:4fb402a7",
+        "size": 4418472,
+        "uri": "root://eospublic.cern.ch//eos/opendata/atlas/rucio/opendata/ODEO_FEB2025_v0_3lep_mc_700902.Sh_2214_Ztt_maxHTpTV2_Mll10_40_CFilterBVeto.3lep.root"
+      },
+      {
+        "checksum": "adler32:591f0bf1",
+        "size": 7462914,
+        "uri": "root://eospublic.cern.ch//eos/opendata/atlas/rucio/opendata/ODEO_FEB2025_v0_3lep_mc_700903.Sh_2214_Ztt_maxHTpTV2_Mll10_40_CVetoBVeto.3lep.root"
+      },
+      {
+        "checksum": "adler32:16c6ff2a",
+        "size": 111704,
+        "uri": "root://eospublic.cern.ch//eos/opendata/atlas/rucio/opendata/ODEO_FEB2025_v0_3lep_mc_801976.Py8EG_A14NNPDF23LO_Zprime_NoInt_tautau_SSM3000.3lep.root"
+      },
+      {
+        "checksum": "adler32:09061c55",
+        "size": 29616,
+        "uri": "root://eospublic.cern.ch//eos/opendata/atlas/rucio/opendata/ODEO_FEB2025_v0_3lep_mc_801978.Py8EG_A14NNPDF23LO_Wprime_taunu_SSM3000.3lep.root"
+      }
+    ],
+    "license": {
+      "attribution": "CC0-1.0"
+    },
+    "methodology": {
+      "description": "<p>These data were created during LS2 as part of a major reprocessing campaign of the Run 2 data. All data were reprocessed using Athena Release 22, and new corresponding MC simulation samples were produced. These data and MC simulation datasets were processed into ROOT ntuple files from the DAOD_PHYSLITE format that is released as open data for research. For the files in this record, the following skimming selection was applied: At least three leptons with at least 7 GeV of p<sub>T</sub> each"
+    },
+    "publisher": "CERN Open Data Portal",
+    "recid": "93925",
+    "relations": [
+      {
+        "description": "For citing all the Open Data for Education and Outreach from this release, and to find other related datasets, please see",
+        "doi": "10.7483/OPENDATA.ATLAS.B5M9.44TN",
+        "recid": "93910",
+        "title": "ROOT ntuple format 2015-2016 proton-proton Open Data for Education and Outreach from the ATLAS experiment",
+        "type": "isChildOf"
+      }
+    ],
+    "run_period": [
+      "2015",
+      "2016"
+    ],
+    "title": "ATLAS ROOT ntuple format MC simulation, 2015+2016 proton-proton collisions beta release, 3lep skim",
+    "type": {
+      "primary": "Dataset",
+      "secondary": [
+        "Simulated"
+      ]
+    },
+    "usage": {
+      "description": "<p> The data and MC simulation provided by the ATLAS experiment in root ntuple format is released under a CC0 license; citation of the data and acknowledgement of the collaboration is requested. This format can be used directly using ROOT or uproot for simple studies and is primarily intended for educational and outreach purposes. <p>Extensive instructions for interacting with the data, as well as documentation of the dataset naming conventions and their contents, are provided on the ATLAS Open Data website linked below. For those interested in implementing a research-quality data analysis, the open data designed for research (also linked below) may be a better starting point. Please be sure to cite the Open Data that you use, in line with the policy below.",
+      "links": [
+        {
+          "description": "ATLAS Open Data Website",
+          "url": "http://opendata.atlas.cern"
+        },
+        {
+          "description": "Resources to understand and use the open data for education and outreach",
+          "url": "https://opendata.atlas.cern/docs/category/13-tev-tutorials-for-education"
+        },
+        {
+          "description": "More about this ntuple format",
+          "url": "https://opendata.atlas.cern/docs/data/for_education/13TeV25_details"
+        },
+        {
+          "description": "Ntuple making framework",
+          "url": "http://gitlab.cern.ch/atlas-outreach-data-tools/physlitetoopendata"
+        },
+        {
+          "description": "Citation policy",
+          "url": "https://opendata.atlas.cern/docs/documentation/ethical_legal/citation_policy"
+        }
+      ]
+    }
+  }
+]

--- a/data/records/atlas-odeo-FEB2025-3lep-mc.json
+++ b/data/records/atlas-odeo-FEB2025-3lep-mc.json
@@ -1939,15 +1939,15 @@
         },
         {
           "description": "Resources to understand and use the open data for education and outreach",
-          "url": "https://opendata.atlas.cern/docs/category/13-tev-tutorials-for-education"
+          "url": "https://opendata.atlas.cern/docs/category/13-tev-2025-beta-release"
         },
         {
           "description": "More about this ntuple format",
-          "url": "https://opendata.atlas.cern/docs/data/for_education/13TeV25_details"
+          "url": "https://opendata.atlas.cern/docs/data/for_education/13TeV25_details#variable-list"
         },
         {
-          "description": "Ntuple making framework",
-          "url": "http://gitlab.cern.ch/atlas-outreach-data-tools/physlitetoopendata"
+          "description": "Ntuple making framework (PhysLiteToOpenData)",
+          "url": "https://doi.org/10.5281/zenodo.15791091"
         },
         {
           "description": "Citation policy",

--- a/data/records/atlas-odeo-FEB2025-4lep-data.json
+++ b/data/records/atlas-odeo-FEB2025-4lep-data.json
@@ -1,0 +1,174 @@
+[
+  {
+    "abstract": {
+      "description": "Run 2 2015+2016 proton-proton collision data beta release, 4lep skim from the ATLAS experiment"
+    },
+    "accelerator": "CERN-LHC",
+    "categories": {
+      "source": "ATLAS Collaboration"
+    },
+    "collaboration": {
+      "name": "ATLAS collaboration"
+    },
+    "collections": [
+      "ATLAS-Primary-Datasets"
+    ],
+    "collision_information": {
+      "energy": "13TeV",
+      "type": "pp"
+    },
+    "date_created": [
+      "2015",
+      "2016"
+    ],
+    "date_published": "2025",
+    "date_reprocessed": "2020",
+    "distribution": {
+      "formats": [
+        "root"
+      ],
+      "number_events": 1515848,
+      "number_files": 16,
+      "size": 658407392
+    },
+    "doi": "10.7483/OPENDATA.ATLAS.7UW9.C9LL",
+    "experiment": [
+      "ATLAS"
+    ],
+    "files": [
+      {
+        "checksum": "adler32:849a15bd",
+        "size": 2358002,
+        "uri": "root://eospublic.cern.ch//eos/opendata/atlas/rucio/opendata/ODEO_FEB2025_v0_4lep_data15_periodD.4lep.root"
+      },
+      {
+        "checksum": "adler32:641bea41",
+        "size": 13461218,
+        "uri": "root://eospublic.cern.ch//eos/opendata/atlas/rucio/opendata/ODEO_FEB2025_v0_4lep_data15_periodE.4lep.root"
+      },
+      {
+        "checksum": "adler32:9b2cc664",
+        "size": 9236190,
+        "uri": "root://eospublic.cern.ch//eos/opendata/atlas/rucio/opendata/ODEO_FEB2025_v0_4lep_data15_periodF.4lep.root"
+      },
+      {
+        "checksum": "adler32:c443ffc7",
+        "size": 19424744,
+        "uri": "root://eospublic.cern.ch//eos/opendata/atlas/rucio/opendata/ODEO_FEB2025_v0_4lep_data15_periodG.4lep.root"
+      },
+      {
+        "checksum": "adler32:35179f62",
+        "size": 6000089,
+        "uri": "root://eospublic.cern.ch//eos/opendata/atlas/rucio/opendata/ODEO_FEB2025_v0_4lep_data15_periodH.4lep.root"
+      },
+      {
+        "checksum": "adler32:3acc14fa",
+        "size": 35827539,
+        "uri": "root://eospublic.cern.ch//eos/opendata/atlas/rucio/opendata/ODEO_FEB2025_v0_4lep_data15_periodJ.4lep.root"
+      },
+      {
+        "checksum": "adler32:5b6c4d27",
+        "size": 16412334,
+        "uri": "root://eospublic.cern.ch//eos/opendata/atlas/rucio/opendata/ODEO_FEB2025_v0_4lep_data16_periodA.4lep.root"
+      },
+      {
+        "checksum": "adler32:acbfb84e",
+        "size": 34062854,
+        "uri": "root://eospublic.cern.ch//eos/opendata/atlas/rucio/opendata/ODEO_FEB2025_v0_4lep_data16_periodB.4lep.root"
+      },
+      {
+        "checksum": "adler32:c157d3a6",
+        "size": 43906527,
+        "uri": "root://eospublic.cern.ch//eos/opendata/atlas/rucio/opendata/ODEO_FEB2025_v0_4lep_data16_periodC.4lep.root"
+      },
+      {
+        "checksum": "adler32:649a4306",
+        "size": 84517557,
+        "uri": "root://eospublic.cern.ch//eos/opendata/atlas/rucio/opendata/ODEO_FEB2025_v0_4lep_data16_periodD.4lep.root"
+      },
+      {
+        "checksum": "adler32:c36ae42d",
+        "size": 26174221,
+        "uri": "root://eospublic.cern.ch//eos/opendata/atlas/rucio/opendata/ODEO_FEB2025_v0_4lep_data16_periodE.4lep.root"
+      },
+      {
+        "checksum": "adler32:4e039cb8",
+        "size": 56891657,
+        "uri": "root://eospublic.cern.ch//eos/opendata/atlas/rucio/opendata/ODEO_FEB2025_v0_4lep_data16_periodF.4lep.root"
+      },
+      {
+        "checksum": "adler32:3d18de52",
+        "size": 63339391,
+        "uri": "root://eospublic.cern.ch//eos/opendata/atlas/rucio/opendata/ODEO_FEB2025_v0_4lep_data16_periodG.4lep.root"
+      },
+      {
+        "checksum": "adler32:6c7ff373",
+        "size": 96671933,
+        "uri": "root://eospublic.cern.ch//eos/opendata/atlas/rucio/opendata/ODEO_FEB2025_v0_4lep_data16_periodI.4lep.root"
+      },
+      {
+        "checksum": "adler32:d6b71026",
+        "size": 39264426,
+        "uri": "root://eospublic.cern.ch//eos/opendata/atlas/rucio/opendata/ODEO_FEB2025_v0_4lep_data16_periodK.4lep.root"
+      },
+      {
+        "checksum": "adler32:c12ad84d",
+        "size": 110858710,
+        "uri": "root://eospublic.cern.ch//eos/opendata/atlas/rucio/opendata/ODEO_FEB2025_v0_4lep_data16_periodL.4lep.root"
+      }
+    ],
+    "license": {
+      "attribution": "CC0-1.0"
+    },
+    "methodology": {
+      "description": "<p>These data were created during LS2 as part of a major reprocessing campaign of the Run 2 data. All data were reprocessed using Athena Release 22, and new corresponding MC simulation samples were produced. These data and MC simulation datasets were processed into ROOT ntuple files from the DAOD_PHYSLITE format that is released as open data for research. For the files in this record, the following skimming selection was applied: At least four leptons with at least 7 GeV of p<sub>T</sub> each"
+    },
+    "publisher": "CERN Open Data Portal",
+    "recid": "93918",
+    "relations": [
+      {
+        "description": "For citing all the Open Data for Education and Outreach from this release, and to find other related datasets, please see",
+        "doi": "10.7483/OPENDATA.ATLAS.B5M9.44TN",
+        "recid": "93910",
+        "title": "ROOT ntuple format 2015-2016 proton-proton Open Data for Education and Outreach from the ATLAS experiment",
+        "type": "isChildOf"
+      }
+    ],
+    "run_period": [
+      "2015",
+      "2016"
+    ],
+    "title": "ATLAS ROOT ntuple format Run 2 2015+2016 proton-proton collision data beta release, 4lep skim",
+    "type": {
+      "primary": "Dataset",
+      "secondary": [
+        "Collision"
+      ]
+    },
+    "usage": {
+      "description": "<p> The data and MC simulation provided by the ATLAS experiment in root ntuple format is released under a CC0 license; citation of the data and acknowledgement of the collaboration is requested. This format can be used directly using ROOT or uproot for simple studies and is primarily intended for educational and outreach purposes. <p>Extensive instructions for interacting with the data, as well as documentation of the dataset naming conventions and their contents, are provided on the ATLAS Open Data website linked below. For those interested in implementing a research-quality data analysis, the open data designed for research (also linked below) may be a better starting point. Please be sure to cite the Open Data that you use, in line with the policy below.",
+      "links": [
+        {
+          "description": "ATLAS Open Data Website",
+          "url": "http://opendata.atlas.cern"
+        },
+        {
+          "description": "Resources to understand and use the open data for education and outreach",
+          "url": "https://opendata.atlas.cern/docs/category/13-tev-tutorials-for-education"
+        },
+        {
+          "description": "More about this ntuple format",
+          "url": "https://opendata.atlas.cern/docs/data/for_education/13TeV25_details"
+        },
+        {
+          "description": "Ntuple making framework",
+          "url": "http://gitlab.cern.ch/atlas-outreach-data-tools/physlitetoopendata"
+        },
+        {
+          "description": "Citation policy",
+          "url": "https://opendata.atlas.cern/docs/documentation/ethical_legal/citation_policy"
+        }
+      ]
+    }
+  }
+]

--- a/data/records/atlas-odeo-FEB2025-4lep-data.json
+++ b/data/records/atlas-odeo-FEB2025-4lep-data.json
@@ -154,15 +154,15 @@
         },
         {
           "description": "Resources to understand and use the open data for education and outreach",
-          "url": "https://opendata.atlas.cern/docs/category/13-tev-tutorials-for-education"
+          "url": "https://opendata.atlas.cern/docs/category/13-tev-2025-beta-release"
         },
         {
           "description": "More about this ntuple format",
-          "url": "https://opendata.atlas.cern/docs/data/for_education/13TeV25_details"
+          "url": "https://opendata.atlas.cern/docs/data/for_education/13TeV25_details#variable-list"
         },
         {
-          "description": "Ntuple making framework",
-          "url": "http://gitlab.cern.ch/atlas-outreach-data-tools/physlitetoopendata"
+          "description": "Ntuple making framework (PhysLiteToOpenData)",
+          "url": "https://doi.org/10.5281/zenodo.15791091"
         },
         {
           "description": "Citation policy",

--- a/data/records/atlas-odeo-FEB2025-4lep-mc.json
+++ b/data/records/atlas-odeo-FEB2025-4lep-mc.json
@@ -1,0 +1,1959 @@
+[
+  {
+    "abstract": {
+      "description": "MC simulation, 2015+2016 proton-proton collisions beta release, 4lep skim from the ATLAS experiment"
+    },
+    "accelerator": "CERN-LHC",
+    "categories": {
+      "source": "ATLAS Collaboration"
+    },
+    "collaboration": {
+      "name": "ATLAS collaboration"
+    },
+    "collections": [
+      "ATLAS-Primary-Datasets"
+    ],
+    "collision_information": {
+      "energy": "13TeV",
+      "type": "pp"
+    },
+    "date_created": [
+      "2015",
+      "2016"
+    ],
+    "date_published": "2025",
+    "date_reprocessed": "2020",
+    "distribution": {
+      "formats": [
+        "root"
+      ],
+      "number_events": 1509317,
+      "number_files": 373,
+      "size": 968429812
+    },
+    "doi": "10.7483/OPENDATA.ATLAS.IPG4.6M6X",
+    "experiment": [
+      "ATLAS"
+    ],
+    "files": [
+      {
+        "checksum": "adler32:9d82601a",
+        "size": 40204,
+        "uri": "root://eospublic.cern.ch//eos/opendata/atlas/rucio/opendata/ODEO_FEB2025_v0_4lep_mc_301204.Pythia8EvtGen_A14MSTW2008LO_Zprime_NoInt_ee_SSM3000.4lep.root"
+      },
+      {
+        "checksum": "adler32:71949508",
+        "size": 45930,
+        "uri": "root://eospublic.cern.ch//eos/opendata/atlas/rucio/opendata/ODEO_FEB2025_v0_4lep_mc_301209.Pythia8EvtGen_A14MSTW2008LO_Zprime_NoInt_mumu_SSM3000.4lep.root"
+      },
+      {
+        "checksum": "adler32:175957d8",
+        "size": 26036,
+        "uri": "root://eospublic.cern.ch//eos/opendata/atlas/rucio/opendata/ODEO_FEB2025_v0_4lep_mc_301243.Pythia8EvtGen_A14NNPDF23LO_Wprime_enu_SSM3000.4lep.root"
+      },
+      {
+        "checksum": "adler32:e319187c",
+        "size": 25933,
+        "uri": "root://eospublic.cern.ch//eos/opendata/atlas/rucio/opendata/ODEO_FEB2025_v0_4lep_mc_301247.Pythia8EvtGen_A14NNPDF23LO_Wprime_munu_SSM3000.4lep.root"
+      },
+      {
+        "checksum": "adler32:830b7148",
+        "size": 90180,
+        "uri": "root://eospublic.cern.ch//eos/opendata/atlas/rucio/opendata/ODEO_FEB2025_v0_4lep_mc_301333.Pythia8EvtGen_A14NNPDF23LO_zprime3000_tt.4lep.root"
+      },
+      {
+        "checksum": "adler32:62c05eed",
+        "size": 32046,
+        "uri": "root://eospublic.cern.ch//eos/opendata/atlas/rucio/opendata/ODEO_FEB2025_v0_4lep_mc_301826.Pythia8EvtGen_A14NNPDF23LO_Wprime_qq_3000.4lep.root"
+      },
+      {
+        "checksum": "adler32:e0fce9f5",
+        "size": 35114,
+        "uri": "root://eospublic.cern.ch//eos/opendata/atlas/rucio/opendata/ODEO_FEB2025_v0_4lep_mc_301928.Pythia8EvtGen_A14NNPDF23LO_Zprimebb3000.4lep.root"
+      },
+      {
+        "checksum": "adler32:ca4df97a",
+        "size": 394149,
+        "uri": "root://eospublic.cern.ch//eos/opendata/atlas/rucio/opendata/ODEO_FEB2025_v0_4lep_mc_302520.Pythia8EvtGen_A14NNPDF23LO_2DP20_Mass_55_100.4lep.root"
+      },
+      {
+        "checksum": "adler32:80e2d471",
+        "size": 73852,
+        "uri": "root://eospublic.cern.ch//eos/opendata/atlas/rucio/opendata/ODEO_FEB2025_v0_4lep_mc_302521.Pythia8EvtGen_A14NNPDF23LO_2DP20_Mass_100_160.4lep.root"
+      },
+      {
+        "checksum": "adler32:52497fc2",
+        "size": 26032,
+        "uri": "root://eospublic.cern.ch//eos/opendata/atlas/rucio/opendata/ODEO_FEB2025_v0_4lep_mc_302522.Pythia8EvtGen_A14NNPDF23LO_2DP20_Mass_160_250.4lep.root"
+      },
+      {
+        "checksum": "adler32:13b56fba",
+        "size": 1283,
+        "uri": "root://eospublic.cern.ch//eos/opendata/atlas/rucio/opendata/ODEO_FEB2025_v0_4lep_mc_302523.Pythia8EvtGen_A14NNPDF23LO_2DP20_Mass_250_400.4lep.root"
+      },
+      {
+        "checksum": "adler32:99016f20",
+        "size": 1283,
+        "uri": "root://eospublic.cern.ch//eos/opendata/atlas/rucio/opendata/ODEO_FEB2025_v0_4lep_mc_302524.Pythia8EvtGen_A14NNPDF23LO_2DP20_Mass_400_650.4lep.root"
+      },
+      {
+        "checksum": "adler32:affe7266",
+        "size": 1291,
+        "uri": "root://eospublic.cern.ch//eos/opendata/atlas/rucio/opendata/ODEO_FEB2025_v0_4lep_mc_302525.Pythia8EvtGen_A14NNPDF23LO_2DP20_Mass_650_1000.4lep.root"
+      },
+      {
+        "checksum": "adler32:52731fef",
+        "size": 38173,
+        "uri": "root://eospublic.cern.ch//eos/opendata/atlas/rucio/opendata/ODEO_FEB2025_v0_4lep_mc_302526.Pythia8EvtGen_A14NNPDF23LO_2DP20_Mass_1000_1500.4lep.root"
+      },
+      {
+        "checksum": "adler32:e25a7120",
+        "size": 1299,
+        "uri": "root://eospublic.cern.ch//eos/opendata/atlas/rucio/opendata/ODEO_FEB2025_v0_4lep_mc_302527.Pythia8EvtGen_A14NNPDF23LO_2DP20_Mass_1500_2000.4lep.root"
+      },
+      {
+        "checksum": "adler32:6b45748c",
+        "size": 1299,
+        "uri": "root://eospublic.cern.ch//eos/opendata/atlas/rucio/opendata/ODEO_FEB2025_v0_4lep_mc_302528.Pythia8EvtGen_A14NNPDF23LO_2DP20_Mass_2000_2500.4lep.root"
+      },
+      {
+        "checksum": "adler32:95847416",
+        "size": 1299,
+        "uri": "root://eospublic.cern.ch//eos/opendata/atlas/rucio/opendata/ODEO_FEB2025_v0_4lep_mc_302529.Pythia8EvtGen_A14NNPDF23LO_2DP20_Mass_2500_3000.4lep.root"
+      },
+      {
+        "checksum": "adler32:5fa07a25",
+        "size": 27307,
+        "uri": "root://eospublic.cern.ch//eos/opendata/atlas/rucio/opendata/ODEO_FEB2025_v0_4lep_mc_302530.Pythia8EvtGen_A14NNPDF23LO_2DP20_Mass_3000_3500.4lep.root"
+      },
+      {
+        "checksum": "adler32:3d4cc149",
+        "size": 39618,
+        "uri": "root://eospublic.cern.ch//eos/opendata/atlas/rucio/opendata/ODEO_FEB2025_v0_4lep_mc_302531.Pythia8EvtGen_A14NNPDF23LO_2DP20_Mass_3500_4000.4lep.root"
+      },
+      {
+        "checksum": "adler32:a9ce22cc",
+        "size": 27131,
+        "uri": "root://eospublic.cern.ch//eos/opendata/atlas/rucio/opendata/ODEO_FEB2025_v0_4lep_mc_302532.Pythia8EvtGen_A14NNPDF23LO_2DP20_Mass_4000_4500.4lep.root"
+      },
+      {
+        "checksum": "adler32:aa3e7354",
+        "size": 1299,
+        "uri": "root://eospublic.cern.ch//eos/opendata/atlas/rucio/opendata/ODEO_FEB2025_v0_4lep_mc_302533.Pythia8EvtGen_A14NNPDF23LO_2DP20_Mass_4500_5000.4lep.root"
+      },
+      {
+        "checksum": "adler32:b2d44679",
+        "size": 40709,
+        "uri": "root://eospublic.cern.ch//eos/opendata/atlas/rucio/opendata/ODEO_FEB2025_v0_4lep_mc_302534.Pythia8EvtGen_A14NNPDF23LO_2DP20_Mass_5000_inf.4lep.root"
+      },
+      {
+        "checksum": "adler32:c557eb72",
+        "size": 74961,
+        "uri": "root://eospublic.cern.ch//eos/opendata/atlas/rucio/opendata/ODEO_FEB2025_v0_4lep_mc_302733.MadGraphPythia8EvtGen_A14NNPDF23LO_WpL_tblep_M3000.4lep.root"
+      },
+      {
+        "checksum": "adler32:9746933d",
+        "size": 154312,
+        "uri": "root://eospublic.cern.ch//eos/opendata/atlas/rucio/opendata/ODEO_FEB2025_v0_4lep_mc_304014.MadGraphPythia8EvtGen_A14NNPDF23_3top_SM.4lep.root"
+      },
+      {
+        "checksum": "adler32:bcd3c5fb",
+        "size": 50879,
+        "uri": "root://eospublic.cern.ch//eos/opendata/atlas/rucio/opendata/ODEO_FEB2025_v0_4lep_mc_306149.MadGraphPythia8EvtGen_A14NNPDF23LO_WpL_tbhad_M3000.4lep.root"
+      },
+      {
+        "checksum": "adler32:4facaabe",
+        "size": 26061,
+        "uri": "root://eospublic.cern.ch//eos/opendata/atlas/rucio/opendata/ODEO_FEB2025_v0_4lep_mc_311490.PowhegPy8EG_A14N23LO_DMA_500_700_gq0p25.4lep.root"
+      },
+      {
+        "checksum": "adler32:34c87471",
+        "size": 1905174,
+        "uri": "root://eospublic.cern.ch//eos/opendata/atlas/rucio/opendata/ODEO_FEB2025_v0_4lep_mc_312613.aMcAtNloPy8EG_A14N30NLO_LQd_gstML_0p3_nonallhad_M1000.4lep.root"
+      },
+      {
+        "checksum": "adler32:4933dc12",
+        "size": 26100,
+        "uri": "root://eospublic.cern.ch//eos/opendata/atlas/rucio/opendata/ODEO_FEB2025_v0_4lep_mc_341456.PowhegPythia8EvtGen_CT10_AZNLO_ZH125J_MINLO_veveWWlvqq_VpT.4lep.root"
+      },
+      {
+        "checksum": "adler32:4d02b1a4",
+        "size": 1403,
+        "uri": "root://eospublic.cern.ch//eos/opendata/atlas/rucio/opendata/ODEO_FEB2025_v0_4lep_mc_341458.PowhegPythia8EvtGen_CT10_AZNLO_ZH125J_MINLO_vmuvmuWWlvqq_VpT.4lep.root"
+      },
+      {
+        "checksum": "adler32:ca74de36",
+        "size": 26112,
+        "uri": "root://eospublic.cern.ch//eos/opendata/atlas/rucio/opendata/ODEO_FEB2025_v0_4lep_mc_341460.PowhegPy8EG_CT10_AZNLO_ZH125J_MINLO_vtauvtauWWlvqq_VpT.4lep.root"
+      },
+      {
+        "checksum": "adler32:3629a656",
+        "size": 26011,
+        "uri": "root://eospublic.cern.ch//eos/opendata/atlas/rucio/opendata/ODEO_FEB2025_v0_4lep_mc_343981.PowhegPythia8EvtGen_NNLOPS_nnlo_30_ggH125_gamgam.4lep.root"
+      },
+      {
+        "checksum": "adler32:9c43def5",
+        "size": 12340472,
+        "uri": "root://eospublic.cern.ch//eos/opendata/atlas/rucio/opendata/ODEO_FEB2025_v0_4lep_mc_344158.aMcAtNloPythia8EvtGen_A14NNPDF23LO_ppx0_FxFx_Np012_SM.4lep.root"
+      },
+      {
+        "checksum": "adler32:1e292299",
+        "size": 27093,
+        "uri": "root://eospublic.cern.ch//eos/opendata/atlas/rucio/opendata/ODEO_FEB2025_v0_4lep_mc_345056.PowhegPythia8EvtGen_NNPDF3_AZNLO_ZH125J_MINLO_vvbb_VpT.4lep.root"
+      },
+      {
+        "checksum": "adler32:93340155",
+        "size": 26173,
+        "uri": "root://eospublic.cern.ch//eos/opendata/atlas/rucio/opendata/ODEO_FEB2025_v0_4lep_mc_345058.PowhegPythia8EvtGen_NNPDF3_AZNLO_ggZH125_vvbb.4lep.root"
+      },
+      {
+        "checksum": "adler32:317db9f6",
+        "size": 185737317,
+        "uri": "root://eospublic.cern.ch//eos/opendata/atlas/rucio/opendata/ODEO_FEB2025_v0_4lep_mc_345060.PowhegPythia8EvtGen_NNLOPS_nnlo_30_ggH125_ZZ4l.4lep.root"
+      },
+      {
+        "checksum": "adler32:0288a985",
+        "size": 41124,
+        "uri": "root://eospublic.cern.ch//eos/opendata/atlas/rucio/opendata/ODEO_FEB2025_v0_4lep_mc_345061.PowhegPythia8EvtGen_NNPDF3_AZNLO_ggZH125_HgamgamZinc.4lep.root"
+      },
+      {
+        "checksum": "adler32:ed171f48",
+        "size": 4276985,
+        "uri": "root://eospublic.cern.ch//eos/opendata/atlas/rucio/opendata/ODEO_FEB2025_v0_4lep_mc_345066.PowhegPythia8EvtGen_NNPDF3_AZNLO_ggZH125_ZZ4lepZinc.4lep.root"
+      },
+      {
+        "checksum": "adler32:8783991d",
+        "size": 62636,
+        "uri": "root://eospublic.cern.ch//eos/opendata/atlas/rucio/opendata/ODEO_FEB2025_v0_4lep_mc_345097.PowhegPythia8EvtGen_NNLOPS_nnlo_30_ggH125_mumu.4lep.root"
+      },
+      {
+        "checksum": "adler32:ed4a1267",
+        "size": 733870,
+        "uri": "root://eospublic.cern.ch//eos/opendata/atlas/rucio/opendata/ODEO_FEB2025_v0_4lep_mc_345098.PowhegPythia8EvtGen_NNPDF3_AZNLO_ggZH125_Hmumu_Zinc.4lep.root"
+      },
+      {
+        "checksum": "adler32:cf0ab8dd",
+        "size": 652560,
+        "uri": "root://eospublic.cern.ch//eos/opendata/atlas/rucio/opendata/ODEO_FEB2025_v0_4lep_mc_345103.PowhegPythia8EvtGen_NNPDF30_AZNLO_ZH125J_Hmumu_Zincl_MINLO.4lep.root"
+      },
+      {
+        "checksum": "adler32:0663f7f6",
+        "size": 74024,
+        "uri": "root://eospublic.cern.ch//eos/opendata/atlas/rucio/opendata/ODEO_FEB2025_v0_4lep_mc_345104.PowhegPythia8EvtGen_NNPDF30_AZNLO_WpH125J_Hmumu_Wincl_MINLO.4lep.root"
+      },
+      {
+        "checksum": "adler32:2b35872b",
+        "size": 60126,
+        "uri": "root://eospublic.cern.ch//eos/opendata/atlas/rucio/opendata/ODEO_FEB2025_v0_4lep_mc_345105.PowhegPythia8EvtGen_NNPDF30_AZNLO_WmH125J_Hmumu_Wincl_MINLO.4lep.root"
+      },
+      {
+        "checksum": "adler32:822ad9f1",
+        "size": 66118,
+        "uri": "root://eospublic.cern.ch//eos/opendata/atlas/rucio/opendata/ODEO_FEB2025_v0_4lep_mc_345106.PowhegPythia8EvtGen_NNPDF30_AZNLOCTEQ6L1_VBFH125_mumu.4lep.root"
+      },
+      {
+        "checksum": "adler32:8bb57c7e",
+        "size": 27237,
+        "uri": "root://eospublic.cern.ch//eos/opendata/atlas/rucio/opendata/ODEO_FEB2025_v0_4lep_mc_345112.PowhegPythia8EvtGen_NNPDF3_AZNLO_ZH125J_MINLO_vvcc_VpT.4lep.root"
+      },
+      {
+        "checksum": "adler32:f8fa8210",
+        "size": 1283,
+        "uri": "root://eospublic.cern.ch//eos/opendata/atlas/rucio/opendata/ODEO_FEB2025_v0_4lep_mc_345114.PowhegPythia8EvtGen_NNPDF3_AZNLO_ggZH125_vvcc.4lep.root"
+      },
+      {
+        "checksum": "adler32:3fb16fea",
+        "size": 66645,
+        "uri": "root://eospublic.cern.ch//eos/opendata/atlas/rucio/opendata/ODEO_FEB2025_v0_4lep_mc_345120.PowhegPy8EG_NNLOPS_nnlo_30_ggH125_tautaul13l7.4lep.root"
+      },
+      {
+        "checksum": "adler32:16ccbbc1",
+        "size": 39415,
+        "uri": "root://eospublic.cern.ch//eos/opendata/atlas/rucio/opendata/ODEO_FEB2025_v0_4lep_mc_345121.PowhegPy8EG_NNLOPS_nnlo_30_ggH125_tautaulm15hp20.4lep.root"
+      },
+      {
+        "checksum": "adler32:65f23005",
+        "size": 26236,
+        "uri": "root://eospublic.cern.ch//eos/opendata/atlas/rucio/opendata/ODEO_FEB2025_v0_4lep_mc_345122.PowhegPy8EG_NNLOPS_nnlo_30_ggH125_tautaulp15hm20.4lep.root"
+      },
+      {
+        "checksum": "adler32:4a778b05",
+        "size": 25969,
+        "uri": "root://eospublic.cern.ch//eos/opendata/atlas/rucio/opendata/ODEO_FEB2025_v0_4lep_mc_345123.PowhegPy8EG_NNLOPS_nnlo_30_ggH125_tautauh30h20.4lep.root"
+      },
+      {
+        "checksum": "adler32:61822be1",
+        "size": 296580,
+        "uri": "root://eospublic.cern.ch//eos/opendata/atlas/rucio/opendata/ODEO_FEB2025_v0_4lep_mc_345124.PowhegPy8EG_NNLOPS_nnlo_30_ggH125_etau_filt.4lep.root"
+      },
+      {
+        "checksum": "adler32:384f7536",
+        "size": 305764,
+        "uri": "root://eospublic.cern.ch//eos/opendata/atlas/rucio/opendata/ODEO_FEB2025_v0_4lep_mc_345125.PowhegPy8EG_NNLOPS_nnlo_30_ggH125_mutau_filt.4lep.root"
+      },
+      {
+        "checksum": "adler32:3829602d",
+        "size": 27159,
+        "uri": "root://eospublic.cern.ch//eos/opendata/atlas/rucio/opendata/ODEO_FEB2025_v0_4lep_mc_345211.PowhegPy8EG_NNPDF30_AZNLO_WmH125J_Winc_MINLO_tautau.4lep.root"
+      },
+      {
+        "checksum": "adler32:8adf8e6e",
+        "size": 29020,
+        "uri": "root://eospublic.cern.ch//eos/opendata/atlas/rucio/opendata/ODEO_FEB2025_v0_4lep_mc_345212.PowhegPy8EG_NNPDF30_AZNLO_WpH125J_Winc_MINLO_tautau.4lep.root"
+      },
+      {
+        "checksum": "adler32:476a4458",
+        "size": 44550,
+        "uri": "root://eospublic.cern.ch//eos/opendata/atlas/rucio/opendata/ODEO_FEB2025_v0_4lep_mc_345213.PowhegPy8EG_NNPDF30_AZNLO_WmH125J_Winc_MINLO_etau.4lep.root"
+      },
+      {
+        "checksum": "adler32:e5dabb95",
+        "size": 60882,
+        "uri": "root://eospublic.cern.ch//eos/opendata/atlas/rucio/opendata/ODEO_FEB2025_v0_4lep_mc_345214.PowhegPy8EG_NNPDF30_AZNLO_WpH125J_Winc_MINLO_etau.4lep.root"
+      },
+      {
+        "checksum": "adler32:65f79a6f",
+        "size": 42414,
+        "uri": "root://eospublic.cern.ch//eos/opendata/atlas/rucio/opendata/ODEO_FEB2025_v0_4lep_mc_345215.PowhegPy8EG_NNPDF30_AZNLO_WmH125J_Winc_MINLO_mutau.4lep.root"
+      },
+      {
+        "checksum": "adler32:913378c5",
+        "size": 64598,
+        "uri": "root://eospublic.cern.ch//eos/opendata/atlas/rucio/opendata/ODEO_FEB2025_v0_4lep_mc_345216.PowhegPy8EG_NNPDF30_AZNLO_WpH125J_Winc_MINLO_mutau.4lep.root"
+      },
+      {
+        "checksum": "adler32:3b23124a",
+        "size": 76778,
+        "uri": "root://eospublic.cern.ch//eos/opendata/atlas/rucio/opendata/ODEO_FEB2025_v0_4lep_mc_345217.PowhegPy8EG_NNPDF30_AZNLO_ZH125J_Zinc_MINLO_tautau.4lep.root"
+      },
+      {
+        "checksum": "adler32:e59bc045",
+        "size": 319344,
+        "uri": "root://eospublic.cern.ch//eos/opendata/atlas/rucio/opendata/ODEO_FEB2025_v0_4lep_mc_345218.PowhegPy8EG_NNPDF30_AZNLO_ZH125J_Zinc_MINLO_etau.4lep.root"
+      },
+      {
+        "checksum": "adler32:39e44d69",
+        "size": 239186,
+        "uri": "root://eospublic.cern.ch//eos/opendata/atlas/rucio/opendata/ODEO_FEB2025_v0_4lep_mc_345219.PowhegPy8EG_NNPDF30_AZNLO_ZH125J_Zinc_MINLO_mutau.4lep.root"
+      },
+      {
+        "checksum": "adler32:881ec1eb",
+        "size": 952333,
+        "uri": "root://eospublic.cern.ch//eos/opendata/atlas/rucio/opendata/ODEO_FEB2025_v0_4lep_mc_345316.PowhegPythia8EvtGen_NNLOPS_nnlo_30_ggH125_Zy_Zll.4lep.root"
+      },
+      {
+        "checksum": "adler32:020c6273",
+        "size": 77069,
+        "uri": "root://eospublic.cern.ch//eos/opendata/atlas/rucio/opendata/ODEO_FEB2025_v0_4lep_mc_345317.PowhegPythia8EvtGen_NNPDF30_AZNLO_WmH125J_Hyy_Wincl_MINLO.4lep.root"
+      },
+      {
+        "checksum": "adler32:4d55b565",
+        "size": 42976,
+        "uri": "root://eospublic.cern.ch//eos/opendata/atlas/rucio/opendata/ODEO_FEB2025_v0_4lep_mc_345318.PowhegPythia8EvtGen_NNPDF30_AZNLO_WpH125J_Hyy_Wincl_MINLO.4lep.root"
+      },
+      {
+        "checksum": "adler32:4d34300d",
+        "size": 56944,
+        "uri": "root://eospublic.cern.ch//eos/opendata/atlas/rucio/opendata/ODEO_FEB2025_v0_4lep_mc_345319.PowhegPythia8EvtGen_NNPDF30_AZNLO_ZH125J_Hyy_Zincl_MINLO.4lep.root"
+      },
+      {
+        "checksum": "adler32:5d1328e4",
+        "size": 99236,
+        "uri": "root://eospublic.cern.ch//eos/opendata/atlas/rucio/opendata/ODEO_FEB2025_v0_4lep_mc_345320.PowhegPythia8EvtGen_NNPDF30_AZNLO_WmH125J_HZy_Wincl_MINLO.4lep.root"
+      },
+      {
+        "checksum": "adler32:263b1efc",
+        "size": 93975,
+        "uri": "root://eospublic.cern.ch//eos/opendata/atlas/rucio/opendata/ODEO_FEB2025_v0_4lep_mc_345321.PowhegPythia8EvtGen_NNPDF30_AZNLO_WpH125J_HZy_Wincl_MINLO.4lep.root"
+      },
+      {
+        "checksum": "adler32:70e9e419",
+        "size": 470620,
+        "uri": "root://eospublic.cern.ch//eos/opendata/atlas/rucio/opendata/ODEO_FEB2025_v0_4lep_mc_345322.PowhegPythia8EvtGen_NNPDF30_AZNLO_ZH125J_HZy_Zincl_MINLO.4lep.root"
+      },
+      {
+        "checksum": "adler32:bf158b35",
+        "size": 50578,
+        "uri": "root://eospublic.cern.ch//eos/opendata/atlas/rucio/opendata/ODEO_FEB2025_v0_4lep_mc_345324.PowhegPythia8EvtGen_NNLOPS_NN30_ggH125_WWlvlv_EF_15_5.4lep.root"
+      },
+      {
+        "checksum": "adler32:bfd07112",
+        "size": 86437,
+        "uri": "root://eospublic.cern.ch//eos/opendata/atlas/rucio/opendata/ODEO_FEB2025_v0_4lep_mc_345325.PowhegPythia8EvtGen_NNPDF3_AZNLO_WpH125J_MINLO_qqWWlvlv.4lep.root"
+      },
+      {
+        "checksum": "adler32:e50a593b",
+        "size": 98705,
+        "uri": "root://eospublic.cern.ch//eos/opendata/atlas/rucio/opendata/ODEO_FEB2025_v0_4lep_mc_345433.PowhegPythia8EvtGen_NNPDF3_AZNLO_WmH125J_MINLO_qqWWlvlv.4lep.root"
+      },
+      {
+        "checksum": "adler32:5c90d078",
+        "size": 31194,
+        "uri": "root://eospublic.cern.ch//eos/opendata/atlas/rucio/opendata/ODEO_FEB2025_v0_4lep_mc_345445.PowhegPythia8EvtGen_NNPDF3_AZNLO_ZH125J_MINLO_vvWWlvlv.4lep.root"
+      },
+      {
+        "checksum": "adler32:a736595e",
+        "size": 26225,
+        "uri": "root://eospublic.cern.ch//eos/opendata/atlas/rucio/opendata/ODEO_FEB2025_v0_4lep_mc_345596.PowhegPythia8EvtGen_NNPDF3_AZNLO_ggZH125_Zinc_HZZinv.4lep.root"
+      },
+      {
+        "checksum": "adler32:cab5ccbf",
+        "size": 84304,
+        "uri": "root://eospublic.cern.ch//eos/opendata/atlas/rucio/opendata/ODEO_FEB2025_v0_4lep_mc_345697.MadGraphPythia8EvtGen_AZNLOCTEQ6L1_ggfhtautaullNp2.4lep.root"
+      },
+      {
+        "checksum": "adler32:c47c31a6",
+        "size": 57195,
+        "uri": "root://eospublic.cern.ch//eos/opendata/atlas/rucio/opendata/ODEO_FEB2025_v0_4lep_mc_345698.MadGraphPythia8EvtGen_AZNLOCTEQ6L1_ggfhtautaulhNp2.4lep.root"
+      },
+      {
+        "checksum": "adler32:481e401e",
+        "size": 26154,
+        "uri": "root://eospublic.cern.ch//eos/opendata/atlas/rucio/opendata/ODEO_FEB2025_v0_4lep_mc_345699.MadGraphPythia8EvtGen_AZNLOCTEQ6L1_ggfhtautauhhNp2.4lep.root"
+      },
+      {
+        "checksum": "adler32:cb1c26b7",
+        "size": 486691,
+        "uri": "root://eospublic.cern.ch//eos/opendata/atlas/rucio/opendata/ODEO_FEB2025_v0_4lep_mc_345833.PowhegPythia8EvtGen_NNPDF30_AZNLOCTEQ6L1_VBFH125_Zllgam.4lep.root"
+      },
+      {
+        "checksum": "adler32:81a56230",
+        "size": 42600,
+        "uri": "root://eospublic.cern.ch//eos/opendata/atlas/rucio/opendata/ODEO_FEB2025_v0_4lep_mc_345834.PowhegPythia8EvtGen_NNPDF30_AZNLOCTEQ6L1_VBFH125_gamstargam.4lep.root"
+      },
+      {
+        "checksum": "adler32:61cb0cbd",
+        "size": 641306,
+        "uri": "root://eospublic.cern.ch//eos/opendata/atlas/rucio/opendata/ODEO_FEB2025_v0_4lep_mc_345876.PowhegPythia8EvtGen_NNPDF30_AZNLO_ZH125J_Hee__Zincl_MINLO.4lep.root"
+      },
+      {
+        "checksum": "adler32:10d3de10",
+        "size": 51690,
+        "uri": "root://eospublic.cern.ch//eos/opendata/atlas/rucio/opendata/ODEO_FEB2025_v0_4lep_mc_345877.PowhegPythia8EvtGen_NNPDF30_AZNLO_WpH125J_Hee_Wincl_MINLO.4lep.root"
+      },
+      {
+        "checksum": "adler32:8535f3c4",
+        "size": 54946,
+        "uri": "root://eospublic.cern.ch//eos/opendata/atlas/rucio/opendata/ODEO_FEB2025_v0_4lep_mc_345878.PowhegPythia8EvtGen_NNPDF30_AZNLO_WmH125J_Hee_Wincl_MINLO.4lep.root"
+      },
+      {
+        "checksum": "adler32:1aa2fbda",
+        "size": 40172,
+        "uri": "root://eospublic.cern.ch//eos/opendata/atlas/rucio/opendata/ODEO_FEB2025_v0_4lep_mc_345944.aMcAtNloPy8EG_A14NNPDF23LO_ppx0yy_FxFx_Np012_SM.4lep.root"
+      },
+      {
+        "checksum": "adler32:c42f0cdb",
+        "size": 89124,
+        "uri": "root://eospublic.cern.ch//eos/opendata/atlas/rucio/opendata/ODEO_FEB2025_v0_4lep_mc_345948.PowhegPy8EG_NNPDF30_AZNLOCTEQ6L1_VBFH125_WWlvlv.4lep.root"
+      },
+      {
+        "checksum": "adler32:3763da74",
+        "size": 41217,
+        "uri": "root://eospublic.cern.ch//eos/opendata/atlas/rucio/opendata/ODEO_FEB2025_v0_4lep_mc_345949.PowhegPythia8EvtGen_NNPDF30_AZNLOCTEQ6L1_VBFH125_bb.4lep.root"
+      },
+      {
+        "checksum": "adler32:384a4c82",
+        "size": 78020,
+        "uri": "root://eospublic.cern.ch//eos/opendata/atlas/rucio/opendata/ODEO_FEB2025_v0_4lep_mc_345961.PowhegPythia8EvtGen_NNLOPS_nnlo_30_ggH125_gamstargam.4lep.root"
+      },
+      {
+        "checksum": "adler32:540f3eac",
+        "size": 58878,
+        "uri": "root://eospublic.cern.ch//eos/opendata/atlas/rucio/opendata/ODEO_FEB2025_v0_4lep_mc_345963.PowhegPythia8EvtGen_NNPDF30_AZNLO_WmH125J_Hgamstargam_MINLO.4lep.root"
+      },
+      {
+        "checksum": "adler32:c289ef5c",
+        "size": 50654,
+        "uri": "root://eospublic.cern.ch//eos/opendata/atlas/rucio/opendata/ODEO_FEB2025_v0_4lep_mc_345964.PowhegPythia8EvtGen_NNPDF30_AZNLO_WpH125J_Hgamstargam_MINLO.4lep.root"
+      },
+      {
+        "checksum": "adler32:830d23bb",
+        "size": 212687,
+        "uri": "root://eospublic.cern.ch//eos/opendata/atlas/rucio/opendata/ODEO_FEB2025_v0_4lep_mc_345965.PowhegPythia8EvtGen_NNPDF30_AZNLO_ZH125J_Hgamstargam_MINLO.4lep.root"
+      },
+      {
+        "checksum": "adler32:0fa6bf6a",
+        "size": 35013,
+        "uri": "root://eospublic.cern.ch//eos/opendata/atlas/rucio/opendata/ODEO_FEB2025_v0_4lep_mc_346188.aMcAtNloPythia8EvtGen_tHjb125_4fl_gamgam.4lep.root"
+      },
+      {
+        "checksum": "adler32:65c0f7f0",
+        "size": 98921,
+        "uri": "root://eospublic.cern.ch//eos/opendata/atlas/rucio/opendata/ODEO_FEB2025_v0_4lep_mc_346189.aMcAtNloPythia8EvtGen_ttH_gamgam.4lep.root"
+      },
+      {
+        "checksum": "adler32:77eab919",
+        "size": 66669,
+        "uri": "root://eospublic.cern.ch//eos/opendata/atlas/rucio/opendata/ODEO_FEB2025_v0_4lep_mc_346190.PowhegPy8EG_NNPDF30_AZNLOCTEQ6L1_VBFH125_tautaul13l7.4lep.root"
+      },
+      {
+        "checksum": "adler32:b38f094b",
+        "size": 39603,
+        "uri": "root://eospublic.cern.ch//eos/opendata/atlas/rucio/opendata/ODEO_FEB2025_v0_4lep_mc_346191.PowhegPy8EG_NNPDF30_AZNLOCTEQ6L1_VBFH125_tautaulm15hp20.4lep.root"
+      },
+      {
+        "checksum": "adler32:34fb6fb9",
+        "size": 26170,
+        "uri": "root://eospublic.cern.ch//eos/opendata/atlas/rucio/opendata/ODEO_FEB2025_v0_4lep_mc_346192.PowhegPy8EG_NNPDF30_AZNLOCTEQ6L1_VBFH125_tautaulp15hm20.4lep.root"
+      },
+      {
+        "checksum": "adler32:1ca38482",
+        "size": 1347,
+        "uri": "root://eospublic.cern.ch//eos/opendata/atlas/rucio/opendata/ODEO_FEB2025_v0_4lep_mc_346193.PowhegPy8EG_NNPDF30_AZNLOCTEQ6L1_VBFH125_tautauh30h20.4lep.root"
+      },
+      {
+        "checksum": "adler32:7f4e1289",
+        "size": 93188,
+        "uri": "root://eospublic.cern.ch//eos/opendata/atlas/rucio/opendata/ODEO_FEB2025_v0_4lep_mc_346194.PowhegPy8EG_NNPDF30_AZNLOCTEQ6L1_VBFH125_etau_filt.4lep.root"
+      },
+      {
+        "checksum": "adler32:7bf79706",
+        "size": 86065,
+        "uri": "root://eospublic.cern.ch//eos/opendata/atlas/rucio/opendata/ODEO_FEB2025_v0_4lep_mc_346195.PowhegPy8EG_NNPDF30_AZNLOCTEQ6L1_VBFH125_mutau_filt.4lep.root"
+      },
+      {
+        "checksum": "adler32:03918fac",
+        "size": 2570652,
+        "uri": "root://eospublic.cern.ch//eos/opendata/atlas/rucio/opendata/ODEO_FEB2025_v0_4lep_mc_346198.PhPy8EG_A14NNPDF23_NNPDF30ME_ttH125_Zgam.4lep.root"
+      },
+      {
+        "checksum": "adler32:f46964ec",
+        "size": 27221,
+        "uri": "root://eospublic.cern.ch//eos/opendata/atlas/rucio/opendata/ODEO_FEB2025_v0_4lep_mc_346214.PowhegPy8EG_NNPDF30_AZNLOCTEQ6L1_VBFH125_gamgam.4lep.root"
+      },
+      {
+        "checksum": "adler32:c92c3eaa",
+        "size": 41489921,
+        "uri": "root://eospublic.cern.ch//eos/opendata/atlas/rucio/opendata/ODEO_FEB2025_v0_4lep_mc_346228.PowhegPy8EG_NNPDF30_AZNLOCTEQ6L1_VBFH125_ZZ4lep_notau.4lep.root"
+      },
+      {
+        "checksum": "adler32:2af24a40",
+        "size": 65035,
+        "uri": "root://eospublic.cern.ch//eos/opendata/atlas/rucio/opendata/ODEO_FEB2025_v0_4lep_mc_346310.PowhegPythia8EvtGen_NNPDF30_AZNLO_ZH125J_Zincl_H_incl_MINLO.4lep.root"
+      },
+      {
+        "checksum": "adler32:7e9ec1c1",
+        "size": 29299,
+        "uri": "root://eospublic.cern.ch//eos/opendata/atlas/rucio/opendata/ODEO_FEB2025_v0_4lep_mc_346311.PowhegPythia8EvtGen_NNPDF30_AZNLO_WpH125J_Wincl_H_incl_MINLO.4lep.root"
+      },
+      {
+        "checksum": "adler32:561f27bf",
+        "size": 29966,
+        "uri": "root://eospublic.cern.ch//eos/opendata/atlas/rucio/opendata/ODEO_FEB2025_v0_4lep_mc_346312.PowhegPythia8EvtGen_NNPDF30_AZNLO_WmH125J_Wincl_H_incl_MINLO.4lep.root"
+      },
+      {
+        "checksum": "adler32:fd4e7b1e",
+        "size": 70772,
+        "uri": "root://eospublic.cern.ch//eos/opendata/atlas/rucio/opendata/ODEO_FEB2025_v0_4lep_mc_346317.PowhegPy8EG_NNPDF30_AZNLOCTEQ6L1_VBFH125_incl.4lep.root"
+      },
+      {
+        "checksum": "adler32:e0befbfb",
+        "size": 5694876,
+        "uri": "root://eospublic.cern.ch//eos/opendata/atlas/rucio/opendata/ODEO_FEB2025_v0_4lep_mc_346340.PowhegPy8EG_A14NNPDF23_NNPDF30ME_ttH125_ZZ4l_allhad.4lep.root"
+      },
+      {
+        "checksum": "adler32:51ef431e",
+        "size": 10693540,
+        "uri": "root://eospublic.cern.ch//eos/opendata/atlas/rucio/opendata/ODEO_FEB2025_v0_4lep_mc_346341.PowhegPy8EG_A14NNPDF23_NNPDF30ME_ttH125_ZZ4l_semilep.4lep.root"
+      },
+      {
+        "checksum": "adler32:64640e09",
+        "size": 14125189,
+        "uri": "root://eospublic.cern.ch//eos/opendata/atlas/rucio/opendata/ODEO_FEB2025_v0_4lep_mc_346342.PowhegPy8EG_A14NNPDF23_NNPDF30ME_ttH125_ZZ4l_dilep.4lep.root"
+      },
+      {
+        "checksum": "adler32:aa89bb2c",
+        "size": 74710,
+        "uri": "root://eospublic.cern.ch//eos/opendata/atlas/rucio/opendata/ODEO_FEB2025_v0_4lep_mc_346343.PhPy8EG_A14NNPDF23_NNPDF30ME_ttH125_allhad.4lep.root"
+      },
+      {
+        "checksum": "adler32:8669242a",
+        "size": 136037,
+        "uri": "root://eospublic.cern.ch//eos/opendata/atlas/rucio/opendata/ODEO_FEB2025_v0_4lep_mc_346344.PhPy8EG_A14NNPDF23_NNPDF30ME_ttH125_semilep.4lep.root"
+      },
+      {
+        "checksum": "adler32:7160898e",
+        "size": 1279519,
+        "uri": "root://eospublic.cern.ch//eos/opendata/atlas/rucio/opendata/ODEO_FEB2025_v0_4lep_mc_346345.PhPy8EG_A14NNPDF23_NNPDF30ME_ttH125_dilep.4lep.root"
+      },
+      {
+        "checksum": "adler32:9a66f016",
+        "size": 27087,
+        "uri": "root://eospublic.cern.ch//eos/opendata/atlas/rucio/opendata/ODEO_FEB2025_v0_4lep_mc_346398.PowhegHerwig7EvtGen_NNPDF3_AZNLO_ZH125J_MINLO_vvbb_VpT.4lep.root"
+      },
+      {
+        "checksum": "adler32:0d5e810c",
+        "size": 1291,
+        "uri": "root://eospublic.cern.ch//eos/opendata/atlas/rucio/opendata/ODEO_FEB2025_v0_4lep_mc_346400.PowhegHerwig7EvtGen_NNPDF3_AZNLO_ggZH125J_vvbb.4lep.root"
+      },
+      {
+        "checksum": "adler32:9ccd81d1",
+        "size": 3204321,
+        "uri": "root://eospublic.cern.ch//eos/opendata/atlas/rucio/opendata/ODEO_FEB2025_v0_4lep_mc_346414.aMcAtNloPythia8EvtGen_tHjb125_4fl_ZZ4l.4lep.root"
+      },
+      {
+        "checksum": "adler32:966baf70",
+        "size": 112325206,
+        "uri": "root://eospublic.cern.ch//eos/opendata/atlas/rucio/opendata/ODEO_FEB2025_v0_4lep_mc_346446.PhH7EG_H7UE_NNLOPS_nnlo_30_ggH125_ZZ4l_noTau.4lep.root"
+      },
+      {
+        "checksum": "adler32:d6235329",
+        "size": 41635449,
+        "uri": "root://eospublic.cern.ch//eos/opendata/atlas/rucio/opendata/ODEO_FEB2025_v0_4lep_mc_346447.PhH7EG_H7UE_NNPDF30_VBFH125_ZZ4lep_noTau.4lep.root"
+      },
+      {
+        "checksum": "adler32:dc1ffe35",
+        "size": 7327142,
+        "uri": "root://eospublic.cern.ch//eos/opendata/atlas/rucio/opendata/ODEO_FEB2025_v0_4lep_mc_346448.PhH7EG_H7UE_NNPDF30_ZH125J_Zincl_MINLO.4lep.root"
+      },
+      {
+        "checksum": "adler32:22449ed7",
+        "size": 5945902,
+        "uri": "root://eospublic.cern.ch//eos/opendata/atlas/rucio/opendata/ODEO_FEB2025_v0_4lep_mc_346449.PhH7EG_H7UE_NNPDF30_WpH125J_Wincl_MINLO.4lep.root"
+      },
+      {
+        "checksum": "adler32:6b05e4e0",
+        "size": 3167273,
+        "uri": "root://eospublic.cern.ch//eos/opendata/atlas/rucio/opendata/ODEO_FEB2025_v0_4lep_mc_346450.PhH7EG_H7UE_NNPDF30_WmH125J_Wincl_MINLO.4lep.root"
+      },
+      {
+        "checksum": "adler32:785e2e31",
+        "size": 4082430,
+        "uri": "root://eospublic.cern.ch//eos/opendata/atlas/rucio/opendata/ODEO_FEB2025_v0_4lep_mc_346451.PhH7EG_H7UE_NNPDF3_ggZH125_ZZ4lepZinc.4lep.root"
+      },
+      {
+        "checksum": "adler32:845bdf50",
+        "size": 5712529,
+        "uri": "root://eospublic.cern.ch//eos/opendata/atlas/rucio/opendata/ODEO_FEB2025_v0_4lep_mc_346452.PhH7EG_H7UE_NNPDF30ME_ttH125_ZZ4l_allhad_noTau.4lep.root"
+      },
+      {
+        "checksum": "adler32:3a74c0d6",
+        "size": 10567615,
+        "uri": "root://eospublic.cern.ch//eos/opendata/atlas/rucio/opendata/ODEO_FEB2025_v0_4lep_mc_346453.PhH7EG_H7UE_NNPDF30ME_ttH125_ZZ4l_semilep_noTau.4lep.root"
+      },
+      {
+        "checksum": "adler32:7bcabbd2",
+        "size": 14213068,
+        "uri": "root://eospublic.cern.ch//eos/opendata/atlas/rucio/opendata/ODEO_FEB2025_v0_4lep_mc_346454.PhH7EG_H7UE_NNPDF30ME_ttH125_ZZ4l_dilep_noTau.4lep.root"
+      },
+      {
+        "checksum": "adler32:adf75a38",
+        "size": 54191,
+        "uri": "root://eospublic.cern.ch//eos/opendata/atlas/rucio/opendata/ODEO_FEB2025_v0_4lep_mc_346486.aMcAtNloPythia8EvtGen_tWH125_yy.4lep.root"
+      },
+      {
+        "checksum": "adler32:5c902062",
+        "size": 4877907,
+        "uri": "root://eospublic.cern.ch//eos/opendata/atlas/rucio/opendata/ODEO_FEB2025_v0_4lep_mc_346511.aMcAtNloPythia8EvtGen_tWH125_ZZ4l.4lep.root"
+      },
+      {
+        "checksum": "adler32:306270d0",
+        "size": 367457,
+        "uri": "root://eospublic.cern.ch//eos/opendata/atlas/rucio/opendata/ODEO_FEB2025_v0_4lep_mc_346524.PowhegPythia8EvtGen_NNPDF3_AZNLO_ggZH125J_MINLO_ZinclWWlvlv.4lep.root"
+      },
+      {
+        "checksum": "adler32:b6623145",
+        "size": 178458,
+        "uri": "root://eospublic.cern.ch//eos/opendata/atlas/rucio/opendata/ODEO_FEB2025_v0_4lep_mc_346525.PowhegPythia8EvtGen_A14NNPDF23_NNPDF30ME_ttH125_gamgam.4lep.root"
+      },
+      {
+        "checksum": "adler32:1baee792",
+        "size": 154409,
+        "uri": "root://eospublic.cern.ch//eos/opendata/atlas/rucio/opendata/ODEO_FEB2025_v0_4lep_mc_346526.PowhegHerwig7EvtGen_H7UE_NNPDF30ME_ttH125_gamgam.4lep.root"
+      },
+      {
+        "checksum": "adler32:3e649380",
+        "size": 1347,
+        "uri": "root://eospublic.cern.ch//eos/opendata/atlas/rucio/opendata/ODEO_FEB2025_v0_4lep_mc_346588.PowhegPythia8EvtGen_NNLOPS_nnlo_30_ggH125_ZZ4nu_MET75.4lep.root"
+      },
+      {
+        "checksum": "adler32:8d938d31",
+        "size": 116015,
+        "uri": "root://eospublic.cern.ch//eos/opendata/atlas/rucio/opendata/ODEO_FEB2025_v0_4lep_mc_346601.aMcAtNloHerwig7EvtGen_MEN30NLO_ttH125_gamgam.4lep.root"
+      },
+      {
+        "checksum": "adler32:6f00da46",
+        "size": 29908,
+        "uri": "root://eospublic.cern.ch//eos/opendata/atlas/rucio/opendata/ODEO_FEB2025_v0_4lep_mc_346602.aMcAtNloHerwig7EvtGen_MEN30NLO_tHjb125_gamgam.4lep.root"
+      },
+      {
+        "checksum": "adler32:7cbd9d60",
+        "size": 1379,
+        "uri": "root://eospublic.cern.ch//eos/opendata/atlas/rucio/opendata/ODEO_FEB2025_v0_4lep_mc_346605.PowhegPythia8EvtGen_NNPDF30_AZNLO_WpH125J_WinclHinv_MET75.4lep.root"
+      },
+      {
+        "checksum": "adler32:03099d7e",
+        "size": 1379,
+        "uri": "root://eospublic.cern.ch//eos/opendata/atlas/rucio/opendata/ODEO_FEB2025_v0_4lep_mc_346606.PowhegPythia8EvtGen_NNPDF30_AZNLO_WmH125J_WinclHinv_MET75.4lep.root"
+      },
+      {
+        "checksum": "adler32:3802ad05",
+        "size": 27401,
+        "uri": "root://eospublic.cern.ch//eos/opendata/atlas/rucio/opendata/ODEO_FEB2025_v0_4lep_mc_346607.PowhegPythia8EvtGen_NNPDF30_AZNLO_ZH125J_ZinclHinv_MET75.4lep.root"
+      },
+      {
+        "checksum": "adler32:1d46ce5b",
+        "size": 97279,
+        "uri": "root://eospublic.cern.ch//eos/opendata/atlas/rucio/opendata/ODEO_FEB2025_v0_4lep_mc_346632.PowhegPy8EG_A14NNPDF23_NNPDF30ME_ttH125_ZZ4nu_semilep.4lep.root"
+      },
+      {
+        "checksum": "adler32:78246bcf",
+        "size": 44672,
+        "uri": "root://eospublic.cern.ch//eos/opendata/atlas/rucio/opendata/ODEO_FEB2025_v0_4lep_mc_346633.PowhegPy8EG_A14NNPDF23_NNPDF30ME_ttH125_ZZ4nu_allhad.4lep.root"
+      },
+      {
+        "checksum": "adler32:07f3c757",
+        "size": 83000,
+        "uri": "root://eospublic.cern.ch//eos/opendata/atlas/rucio/opendata/ODEO_FEB2025_v0_4lep_mc_346634.PowhegPy8EG_A14NNPDF23_NNPDF30ME_ttH125_ZZ4nu_dilep.4lep.root"
+      },
+      {
+        "checksum": "adler32:1509d341",
+        "size": 10609057,
+        "uri": "root://eospublic.cern.ch//eos/opendata/atlas/rucio/opendata/ODEO_FEB2025_v0_4lep_mc_346645.PowhegPythia8EvtGen_NNPDF30_AZNLO_ZH125J_Zincl_MINLO_shw.4lep.root"
+      },
+      {
+        "checksum": "adler32:ec204d9d",
+        "size": 6114288,
+        "uri": "root://eospublic.cern.ch//eos/opendata/atlas/rucio/opendata/ODEO_FEB2025_v0_4lep_mc_346646.PowhegPythia8EvtGen_NNPDF30_AZNLO_WpH125J_Wincl_MINLO_shw.4lep.root"
+      },
+      {
+        "checksum": "adler32:344a6908",
+        "size": 3301718,
+        "uri": "root://eospublic.cern.ch//eos/opendata/atlas/rucio/opendata/ODEO_FEB2025_v0_4lep_mc_346647.PowhegPythia8EvtGen_NNPDF30_AZNLO_WmH125J_Wincl_MINLO_shw.4lep.root"
+      },
+      {
+        "checksum": "adler32:5ce64a4b",
+        "size": 40683,
+        "uri": "root://eospublic.cern.ch//eos/opendata/atlas/rucio/opendata/ODEO_FEB2025_v0_4lep_mc_346726.PowhegHerwig7EvtGen_NNPDF3_AZNLO_ZH125J_MINLO_vvcc_VpT.4lep.root"
+      },
+      {
+        "checksum": "adler32:4ea083ec",
+        "size": 1291,
+        "uri": "root://eospublic.cern.ch//eos/opendata/atlas/rucio/opendata/ODEO_FEB2025_v0_4lep_mc_346728.PowhegHerwig7EvtGen_NNPDF3_AZNLO_ggZH125J_vvcc.4lep.root"
+      },
+      {
+        "checksum": "adler32:99c85bf3",
+        "size": 126855,
+        "uri": "root://eospublic.cern.ch//eos/opendata/atlas/rucio/opendata/ODEO_FEB2025_v0_4lep_mc_346797.PhH7EG_H7UE_NNLOPS_nnlo_30_ggH125_gamgam.4lep.root"
+      },
+      {
+        "checksum": "adler32:17e2b513",
+        "size": 274069,
+        "uri": "root://eospublic.cern.ch//eos/opendata/atlas/rucio/opendata/ODEO_FEB2025_v0_4lep_mc_346802.PhH7EG_NNLOPS_nnlo_30_ggH125_WWlvlv_noTau.4lep.root"
+      },
+      {
+        "checksum": "adler32:47009326",
+        "size": 60156,
+        "uri": "root://eospublic.cern.ch//eos/opendata/atlas/rucio/opendata/ODEO_FEB2025_v0_4lep_mc_346877.PhH7EG_NNPDF30_VBFH125_WWlvlv.4lep.root"
+      },
+      {
+        "checksum": "adler32:756a654b",
+        "size": 1219,
+        "uri": "root://eospublic.cern.ch//eos/opendata/atlas/rucio/opendata/ODEO_FEB2025_v0_4lep_mc_346878.PhH7EG_H7UE_NNPDF30_VBF125_gammagamma.4lep.root"
+      },
+      {
+        "checksum": "adler32:00e09a52",
+        "size": 51945,
+        "uri": "root://eospublic.cern.ch//eos/opendata/atlas/rucio/opendata/ODEO_FEB2025_v0_4lep_mc_346879.PhH7EG_H7UE_NNPDF30_ZH125J_Zincl_MINLO_gammagamma.4lep.root"
+      },
+      {
+        "checksum": "adler32:1dbcd35d",
+        "size": 28146,
+        "uri": "root://eospublic.cern.ch//eos/opendata/atlas/rucio/opendata/ODEO_FEB2025_v0_4lep_mc_346880.PhH7EG_H7UE_NNPDF30_WmH125J_Wincl_MINLO_gammagamma.4lep.root"
+      },
+      {
+        "checksum": "adler32:3883da2b",
+        "size": 29063,
+        "uri": "root://eospublic.cern.ch//eos/opendata/atlas/rucio/opendata/ODEO_FEB2025_v0_4lep_mc_346881.PhH7EG_H7UE_NNPDF30_WpH125J_Wincl_MINLO_gammagamma.4lep.root"
+      },
+      {
+        "checksum": "adler32:65599f3a",
+        "size": 34942,
+        "uri": "root://eospublic.cern.ch//eos/opendata/atlas/rucio/opendata/ODEO_FEB2025_v0_4lep_mc_346882.PhH7EG_H7UE_NNPDF30_ggZH125_gammagamma.4lep.root"
+      },
+      {
+        "checksum": "adler32:d91fb763",
+        "size": 124246,
+        "uri": "root://eospublic.cern.ch//eos/opendata/atlas/rucio/opendata/ODEO_FEB2025_v0_4lep_mc_346919.PhPy8EG_A14NNPDF23_NNPDF30ME_ttH125_allhad_tautau_unpol.4lep.root"
+      },
+      {
+        "checksum": "adler32:b215e099",
+        "size": 340410,
+        "uri": "root://eospublic.cern.ch//eos/opendata/atlas/rucio/opendata/ODEO_FEB2025_v0_4lep_mc_346923.PhPy8EG_A14NNPDF23_NNPDF30ME_ttH125_semilep_tautau_unpol.4lep.root"
+      },
+      {
+        "checksum": "adler32:eba5960e",
+        "size": 1300652,
+        "uri": "root://eospublic.cern.ch//eos/opendata/atlas/rucio/opendata/ODEO_FEB2025_v0_4lep_mc_346927.PhPy8EG_A14NNPDF23_NNPDF30ME_ttH125_dilep_tautau_unpol.4lep.root"
+      },
+      {
+        "checksum": "adler32:844a05da",
+        "size": 325425,
+        "uri": "root://eospublic.cern.ch//eos/opendata/atlas/rucio/opendata/ODEO_FEB2025_v0_4lep_mc_364242.Sherpa_222_NNPDF30NNLO_WWW_3l3v_EW6.4lep.root"
+      },
+      {
+        "checksum": "adler32:ee392176",
+        "size": 3842152,
+        "uri": "root://eospublic.cern.ch//eos/opendata/atlas/rucio/opendata/ODEO_FEB2025_v0_4lep_mc_364243.Sherpa_222_NNPDF30NNLO_WWZ_4l2v_EW6.4lep.root"
+      },
+      {
+        "checksum": "adler32:f7488025",
+        "size": 32069,
+        "uri": "root://eospublic.cern.ch//eos/opendata/atlas/rucio/opendata/ODEO_FEB2025_v0_4lep_mc_364244.Sherpa_222_NNPDF30NNLO_WWZ_2l4v_EW6.4lep.root"
+      },
+      {
+        "checksum": "adler32:31b7cd3c",
+        "size": 7401865,
+        "uri": "root://eospublic.cern.ch//eos/opendata/atlas/rucio/opendata/ODEO_FEB2025_v0_4lep_mc_364245.Sherpa_222_NNPDF30NNLO_WZZ_5l1v_EW6.4lep.root"
+      },
+      {
+        "checksum": "adler32:32e8aa0a",
+        "size": 157203,
+        "uri": "root://eospublic.cern.ch//eos/opendata/atlas/rucio/opendata/ODEO_FEB2025_v0_4lep_mc_364246.Sherpa_222_NNPDF30NNLO_WZZ_3l3v_EW6.4lep.root"
+      },
+      {
+        "checksum": "adler32:043476ee",
+        "size": 8424253,
+        "uri": "root://eospublic.cern.ch//eos/opendata/atlas/rucio/opendata/ODEO_FEB2025_v0_4lep_mc_364247.Sherpa_222_NNPDF30NNLO_ZZZ_6l0v_EW6.4lep.root"
+      },
+      {
+        "checksum": "adler32:aaefcec1",
+        "size": 949529,
+        "uri": "root://eospublic.cern.ch//eos/opendata/atlas/rucio/opendata/ODEO_FEB2025_v0_4lep_mc_364248.Sherpa_222_NNPDF30NNLO_ZZZ_4l2v_EW6.4lep.root"
+      },
+      {
+        "checksum": "adler32:d8e57e85",
+        "size": 27835,
+        "uri": "root://eospublic.cern.ch//eos/opendata/atlas/rucio/opendata/ODEO_FEB2025_v0_4lep_mc_364249.Sherpa_222_NNPDF30NNLO_ZZZ_2l4v_EW6.4lep.root"
+      },
+      {
+        "checksum": "adler32:95d64680",
+        "size": 46971,
+        "uri": "root://eospublic.cern.ch//eos/opendata/atlas/rucio/opendata/ODEO_FEB2025_v0_4lep_mc_364336.Sherpa_222_NNPDF30NNLO_WpWpWn_sslvlvjj_EW6.4lep.root"
+      },
+      {
+        "checksum": "adler32:94eacfee",
+        "size": 45530,
+        "uri": "root://eospublic.cern.ch//eos/opendata/atlas/rucio/opendata/ODEO_FEB2025_v0_4lep_mc_364337.Sherpa_222_NNPDF30NNLO_WnWnWp_sslvlvjj_EW6.4lep.root"
+      },
+      {
+        "checksum": "adler32:196dbf1a",
+        "size": 41533,
+        "uri": "root://eospublic.cern.ch//eos/opendata/atlas/rucio/opendata/ODEO_FEB2025_v0_4lep_mc_364338.Sherpa_222_NNPDF30NNLO_WpWpWn_oslvlvjj_EW6.4lep.root"
+      },
+      {
+        "checksum": "adler32:cf5ec1f2",
+        "size": 33378,
+        "uri": "root://eospublic.cern.ch//eos/opendata/atlas/rucio/opendata/ODEO_FEB2025_v0_4lep_mc_364339.Sherpa_222_NNPDF30NNLO_WnWnWp_oslvlvjj_EW6.4lep.root"
+      },
+      {
+        "checksum": "adler32:04dd3616",
+        "size": 171477,
+        "uri": "root://eospublic.cern.ch//eos/opendata/atlas/rucio/opendata/ODEO_FEB2025_v0_4lep_mc_364350.Sherpa_224_NNPDF30NNLO_Diphoton_myy_0_50.4lep.root"
+      },
+      {
+        "checksum": "adler32:c43d4ca5",
+        "size": 1471379,
+        "uri": "root://eospublic.cern.ch//eos/opendata/atlas/rucio/opendata/ODEO_FEB2025_v0_4lep_mc_364351.Sherpa_224_NNPDF30NNLO_Diphoton_myy_50_90.4lep.root"
+      },
+      {
+        "checksum": "adler32:11133618",
+        "size": 377422,
+        "uri": "root://eospublic.cern.ch//eos/opendata/atlas/rucio/opendata/ODEO_FEB2025_v0_4lep_mc_364352.Sherpa_224_NNPDF30NNLO_Diphoton_myy_90_175.4lep.root"
+      },
+      {
+        "checksum": "adler32:5ef3ce10",
+        "size": 78592,
+        "uri": "root://eospublic.cern.ch//eos/opendata/atlas/rucio/opendata/ODEO_FEB2025_v0_4lep_mc_364353.Sherpa_224_NNPDF30NNLO_Diphoton_myy_175_2000.4lep.root"
+      },
+      {
+        "checksum": "adler32:c377524a",
+        "size": 28873,
+        "uri": "root://eospublic.cern.ch//eos/opendata/atlas/rucio/opendata/ODEO_FEB2025_v0_4lep_mc_364354.Sherpa_224_NNPDF30NNLO_Diphoton_myy_2000_E_CMS.4lep.root"
+      },
+      {
+        "checksum": "adler32:ef3f53ce",
+        "size": 61961,
+        "uri": "root://eospublic.cern.ch//eos/opendata/atlas/rucio/opendata/ODEO_FEB2025_v0_4lep_mc_364541.Sherpa_222_NNPDF30NNLO_SinglePhoton_pty_17_35.4lep.root"
+      },
+      {
+        "checksum": "adler32:2f38f23e",
+        "size": 86241,
+        "uri": "root://eospublic.cern.ch//eos/opendata/atlas/rucio/opendata/ODEO_FEB2025_v0_4lep_mc_364542.Sherpa_222_NNPDF30NNLO_SinglePhoton_pty_35_70.4lep.root"
+      },
+      {
+        "checksum": "adler32:4545357d",
+        "size": 292795,
+        "uri": "root://eospublic.cern.ch//eos/opendata/atlas/rucio/opendata/ODEO_FEB2025_v0_4lep_mc_364543.Sherpa_222_NNPDF30NNLO_SinglePhoton_pty_70_140.4lep.root"
+      },
+      {
+        "checksum": "adler32:6d071640",
+        "size": 981510,
+        "uri": "root://eospublic.cern.ch//eos/opendata/atlas/rucio/opendata/ODEO_FEB2025_v0_4lep_mc_364544.Sherpa_222_NNPDF30NNLO_SinglePhoton_pty_140_280.4lep.root"
+      },
+      {
+        "checksum": "adler32:f68a99aa",
+        "size": 301856,
+        "uri": "root://eospublic.cern.ch//eos/opendata/atlas/rucio/opendata/ODEO_FEB2025_v0_4lep_mc_364545.Sherpa_222_NNPDF30NNLO_SinglePhoton_pty_280_500.4lep.root"
+      },
+      {
+        "checksum": "adler32:1785a6f6",
+        "size": 41385,
+        "uri": "root://eospublic.cern.ch//eos/opendata/atlas/rucio/opendata/ODEO_FEB2025_v0_4lep_mc_364546.Sherpa_222_NNPDF30NNLO_SinglePhoton_pty_500_1000.4lep.root"
+      },
+      {
+        "checksum": "adler32:12dd51be",
+        "size": 56147,
+        "uri": "root://eospublic.cern.ch//eos/opendata/atlas/rucio/opendata/ODEO_FEB2025_v0_4lep_mc_364547.Sherpa_222_NNPDF30NNLO_SinglePhoton_pty_1000_E_CMS.4lep.root"
+      },
+      {
+        "checksum": "adler32:46c27ae4",
+        "size": 1267,
+        "uri": "root://eospublic.cern.ch//eos/opendata/atlas/rucio/opendata/ODEO_FEB2025_v0_4lep_mc_364700.Pythia8EvtGen_A14NNPDF23LO_jetjet_JZ0WithSW.4lep.root"
+      },
+      {
+        "checksum": "adler32:5285d7f4",
+        "size": 26091,
+        "uri": "root://eospublic.cern.ch//eos/opendata/atlas/rucio/opendata/ODEO_FEB2025_v0_4lep_mc_364701.Pythia8EvtGen_A14NNPDF23LO_jetjet_JZ1WithSW.4lep.root"
+      },
+      {
+        "checksum": "adler32:408a47c3",
+        "size": 895166,
+        "uri": "root://eospublic.cern.ch//eos/opendata/atlas/rucio/opendata/ODEO_FEB2025_v0_4lep_mc_364702.Pythia8EvtGen_A14NNPDF23LO_jetjet_JZ2WithSW.4lep.root"
+      },
+      {
+        "checksum": "adler32:44471390",
+        "size": 6971488,
+        "uri": "root://eospublic.cern.ch//eos/opendata/atlas/rucio/opendata/ODEO_FEB2025_v0_4lep_mc_364703.Pythia8EvtGen_A14NNPDF23LO_jetjet_JZ3WithSW.4lep.root"
+      },
+      {
+        "checksum": "adler32:0ed2e642",
+        "size": 12083828,
+        "uri": "root://eospublic.cern.ch//eos/opendata/atlas/rucio/opendata/ODEO_FEB2025_v0_4lep_mc_364704.Pythia8EvtGen_A14NNPDF23LO_jetjet_JZ4WithSW.4lep.root"
+      },
+      {
+        "checksum": "adler32:77993c1a",
+        "size": 2418993,
+        "uri": "root://eospublic.cern.ch//eos/opendata/atlas/rucio/opendata/ODEO_FEB2025_v0_4lep_mc_364705.Pythia8EvtGen_A14NNPDF23LO_jetjet_JZ5WithSW.4lep.root"
+      },
+      {
+        "checksum": "adler32:2abb5d38",
+        "size": 165502,
+        "uri": "root://eospublic.cern.ch//eos/opendata/atlas/rucio/opendata/ODEO_FEB2025_v0_4lep_mc_364706.Pythia8EvtGen_A14NNPDF23LO_jetjet_JZ6WithSW.4lep.root"
+      },
+      {
+        "checksum": "adler32:1e263b0e",
+        "size": 143362,
+        "uri": "root://eospublic.cern.ch//eos/opendata/atlas/rucio/opendata/ODEO_FEB2025_v0_4lep_mc_364707.Pythia8EvtGen_A14NNPDF23LO_jetjet_JZ7WithSW.4lep.root"
+      },
+      {
+        "checksum": "adler32:abf34a25",
+        "size": 314607,
+        "uri": "root://eospublic.cern.ch//eos/opendata/atlas/rucio/opendata/ODEO_FEB2025_v0_4lep_mc_364708.Pythia8EvtGen_A14NNPDF23LO_jetjet_JZ8WithSW.4lep.root"
+      },
+      {
+        "checksum": "adler32:be87848b",
+        "size": 214373,
+        "uri": "root://eospublic.cern.ch//eos/opendata/atlas/rucio/opendata/ODEO_FEB2025_v0_4lep_mc_364709.Pythia8EvtGen_A14NNPDF23LO_jetjet_JZ9WithSW.4lep.root"
+      },
+      {
+        "checksum": "adler32:b0d7ee85",
+        "size": 769291,
+        "uri": "root://eospublic.cern.ch//eos/opendata/atlas/rucio/opendata/ODEO_FEB2025_v0_4lep_mc_364710.Pythia8EvtGen_A14NNPDF23LO_jetjet_JZ10WithSW.4lep.root"
+      },
+      {
+        "checksum": "adler32:8988bef8",
+        "size": 481792,
+        "uri": "root://eospublic.cern.ch//eos/opendata/atlas/rucio/opendata/ODEO_FEB2025_v0_4lep_mc_364711.Pythia8EvtGen_A14NNPDF23LO_jetjet_JZ11WithSW.4lep.root"
+      },
+      {
+        "checksum": "adler32:48e34187",
+        "size": 768303,
+        "uri": "root://eospublic.cern.ch//eos/opendata/atlas/rucio/opendata/ODEO_FEB2025_v0_4lep_mc_364712.Pythia8EvtGen_A14NNPDF23LO_jetjet_JZ12WithSW.4lep.root"
+      },
+      {
+        "checksum": "adler32:f71e5ddf",
+        "size": 118963,
+        "uri": "root://eospublic.cern.ch//eos/opendata/atlas/rucio/opendata/ODEO_FEB2025_v0_4lep_mc_375884.MGPy8EG_A14N_GG_ttn1_2000_5000_200.4lep.root"
+      },
+      {
+        "checksum": "adler32:022cbe7b",
+        "size": 32206,
+        "uri": "root://eospublic.cern.ch//eos/opendata/atlas/rucio/opendata/ODEO_FEB2025_v0_4lep_mc_376359.MGPy8EG_A14N23LO_SS_onestepCC_1600_900_200.4lep.root"
+      },
+      {
+        "checksum": "adler32:deee3dc3",
+        "size": 28850,
+        "uri": "root://eospublic.cern.ch//eos/opendata/atlas/rucio/opendata/ODEO_FEB2025_v0_4lep_mc_376518.MadGraphPythia8EvtGen_A14NNPDF23LO_GG_direct_2400_200.4lep.root"
+      },
+      {
+        "checksum": "adler32:2dc326e6",
+        "size": 78065,
+        "uri": "root://eospublic.cern.ch//eos/opendata/atlas/rucio/opendata/ODEO_FEB2025_v0_4lep_mc_392202.MGPy8EG_A14N23LO_C1N2_WZ_500p0_100p0_3L_2L7.4lep.root"
+      },
+      {
+        "checksum": "adler32:a61710a5",
+        "size": 26257,
+        "uri": "root://eospublic.cern.ch//eos/opendata/atlas/rucio/opendata/ODEO_FEB2025_v0_4lep_mc_394997.MGPy8EG_A14N23LO_SM_N2C1p_105_100_2L2MET75_MadSpin.4lep.root"
+      },
+      {
+        "checksum": "adler32:fe38eba1",
+        "size": 65788,
+        "uri": "root://eospublic.cern.ch//eos/opendata/atlas/rucio/opendata/ODEO_FEB2025_v0_4lep_mc_398384.MGPy8EG_A14N23LO_C1N2N1_GGMHinoZh50_800_noFilter.4lep.root"
+      },
+      {
+        "checksum": "adler32:0be62a63",
+        "size": 131872,
+        "uri": "root://eospublic.cern.ch//eos/opendata/atlas/rucio/opendata/ODEO_FEB2025_v0_4lep_mc_410081.MadGraphPythia8EvtGen_A14NNPDF23_ttbarWW.4lep.root"
+      },
+      {
+        "checksum": "adler32:0c54b0b9",
+        "size": 473614,
+        "uri": "root://eospublic.cern.ch//eos/opendata/atlas/rucio/opendata/ODEO_FEB2025_v0_4lep_mc_410082.MadGraphPythia8EvtGen_A14NNPDF23LO_ttgamma_noallhad.4lep.root"
+      },
+      {
+        "checksum": "adler32:000ac01e",
+        "size": 77522,
+        "uri": "root://eospublic.cern.ch//eos/opendata/atlas/rucio/opendata/ODEO_FEB2025_v0_4lep_mc_410087.MadGraphPythia8EvtGen_A14NNPDF23LO_ttgamma_allhad.4lep.root"
+      },
+      {
+        "checksum": "adler32:4751963a",
+        "size": 134884,
+        "uri": "root://eospublic.cern.ch//eos/opendata/atlas/rucio/opendata/ODEO_FEB2025_v0_4lep_mc_410155.aMcAtNloPythia8EvtGen_MEN30NLO_A14N23LO_ttW.4lep.root"
+      },
+      {
+        "checksum": "adler32:6bd9c0c1",
+        "size": 73966,
+        "uri": "root://eospublic.cern.ch//eos/opendata/atlas/rucio/opendata/ODEO_FEB2025_v0_4lep_mc_410156.aMcAtNloPythia8EvtGen_MEN30NLO_A14N23LO_ttZnunu.4lep.root"
+      },
+      {
+        "checksum": "adler32:52cd4a22",
+        "size": 121816,
+        "uri": "root://eospublic.cern.ch//eos/opendata/atlas/rucio/opendata/ODEO_FEB2025_v0_4lep_mc_410157.aMcAtNloPythia8EvtGen_MEN30NLO_A14N23LO_ttZqq.4lep.root"
+      },
+      {
+        "checksum": "adler32:396d33ee",
+        "size": 1917035,
+        "uri": "root://eospublic.cern.ch//eos/opendata/atlas/rucio/opendata/ODEO_FEB2025_v0_4lep_mc_410218.aMcAtNloPythia8EvtGen_MEN30NLO_A14N23LO_ttee.4lep.root"
+      },
+      {
+        "checksum": "adler32:f506393c",
+        "size": 3084204,
+        "uri": "root://eospublic.cern.ch//eos/opendata/atlas/rucio/opendata/ODEO_FEB2025_v0_4lep_mc_410219.aMcAtNloPythia8EvtGen_MEN30NLO_A14N23LO_ttmumu.4lep.root"
+      },
+      {
+        "checksum": "adler32:8c14270c",
+        "size": 453351,
+        "uri": "root://eospublic.cern.ch//eos/opendata/atlas/rucio/opendata/ODEO_FEB2025_v0_4lep_mc_410220.aMcAtNloPythia8EvtGen_MEN30NLO_A14N23LO_tttautau.4lep.root"
+      },
+      {
+        "checksum": "adler32:8a302037",
+        "size": 561467,
+        "uri": "root://eospublic.cern.ch//eos/opendata/atlas/rucio/opendata/ODEO_FEB2025_v0_4lep_mc_410389.MadGraphPythia8EvtGen_A14NNPDF23_ttgamma_nonallhadronic.4lep.root"
+      },
+      {
+        "checksum": "adler32:7204ad52",
+        "size": 476922,
+        "uri": "root://eospublic.cern.ch//eos/opendata/atlas/rucio/opendata/ODEO_FEB2025_v0_4lep_mc_410395.MGH7EG_H7UE_ttgamma_nonallhadronic.4lep.root"
+      },
+      {
+        "checksum": "adler32:8da43a81",
+        "size": 100620,
+        "uri": "root://eospublic.cern.ch//eos/opendata/atlas/rucio/opendata/ODEO_FEB2025_v0_4lep_mc_410396.MGH7EG_H7UE_ttgamma_allhadronic.4lep.root"
+      },
+      {
+        "checksum": "adler32:a2a600af",
+        "size": 617752,
+        "uri": "root://eospublic.cern.ch//eos/opendata/atlas/rucio/opendata/ODEO_FEB2025_v0_4lep_mc_410408.aMcAtNloPythia8EvtGen_tWZ_Ztoll_minDR1.4lep.root"
+      },
+      {
+        "checksum": "adler32:1c0aa793",
+        "size": 16832832,
+        "uri": "root://eospublic.cern.ch//eos/opendata/atlas/rucio/opendata/ODEO_FEB2025_v0_4lep_mc_410470.PhPy8EG_A14_ttbar_hdamp258p75_nonallhad.4lep.root"
+      },
+      {
+        "checksum": "adler32:3be14ef6",
+        "size": 2939202,
+        "uri": "root://eospublic.cern.ch//eos/opendata/atlas/rucio/opendata/ODEO_FEB2025_v0_4lep_mc_410471.PhPy8EG_A14_ttbar_hdamp258p75_allhad.4lep.root"
+      },
+      {
+        "checksum": "adler32:496ed03f",
+        "size": 190255,
+        "uri": "root://eospublic.cern.ch//eos/opendata/atlas/rucio/opendata/ODEO_FEB2025_v0_4lep_mc_410560.MadGraphPythia8EvtGen_A14_tZ_4fl_tchan_noAllHad.4lep.root"
+      },
+      {
+        "checksum": "adler32:3558fe33",
+        "size": 59276,
+        "uri": "root://eospublic.cern.ch//eos/opendata/atlas/rucio/opendata/ODEO_FEB2025_v0_4lep_mc_410644.PowhegPythia8EvtGen_A14_singletop_schan_lept_top.4lep.root"
+      },
+      {
+        "checksum": "adler32:3d77678a",
+        "size": 44423,
+        "uri": "root://eospublic.cern.ch//eos/opendata/atlas/rucio/opendata/ODEO_FEB2025_v0_4lep_mc_410645.PowhegPythia8EvtGen_A14_singletop_schan_lept_antitop.4lep.root"
+      },
+      {
+        "checksum": "adler32:773be5e2",
+        "size": 710216,
+        "uri": "root://eospublic.cern.ch//eos/opendata/atlas/rucio/opendata/ODEO_FEB2025_v0_4lep_mc_410658.PhPy8EG_A14_tchan_BW50_lept_top.4lep.root"
+      },
+      {
+        "checksum": "adler32:247c1d37",
+        "size": 398992,
+        "uri": "root://eospublic.cern.ch//eos/opendata/atlas/rucio/opendata/ODEO_FEB2025_v0_4lep_mc_410659.PhPy8EG_A14_tchan_BW50_lept_antitop.4lep.root"
+      },
+      {
+        "checksum": "adler32:0b1c1a17",
+        "size": 2257358,
+        "uri": "root://eospublic.cern.ch//eos/opendata/atlas/rucio/opendata/ODEO_FEB2025_v0_4lep_mc_411233.PowhegHerwig7EvtGen_tt_hdamp258p75_713_SingleLep.4lep.root"
+      },
+      {
+        "checksum": "adler32:a47ce681",
+        "size": 3569442,
+        "uri": "root://eospublic.cern.ch//eos/opendata/atlas/rucio/opendata/ODEO_FEB2025_v0_4lep_mc_411234.PowhegHerwig7EvtGen_tt_hdamp258p75_713_dil.4lep.root"
+      },
+      {
+        "checksum": "adler32:8c03caca",
+        "size": 3554968,
+        "uri": "root://eospublic.cern.ch//eos/opendata/atlas/rucio/opendata/ODEO_FEB2025_v0_4lep_mc_411316.PowhegHerwig7EvtGen_tt_hdamp258p75_713_allhad.4lep.root"
+      },
+      {
+        "checksum": "adler32:fa137bd7",
+        "size": 1052935,
+        "uri": "root://eospublic.cern.ch//eos/opendata/atlas/rucio/opendata/ODEO_FEB2025_v0_4lep_mc_412043.aMcAtNloPythia8EvtGen_A14NNPDF31_SM4topsNLO.4lep.root"
+      },
+      {
+        "checksum": "adler32:ab0f10e0",
+        "size": 987172,
+        "uri": "root://eospublic.cern.ch//eos/opendata/atlas/rucio/opendata/ODEO_FEB2025_v0_4lep_mc_412044.aMcAtNloHerwig7EvtGen_H7UE_SM4topsNLO.4lep.root"
+      },
+      {
+        "checksum": "adler32:3c5e769a",
+        "size": 1259,
+        "uri": "root://eospublic.cern.ch//eos/opendata/atlas/rucio/opendata/ODEO_FEB2025_v0_4lep_mc_423099.Pythia8EvtGen_A14NNPDF23LO_gammajet_DP8_17.4lep.root"
+      },
+      {
+        "checksum": "adler32:0b8b76a2",
+        "size": 1267,
+        "uri": "root://eospublic.cern.ch//eos/opendata/atlas/rucio/opendata/ODEO_FEB2025_v0_4lep_mc_423100.Pythia8EvtGen_A14NNPDF23LO_gammajet_DP17_35.4lep.root"
+      },
+      {
+        "checksum": "adler32:c93e4ee9",
+        "size": 51432,
+        "uri": "root://eospublic.cern.ch//eos/opendata/atlas/rucio/opendata/ODEO_FEB2025_v0_4lep_mc_423101.Pythia8EvtGen_A14NNPDF23LO_gammajet_DP35_50.4lep.root"
+      },
+      {
+        "checksum": "adler32:81c7a7c0",
+        "size": 110078,
+        "uri": "root://eospublic.cern.ch//eos/opendata/atlas/rucio/opendata/ODEO_FEB2025_v0_4lep_mc_423102.Pythia8EvtGen_A14NNPDF23LO_gammajet_DP50_70.4lep.root"
+      },
+      {
+        "checksum": "adler32:7e41cf43",
+        "size": 124047,
+        "uri": "root://eospublic.cern.ch//eos/opendata/atlas/rucio/opendata/ODEO_FEB2025_v0_4lep_mc_423103.Pythia8EvtGen_A14NNPDF23LO_gammajet_DP70_140.4lep.root"
+      },
+      {
+        "checksum": "adler32:74500de3",
+        "size": 194748,
+        "uri": "root://eospublic.cern.ch//eos/opendata/atlas/rucio/opendata/ODEO_FEB2025_v0_4lep_mc_423104.Pythia8EvtGen_A14NNPDF23LO_gammajet_DP140_280.4lep.root"
+      },
+      {
+        "checksum": "adler32:95855e08",
+        "size": 278542,
+        "uri": "root://eospublic.cern.ch//eos/opendata/atlas/rucio/opendata/ODEO_FEB2025_v0_4lep_mc_423105.Pythia8EvtGen_A14NNPDF23LO_gammajet_DP280_500.4lep.root"
+      },
+      {
+        "checksum": "adler32:aab6400c",
+        "size": 50892,
+        "uri": "root://eospublic.cern.ch//eos/opendata/atlas/rucio/opendata/ODEO_FEB2025_v0_4lep_mc_423106.Pythia8EvtGen_A14NNPDF23LO_gammajet_DP500_800.4lep.root"
+      },
+      {
+        "checksum": "adler32:5a0d5ea4",
+        "size": 45197,
+        "uri": "root://eospublic.cern.ch//eos/opendata/atlas/rucio/opendata/ODEO_FEB2025_v0_4lep_mc_423107.Pythia8EvtGen_A14NNPDF23LO_gammajet_DP800_1000.4lep.root"
+      },
+      {
+        "checksum": "adler32:d5e8e5eb",
+        "size": 60386,
+        "uri": "root://eospublic.cern.ch//eos/opendata/atlas/rucio/opendata/ODEO_FEB2025_v0_4lep_mc_423108.Pythia8EvtGen_A14NNPDF23LO_gammajet_DP1000_1500.4lep.root"
+      },
+      {
+        "checksum": "adler32:028d72ef",
+        "size": 32819,
+        "uri": "root://eospublic.cern.ch//eos/opendata/atlas/rucio/opendata/ODEO_FEB2025_v0_4lep_mc_423109.Pythia8EvtGen_A14NNPDF23LO_gammajet_DP1500_2000.4lep.root"
+      },
+      {
+        "checksum": "adler32:aa10149b",
+        "size": 32849,
+        "uri": "root://eospublic.cern.ch//eos/opendata/atlas/rucio/opendata/ODEO_FEB2025_v0_4lep_mc_423110.Pythia8EvtGen_A14NNPDF23LO_gammajet_DP2000_2500.4lep.root"
+      },
+      {
+        "checksum": "adler32:6eded493",
+        "size": 46553,
+        "uri": "root://eospublic.cern.ch//eos/opendata/atlas/rucio/opendata/ODEO_FEB2025_v0_4lep_mc_423111.Pythia8EvtGen_A14NNPDF23LO_gammajet_DP2500_3000.4lep.root"
+      },
+      {
+        "checksum": "adler32:361cea1d",
+        "size": 46399,
+        "uri": "root://eospublic.cern.ch//eos/opendata/atlas/rucio/opendata/ODEO_FEB2025_v0_4lep_mc_423112.Pythia8EvtGen_A14NNPDF23LO_gammajet_DP3000_inf.4lep.root"
+      },
+      {
+        "checksum": "adler32:58ee0439",
+        "size": 81359,
+        "uri": "root://eospublic.cern.ch//eos/opendata/atlas/rucio/opendata/ODEO_FEB2025_v0_4lep_mc_448624.MGPy8EG_A14N23LO_TT_higgsinoRPV_1075_700.4lep.root"
+      },
+      {
+        "checksum": "adler32:cc2cec1e",
+        "size": 146389,
+        "uri": "root://eospublic.cern.ch//eos/opendata/atlas/rucio/opendata/ODEO_FEB2025_v0_4lep_mc_449595.MGPy8EG_A14N23LO_TT_RPVdirectBL_1400.4lep.root"
+      },
+      {
+        "checksum": "adler32:2ee61fc4",
+        "size": 61445,
+        "uri": "root://eospublic.cern.ch//eos/opendata/atlas/rucio/opendata/ODEO_FEB2025_v0_4lep_mc_450576.PowhegPythia8EvtGen_NNLOPS_nnlo_30_VBFH125_ZZllbb.4lep.root"
+      },
+      {
+        "checksum": "adler32:00c2c85f",
+        "size": 67763,
+        "uri": "root://eospublic.cern.ch//eos/opendata/atlas/rucio/opendata/ODEO_FEB2025_v0_4lep_mc_500335.MGH7EG_VBFHWWlvlv.4lep.root"
+      },
+      {
+        "checksum": "adler32:7e90b802",
+        "size": 63675,
+        "uri": "root://eospublic.cern.ch//eos/opendata/atlas/rucio/opendata/ODEO_FEB2025_v0_4lep_mc_500553.aMCPy8EG_ZH_FxFx_Hyy.4lep.root"
+      },
+      {
+        "checksum": "adler32:462c395f",
+        "size": 28796,
+        "uri": "root://eospublic.cern.ch//eos/opendata/atlas/rucio/opendata/ODEO_FEB2025_v0_4lep_mc_500554.aMCPy8EG_WH_FxFx_Hyy.4lep.root"
+      },
+      {
+        "checksum": "adler32:b405a412",
+        "size": 70199,
+        "uri": "root://eospublic.cern.ch//eos/opendata/atlas/rucio/opendata/ODEO_FEB2025_v0_4lep_mc_500555.aMCPy8EG_ggZH_Hyy.4lep.root"
+      },
+      {
+        "checksum": "adler32:136b51de",
+        "size": 28794,
+        "uri": "root://eospublic.cern.ch//eos/opendata/atlas/rucio/opendata/ODEO_FEB2025_v0_4lep_mc_501058.MGPy8EG_StauStauDirect_200p0_1p0_TFilt.4lep.root"
+      },
+      {
+        "checksum": "adler32:a0f5bfb3",
+        "size": 43727,
+        "uri": "root://eospublic.cern.ch//eos/opendata/atlas/rucio/opendata/ODEO_FEB2025_v0_4lep_mc_506098.aMCPy8EG_WpH_FxFx_Htautau.4lep.root"
+      },
+      {
+        "checksum": "adler32:bc73971a",
+        "size": 83803,
+        "uri": "root://eospublic.cern.ch//eos/opendata/atlas/rucio/opendata/ODEO_FEB2025_v0_4lep_mc_506099.aMCPy8EG_ZH_FxFx_Htautau.4lep.root"
+      },
+      {
+        "checksum": "adler32:f3b34731",
+        "size": 1123,
+        "uri": "root://eospublic.cern.ch//eos/opendata/atlas/rucio/opendata/ODEO_FEB2025_v0_4lep_mc_506101.aMCH7EG_VBF_Htautauh30h20.4lep.root"
+      },
+      {
+        "checksum": "adler32:e320c490",
+        "size": 83301,
+        "uri": "root://eospublic.cern.ch//eos/opendata/atlas/rucio/opendata/ODEO_FEB2025_v0_4lep_mc_506102.aMCH7EG_VBF_Htautaul13l7.4lep.root"
+      },
+      {
+        "checksum": "adler32:887fb0b3",
+        "size": 25909,
+        "uri": "root://eospublic.cern.ch//eos/opendata/atlas/rucio/opendata/ODEO_FEB2025_v0_4lep_mc_506103.aMCH7EG_VBF_Htautaulp15hm20.4lep.root"
+      },
+      {
+        "checksum": "adler32:adcebb71",
+        "size": 56878,
+        "uri": "root://eospublic.cern.ch//eos/opendata/atlas/rucio/opendata/ODEO_FEB2025_v0_4lep_mc_506104.aMCH7EG_VBF_Htautaulm15hp20.4lep.root"
+      },
+      {
+        "checksum": "adler32:f8352e87",
+        "size": 26901,
+        "uri": "root://eospublic.cern.ch//eos/opendata/atlas/rucio/opendata/ODEO_FEB2025_v0_4lep_mc_506811.aMCH7EG_VBF_HC_Hyy.4lep.root"
+      },
+      {
+        "checksum": "adler32:f9b49277",
+        "size": 28134,
+        "uri": "root://eospublic.cern.ch//eos/opendata/atlas/rucio/opendata/ODEO_FEB2025_v0_4lep_mc_506813.aMCPy8EG_ZH_had_FxFx_Hyy.4lep.root"
+      },
+      {
+        "checksum": "adler32:5d584677",
+        "size": 1099,
+        "uri": "root://eospublic.cern.ch//eos/opendata/atlas/rucio/opendata/ODEO_FEB2025_v0_4lep_mc_506814.aMCPy8EG_ggZH_Zhad_Hyy.4lep.root"
+      },
+      {
+        "checksum": "adler32:2d88b61f",
+        "size": 33228,
+        "uri": "root://eospublic.cern.ch//eos/opendata/atlas/rucio/opendata/ODEO_FEB2025_v0_4lep_mc_507366.MGPy8EG_A14NNPDF23LO_GGM_N1N2C1_950.4lep.root"
+      },
+      {
+        "checksum": "adler32:2a4b34e5",
+        "size": 226712,
+        "uri": "root://eospublic.cern.ch//eos/opendata/atlas/rucio/opendata/ODEO_FEB2025_v0_4lep_mc_510097.MGPy8EG_A14N23LO_DM_4topscalar_p1000_c1_nonallhad.4lep.root"
+      },
+      {
+        "checksum": "adler32:8bf007b9",
+        "size": 38319,
+        "uri": "root://eospublic.cern.ch//eos/opendata/atlas/rucio/opendata/ODEO_FEB2025_v0_4lep_mc_523692.MGPy8EG_A14N23LO_TT_tN1_1200_200_MS.4lep.root"
+      },
+      {
+        "checksum": "adler32:ca94962c",
+        "size": 334634,
+        "uri": "root://eospublic.cern.ch//eos/opendata/atlas/rucio/opendata/ODEO_FEB2025_v0_4lep_mc_600017.PhH7EG_H7UE_716_tchan_lept_antitop.4lep.root"
+      },
+      {
+        "checksum": "adler32:ab7d644f",
+        "size": 560056,
+        "uri": "root://eospublic.cern.ch//eos/opendata/atlas/rucio/opendata/ODEO_FEB2025_v0_4lep_mc_600018.PhH7EG_H7UE_716_tchan_lept_top.4lep.root"
+      },
+      {
+        "checksum": "adler32:d9e608c7",
+        "size": 49003,
+        "uri": "root://eospublic.cern.ch//eos/opendata/atlas/rucio/opendata/ODEO_FEB2025_v0_4lep_mc_600019.PhH7EG_H7UE_716_schan_lept_antitop.4lep.root"
+      },
+      {
+        "checksum": "adler32:a810a1a8",
+        "size": 48846,
+        "uri": "root://eospublic.cern.ch//eos/opendata/atlas/rucio/opendata/ODEO_FEB2025_v0_4lep_mc_600020.PhH7EG_H7UE_716_schan_lept_top.4lep.root"
+      },
+      {
+        "checksum": "adler32:a6b676e5",
+        "size": 1243,
+        "uri": "root://eospublic.cern.ch//eos/opendata/atlas/rucio/opendata/ODEO_FEB2025_v0_4lep_mc_600565.PhH7EG_ggH125_tautauh30h20_ShowerSys_fix.4lep.root"
+      },
+      {
+        "checksum": "adler32:8e5267b3",
+        "size": 204044,
+        "uri": "root://eospublic.cern.ch//eos/opendata/atlas/rucio/opendata/ODEO_FEB2025_v0_4lep_mc_600566.PhH7EG_ggH125_tautaul13l7_ShowerSys_fix.4lep.root"
+      },
+      {
+        "checksum": "adler32:bfdf5c47",
+        "size": 51948,
+        "uri": "root://eospublic.cern.ch//eos/opendata/atlas/rucio/opendata/ODEO_FEB2025_v0_4lep_mc_600567.PhH7EG_ggH125_ttlp15hm20_ShowerSys_fix.4lep.root"
+      },
+      {
+        "checksum": "adler32:0b4f2a80",
+        "size": 40188,
+        "uri": "root://eospublic.cern.ch//eos/opendata/atlas/rucio/opendata/ODEO_FEB2025_v0_4lep_mc_600568.PhH7EG_ggH125_ttlm15hp20_ShowerSys_fix.4lep.root"
+      },
+      {
+        "checksum": "adler32:4bffb419",
+        "size": 26003,
+        "uri": "root://eospublic.cern.ch//eos/opendata/atlas/rucio/opendata/ODEO_FEB2025_v0_4lep_mc_600569.PhH7EG_VBFH125_tautauh30h20_ShowerSys_fix.4lep.root"
+      },
+      {
+        "checksum": "adler32:2808b0af",
+        "size": 80808,
+        "uri": "root://eospublic.cern.ch//eos/opendata/atlas/rucio/opendata/ODEO_FEB2025_v0_4lep_mc_600570.PhH7EG_VBFH125_tautaul13l7_ShowerSys_fix.4lep.root"
+      },
+      {
+        "checksum": "adler32:4be725a7",
+        "size": 27209,
+        "uri": "root://eospublic.cern.ch//eos/opendata/atlas/rucio/opendata/ODEO_FEB2025_v0_4lep_mc_600571.PhH7EG_VBFH125_tautaulp15hm20_ShowerSys_fix.4lep.root"
+      },
+      {
+        "checksum": "adler32:d58e3e0b",
+        "size": 27112,
+        "uri": "root://eospublic.cern.ch//eos/opendata/atlas/rucio/opendata/ODEO_FEB2025_v0_4lep_mc_600572.PhH7EG_VBFH125_tautaulm15hp20_ShowerSys_fix.4lep.root"
+      },
+      {
+        "checksum": "adler32:b531a96d",
+        "size": 31033,
+        "uri": "root://eospublic.cern.ch//eos/opendata/atlas/rucio/opendata/ODEO_FEB2025_v0_4lep_mc_600573.PhH7EG_WmH125J_Winc_MINLO_tt_ShowerSys_fix.4lep.root"
+      },
+      {
+        "checksum": "adler32:8b7388e1",
+        "size": 44171,
+        "uri": "root://eospublic.cern.ch//eos/opendata/atlas/rucio/opendata/ODEO_FEB2025_v0_4lep_mc_600574.PhH7EG_WpH125J_Winc_MINLO_tt_ShowerSys_fix.4lep.root"
+      },
+      {
+        "checksum": "adler32:5c3ff2ef",
+        "size": 116198,
+        "uri": "root://eospublic.cern.ch//eos/opendata/atlas/rucio/opendata/ODEO_FEB2025_v0_4lep_mc_600575.PhH7EG_ZH125J_Zinc_MINLO_tautau_ShowerSys_fix.4lep.root"
+      },
+      {
+        "checksum": "adler32:f751dd7e",
+        "size": 77485,
+        "uri": "root://eospublic.cern.ch//eos/opendata/atlas/rucio/opendata/ODEO_FEB2025_v0_4lep_mc_600686.PhPy8EG_NNPDF3_AZNLO_ggZH125_Htautau_Zinc.4lep.root"
+      },
+      {
+        "checksum": "adler32:b8977821",
+        "size": 857951,
+        "uri": "root://eospublic.cern.ch//eos/opendata/atlas/rucio/opendata/ODEO_FEB2025_v0_4lep_mc_601352.PhPy8EG_tW_dyn_DR_incl_antitop.4lep.root"
+      },
+      {
+        "checksum": "adler32:5046b5fc",
+        "size": 842059,
+        "uri": "root://eospublic.cern.ch//eos/opendata/atlas/rucio/opendata/ODEO_FEB2025_v0_4lep_mc_601355.PhPy8EG_tW_dyn_DR_incl_top.4lep.root"
+      },
+      {
+        "checksum": "adler32:fb364486",
+        "size": 351541,
+        "uri": "root://eospublic.cern.ch//eos/opendata/atlas/rucio/opendata/ODEO_FEB2025_v0_4lep_mc_601487.PhPy8EG_A14_tchan_pThard1_lep_antitop.4lep.root"
+      },
+      {
+        "checksum": "adler32:4508e4bb",
+        "size": 578974,
+        "uri": "root://eospublic.cern.ch//eos/opendata/atlas/rucio/opendata/ODEO_FEB2025_v0_4lep_mc_601489.PhPy8EG_A14_tchan_pThard1_lep_top.4lep.root"
+      },
+      {
+        "checksum": "adler32:24c35f31",
+        "size": 6393628,
+        "uri": "root://eospublic.cern.ch//eos/opendata/atlas/rucio/opendata/ODEO_FEB2025_v0_4lep_mc_601491.PhPy8EG_A14_ttbar_pThard1_dil.4lep.root"
+      },
+      {
+        "checksum": "adler32:80cec37e",
+        "size": 55439,
+        "uri": "root://eospublic.cern.ch//eos/opendata/atlas/rucio/opendata/ODEO_FEB2025_v0_4lep_mc_601495.PhPy8EG_A14_ttbar_pThard1_allhad.4lep.root"
+      },
+      {
+        "checksum": "adler32:d91a9331",
+        "size": 8263835,
+        "uri": "root://eospublic.cern.ch//eos/opendata/atlas/rucio/opendata/ODEO_FEB2025_v0_4lep_mc_601497.PhPy8EG_A14_ttbar_pThard1_singlelep.4lep.root"
+      },
+      {
+        "checksum": "adler32:5bc3c4fa",
+        "size": 238681,
+        "uri": "root://eospublic.cern.ch//eos/opendata/atlas/rucio/opendata/ODEO_FEB2025_v0_4lep_mc_601624.PhPy8EG_tW_DS_dyn_dil_antitop.4lep.root"
+      },
+      {
+        "checksum": "adler32:5b5ecb36",
+        "size": 772504,
+        "uri": "root://eospublic.cern.ch//eos/opendata/atlas/rucio/opendata/ODEO_FEB2025_v0_4lep_mc_601627.PhPy8EG_tW_DS_dyn_incl_antitop.4lep.root"
+      },
+      {
+        "checksum": "adler32:e071979a",
+        "size": 273607,
+        "uri": "root://eospublic.cern.ch//eos/opendata/atlas/rucio/opendata/ODEO_FEB2025_v0_4lep_mc_601628.PhPy8EG_tW_DS_dyn_dil_top.4lep.root"
+      },
+      {
+        "checksum": "adler32:dc5d30c5",
+        "size": 734464,
+        "uri": "root://eospublic.cern.ch//eos/opendata/atlas/rucio/opendata/ODEO_FEB2025_v0_4lep_mc_601631.PhPy8EG_tW_DS_dyn_incl_top.4lep.root"
+      },
+      {
+        "checksum": "adler32:1ceed6d3",
+        "size": 791637,
+        "uri": "root://eospublic.cern.ch//eos/opendata/atlas/rucio/opendata/ODEO_FEB2025_v0_4lep_mc_601761.PhPy8EG_tW_dyn_DR_pThard1_incl_top.4lep.root"
+      },
+      {
+        "checksum": "adler32:52dcd0b3",
+        "size": 806997,
+        "uri": "root://eospublic.cern.ch//eos/opendata/atlas/rucio/opendata/ODEO_FEB2025_v0_4lep_mc_601762.PhPy8EG_tW_dyn_DR_pThard1_incl_antitop.4lep.root"
+      },
+      {
+        "checksum": "adler32:6efc1ce9",
+        "size": 285276,
+        "uri": "root://eospublic.cern.ch//eos/opendata/atlas/rucio/opendata/ODEO_FEB2025_v0_4lep_mc_601763.PhPy8EG_tW_dyn_DR_pThard1_dil_top.4lep.root"
+      },
+      {
+        "checksum": "adler32:127f4a68",
+        "size": 310293,
+        "uri": "root://eospublic.cern.ch//eos/opendata/atlas/rucio/opendata/ODEO_FEB2025_v0_4lep_mc_601764.PhPy8EG_tW_dyn_DR_pThard1_dil_antitop.4lep.root"
+      },
+      {
+        "checksum": "adler32:7010d848",
+        "size": 211289,
+        "uri": "root://eospublic.cern.ch//eos/opendata/atlas/rucio/opendata/ODEO_FEB2025_v0_4lep_mc_700000.Sh_228_ttW.4lep.root"
+      },
+      {
+        "checksum": "adler32:b4e34f9c",
+        "size": 25802,
+        "uri": "root://eospublic.cern.ch//eos/opendata/atlas/rucio/opendata/ODEO_FEB2025_v0_4lep_mc_700007.Sh_228_yyy_01NLO.4lep.root"
+      },
+      {
+        "checksum": "adler32:b1c3aa2a",
+        "size": 144344,
+        "uri": "root://eospublic.cern.ch//eos/opendata/atlas/rucio/opendata/ODEO_FEB2025_v0_4lep_mc_700195.Sh_2210_eegammagamma.4lep.root"
+      },
+      {
+        "checksum": "adler32:e771dbf3",
+        "size": 237945,
+        "uri": "root://eospublic.cern.ch//eos/opendata/atlas/rucio/opendata/ODEO_FEB2025_v0_4lep_mc_700196.Sh_2210_mumugammagamma.4lep.root"
+      },
+      {
+        "checksum": "adler32:4581a7b0",
+        "size": 28909,
+        "uri": "root://eospublic.cern.ch//eos/opendata/atlas/rucio/opendata/ODEO_FEB2025_v0_4lep_mc_700197.Sh_2210_tautaugammagamma.4lep.root"
+      },
+      {
+        "checksum": "adler32:5ae849e5",
+        "size": 1099,
+        "uri": "root://eospublic.cern.ch//eos/opendata/atlas/rucio/opendata/ODEO_FEB2025_v0_4lep_mc_700198.Sh_2210_nunugammagamma.4lep.root"
+      },
+      {
+        "checksum": "adler32:02ae4f87",
+        "size": 45971,
+        "uri": "root://eospublic.cern.ch//eos/opendata/atlas/rucio/opendata/ODEO_FEB2025_v0_4lep_mc_700199.Sh_2210_enugammagamma.4lep.root"
+      },
+      {
+        "checksum": "adler32:924681e2",
+        "size": 44664,
+        "uri": "root://eospublic.cern.ch//eos/opendata/atlas/rucio/opendata/ODEO_FEB2025_v0_4lep_mc_700200.Sh_2210_munugammagamma.4lep.root"
+      },
+      {
+        "checksum": "adler32:416a4284",
+        "size": 37768,
+        "uri": "root://eospublic.cern.ch//eos/opendata/atlas/rucio/opendata/ODEO_FEB2025_v0_4lep_mc_700201.Sh_2210_taunugammagamma.4lep.root"
+      },
+      {
+        "checksum": "adler32:7e4c17b9",
+        "size": 7495036,
+        "uri": "root://eospublic.cern.ch//eos/opendata/atlas/rucio/opendata/ODEO_FEB2025_v0_4lep_mc_700320.Sh_2211_Zee_maxHTpTV2_BFilter.4lep.root"
+      },
+      {
+        "checksum": "adler32:bcce7778",
+        "size": 21281507,
+        "uri": "root://eospublic.cern.ch//eos/opendata/atlas/rucio/opendata/ODEO_FEB2025_v0_4lep_mc_700321.Sh_2211_Zee_maxHTpTV2_CFilterBVeto.4lep.root"
+      },
+      {
+        "checksum": "adler32:11a1d197",
+        "size": 36893717,
+        "uri": "root://eospublic.cern.ch//eos/opendata/atlas/rucio/opendata/ODEO_FEB2025_v0_4lep_mc_700322.Sh_2211_Zee_maxHTpTV2_CVetoBVeto.4lep.root"
+      },
+      {
+        "checksum": "adler32:7f812916",
+        "size": 7099307,
+        "uri": "root://eospublic.cern.ch//eos/opendata/atlas/rucio/opendata/ODEO_FEB2025_v0_4lep_mc_700323.Sh_2211_Zmumu_maxHTpTV2_BFilter.4lep.root"
+      },
+      {
+        "checksum": "adler32:6fa815f0",
+        "size": 21127899,
+        "uri": "root://eospublic.cern.ch//eos/opendata/atlas/rucio/opendata/ODEO_FEB2025_v0_4lep_mc_700324.Sh_2211_Zmumu_maxHTpTV2_CFilterBVeto.4lep.root"
+      },
+      {
+        "checksum": "adler32:d6c1531e",
+        "size": 38482784,
+        "uri": "root://eospublic.cern.ch//eos/opendata/atlas/rucio/opendata/ODEO_FEB2025_v0_4lep_mc_700325.Sh_2211_Zmumu_maxHTpTV2_CVetoBVeto.4lep.root"
+      },
+      {
+        "checksum": "adler32:b7596d2e",
+        "size": 221631,
+        "uri": "root://eospublic.cern.ch//eos/opendata/atlas/rucio/opendata/ODEO_FEB2025_v0_4lep_mc_700335.Sh_2211_Znunu_pTV2_BFilter.4lep.root"
+      },
+      {
+        "checksum": "adler32:1da887e2",
+        "size": 378450,
+        "uri": "root://eospublic.cern.ch//eos/opendata/atlas/rucio/opendata/ODEO_FEB2025_v0_4lep_mc_700336.Sh_2211_Znunu_pTV2_CFilterBVeto.4lep.root"
+      },
+      {
+        "checksum": "adler32:69ff52db",
+        "size": 701239,
+        "uri": "root://eospublic.cern.ch//eos/opendata/atlas/rucio/opendata/ODEO_FEB2025_v0_4lep_mc_700337.Sh_2211_Znunu_pTV2_CVetoBVeto.4lep.root"
+      },
+      {
+        "checksum": "adler32:0a9ff23b",
+        "size": 6240275,
+        "uri": "root://eospublic.cern.ch//eos/opendata/atlas/rucio/opendata/ODEO_FEB2025_v0_4lep_mc_700338.Sh_2211_Wenu_maxHTpTV2_BFilter.4lep.root"
+      },
+      {
+        "checksum": "adler32:5150637c",
+        "size": 19668987,
+        "uri": "root://eospublic.cern.ch//eos/opendata/atlas/rucio/opendata/ODEO_FEB2025_v0_4lep_mc_700339.Sh_2211_Wenu_maxHTpTV2_CFilterBVeto.4lep.root"
+      },
+      {
+        "checksum": "adler32:ea7f02c2",
+        "size": 14605639,
+        "uri": "root://eospublic.cern.ch//eos/opendata/atlas/rucio/opendata/ODEO_FEB2025_v0_4lep_mc_700340.Sh_2211_Wenu_maxHTpTV2_CVetoBVeto.4lep.root"
+      },
+      {
+        "checksum": "adler32:470ad5e9",
+        "size": 6531238,
+        "uri": "root://eospublic.cern.ch//eos/opendata/atlas/rucio/opendata/ODEO_FEB2025_v0_4lep_mc_700341.Sh_2211_Wmunu_maxHTpTV2_BFilter.4lep.root"
+      },
+      {
+        "checksum": "adler32:a10b5232",
+        "size": 18220400,
+        "uri": "root://eospublic.cern.ch//eos/opendata/atlas/rucio/opendata/ODEO_FEB2025_v0_4lep_mc_700342.Sh_2211_Wmunu_maxHTpTV2_CFilterBVeto.4lep.root"
+      },
+      {
+        "checksum": "adler32:223e9ce3",
+        "size": 13845224,
+        "uri": "root://eospublic.cern.ch//eos/opendata/atlas/rucio/opendata/ODEO_FEB2025_v0_4lep_mc_700343.Sh_2211_Wmunu_maxHTpTV2_CVetoBVeto.4lep.root"
+      },
+      {
+        "checksum": "adler32:78021002",
+        "size": 1772542,
+        "uri": "root://eospublic.cern.ch//eos/opendata/atlas/rucio/opendata/ODEO_FEB2025_v0_4lep_mc_700344.Sh_2211_Wtaunu_L_maxHTpTV2_BFilter.4lep.root"
+      },
+      {
+        "checksum": "adler32:89572b72",
+        "size": 5664659,
+        "uri": "root://eospublic.cern.ch//eos/opendata/atlas/rucio/opendata/ODEO_FEB2025_v0_4lep_mc_700345.Sh_2211_Wtaunu_L_maxHTpTV2_CFilterBVeto.4lep.root"
+      },
+      {
+        "checksum": "adler32:043506fe",
+        "size": 7490507,
+        "uri": "root://eospublic.cern.ch//eos/opendata/atlas/rucio/opendata/ODEO_FEB2025_v0_4lep_mc_700346.Sh_2211_Wtaunu_L_maxHTpTV2_CVetoBVeto.4lep.root"
+      },
+      {
+        "checksum": "adler32:b096a8f6",
+        "size": 1460673,
+        "uri": "root://eospublic.cern.ch//eos/opendata/atlas/rucio/opendata/ODEO_FEB2025_v0_4lep_mc_700347.Sh_2211_Wtaunu_H_maxHTpTV2_BFilter.4lep.root"
+      },
+      {
+        "checksum": "adler32:f93d285c",
+        "size": 837996,
+        "uri": "root://eospublic.cern.ch//eos/opendata/atlas/rucio/opendata/ODEO_FEB2025_v0_4lep_mc_700348.Sh_2211_Wtaunu_H_maxHTpTV2_CFilterBVeto.4lep.root"
+      },
+      {
+        "checksum": "adler32:3c359906",
+        "size": 2924990,
+        "uri": "root://eospublic.cern.ch//eos/opendata/atlas/rucio/opendata/ODEO_FEB2025_v0_4lep_mc_700349.Sh_2211_Wtaunu_H_maxHTpTV2_CVetoBVeto.4lep.root"
+      },
+      {
+        "checksum": "adler32:c753c384",
+        "size": 88896,
+        "uri": "root://eospublic.cern.ch//eos/opendata/atlas/rucio/opendata/ODEO_FEB2025_v0_4lep_mc_700352.Sh_2211_pTZ100_Zqqgamma.4lep.root"
+      },
+      {
+        "checksum": "adler32:429e2397",
+        "size": 66399,
+        "uri": "root://eospublic.cern.ch//eos/opendata/atlas/rucio/opendata/ODEO_FEB2025_v0_4lep_mc_700353.Sh_2211_pTZ100_Zbbgamma.4lep.root"
+      },
+      {
+        "checksum": "adler32:9175f6bc",
+        "size": 113199,
+        "uri": "root://eospublic.cern.ch//eos/opendata/atlas/rucio/opendata/ODEO_FEB2025_v0_4lep_mc_700358.Sh_2211_Zee2jets_Min_N_TChannel.4lep.root"
+      },
+      {
+        "checksum": "adler32:351db8af",
+        "size": 99066,
+        "uri": "root://eospublic.cern.ch//eos/opendata/atlas/rucio/opendata/ODEO_FEB2025_v0_4lep_mc_700359.Sh_2211_Zmm2jets_Min_N_TChannel.4lep.root"
+      },
+      {
+        "checksum": "adler32:4aad672b",
+        "size": 46945,
+        "uri": "root://eospublic.cern.ch//eos/opendata/atlas/rucio/opendata/ODEO_FEB2025_v0_4lep_mc_700360.Sh_2211_Ztt2jets_Min_N_TChannel.4lep.root"
+      },
+      {
+        "checksum": "adler32:24f9f587",
+        "size": 25768,
+        "uri": "root://eospublic.cern.ch//eos/opendata/atlas/rucio/opendata/ODEO_FEB2025_v0_4lep_mc_700361.Sh_2211_Znunu2jets_Min_N_TChannel.4lep.root"
+      },
+      {
+        "checksum": "adler32:15177b0b",
+        "size": 147992,
+        "uri": "root://eospublic.cern.ch//eos/opendata/atlas/rucio/opendata/ODEO_FEB2025_v0_4lep_mc_700362.Sh_2211_Wenu2jets_Min_N_TChannel.4lep.root"
+      },
+      {
+        "checksum": "adler32:a0fbbf65",
+        "size": 175493,
+        "uri": "root://eospublic.cern.ch//eos/opendata/atlas/rucio/opendata/ODEO_FEB2025_v0_4lep_mc_700363.Sh_2211_Wmunu2jets_Min_N_TChannel.4lep.root"
+      },
+      {
+        "checksum": "adler32:09e7c9e0",
+        "size": 50024,
+        "uri": "root://eospublic.cern.ch//eos/opendata/atlas/rucio/opendata/ODEO_FEB2025_v0_4lep_mc_700364.Sh_2211_Wtaunu2jets_Min_N_TChannel.4lep.root"
+      },
+      {
+        "checksum": "adler32:c7542850",
+        "size": 6946979,
+        "uri": "root://eospublic.cern.ch//eos/opendata/atlas/rucio/opendata/ODEO_FEB2025_v0_4lep_mc_700398.Sh_2211_mumugamma.4lep.root"
+      },
+      {
+        "checksum": "adler32:bb98a2b2",
+        "size": 7443451,
+        "uri": "root://eospublic.cern.ch//eos/opendata/atlas/rucio/opendata/ODEO_FEB2025_v0_4lep_mc_700399.Sh_2211_eegamma.4lep.root"
+      },
+      {
+        "checksum": "adler32:91e3d320",
+        "size": 1693087,
+        "uri": "root://eospublic.cern.ch//eos/opendata/atlas/rucio/opendata/ODEO_FEB2025_v0_4lep_mc_700400.Sh_2211_tautaugamma.4lep.root"
+      },
+      {
+        "checksum": "adler32:0fbce579",
+        "size": 298037,
+        "uri": "root://eospublic.cern.ch//eos/opendata/atlas/rucio/opendata/ODEO_FEB2025_v0_4lep_mc_700401.Sh_2211_nunugamma.4lep.root"
+      },
+      {
+        "checksum": "adler32:cb137aa7",
+        "size": 5548040,
+        "uri": "root://eospublic.cern.ch//eos/opendata/atlas/rucio/opendata/ODEO_FEB2025_v0_4lep_mc_700402.Sh_2211_munugamma.4lep.root"
+      },
+      {
+        "checksum": "adler32:47ca0cae",
+        "size": 5653251,
+        "uri": "root://eospublic.cern.ch//eos/opendata/atlas/rucio/opendata/ODEO_FEB2025_v0_4lep_mc_700403.Sh_2211_enugamma.4lep.root"
+      },
+      {
+        "checksum": "adler32:e5ffd001",
+        "size": 3663734,
+        "uri": "root://eospublic.cern.ch//eos/opendata/atlas/rucio/opendata/ODEO_FEB2025_v0_4lep_mc_700404.Sh_2211_taunugamma.4lep.root"
+      },
+      {
+        "checksum": "adler32:fdf8cf03",
+        "size": 26013,
+        "uri": "root://eospublic.cern.ch//eos/opendata/atlas/rucio/opendata/ODEO_FEB2025_v0_4lep_mc_700442.Sh_2211_gamma2jets_pTy140_Min_N_TChannel.4lep.root"
+      },
+      {
+        "checksum": "adler32:e69a0179",
+        "size": 629310,
+        "uri": "root://eospublic.cern.ch//eos/opendata/atlas/rucio/opendata/ODEO_FEB2025_v0_4lep_mc_700467.Sh_2211_Zee_maxHTpTV2_m10_40_pT5_BFilter.4lep.root"
+      },
+      {
+        "checksum": "adler32:0ebaace6",
+        "size": 1843506,
+        "uri": "root://eospublic.cern.ch//eos/opendata/atlas/rucio/opendata/ODEO_FEB2025_v0_4lep_mc_700468.Sh_2211_Zee_maxHTpTV2_m10_40_pT5_CFilterBVeto.4lep.root"
+      },
+      {
+        "checksum": "adler32:3ae039c3",
+        "size": 8743054,
+        "uri": "root://eospublic.cern.ch//eos/opendata/atlas/rucio/opendata/ODEO_FEB2025_v0_4lep_mc_700469.Sh_2211_Zee_maxHTpTV2_m10_40_pT5_CVetoBVeto.4lep.root"
+      },
+      {
+        "checksum": "adler32:fe7f9c61",
+        "size": 605650,
+        "uri": "root://eospublic.cern.ch//eos/opendata/atlas/rucio/opendata/ODEO_FEB2025_v0_4lep_mc_700470.Sh_2211_Zmumu_maxHTpTV2_m10_40_pT5_BFilter.4lep.root"
+      },
+      {
+        "checksum": "adler32:f29eb1e2",
+        "size": 1810180,
+        "uri": "root://eospublic.cern.ch//eos/opendata/atlas/rucio/opendata/ODEO_FEB2025_v0_4lep_mc_700471.Sh_2211_Zmumu_maxHTpTV2_m10_40_pT5_CFilterBVeto.4lep.root"
+      },
+      {
+        "checksum": "adler32:4d67b0a4",
+        "size": 8871294,
+        "uri": "root://eospublic.cern.ch//eos/opendata/atlas/rucio/opendata/ODEO_FEB2025_v0_4lep_mc_700472.Sh_2211_Zmumu_maxHTpTV2_m10_40_pT5_CVetoBVeto.4lep.root"
+      },
+      {
+        "checksum": "adler32:ee47f54f",
+        "size": 645782,
+        "uri": "root://eospublic.cern.ch//eos/opendata/atlas/rucio/opendata/ODEO_FEB2025_v0_4lep_mc_700488.Sh_2211_WlvWqq.4lep.root"
+      },
+      {
+        "checksum": "adler32:92fc59c6",
+        "size": 165128,
+        "uri": "root://eospublic.cern.ch//eos/opendata/atlas/rucio/opendata/ODEO_FEB2025_v0_4lep_mc_700489.Sh_2211_WlvZqq.4lep.root"
+      },
+      {
+        "checksum": "adler32:60604f1f",
+        "size": 73464,
+        "uri": "root://eospublic.cern.ch//eos/opendata/atlas/rucio/opendata/ODEO_FEB2025_v0_4lep_mc_700490.Sh_2211_WlvZbb.4lep.root"
+      },
+      {
+        "checksum": "adler32:d73ab730",
+        "size": 37543,
+        "uri": "root://eospublic.cern.ch//eos/opendata/atlas/rucio/opendata/ODEO_FEB2025_v0_4lep_mc_700491.Sh_2211_WqqZvv.4lep.root"
+      },
+      {
+        "checksum": "adler32:fba3faa4",
+        "size": 186048,
+        "uri": "root://eospublic.cern.ch//eos/opendata/atlas/rucio/opendata/ODEO_FEB2025_v0_4lep_mc_700492.Sh_2211_WqqZll.4lep.root"
+      },
+      {
+        "checksum": "adler32:d2e0711c",
+        "size": 123739,
+        "uri": "root://eospublic.cern.ch//eos/opendata/atlas/rucio/opendata/ODEO_FEB2025_v0_4lep_mc_700493.Sh_2211_ZqqZll.4lep.root"
+      },
+      {
+        "checksum": "adler32:3d525b52",
+        "size": 209313,
+        "uri": "root://eospublic.cern.ch//eos/opendata/atlas/rucio/opendata/ODEO_FEB2025_v0_4lep_mc_700494.Sh_2211_ZbbZll.4lep.root"
+      },
+      {
+        "checksum": "adler32:81362290",
+        "size": 37838,
+        "uri": "root://eospublic.cern.ch//eos/opendata/atlas/rucio/opendata/ODEO_FEB2025_v0_4lep_mc_700495.Sh_2211_ZqqZvv.4lep.root"
+      },
+      {
+        "checksum": "adler32:3735c37c",
+        "size": 25936,
+        "uri": "root://eospublic.cern.ch//eos/opendata/atlas/rucio/opendata/ODEO_FEB2025_v0_4lep_mc_700496.Sh_2211_ZbbZvv.4lep.root"
+      },
+      {
+        "checksum": "adler32:0092f3ca",
+        "size": 46322,
+        "uri": "root://eospublic.cern.ch//eos/opendata/atlas/rucio/opendata/ODEO_FEB2025_v0_4lep_mc_700507.Sh_2211_pTW140_Wqqgamma.4lep.root"
+      },
+      {
+        "checksum": "adler32:814c8f83",
+        "size": 2816583,
+        "uri": "root://eospublic.cern.ch//eos/opendata/atlas/rucio/opendata/ODEO_FEB2025_v0_4lep_mc_700587.Sh_2212_lllljj.4lep.root"
+      },
+      {
+        "checksum": "adler32:b5a210ef",
+        "size": 109125,
+        "uri": "root://eospublic.cern.ch//eos/opendata/atlas/rucio/opendata/ODEO_FEB2025_v0_4lep_mc_700588.Sh_2212_lllvjj.4lep.root"
+      },
+      {
+        "checksum": "adler32:11232b8f",
+        "size": 33459,
+        "uri": "root://eospublic.cern.ch//eos/opendata/atlas/rucio/opendata/ODEO_FEB2025_v0_4lep_mc_700589.Sh_2212_llvvjj_os.4lep.root"
+      },
+      {
+        "checksum": "adler32:c6473e93",
+        "size": 72665,
+        "uri": "root://eospublic.cern.ch//eos/opendata/atlas/rucio/opendata/ODEO_FEB2025_v0_4lep_mc_700590.Sh_2212_llvvjj_ss.4lep.root"
+      },
+      {
+        "checksum": "adler32:26f5b66b",
+        "size": 179796,
+        "uri": "root://eospublic.cern.ch//eos/opendata/atlas/rucio/opendata/ODEO_FEB2025_v0_4lep_mc_700591.Sh_2212_lllljj_Int.4lep.root"
+      },
+      {
+        "checksum": "adler32:863f7ac7",
+        "size": 58133,
+        "uri": "root://eospublic.cern.ch//eos/opendata/atlas/rucio/opendata/ODEO_FEB2025_v0_4lep_mc_700592.Sh_2212_lllvjj_Int.4lep.root"
+      },
+      {
+        "checksum": "adler32:abc2fa7b",
+        "size": 36459,
+        "uri": "root://eospublic.cern.ch//eos/opendata/atlas/rucio/opendata/ODEO_FEB2025_v0_4lep_mc_700593.Sh_2212_llvvjj_os_Int.4lep.root"
+      },
+      {
+        "checksum": "adler32:09d00d8a",
+        "size": 42373,
+        "uri": "root://eospublic.cern.ch//eos/opendata/atlas/rucio/opendata/ODEO_FEB2025_v0_4lep_mc_700594.Sh_2212_llvvjj_ss_Int.4lep.root"
+      },
+      {
+        "checksum": "adler32:568587c6",
+        "size": 5559360,
+        "uri": "root://eospublic.cern.ch//eos/opendata/atlas/rucio/opendata/ODEO_FEB2025_v0_4lep_mc_700600.Sh_2212_llll.4lep.root"
+      },
+      {
+        "checksum": "adler32:a362f624",
+        "size": 802658,
+        "uri": "root://eospublic.cern.ch//eos/opendata/atlas/rucio/opendata/ODEO_FEB2025_v0_4lep_mc_700601.Sh_2212_lllv.4lep.root"
+      },
+      {
+        "checksum": "adler32:bbc93039",
+        "size": 300695,
+        "uri": "root://eospublic.cern.ch//eos/opendata/atlas/rucio/opendata/ODEO_FEB2025_v0_4lep_mc_700602.Sh_2212_llvv_os.4lep.root"
+      },
+      {
+        "checksum": "adler32:2d8d265f",
+        "size": 104646,
+        "uri": "root://eospublic.cern.ch//eos/opendata/atlas/rucio/opendata/ODEO_FEB2025_v0_4lep_mc_700603.Sh_2212_llvv_ss.4lep.root"
+      },
+      {
+        "checksum": "adler32:94fb85cb",
+        "size": 66320,
+        "uri": "root://eospublic.cern.ch//eos/opendata/atlas/rucio/opendata/ODEO_FEB2025_v0_4lep_mc_700604.Sh_2212_lvvv.4lep.root"
+      },
+      {
+        "checksum": "adler32:158228db",
+        "size": 1019,
+        "uri": "root://eospublic.cern.ch//eos/opendata/atlas/rucio/opendata/ODEO_FEB2025_v0_4lep_mc_700605.Sh_2212_vvvv.4lep.root"
+      },
+      {
+        "checksum": "adler32:8b45c73c",
+        "size": 46314,
+        "uri": "root://eospublic.cern.ch//eos/opendata/atlas/rucio/opendata/ODEO_FEB2025_v0_4lep_mc_700709.Sh_2212_lvgammajj.4lep.root"
+      },
+      {
+        "checksum": "adler32:5d5acd9e",
+        "size": 231317,
+        "uri": "root://eospublic.cern.ch//eos/opendata/atlas/rucio/opendata/ODEO_FEB2025_v0_4lep_mc_700710.Sh_2212_llgammajj.4lep.root"
+      },
+      {
+        "checksum": "adler32:8547f8ed",
+        "size": 1638733,
+        "uri": "root://eospublic.cern.ch//eos/opendata/atlas/rucio/opendata/ODEO_FEB2025_v0_4lep_mc_700792.Sh_2214_Ztautau_maxHTpTV2_BFilter.4lep.root"
+      },
+      {
+        "checksum": "adler32:34d87fc3",
+        "size": 5953512,
+        "uri": "root://eospublic.cern.ch//eos/opendata/atlas/rucio/opendata/ODEO_FEB2025_v0_4lep_mc_700793.Sh_2214_Ztautau_maxHTpTV2_CFilterBVeto.4lep.root"
+      },
+      {
+        "checksum": "adler32:23ab2b47",
+        "size": 9256774,
+        "uri": "root://eospublic.cern.ch//eos/opendata/atlas/rucio/opendata/ODEO_FEB2025_v0_4lep_mc_700794.Sh_2214_Ztautau_maxHTpTV2_CVetoBVeto.4lep.root"
+      },
+      {
+        "checksum": "adler32:638f685a",
+        "size": 2078051,
+        "uri": "root://eospublic.cern.ch//eos/opendata/atlas/rucio/opendata/ODEO_FEB2025_v0_4lep_mc_700843.Sh_2214_Wqq_ptW_200_ECMS.4lep.root"
+      },
+      {
+        "checksum": "adler32:28de4896",
+        "size": 735841,
+        "uri": "root://eospublic.cern.ch//eos/opendata/atlas/rucio/opendata/ODEO_FEB2025_v0_4lep_mc_700849.Sh_2214_Zqq_ptZ_200_ECMS.4lep.root"
+      },
+      {
+        "checksum": "adler32:ec600777",
+        "size": 318024,
+        "uri": "root://eospublic.cern.ch//eos/opendata/atlas/rucio/opendata/ODEO_FEB2025_v0_4lep_mc_700855.Sh_2214_Zbb_ptZ_200_ECMS.4lep.root"
+      },
+      {
+        "checksum": "adler32:6eb45522",
+        "size": 329734,
+        "uri": "root://eospublic.cern.ch//eos/opendata/atlas/rucio/opendata/ODEO_FEB2025_v0_4lep_mc_700901.Sh_2214_Ztt_maxHTpTV2_Mll10_40_BFilter.4lep.root"
+      },
+      {
+        "checksum": "adler32:0d530baf",
+        "size": 1538510,
+        "uri": "root://eospublic.cern.ch//eos/opendata/atlas/rucio/opendata/ODEO_FEB2025_v0_4lep_mc_700902.Sh_2214_Ztt_maxHTpTV2_Mll10_40_CFilterBVeto.4lep.root"
+      },
+      {
+        "checksum": "adler32:4404f398",
+        "size": 2393333,
+        "uri": "root://eospublic.cern.ch//eos/opendata/atlas/rucio/opendata/ODEO_FEB2025_v0_4lep_mc_700903.Sh_2214_Ztt_maxHTpTV2_Mll10_40_CVetoBVeto.4lep.root"
+      },
+      {
+        "checksum": "adler32:bd070a99",
+        "size": 35077,
+        "uri": "root://eospublic.cern.ch//eos/opendata/atlas/rucio/opendata/ODEO_FEB2025_v0_4lep_mc_801976.Py8EG_A14NNPDF23LO_Zprime_NoInt_tautau_SSM3000.4lep.root"
+      },
+      {
+        "checksum": "adler32:8ffe6cd9",
+        "size": 1235,
+        "uri": "root://eospublic.cern.ch//eos/opendata/atlas/rucio/opendata/ODEO_FEB2025_v0_4lep_mc_801978.Py8EG_A14NNPDF23LO_Wprime_taunu_SSM3000.4lep.root"
+      }
+    ],
+    "license": {
+      "attribution": "CC0-1.0"
+    },
+    "methodology": {
+      "description": "<p>These data were created during LS2 as part of a major reprocessing campaign of the Run 2 data. All data were reprocessed using Athena Release 22, and new corresponding MC simulation samples were produced. These data and MC simulation datasets were processed into ROOT ntuple files from the DAOD_PHYSLITE format that is released as open data for research. For the files in this record, the following skimming selection was applied: At least four leptons with at least 7 GeV of p<sub>T</sub> each"
+    },
+    "publisher": "CERN Open Data Portal",
+    "recid": "93932",
+    "relations": [
+      {
+        "description": "For citing all the Open Data for Education and Outreach from this release, and to find other related datasets, please see",
+        "doi": "10.7483/OPENDATA.ATLAS.B5M9.44TN",
+        "recid": "93910",
+        "title": "ROOT ntuple format 2015-2016 proton-proton Open Data for Education and Outreach from the ATLAS experiment",
+        "type": "isChildOf"
+      }
+    ],
+    "run_period": [
+      "2015",
+      "2016"
+    ],
+    "title": "ATLAS ROOT ntuple format MC simulation, 2015+2016 proton-proton collisions beta release, 4lep skim",
+    "type": {
+      "primary": "Dataset",
+      "secondary": [
+        "Simulated"
+      ]
+    },
+    "usage": {
+      "description": "<p> The data and MC simulation provided by the ATLAS experiment in root ntuple format is released under a CC0 license; citation of the data and acknowledgement of the collaboration is requested. This format can be used directly using ROOT or uproot for simple studies and is primarily intended for educational and outreach purposes. <p>Extensive instructions for interacting with the data, as well as documentation of the dataset naming conventions and their contents, are provided on the ATLAS Open Data website linked below. For those interested in implementing a research-quality data analysis, the open data designed for research (also linked below) may be a better starting point. Please be sure to cite the Open Data that you use, in line with the policy below.",
+      "links": [
+        {
+          "description": "ATLAS Open Data Website",
+          "url": "http://opendata.atlas.cern"
+        },
+        {
+          "description": "Resources to understand and use the open data for education and outreach",
+          "url": "https://opendata.atlas.cern/docs/category/13-tev-tutorials-for-education"
+        },
+        {
+          "description": "More about this ntuple format",
+          "url": "https://opendata.atlas.cern/docs/data/for_education/13TeV25_details"
+        },
+        {
+          "description": "Ntuple making framework",
+          "url": "http://gitlab.cern.ch/atlas-outreach-data-tools/physlitetoopendata"
+        },
+        {
+          "description": "Citation policy",
+          "url": "https://opendata.atlas.cern/docs/documentation/ethical_legal/citation_policy"
+        }
+      ]
+    }
+  }
+]

--- a/data/records/atlas-odeo-FEB2025-4lep-mc.json
+++ b/data/records/atlas-odeo-FEB2025-4lep-mc.json
@@ -1939,15 +1939,15 @@
         },
         {
           "description": "Resources to understand and use the open data for education and outreach",
-          "url": "https://opendata.atlas.cern/docs/category/13-tev-tutorials-for-education"
+          "url": "https://opendata.atlas.cern/docs/category/13-tev-2025-beta-release"
         },
         {
           "description": "More about this ntuple format",
-          "url": "https://opendata.atlas.cern/docs/data/for_education/13TeV25_details"
+          "url": "https://opendata.atlas.cern/docs/data/for_education/13TeV25_details#variable-list"
         },
         {
-          "description": "Ntuple making framework",
-          "url": "http://gitlab.cern.ch/atlas-outreach-data-tools/physlitetoopendata"
+          "description": "Ntuple making framework (PhysLiteToOpenData)",
+          "url": "https://doi.org/10.5281/zenodo.15791091"
         },
         {
           "description": "Citation policy",

--- a/data/records/atlas-odeo-FEB2025-exactly3lep-data.json
+++ b/data/records/atlas-odeo-FEB2025-exactly3lep-data.json
@@ -1,0 +1,174 @@
+[
+  {
+    "abstract": {
+      "description": "Run 2 2015+2016 proton-proton collision data beta release, exactly3lep skim from the ATLAS experiment"
+    },
+    "accelerator": "CERN-LHC",
+    "categories": {
+      "source": "ATLAS Collaboration"
+    },
+    "collaboration": {
+      "name": "ATLAS collaboration"
+    },
+    "collections": [
+      "ATLAS-Primary-Datasets"
+    ],
+    "collision_information": {
+      "energy": "13TeV",
+      "type": "pp"
+    },
+    "date_created": [
+      "2015",
+      "2016"
+    ],
+    "date_published": "2025",
+    "date_reprocessed": "2020",
+    "distribution": {
+      "formats": [
+        "root"
+      ],
+      "number_events": 15677770,
+      "number_files": 16,
+      "size": 5146565258
+    },
+    "doi": "10.7483/OPENDATA.ATLAS.L5QV.U2XC",
+    "experiment": [
+      "ATLAS"
+    ],
+    "files": [
+      {
+        "checksum": "adler32:8a6573dc",
+        "size": 16214651,
+        "uri": "root://eospublic.cern.ch//eos/opendata/atlas/rucio/opendata/ODEO_FEB2025_v0_exactly3lep_data15_periodD.exactly3lep.root"
+      },
+      {
+        "checksum": "adler32:4bd9acef",
+        "size": 113154607,
+        "uri": "root://eospublic.cern.ch//eos/opendata/atlas/rucio/opendata/ODEO_FEB2025_v0_exactly3lep_data15_periodE.exactly3lep.root"
+      },
+      {
+        "checksum": "adler32:113737f8",
+        "size": 72285944,
+        "uri": "root://eospublic.cern.ch//eos/opendata/atlas/rucio/opendata/ODEO_FEB2025_v0_exactly3lep_data15_periodF.exactly3lep.root"
+      },
+      {
+        "checksum": "adler32:7fbbc463",
+        "size": 160631922,
+        "uri": "root://eospublic.cern.ch//eos/opendata/atlas/rucio/opendata/ODEO_FEB2025_v0_exactly3lep_data15_periodG.exactly3lep.root"
+      },
+      {
+        "checksum": "adler32:33537686",
+        "size": 49849273,
+        "uri": "root://eospublic.cern.ch//eos/opendata/atlas/rucio/opendata/ODEO_FEB2025_v0_exactly3lep_data15_periodH.exactly3lep.root"
+      },
+      {
+        "checksum": "adler32:afa71ba3",
+        "size": 280858884,
+        "uri": "root://eospublic.cern.ch//eos/opendata/atlas/rucio/opendata/ODEO_FEB2025_v0_exactly3lep_data15_periodJ.exactly3lep.root"
+      },
+      {
+        "checksum": "adler32:4115e623",
+        "size": 125204813,
+        "uri": "root://eospublic.cern.ch//eos/opendata/atlas/rucio/opendata/ODEO_FEB2025_v0_exactly3lep_data16_periodA.exactly3lep.root"
+      },
+      {
+        "checksum": "adler32:be46a3b2",
+        "size": 276341332,
+        "uri": "root://eospublic.cern.ch//eos/opendata/atlas/rucio/opendata/ODEO_FEB2025_v0_exactly3lep_data16_periodB.exactly3lep.root"
+      },
+      {
+        "checksum": "adler32:135187c0",
+        "size": 353323224,
+        "uri": "root://eospublic.cern.ch//eos/opendata/atlas/rucio/opendata/ODEO_FEB2025_v0_exactly3lep_data16_periodC.exactly3lep.root"
+      },
+      {
+        "checksum": "adler32:9d60875a",
+        "size": 658657207,
+        "uri": "root://eospublic.cern.ch//eos/opendata/atlas/rucio/opendata/ODEO_FEB2025_v0_exactly3lep_data16_periodD.exactly3lep.root"
+      },
+      {
+        "checksum": "adler32:401f2a74",
+        "size": 203604238,
+        "uri": "root://eospublic.cern.ch//eos/opendata/atlas/rucio/opendata/ODEO_FEB2025_v0_exactly3lep_data16_periodE.exactly3lep.root"
+      },
+      {
+        "checksum": "adler32:8a0794cf",
+        "size": 433629850,
+        "uri": "root://eospublic.cern.ch//eos/opendata/atlas/rucio/opendata/ODEO_FEB2025_v0_exactly3lep_data16_periodF.exactly3lep.root"
+      },
+      {
+        "checksum": "adler32:72c5bc98",
+        "size": 492225618,
+        "uri": "root://eospublic.cern.ch//eos/opendata/atlas/rucio/opendata/ODEO_FEB2025_v0_exactly3lep_data16_periodG.exactly3lep.root"
+      },
+      {
+        "checksum": "adler32:2a114fe0",
+        "size": 751624668,
+        "uri": "root://eospublic.cern.ch//eos/opendata/atlas/rucio/opendata/ODEO_FEB2025_v0_exactly3lep_data16_periodI.exactly3lep.root"
+      },
+      {
+        "checksum": "adler32:d5e67d0b",
+        "size": 304622804,
+        "uri": "root://eospublic.cern.ch//eos/opendata/atlas/rucio/opendata/ODEO_FEB2025_v0_exactly3lep_data16_periodK.exactly3lep.root"
+      },
+      {
+        "checksum": "adler32:7615c9ea",
+        "size": 854336223,
+        "uri": "root://eospublic.cern.ch//eos/opendata/atlas/rucio/opendata/ODEO_FEB2025_v0_exactly3lep_data16_periodL.exactly3lep.root"
+      }
+    ],
+    "license": {
+      "attribution": "CC0-1.0"
+    },
+    "methodology": {
+      "description": "<p>These data were created during LS2 as part of a major reprocessing campaign of the Run 2 data. All data were reprocessed using Athena Release 22, and new corresponding MC simulation samples were produced. These data and MC simulation datasets were processed into ROOT ntuple files from the DAOD_PHYSLITE format that is released as open data for research. For the files in this record, the following skimming selection was applied: Exactly three leptons with at least 7 GeV of p<sub>T</sub> (i.e. a leptonically-decaying W+Z boson enhanced selection)"
+    },
+    "publisher": "CERN Open Data Portal",
+    "recid": "93917",
+    "relations": [
+      {
+        "description": "For citing all the Open Data for Education and Outreach from this release, and to find other related datasets, please see",
+        "doi": "10.7483/OPENDATA.ATLAS.B5M9.44TN",
+        "recid": "93910",
+        "title": "ROOT ntuple format 2015-2016 proton-proton Open Data for Education and Outreach from the ATLAS experiment",
+        "type": "isChildOf"
+      }
+    ],
+    "run_period": [
+      "2015",
+      "2016"
+    ],
+    "title": "ATLAS ROOT ntuple format Run 2 2015+2016 proton-proton collision data beta release, exactly3lep skim",
+    "type": {
+      "primary": "Dataset",
+      "secondary": [
+        "Collision"
+      ]
+    },
+    "usage": {
+      "description": "<p> The data and MC simulation provided by the ATLAS experiment in root ntuple format is released under a CC0 license; citation of the data and acknowledgement of the collaboration is requested. This format can be used directly using ROOT or uproot for simple studies and is primarily intended for educational and outreach purposes. <p>Extensive instructions for interacting with the data, as well as documentation of the dataset naming conventions and their contents, are provided on the ATLAS Open Data website linked below. For those interested in implementing a research-quality data analysis, the open data designed for research (also linked below) may be a better starting point. Please be sure to cite the Open Data that you use, in line with the policy below.",
+      "links": [
+        {
+          "description": "ATLAS Open Data Website",
+          "url": "http://opendata.atlas.cern"
+        },
+        {
+          "description": "Resources to understand and use the open data for education and outreach",
+          "url": "https://opendata.atlas.cern/docs/category/13-tev-tutorials-for-education"
+        },
+        {
+          "description": "More about this ntuple format",
+          "url": "https://opendata.atlas.cern/docs/data/for_education/13TeV25_details"
+        },
+        {
+          "description": "Ntuple making framework",
+          "url": "http://gitlab.cern.ch/atlas-outreach-data-tools/physlitetoopendata"
+        },
+        {
+          "description": "Citation policy",
+          "url": "https://opendata.atlas.cern/docs/documentation/ethical_legal/citation_policy"
+        }
+      ]
+    }
+  }
+]

--- a/data/records/atlas-odeo-FEB2025-exactly3lep-data.json
+++ b/data/records/atlas-odeo-FEB2025-exactly3lep-data.json
@@ -154,15 +154,15 @@
         },
         {
           "description": "Resources to understand and use the open data for education and outreach",
-          "url": "https://opendata.atlas.cern/docs/category/13-tev-tutorials-for-education"
+          "url": "https://opendata.atlas.cern/docs/category/13-tev-2025-beta-release"
         },
         {
           "description": "More about this ntuple format",
-          "url": "https://opendata.atlas.cern/docs/data/for_education/13TeV25_details"
+          "url": "https://opendata.atlas.cern/docs/data/for_education/13TeV25_details#variable-list"
         },
         {
-          "description": "Ntuple making framework",
-          "url": "http://gitlab.cern.ch/atlas-outreach-data-tools/physlitetoopendata"
+          "description": "Ntuple making framework (PhysLiteToOpenData)",
+          "url": "https://doi.org/10.5281/zenodo.15791091"
         },
         {
           "description": "Citation policy",

--- a/data/records/atlas-odeo-FEB2025-exactly3lep-mc.json
+++ b/data/records/atlas-odeo-FEB2025-exactly3lep-mc.json
@@ -1,0 +1,1959 @@
+[
+  {
+    "abstract": {
+      "description": "MC simulation, 2015+2016 proton-proton collisions beta release, exactly3lep skim from the ATLAS experiment"
+    },
+    "accelerator": "CERN-LHC",
+    "categories": {
+      "source": "ATLAS Collaboration"
+    },
+    "collaboration": {
+      "name": "ATLAS collaboration"
+    },
+    "collections": [
+      "ATLAS-Primary-Datasets"
+    ],
+    "collision_information": {
+      "energy": "13TeV",
+      "type": "pp"
+    },
+    "date_created": [
+      "2015",
+      "2016"
+    ],
+    "date_published": "2025",
+    "date_reprocessed": "2020",
+    "distribution": {
+      "formats": [
+        "root"
+      ],
+      "number_events": 6800938,
+      "number_files": 373,
+      "size": 3541549577
+    },
+    "doi": "10.7483/OPENDATA.ATLAS.SCWS.LYYX",
+    "experiment": [
+      "ATLAS"
+    ],
+    "files": [
+      {
+        "checksum": "adler32:054db479",
+        "size": 159937,
+        "uri": "root://eospublic.cern.ch//eos/opendata/atlas/rucio/opendata/ODEO_FEB2025_v0_exactly3lep_mc_301204.Pythia8EvtGen_A14MSTW2008LO_Zprime_NoInt_ee_SSM3000.exactly3lep.root"
+      },
+      {
+        "checksum": "adler32:9b4a260d",
+        "size": 201344,
+        "uri": "root://eospublic.cern.ch//eos/opendata/atlas/rucio/opendata/ODEO_FEB2025_v0_exactly3lep_mc_301209.Pythia8EvtGen_A14MSTW2008LO_Zprime_NoInt_mumu_SSM3000.exactly3lep.root"
+      },
+      {
+        "checksum": "adler32:289994a8",
+        "size": 27972,
+        "uri": "root://eospublic.cern.ch//eos/opendata/atlas/rucio/opendata/ODEO_FEB2025_v0_exactly3lep_mc_301243.Pythia8EvtGen_A14NNPDF23LO_Wprime_enu_SSM3000.exactly3lep.root"
+      },
+      {
+        "checksum": "adler32:839a5ac2",
+        "size": 38608,
+        "uri": "root://eospublic.cern.ch//eos/opendata/atlas/rucio/opendata/ODEO_FEB2025_v0_exactly3lep_mc_301247.Pythia8EvtGen_A14NNPDF23LO_Wprime_munu_SSM3000.exactly3lep.root"
+      },
+      {
+        "checksum": "adler32:bb3d30eb",
+        "size": 260854,
+        "uri": "root://eospublic.cern.ch//eos/opendata/atlas/rucio/opendata/ODEO_FEB2025_v0_exactly3lep_mc_301333.Pythia8EvtGen_A14NNPDF23LO_zprime3000_tt.exactly3lep.root"
+      },
+      {
+        "checksum": "adler32:71125a6a",
+        "size": 59337,
+        "uri": "root://eospublic.cern.ch//eos/opendata/atlas/rucio/opendata/ODEO_FEB2025_v0_exactly3lep_mc_301826.Pythia8EvtGen_A14NNPDF23LO_Wprime_qq_3000.exactly3lep.root"
+      },
+      {
+        "checksum": "adler32:3c35cc14",
+        "size": 57584,
+        "uri": "root://eospublic.cern.ch//eos/opendata/atlas/rucio/opendata/ODEO_FEB2025_v0_exactly3lep_mc_301928.Pythia8EvtGen_A14NNPDF23LO_Zprimebb3000.exactly3lep.root"
+      },
+      {
+        "checksum": "adler32:21ea7c2b",
+        "size": 863042,
+        "uri": "root://eospublic.cern.ch//eos/opendata/atlas/rucio/opendata/ODEO_FEB2025_v0_exactly3lep_mc_302520.Pythia8EvtGen_A14NNPDF23LO_2DP20_Mass_55_100.exactly3lep.root"
+      },
+      {
+        "checksum": "adler32:50500f98",
+        "size": 188515,
+        "uri": "root://eospublic.cern.ch//eos/opendata/atlas/rucio/opendata/ODEO_FEB2025_v0_exactly3lep_mc_302521.Pythia8EvtGen_A14NNPDF23LO_2DP20_Mass_100_160.exactly3lep.root"
+      },
+      {
+        "checksum": "adler32:95178eab",
+        "size": 66115,
+        "uri": "root://eospublic.cern.ch//eos/opendata/atlas/rucio/opendata/ODEO_FEB2025_v0_exactly3lep_mc_302522.Pythia8EvtGen_A14NNPDF23LO_2DP20_Mass_160_250.exactly3lep.root"
+      },
+      {
+        "checksum": "adler32:a14a69fe",
+        "size": 29634,
+        "uri": "root://eospublic.cern.ch//eos/opendata/atlas/rucio/opendata/ODEO_FEB2025_v0_exactly3lep_mc_302523.Pythia8EvtGen_A14NNPDF23LO_2DP20_Mass_250_400.exactly3lep.root"
+      },
+      {
+        "checksum": "adler32:d51a17f5",
+        "size": 45752,
+        "uri": "root://eospublic.cern.ch//eos/opendata/atlas/rucio/opendata/ODEO_FEB2025_v0_exactly3lep_mc_302524.Pythia8EvtGen_A14NNPDF23LO_2DP20_Mass_400_650.exactly3lep.root"
+      },
+      {
+        "checksum": "adler32:ccc04b29",
+        "size": 30098,
+        "uri": "root://eospublic.cern.ch//eos/opendata/atlas/rucio/opendata/ODEO_FEB2025_v0_exactly3lep_mc_302525.Pythia8EvtGen_A14NNPDF23LO_2DP20_Mass_650_1000.exactly3lep.root"
+      },
+      {
+        "checksum": "adler32:9c15e379",
+        "size": 47992,
+        "uri": "root://eospublic.cern.ch//eos/opendata/atlas/rucio/opendata/ODEO_FEB2025_v0_exactly3lep_mc_302526.Pythia8EvtGen_A14NNPDF23LO_2DP20_Mass_1000_1500.exactly3lep.root"
+      },
+      {
+        "checksum": "adler32:122bd39f",
+        "size": 52702,
+        "uri": "root://eospublic.cern.ch//eos/opendata/atlas/rucio/opendata/ODEO_FEB2025_v0_exactly3lep_mc_302527.Pythia8EvtGen_A14NNPDF23LO_2DP20_Mass_1500_2000.exactly3lep.root"
+      },
+      {
+        "checksum": "adler32:ee8ec637",
+        "size": 67709,
+        "uri": "root://eospublic.cern.ch//eos/opendata/atlas/rucio/opendata/ODEO_FEB2025_v0_exactly3lep_mc_302528.Pythia8EvtGen_A14NNPDF23LO_2DP20_Mass_2000_2500.exactly3lep.root"
+      },
+      {
+        "checksum": "adler32:e9efda90",
+        "size": 53217,
+        "uri": "root://eospublic.cern.ch//eos/opendata/atlas/rucio/opendata/ODEO_FEB2025_v0_exactly3lep_mc_302529.Pythia8EvtGen_A14NNPDF23LO_2DP20_Mass_2500_3000.exactly3lep.root"
+      },
+      {
+        "checksum": "adler32:167d0d2c",
+        "size": 75529,
+        "uri": "root://eospublic.cern.ch//eos/opendata/atlas/rucio/opendata/ODEO_FEB2025_v0_exactly3lep_mc_302530.Pythia8EvtGen_A14NNPDF23LO_2DP20_Mass_3000_3500.exactly3lep.root"
+      },
+      {
+        "checksum": "adler32:cb6a6658",
+        "size": 48678,
+        "uri": "root://eospublic.cern.ch//eos/opendata/atlas/rucio/opendata/ODEO_FEB2025_v0_exactly3lep_mc_302531.Pythia8EvtGen_A14NNPDF23LO_2DP20_Mass_3500_4000.exactly3lep.root"
+      },
+      {
+        "checksum": "adler32:ad4c1682",
+        "size": 73321,
+        "uri": "root://eospublic.cern.ch//eos/opendata/atlas/rucio/opendata/ODEO_FEB2025_v0_exactly3lep_mc_302532.Pythia8EvtGen_A14NNPDF23LO_2DP20_Mass_4000_4500.exactly3lep.root"
+      },
+      {
+        "checksum": "adler32:bacfffb4",
+        "size": 37412,
+        "uri": "root://eospublic.cern.ch//eos/opendata/atlas/rucio/opendata/ODEO_FEB2025_v0_exactly3lep_mc_302533.Pythia8EvtGen_A14NNPDF23LO_2DP20_Mass_4500_5000.exactly3lep.root"
+      },
+      {
+        "checksum": "adler32:c266350e",
+        "size": 63662,
+        "uri": "root://eospublic.cern.ch//eos/opendata/atlas/rucio/opendata/ODEO_FEB2025_v0_exactly3lep_mc_302534.Pythia8EvtGen_A14NNPDF23LO_2DP20_Mass_5000_inf.exactly3lep.root"
+      },
+      {
+        "checksum": "adler32:36b1c448",
+        "size": 300760,
+        "uri": "root://eospublic.cern.ch//eos/opendata/atlas/rucio/opendata/ODEO_FEB2025_v0_exactly3lep_mc_302733.MadGraphPythia8EvtGen_A14NNPDF23LO_WpL_tblep_M3000.exactly3lep.root"
+      },
+      {
+        "checksum": "adler32:6b1a2478",
+        "size": 926342,
+        "uri": "root://eospublic.cern.ch//eos/opendata/atlas/rucio/opendata/ODEO_FEB2025_v0_exactly3lep_mc_304014.MadGraphPythia8EvtGen_A14NNPDF23_3top_SM.exactly3lep.root"
+      },
+      {
+        "checksum": "adler32:a8f29d30",
+        "size": 142537,
+        "uri": "root://eospublic.cern.ch//eos/opendata/atlas/rucio/opendata/ODEO_FEB2025_v0_exactly3lep_mc_306149.MadGraphPythia8EvtGen_A14NNPDF23LO_WpL_tbhad_M3000.exactly3lep.root"
+      },
+      {
+        "checksum": "adler32:b9f01734",
+        "size": 33880,
+        "uri": "root://eospublic.cern.ch//eos/opendata/atlas/rucio/opendata/ODEO_FEB2025_v0_exactly3lep_mc_311490.PowhegPy8EG_A14N23LO_DMA_500_700_gq0p25.exactly3lep.root"
+      },
+      {
+        "checksum": "adler32:d729e51a",
+        "size": 6948210,
+        "uri": "root://eospublic.cern.ch//eos/opendata/atlas/rucio/opendata/ODEO_FEB2025_v0_exactly3lep_mc_312613.aMcAtNloPy8EG_A14N30NLO_LQd_gstML_0p3_nonallhad_M1000.exactly3lep.root"
+      },
+      {
+        "checksum": "adler32:47ca7302",
+        "size": 27397,
+        "uri": "root://eospublic.cern.ch//eos/opendata/atlas/rucio/opendata/ODEO_FEB2025_v0_exactly3lep_mc_341456.PowhegPythia8EvtGen_CT10_AZNLO_ZH125J_MINLO_veveWWlvqq_VpT.exactly3lep.root"
+      },
+      {
+        "checksum": "adler32:8b1a6711",
+        "size": 41446,
+        "uri": "root://eospublic.cern.ch//eos/opendata/atlas/rucio/opendata/ODEO_FEB2025_v0_exactly3lep_mc_341458.PowhegPythia8EvtGen_CT10_AZNLO_ZH125J_MINLO_vmuvmuWWlvqq_VpT.exactly3lep.root"
+      },
+      {
+        "checksum": "adler32:61760ad0",
+        "size": 37696,
+        "uri": "root://eospublic.cern.ch//eos/opendata/atlas/rucio/opendata/ODEO_FEB2025_v0_exactly3lep_mc_341460.PowhegPy8EG_CT10_AZNLO_ZH125J_MINLO_vtauvtauWWlvqq_VpT.exactly3lep.root"
+      },
+      {
+        "checksum": "adler32:b0b89b10",
+        "size": 98682,
+        "uri": "root://eospublic.cern.ch//eos/opendata/atlas/rucio/opendata/ODEO_FEB2025_v0_exactly3lep_mc_343981.PowhegPythia8EvtGen_NNLOPS_nnlo_30_ggH125_gamgam.exactly3lep.root"
+      },
+      {
+        "checksum": "adler32:efe1d5b9",
+        "size": 15784142,
+        "uri": "root://eospublic.cern.ch//eos/opendata/atlas/rucio/opendata/ODEO_FEB2025_v0_exactly3lep_mc_344158.aMcAtNloPythia8EvtGen_A14NNPDF23LO_ppx0_FxFx_Np012_SM.exactly3lep.root"
+      },
+      {
+        "checksum": "adler32:01ed815c",
+        "size": 57710,
+        "uri": "root://eospublic.cern.ch//eos/opendata/atlas/rucio/opendata/ODEO_FEB2025_v0_exactly3lep_mc_345056.PowhegPythia8EvtGen_NNPDF3_AZNLO_ZH125J_MINLO_vvbb_VpT.exactly3lep.root"
+      },
+      {
+        "checksum": "adler32:b31a9500",
+        "size": 51877,
+        "uri": "root://eospublic.cern.ch//eos/opendata/atlas/rucio/opendata/ODEO_FEB2025_v0_exactly3lep_mc_345058.PowhegPythia8EvtGen_NNPDF3_AZNLO_ggZH125_vvbb.exactly3lep.root"
+      },
+      {
+        "checksum": "adler32:0e33b7af",
+        "size": 244950433,
+        "uri": "root://eospublic.cern.ch//eos/opendata/atlas/rucio/opendata/ODEO_FEB2025_v0_exactly3lep_mc_345060.PowhegPythia8EvtGen_NNLOPS_nnlo_30_ggH125_ZZ4l.exactly3lep.root"
+      },
+      {
+        "checksum": "adler32:853bc718",
+        "size": 147844,
+        "uri": "root://eospublic.cern.ch//eos/opendata/atlas/rucio/opendata/ODEO_FEB2025_v0_exactly3lep_mc_345061.PowhegPythia8EvtGen_NNPDF3_AZNLO_ggZH125_HgamgamZinc.exactly3lep.root"
+      },
+      {
+        "checksum": "adler32:8d6c372c",
+        "size": 5014434,
+        "uri": "root://eospublic.cern.ch//eos/opendata/atlas/rucio/opendata/ODEO_FEB2025_v0_exactly3lep_mc_345066.PowhegPythia8EvtGen_NNPDF3_AZNLO_ggZH125_ZZ4lepZinc.exactly3lep.root"
+      },
+      {
+        "checksum": "adler32:ddc67604",
+        "size": 465944,
+        "uri": "root://eospublic.cern.ch//eos/opendata/atlas/rucio/opendata/ODEO_FEB2025_v0_exactly3lep_mc_345097.PowhegPythia8EvtGen_NNLOPS_nnlo_30_ggH125_mumu.exactly3lep.root"
+      },
+      {
+        "checksum": "adler32:5ffb2ecd",
+        "size": 949737,
+        "uri": "root://eospublic.cern.ch//eos/opendata/atlas/rucio/opendata/ODEO_FEB2025_v0_exactly3lep_mc_345098.PowhegPythia8EvtGen_NNPDF3_AZNLO_ggZH125_Hmumu_Zinc.exactly3lep.root"
+      },
+      {
+        "checksum": "adler32:9f881148",
+        "size": 1020521,
+        "uri": "root://eospublic.cern.ch//eos/opendata/atlas/rucio/opendata/ODEO_FEB2025_v0_exactly3lep_mc_345103.PowhegPythia8EvtGen_NNPDF30_AZNLO_ZH125J_Hmumu_Zincl_MINLO.exactly3lep.root"
+      },
+      {
+        "checksum": "adler32:500d1c98",
+        "size": 2535576,
+        "uri": "root://eospublic.cern.ch//eos/opendata/atlas/rucio/opendata/ODEO_FEB2025_v0_exactly3lep_mc_345104.PowhegPythia8EvtGen_NNPDF30_AZNLO_WpH125J_Hmumu_Wincl_MINLO.exactly3lep.root"
+      },
+      {
+        "checksum": "adler32:ab67cdba",
+        "size": 1568067,
+        "uri": "root://eospublic.cern.ch//eos/opendata/atlas/rucio/opendata/ODEO_FEB2025_v0_exactly3lep_mc_345105.PowhegPythia8EvtGen_NNPDF30_AZNLO_WmH125J_Hmumu_Wincl_MINLO.exactly3lep.root"
+      },
+      {
+        "checksum": "adler32:8c2e29ba",
+        "size": 596790,
+        "uri": "root://eospublic.cern.ch//eos/opendata/atlas/rucio/opendata/ODEO_FEB2025_v0_exactly3lep_mc_345106.PowhegPythia8EvtGen_NNPDF30_AZNLOCTEQ6L1_VBFH125_mumu.exactly3lep.root"
+      },
+      {
+        "checksum": "adler32:57e756b0",
+        "size": 56182,
+        "uri": "root://eospublic.cern.ch//eos/opendata/atlas/rucio/opendata/ODEO_FEB2025_v0_exactly3lep_mc_345112.PowhegPythia8EvtGen_NNPDF3_AZNLO_ZH125J_MINLO_vvcc_VpT.exactly3lep.root"
+      },
+      {
+        "checksum": "adler32:02d6c52d",
+        "size": 52663,
+        "uri": "root://eospublic.cern.ch//eos/opendata/atlas/rucio/opendata/ODEO_FEB2025_v0_exactly3lep_mc_345114.PowhegPythia8EvtGen_NNPDF3_AZNLO_ggZH125_vvcc.exactly3lep.root"
+      },
+      {
+        "checksum": "adler32:afdc6d7b",
+        "size": 449702,
+        "uri": "root://eospublic.cern.ch//eos/opendata/atlas/rucio/opendata/ODEO_FEB2025_v0_exactly3lep_mc_345120.PowhegPy8EG_NNLOPS_nnlo_30_ggH125_tautaul13l7.exactly3lep.root"
+      },
+      {
+        "checksum": "adler32:9b2a9cec",
+        "size": 74519,
+        "uri": "root://eospublic.cern.ch//eos/opendata/atlas/rucio/opendata/ODEO_FEB2025_v0_exactly3lep_mc_345121.PowhegPy8EG_NNLOPS_nnlo_30_ggH125_tautaulm15hp20.exactly3lep.root"
+      },
+      {
+        "checksum": "adler32:03267221",
+        "size": 105212,
+        "uri": "root://eospublic.cern.ch//eos/opendata/atlas/rucio/opendata/ODEO_FEB2025_v0_exactly3lep_mc_345122.PowhegPy8EG_NNLOPS_nnlo_30_ggH125_tautaulp15hm20.exactly3lep.root"
+      },
+      {
+        "checksum": "adler32:b2e6e9ad",
+        "size": 58551,
+        "uri": "root://eospublic.cern.ch//eos/opendata/atlas/rucio/opendata/ODEO_FEB2025_v0_exactly3lep_mc_345123.PowhegPy8EG_NNLOPS_nnlo_30_ggH125_tautauh30h20.exactly3lep.root"
+      },
+      {
+        "checksum": "adler32:31672a80",
+        "size": 1571341,
+        "uri": "root://eospublic.cern.ch//eos/opendata/atlas/rucio/opendata/ODEO_FEB2025_v0_exactly3lep_mc_345124.PowhegPy8EG_NNLOPS_nnlo_30_ggH125_etau_filt.exactly3lep.root"
+      },
+      {
+        "checksum": "adler32:93d5da86",
+        "size": 1689931,
+        "uri": "root://eospublic.cern.ch//eos/opendata/atlas/rucio/opendata/ODEO_FEB2025_v0_exactly3lep_mc_345125.PowhegPy8EG_NNLOPS_nnlo_30_ggH125_mutau_filt.exactly3lep.root"
+      },
+      {
+        "checksum": "adler32:08e573c2",
+        "size": 160279,
+        "uri": "root://eospublic.cern.ch//eos/opendata/atlas/rucio/opendata/ODEO_FEB2025_v0_exactly3lep_mc_345211.PowhegPy8EG_NNPDF30_AZNLO_WmH125J_Winc_MINLO_tautau.exactly3lep.root"
+      },
+      {
+        "checksum": "adler32:2f763a13",
+        "size": 190145,
+        "uri": "root://eospublic.cern.ch//eos/opendata/atlas/rucio/opendata/ODEO_FEB2025_v0_exactly3lep_mc_345212.PowhegPy8EG_NNPDF30_AZNLO_WpH125J_Winc_MINLO_tautau.exactly3lep.root"
+      },
+      {
+        "checksum": "adler32:82744209",
+        "size": 580909,
+        "uri": "root://eospublic.cern.ch//eos/opendata/atlas/rucio/opendata/ODEO_FEB2025_v0_exactly3lep_mc_345213.PowhegPy8EG_NNPDF30_AZNLO_WmH125J_Winc_MINLO_etau.exactly3lep.root"
+      },
+      {
+        "checksum": "adler32:fac26041",
+        "size": 988971,
+        "uri": "root://eospublic.cern.ch//eos/opendata/atlas/rucio/opendata/ODEO_FEB2025_v0_exactly3lep_mc_345214.PowhegPy8EG_NNPDF30_AZNLO_WpH125J_Winc_MINLO_etau.exactly3lep.root"
+      },
+      {
+        "checksum": "adler32:5a839a24",
+        "size": 684468,
+        "uri": "root://eospublic.cern.ch//eos/opendata/atlas/rucio/opendata/ODEO_FEB2025_v0_exactly3lep_mc_345215.PowhegPy8EG_NNPDF30_AZNLO_WmH125J_Winc_MINLO_mutau.exactly3lep.root"
+      },
+      {
+        "checksum": "adler32:ed658bac",
+        "size": 1190774,
+        "uri": "root://eospublic.cern.ch//eos/opendata/atlas/rucio/opendata/ODEO_FEB2025_v0_exactly3lep_mc_345216.PowhegPy8EG_NNPDF30_AZNLO_WpH125J_Winc_MINLO_mutau.exactly3lep.root"
+      },
+      {
+        "checksum": "adler32:2bb9b765",
+        "size": 527233,
+        "uri": "root://eospublic.cern.ch//eos/opendata/atlas/rucio/opendata/ODEO_FEB2025_v0_exactly3lep_mc_345217.PowhegPy8EG_NNPDF30_AZNLO_ZH125J_Zinc_MINLO_tautau.exactly3lep.root"
+      },
+      {
+        "checksum": "adler32:9f90b193",
+        "size": 1325382,
+        "uri": "root://eospublic.cern.ch//eos/opendata/atlas/rucio/opendata/ODEO_FEB2025_v0_exactly3lep_mc_345218.PowhegPy8EG_NNPDF30_AZNLO_ZH125J_Zinc_MINLO_etau.exactly3lep.root"
+      },
+      {
+        "checksum": "adler32:d17b7d23",
+        "size": 1164613,
+        "uri": "root://eospublic.cern.ch//eos/opendata/atlas/rucio/opendata/ODEO_FEB2025_v0_exactly3lep_mc_345219.PowhegPy8EG_NNPDF30_AZNLO_ZH125J_Zinc_MINLO_mutau.exactly3lep.root"
+      },
+      {
+        "checksum": "adler32:f6361e11",
+        "size": 6151371,
+        "uri": "root://eospublic.cern.ch//eos/opendata/atlas/rucio/opendata/ODEO_FEB2025_v0_exactly3lep_mc_345316.PowhegPythia8EvtGen_NNLOPS_nnlo_30_ggH125_Zy_Zll.exactly3lep.root"
+      },
+      {
+        "checksum": "adler32:6cecd196",
+        "size": 279144,
+        "uri": "root://eospublic.cern.ch//eos/opendata/atlas/rucio/opendata/ODEO_FEB2025_v0_exactly3lep_mc_345317.PowhegPythia8EvtGen_NNPDF30_AZNLO_WmH125J_Hyy_Wincl_MINLO.exactly3lep.root"
+      },
+      {
+        "checksum": "adler32:0a6413a0",
+        "size": 169428,
+        "uri": "root://eospublic.cern.ch//eos/opendata/atlas/rucio/opendata/ODEO_FEB2025_v0_exactly3lep_mc_345318.PowhegPythia8EvtGen_NNPDF30_AZNLO_WpH125J_Hyy_Wincl_MINLO.exactly3lep.root"
+      },
+      {
+        "checksum": "adler32:e61284aa",
+        "size": 213048,
+        "uri": "root://eospublic.cern.ch//eos/opendata/atlas/rucio/opendata/ODEO_FEB2025_v0_exactly3lep_mc_345319.PowhegPythia8EvtGen_NNPDF30_AZNLO_ZH125J_Hyy_Zincl_MINLO.exactly3lep.root"
+      },
+      {
+        "checksum": "adler32:c94372c9",
+        "size": 907864,
+        "uri": "root://eospublic.cern.ch//eos/opendata/atlas/rucio/opendata/ODEO_FEB2025_v0_exactly3lep_mc_345320.PowhegPythia8EvtGen_NNPDF30_AZNLO_WmH125J_HZy_Wincl_MINLO.exactly3lep.root"
+      },
+      {
+        "checksum": "adler32:637b4629",
+        "size": 914810,
+        "uri": "root://eospublic.cern.ch//eos/opendata/atlas/rucio/opendata/ODEO_FEB2025_v0_exactly3lep_mc_345321.PowhegPythia8EvtGen_NNPDF30_AZNLO_WpH125J_HZy_Wincl_MINLO.exactly3lep.root"
+      },
+      {
+        "checksum": "adler32:80ad8b4d",
+        "size": 959506,
+        "uri": "root://eospublic.cern.ch//eos/opendata/atlas/rucio/opendata/ODEO_FEB2025_v0_exactly3lep_mc_345322.PowhegPythia8EvtGen_NNPDF30_AZNLO_ZH125J_HZy_Zincl_MINLO.exactly3lep.root"
+      },
+      {
+        "checksum": "adler32:9a2e36e4",
+        "size": 423205,
+        "uri": "root://eospublic.cern.ch//eos/opendata/atlas/rucio/opendata/ODEO_FEB2025_v0_exactly3lep_mc_345324.PowhegPythia8EvtGen_NNLOPS_NN30_ggH125_WWlvlv_EF_15_5.exactly3lep.root"
+      },
+      {
+        "checksum": "adler32:c0877c35",
+        "size": 2307958,
+        "uri": "root://eospublic.cern.ch//eos/opendata/atlas/rucio/opendata/ODEO_FEB2025_v0_exactly3lep_mc_345325.PowhegPythia8EvtGen_NNPDF3_AZNLO_WpH125J_MINLO_qqWWlvlv.exactly3lep.root"
+      },
+      {
+        "checksum": "adler32:1d112f66",
+        "size": 2847166,
+        "uri": "root://eospublic.cern.ch//eos/opendata/atlas/rucio/opendata/ODEO_FEB2025_v0_exactly3lep_mc_345433.PowhegPythia8EvtGen_NNPDF3_AZNLO_WmH125J_MINLO_qqWWlvlv.exactly3lep.root"
+      },
+      {
+        "checksum": "adler32:f8929df4",
+        "size": 108711,
+        "uri": "root://eospublic.cern.ch//eos/opendata/atlas/rucio/opendata/ODEO_FEB2025_v0_exactly3lep_mc_345445.PowhegPythia8EvtGen_NNPDF3_AZNLO_ZH125J_MINLO_vvWWlvlv.exactly3lep.root"
+      },
+      {
+        "checksum": "adler32:5891aa36",
+        "size": 45038,
+        "uri": "root://eospublic.cern.ch//eos/opendata/atlas/rucio/opendata/ODEO_FEB2025_v0_exactly3lep_mc_345596.PowhegPythia8EvtGen_NNPDF3_AZNLO_ggZH125_Zinc_HZZinv.exactly3lep.root"
+      },
+      {
+        "checksum": "adler32:82fae351",
+        "size": 648055,
+        "uri": "root://eospublic.cern.ch//eos/opendata/atlas/rucio/opendata/ODEO_FEB2025_v0_exactly3lep_mc_345697.MadGraphPythia8EvtGen_AZNLOCTEQ6L1_ggfhtautaullNp2.exactly3lep.root"
+      },
+      {
+        "checksum": "adler32:ac491888",
+        "size": 220847,
+        "uri": "root://eospublic.cern.ch//eos/opendata/atlas/rucio/opendata/ODEO_FEB2025_v0_exactly3lep_mc_345698.MadGraphPythia8EvtGen_AZNLOCTEQ6L1_ggfhtautaulhNp2.exactly3lep.root"
+      },
+      {
+        "checksum": "adler32:2b18a97c",
+        "size": 106752,
+        "uri": "root://eospublic.cern.ch//eos/opendata/atlas/rucio/opendata/ODEO_FEB2025_v0_exactly3lep_mc_345699.MadGraphPythia8EvtGen_AZNLOCTEQ6L1_ggfhtautauhhNp2.exactly3lep.root"
+      },
+      {
+        "checksum": "adler32:103722fe",
+        "size": 3878639,
+        "uri": "root://eospublic.cern.ch//eos/opendata/atlas/rucio/opendata/ODEO_FEB2025_v0_exactly3lep_mc_345833.PowhegPythia8EvtGen_NNPDF30_AZNLOCTEQ6L1_VBFH125_Zllgam.exactly3lep.root"
+      },
+      {
+        "checksum": "adler32:43718d88",
+        "size": 224978,
+        "uri": "root://eospublic.cern.ch//eos/opendata/atlas/rucio/opendata/ODEO_FEB2025_v0_exactly3lep_mc_345834.PowhegPythia8EvtGen_NNPDF30_AZNLOCTEQ6L1_VBFH125_gamstargam.exactly3lep.root"
+      },
+      {
+        "checksum": "adler32:a9848559",
+        "size": 988284,
+        "uri": "root://eospublic.cern.ch//eos/opendata/atlas/rucio/opendata/ODEO_FEB2025_v0_exactly3lep_mc_345876.PowhegPythia8EvtGen_NNPDF30_AZNLO_ZH125J_Hee__Zincl_MINLO.exactly3lep.root"
+      },
+      {
+        "checksum": "adler32:d4526a78",
+        "size": 1413962,
+        "uri": "root://eospublic.cern.ch//eos/opendata/atlas/rucio/opendata/ODEO_FEB2025_v0_exactly3lep_mc_345877.PowhegPythia8EvtGen_NNPDF30_AZNLO_WpH125J_Hee_Wincl_MINLO.exactly3lep.root"
+      },
+      {
+        "checksum": "adler32:eba98443",
+        "size": 1523709,
+        "uri": "root://eospublic.cern.ch//eos/opendata/atlas/rucio/opendata/ODEO_FEB2025_v0_exactly3lep_mc_345878.PowhegPythia8EvtGen_NNPDF30_AZNLO_WmH125J_Hee_Wincl_MINLO.exactly3lep.root"
+      },
+      {
+        "checksum": "adler32:5f7b561d",
+        "size": 94502,
+        "uri": "root://eospublic.cern.ch//eos/opendata/atlas/rucio/opendata/ODEO_FEB2025_v0_exactly3lep_mc_345944.aMcAtNloPy8EG_A14NNPDF23LO_ppx0yy_FxFx_Np012_SM.exactly3lep.root"
+      },
+      {
+        "checksum": "adler32:d2b15d40",
+        "size": 704176,
+        "uri": "root://eospublic.cern.ch//eos/opendata/atlas/rucio/opendata/ODEO_FEB2025_v0_exactly3lep_mc_345948.PowhegPy8EG_NNPDF30_AZNLOCTEQ6L1_VBFH125_WWlvlv.exactly3lep.root"
+      },
+      {
+        "checksum": "adler32:d2c24a29",
+        "size": 55814,
+        "uri": "root://eospublic.cern.ch//eos/opendata/atlas/rucio/opendata/ODEO_FEB2025_v0_exactly3lep_mc_345949.PowhegPythia8EvtGen_NNPDF30_AZNLOCTEQ6L1_VBFH125_bb.exactly3lep.root"
+      },
+      {
+        "checksum": "adler32:edf2baa4",
+        "size": 426401,
+        "uri": "root://eospublic.cern.ch//eos/opendata/atlas/rucio/opendata/ODEO_FEB2025_v0_exactly3lep_mc_345961.PowhegPythia8EvtGen_NNLOPS_nnlo_30_ggH125_gamstargam.exactly3lep.root"
+      },
+      {
+        "checksum": "adler32:6fd28c63",
+        "size": 405942,
+        "uri": "root://eospublic.cern.ch//eos/opendata/atlas/rucio/opendata/ODEO_FEB2025_v0_exactly3lep_mc_345963.PowhegPythia8EvtGen_NNPDF30_AZNLO_WmH125J_Hgamstargam_MINLO.exactly3lep.root"
+      },
+      {
+        "checksum": "adler32:5e887ceb",
+        "size": 378783,
+        "uri": "root://eospublic.cern.ch//eos/opendata/atlas/rucio/opendata/ODEO_FEB2025_v0_exactly3lep_mc_345964.PowhegPythia8EvtGen_NNPDF30_AZNLO_WpH125J_Hgamstargam_MINLO.exactly3lep.root"
+      },
+      {
+        "checksum": "adler32:acdf268f",
+        "size": 640831,
+        "uri": "root://eospublic.cern.ch//eos/opendata/atlas/rucio/opendata/ODEO_FEB2025_v0_exactly3lep_mc_345965.PowhegPythia8EvtGen_NNPDF30_AZNLO_ZH125J_Hgamstargam_MINLO.exactly3lep.root"
+      },
+      {
+        "checksum": "adler32:1330e5ca",
+        "size": 116101,
+        "uri": "root://eospublic.cern.ch//eos/opendata/atlas/rucio/opendata/ODEO_FEB2025_v0_exactly3lep_mc_346188.aMcAtNloPythia8EvtGen_tHjb125_4fl_gamgam.exactly3lep.root"
+      },
+      {
+        "checksum": "adler32:007cf7ef",
+        "size": 477858,
+        "uri": "root://eospublic.cern.ch//eos/opendata/atlas/rucio/opendata/ODEO_FEB2025_v0_exactly3lep_mc_346189.aMcAtNloPythia8EvtGen_ttH_gamgam.exactly3lep.root"
+      },
+      {
+        "checksum": "adler32:0b9976ca",
+        "size": 551190,
+        "uri": "root://eospublic.cern.ch//eos/opendata/atlas/rucio/opendata/ODEO_FEB2025_v0_exactly3lep_mc_346190.PowhegPy8EG_NNPDF30_AZNLOCTEQ6L1_VBFH125_tautaul13l7.exactly3lep.root"
+      },
+      {
+        "checksum": "adler32:c24a58fb",
+        "size": 78390,
+        "uri": "root://eospublic.cern.ch//eos/opendata/atlas/rucio/opendata/ODEO_FEB2025_v0_exactly3lep_mc_346191.PowhegPy8EG_NNPDF30_AZNLOCTEQ6L1_VBFH125_tautaulm15hp20.exactly3lep.root"
+      },
+      {
+        "checksum": "adler32:a25713d2",
+        "size": 83468,
+        "uri": "root://eospublic.cern.ch//eos/opendata/atlas/rucio/opendata/ODEO_FEB2025_v0_exactly3lep_mc_346192.PowhegPy8EG_NNPDF30_AZNLOCTEQ6L1_VBFH125_tautaulp15hm20.exactly3lep.root"
+      },
+      {
+        "checksum": "adler32:c5fd3f1d",
+        "size": 48287,
+        "uri": "root://eospublic.cern.ch//eos/opendata/atlas/rucio/opendata/ODEO_FEB2025_v0_exactly3lep_mc_346193.PowhegPy8EG_NNPDF30_AZNLOCTEQ6L1_VBFH125_tautauh30h20.exactly3lep.root"
+      },
+      {
+        "checksum": "adler32:746ac564",
+        "size": 530096,
+        "uri": "root://eospublic.cern.ch//eos/opendata/atlas/rucio/opendata/ODEO_FEB2025_v0_exactly3lep_mc_346194.PowhegPy8EG_NNPDF30_AZNLOCTEQ6L1_VBFH125_etau_filt.exactly3lep.root"
+      },
+      {
+        "checksum": "adler32:9045329c",
+        "size": 498609,
+        "uri": "root://eospublic.cern.ch//eos/opendata/atlas/rucio/opendata/ODEO_FEB2025_v0_exactly3lep_mc_346195.PowhegPy8EG_NNPDF30_AZNLOCTEQ6L1_VBFH125_mutau_filt.exactly3lep.root"
+      },
+      {
+        "checksum": "adler32:4b8e2fcd",
+        "size": 10232052,
+        "uri": "root://eospublic.cern.ch//eos/opendata/atlas/rucio/opendata/ODEO_FEB2025_v0_exactly3lep_mc_346198.PhPy8EG_A14NNPDF23_NNPDF30ME_ttH125_Zgam.exactly3lep.root"
+      },
+      {
+        "checksum": "adler32:be8539bf",
+        "size": 61180,
+        "uri": "root://eospublic.cern.ch//eos/opendata/atlas/rucio/opendata/ODEO_FEB2025_v0_exactly3lep_mc_346214.PowhegPy8EG_NNPDF30_AZNLOCTEQ6L1_VBFH125_gamgam.exactly3lep.root"
+      },
+      {
+        "checksum": "adler32:643cf3e2",
+        "size": 49663693,
+        "uri": "root://eospublic.cern.ch//eos/opendata/atlas/rucio/opendata/ODEO_FEB2025_v0_exactly3lep_mc_346228.PowhegPy8EG_NNPDF30_AZNLOCTEQ6L1_VBFH125_ZZ4lep_notau.exactly3lep.root"
+      },
+      {
+        "checksum": "adler32:cbd58218",
+        "size": 258063,
+        "uri": "root://eospublic.cern.ch//eos/opendata/atlas/rucio/opendata/ODEO_FEB2025_v0_exactly3lep_mc_346310.PowhegPythia8EvtGen_NNPDF30_AZNLO_ZH125J_Zincl_H_incl_MINLO.exactly3lep.root"
+      },
+      {
+        "checksum": "adler32:2592e53b",
+        "size": 92490,
+        "uri": "root://eospublic.cern.ch//eos/opendata/atlas/rucio/opendata/ODEO_FEB2025_v0_exactly3lep_mc_346311.PowhegPythia8EvtGen_NNPDF30_AZNLO_WpH125J_Wincl_H_incl_MINLO.exactly3lep.root"
+      },
+      {
+        "checksum": "adler32:16530990",
+        "size": 75274,
+        "uri": "root://eospublic.cern.ch//eos/opendata/atlas/rucio/opendata/ODEO_FEB2025_v0_exactly3lep_mc_346312.PowhegPythia8EvtGen_NNPDF30_AZNLO_WmH125J_Wincl_H_incl_MINLO.exactly3lep.root"
+      },
+      {
+        "checksum": "adler32:db480a77",
+        "size": 140890,
+        "uri": "root://eospublic.cern.ch//eos/opendata/atlas/rucio/opendata/ODEO_FEB2025_v0_exactly3lep_mc_346317.PowhegPy8EG_NNPDF30_AZNLOCTEQ6L1_VBFH125_incl.exactly3lep.root"
+      },
+      {
+        "checksum": "adler32:20c60091",
+        "size": 7659636,
+        "uri": "root://eospublic.cern.ch//eos/opendata/atlas/rucio/opendata/ODEO_FEB2025_v0_exactly3lep_mc_346340.PowhegPy8EG_A14NNPDF23_NNPDF30ME_ttH125_ZZ4l_allhad.exactly3lep.root"
+      },
+      {
+        "checksum": "adler32:e6ccf242",
+        "size": 5732030,
+        "uri": "root://eospublic.cern.ch//eos/opendata/atlas/rucio/opendata/ODEO_FEB2025_v0_exactly3lep_mc_346341.PowhegPy8EG_A14NNPDF23_NNPDF30ME_ttH125_ZZ4l_semilep.exactly3lep.root"
+      },
+      {
+        "checksum": "adler32:7ce5ed59",
+        "size": 3601495,
+        "uri": "root://eospublic.cern.ch//eos/opendata/atlas/rucio/opendata/ODEO_FEB2025_v0_exactly3lep_mc_346342.PowhegPy8EG_A14NNPDF23_NNPDF30ME_ttH125_ZZ4l_dilep.exactly3lep.root"
+      },
+      {
+        "checksum": "adler32:64e0444b",
+        "size": 284035,
+        "uri": "root://eospublic.cern.ch//eos/opendata/atlas/rucio/opendata/ODEO_FEB2025_v0_exactly3lep_mc_346343.PhPy8EG_A14NNPDF23_NNPDF30ME_ttH125_allhad.exactly3lep.root"
+      },
+      {
+        "checksum": "adler32:5023b9ea",
+        "size": 972859,
+        "uri": "root://eospublic.cern.ch//eos/opendata/atlas/rucio/opendata/ODEO_FEB2025_v0_exactly3lep_mc_346344.PhPy8EG_A14NNPDF23_NNPDF30ME_ttH125_semilep.exactly3lep.root"
+      },
+      {
+        "checksum": "adler32:76c71acd",
+        "size": 7518186,
+        "uri": "root://eospublic.cern.ch//eos/opendata/atlas/rucio/opendata/ODEO_FEB2025_v0_exactly3lep_mc_346345.PhPy8EG_A14NNPDF23_NNPDF30ME_ttH125_dilep.exactly3lep.root"
+      },
+      {
+        "checksum": "adler32:439a4655",
+        "size": 42253,
+        "uri": "root://eospublic.cern.ch//eos/opendata/atlas/rucio/opendata/ODEO_FEB2025_v0_exactly3lep_mc_346398.PowhegHerwig7EvtGen_NNPDF3_AZNLO_ZH125J_MINLO_vvbb_VpT.exactly3lep.root"
+      },
+      {
+        "checksum": "adler32:b8500e0b",
+        "size": 47135,
+        "uri": "root://eospublic.cern.ch//eos/opendata/atlas/rucio/opendata/ODEO_FEB2025_v0_exactly3lep_mc_346400.PowhegHerwig7EvtGen_NNPDF3_AZNLO_ggZH125J_vvbb.exactly3lep.root"
+      },
+      {
+        "checksum": "adler32:f338083c",
+        "size": 4103712,
+        "uri": "root://eospublic.cern.ch//eos/opendata/atlas/rucio/opendata/ODEO_FEB2025_v0_exactly3lep_mc_346414.aMcAtNloPythia8EvtGen_tHjb125_4fl_ZZ4l.exactly3lep.root"
+      },
+      {
+        "checksum": "adler32:60b2f617",
+        "size": 149088601,
+        "uri": "root://eospublic.cern.ch//eos/opendata/atlas/rucio/opendata/ODEO_FEB2025_v0_exactly3lep_mc_346446.PhH7EG_H7UE_NNLOPS_nnlo_30_ggH125_ZZ4l_noTau.exactly3lep.root"
+      },
+      {
+        "checksum": "adler32:d2488c5e",
+        "size": 50202729,
+        "uri": "root://eospublic.cern.ch//eos/opendata/atlas/rucio/opendata/ODEO_FEB2025_v0_exactly3lep_mc_346447.PhH7EG_H7UE_NNPDF30_VBFH125_ZZ4lep_noTau.exactly3lep.root"
+      },
+      {
+        "checksum": "adler32:cf3797c8",
+        "size": 9802306,
+        "uri": "root://eospublic.cern.ch//eos/opendata/atlas/rucio/opendata/ODEO_FEB2025_v0_exactly3lep_mc_346448.PhH7EG_H7UE_NNPDF30_ZH125J_Zincl_MINLO.exactly3lep.root"
+      },
+      {
+        "checksum": "adler32:cd32ec1c",
+        "size": 7926352,
+        "uri": "root://eospublic.cern.ch//eos/opendata/atlas/rucio/opendata/ODEO_FEB2025_v0_exactly3lep_mc_346449.PhH7EG_H7UE_NNPDF30_WpH125J_Wincl_MINLO.exactly3lep.root"
+      },
+      {
+        "checksum": "adler32:9f02f002",
+        "size": 4155847,
+        "uri": "root://eospublic.cern.ch//eos/opendata/atlas/rucio/opendata/ODEO_FEB2025_v0_exactly3lep_mc_346450.PhH7EG_H7UE_NNPDF30_WmH125J_Wincl_MINLO.exactly3lep.root"
+      },
+      {
+        "checksum": "adler32:d2e0cbb0",
+        "size": 4969312,
+        "uri": "root://eospublic.cern.ch//eos/opendata/atlas/rucio/opendata/ODEO_FEB2025_v0_exactly3lep_mc_346451.PhH7EG_H7UE_NNPDF3_ggZH125_ZZ4lepZinc.exactly3lep.root"
+      },
+      {
+        "checksum": "adler32:156aa69a",
+        "size": 7646151,
+        "uri": "root://eospublic.cern.ch//eos/opendata/atlas/rucio/opendata/ODEO_FEB2025_v0_exactly3lep_mc_346452.PhH7EG_H7UE_NNPDF30ME_ttH125_ZZ4l_allhad_noTau.exactly3lep.root"
+      },
+      {
+        "checksum": "adler32:8f3c001c",
+        "size": 5831334,
+        "uri": "root://eospublic.cern.ch//eos/opendata/atlas/rucio/opendata/ODEO_FEB2025_v0_exactly3lep_mc_346453.PhH7EG_H7UE_NNPDF30ME_ttH125_ZZ4l_semilep_noTau.exactly3lep.root"
+      },
+      {
+        "checksum": "adler32:85aa0c15",
+        "size": 3544459,
+        "uri": "root://eospublic.cern.ch//eos/opendata/atlas/rucio/opendata/ODEO_FEB2025_v0_exactly3lep_mc_346454.PhH7EG_H7UE_NNPDF30ME_ttH125_ZZ4l_dilep_noTau.exactly3lep.root"
+      },
+      {
+        "checksum": "adler32:91fb38b6",
+        "size": 250879,
+        "uri": "root://eospublic.cern.ch//eos/opendata/atlas/rucio/opendata/ODEO_FEB2025_v0_exactly3lep_mc_346486.aMcAtNloPythia8EvtGen_tWH125_yy.exactly3lep.root"
+      },
+      {
+        "checksum": "adler32:3a8a8cd6",
+        "size": 5067361,
+        "uri": "root://eospublic.cern.ch//eos/opendata/atlas/rucio/opendata/ODEO_FEB2025_v0_exactly3lep_mc_346511.aMcAtNloPythia8EvtGen_tWH125_ZZ4l.exactly3lep.root"
+      },
+      {
+        "checksum": "adler32:e6703bea",
+        "size": 783631,
+        "uri": "root://eospublic.cern.ch//eos/opendata/atlas/rucio/opendata/ODEO_FEB2025_v0_exactly3lep_mc_346524.PowhegPythia8EvtGen_NNPDF3_AZNLO_ggZH125J_MINLO_ZinclWWlvlv.exactly3lep.root"
+      },
+      {
+        "checksum": "adler32:87314de8",
+        "size": 963089,
+        "uri": "root://eospublic.cern.ch//eos/opendata/atlas/rucio/opendata/ODEO_FEB2025_v0_exactly3lep_mc_346525.PowhegPythia8EvtGen_A14NNPDF23_NNPDF30ME_ttH125_gamgam.exactly3lep.root"
+      },
+      {
+        "checksum": "adler32:a8b2a213",
+        "size": 895306,
+        "uri": "root://eospublic.cern.ch//eos/opendata/atlas/rucio/opendata/ODEO_FEB2025_v0_exactly3lep_mc_346526.PowhegHerwig7EvtGen_H7UE_NNPDF30ME_ttH125_gamgam.exactly3lep.root"
+      },
+      {
+        "checksum": "adler32:b93705f0",
+        "size": 40460,
+        "uri": "root://eospublic.cern.ch//eos/opendata/atlas/rucio/opendata/ODEO_FEB2025_v0_exactly3lep_mc_346588.PowhegPythia8EvtGen_NNLOPS_nnlo_30_ggH125_ZZ4nu_MET75.exactly3lep.root"
+      },
+      {
+        "checksum": "adler32:ac4238b3",
+        "size": 598609,
+        "uri": "root://eospublic.cern.ch//eos/opendata/atlas/rucio/opendata/ODEO_FEB2025_v0_exactly3lep_mc_346601.aMcAtNloHerwig7EvtGen_MEN30NLO_ttH125_gamgam.exactly3lep.root"
+      },
+      {
+        "checksum": "adler32:bac09db6",
+        "size": 88409,
+        "uri": "root://eospublic.cern.ch//eos/opendata/atlas/rucio/opendata/ODEO_FEB2025_v0_exactly3lep_mc_346602.aMcAtNloHerwig7EvtGen_MEN30NLO_tHjb125_gamgam.exactly3lep.root"
+      },
+      {
+        "checksum": "adler32:0c9a6d03",
+        "size": 51695,
+        "uri": "root://eospublic.cern.ch//eos/opendata/atlas/rucio/opendata/ODEO_FEB2025_v0_exactly3lep_mc_346605.PowhegPythia8EvtGen_NNPDF30_AZNLO_WpH125J_WinclHinv_MET75.exactly3lep.root"
+      },
+      {
+        "checksum": "adler32:8a705a02",
+        "size": 44671,
+        "uri": "root://eospublic.cern.ch//eos/opendata/atlas/rucio/opendata/ODEO_FEB2025_v0_exactly3lep_mc_346606.PowhegPythia8EvtGen_NNPDF30_AZNLO_WmH125J_WinclHinv_MET75.exactly3lep.root"
+      },
+      {
+        "checksum": "adler32:a5c5118c",
+        "size": 85149,
+        "uri": "root://eospublic.cern.ch//eos/opendata/atlas/rucio/opendata/ODEO_FEB2025_v0_exactly3lep_mc_346607.PowhegPythia8EvtGen_NNPDF30_AZNLO_ZH125J_ZinclHinv_MET75.exactly3lep.root"
+      },
+      {
+        "checksum": "adler32:7a6a2ae3",
+        "size": 415023,
+        "uri": "root://eospublic.cern.ch//eos/opendata/atlas/rucio/opendata/ODEO_FEB2025_v0_exactly3lep_mc_346632.PowhegPy8EG_A14NNPDF23_NNPDF30ME_ttH125_ZZ4nu_semilep.exactly3lep.root"
+      },
+      {
+        "checksum": "adler32:6fbbe302",
+        "size": 98049,
+        "uri": "root://eospublic.cern.ch//eos/opendata/atlas/rucio/opendata/ODEO_FEB2025_v0_exactly3lep_mc_346633.PowhegPy8EG_A14NNPDF23_NNPDF30ME_ttH125_ZZ4nu_allhad.exactly3lep.root"
+      },
+      {
+        "checksum": "adler32:1387cd16",
+        "size": 632741,
+        "uri": "root://eospublic.cern.ch//eos/opendata/atlas/rucio/opendata/ODEO_FEB2025_v0_exactly3lep_mc_346634.PowhegPy8EG_A14NNPDF23_NNPDF30ME_ttH125_ZZ4nu_dilep.exactly3lep.root"
+      },
+      {
+        "checksum": "adler32:4d03b765",
+        "size": 14336157,
+        "uri": "root://eospublic.cern.ch//eos/opendata/atlas/rucio/opendata/ODEO_FEB2025_v0_exactly3lep_mc_346645.PowhegPythia8EvtGen_NNPDF30_AZNLO_ZH125J_Zincl_MINLO_shw.exactly3lep.root"
+      },
+      {
+        "checksum": "adler32:cbaabe5a",
+        "size": 8275785,
+        "uri": "root://eospublic.cern.ch//eos/opendata/atlas/rucio/opendata/ODEO_FEB2025_v0_exactly3lep_mc_346646.PowhegPythia8EvtGen_NNPDF30_AZNLO_WpH125J_Wincl_MINLO_shw.exactly3lep.root"
+      },
+      {
+        "checksum": "adler32:7688e796",
+        "size": 4469072,
+        "uri": "root://eospublic.cern.ch//eos/opendata/atlas/rucio/opendata/ODEO_FEB2025_v0_exactly3lep_mc_346647.PowhegPythia8EvtGen_NNPDF30_AZNLO_WmH125J_Wincl_MINLO_shw.exactly3lep.root"
+      },
+      {
+        "checksum": "adler32:b62e14ea",
+        "size": 60240,
+        "uri": "root://eospublic.cern.ch//eos/opendata/atlas/rucio/opendata/ODEO_FEB2025_v0_exactly3lep_mc_346726.PowhegHerwig7EvtGen_NNPDF3_AZNLO_ZH125J_MINLO_vvcc_VpT.exactly3lep.root"
+      },
+      {
+        "checksum": "adler32:665565dc",
+        "size": 29504,
+        "uri": "root://eospublic.cern.ch//eos/opendata/atlas/rucio/opendata/ODEO_FEB2025_v0_exactly3lep_mc_346728.PowhegHerwig7EvtGen_NNPDF3_AZNLO_ggZH125J_vvcc.exactly3lep.root"
+      },
+      {
+        "checksum": "adler32:caf07541",
+        "size": 571102,
+        "uri": "root://eospublic.cern.ch//eos/opendata/atlas/rucio/opendata/ODEO_FEB2025_v0_exactly3lep_mc_346797.PhH7EG_H7UE_NNLOPS_nnlo_30_ggH125_gamgam.exactly3lep.root"
+      },
+      {
+        "checksum": "adler32:89df7fc1",
+        "size": 2814282,
+        "uri": "root://eospublic.cern.ch//eos/opendata/atlas/rucio/opendata/ODEO_FEB2025_v0_exactly3lep_mc_346802.PhH7EG_NNLOPS_nnlo_30_ggH125_WWlvlv_noTau.exactly3lep.root"
+      },
+      {
+        "checksum": "adler32:b7fd64b5",
+        "size": 553923,
+        "uri": "root://eospublic.cern.ch//eos/opendata/atlas/rucio/opendata/ODEO_FEB2025_v0_exactly3lep_mc_346877.PhH7EG_NNPDF30_VBFH125_WWlvlv.exactly3lep.root"
+      },
+      {
+        "checksum": "adler32:cc1bef5b",
+        "size": 126081,
+        "uri": "root://eospublic.cern.ch//eos/opendata/atlas/rucio/opendata/ODEO_FEB2025_v0_exactly3lep_mc_346878.PhH7EG_H7UE_NNPDF30_VBF125_gammagamma.exactly3lep.root"
+      },
+      {
+        "checksum": "adler32:bb971d13",
+        "size": 212579,
+        "uri": "root://eospublic.cern.ch//eos/opendata/atlas/rucio/opendata/ODEO_FEB2025_v0_exactly3lep_mc_346879.PhH7EG_H7UE_NNPDF30_ZH125J_Zincl_MINLO_gammagamma.exactly3lep.root"
+      },
+      {
+        "checksum": "adler32:5a0bafb2",
+        "size": 56528,
+        "uri": "root://eospublic.cern.ch//eos/opendata/atlas/rucio/opendata/ODEO_FEB2025_v0_exactly3lep_mc_346880.PhH7EG_H7UE_NNPDF30_WmH125J_Wincl_MINLO_gammagamma.exactly3lep.root"
+      },
+      {
+        "checksum": "adler32:716b3c68",
+        "size": 100958,
+        "uri": "root://eospublic.cern.ch//eos/opendata/atlas/rucio/opendata/ODEO_FEB2025_v0_exactly3lep_mc_346881.PhH7EG_H7UE_NNPDF30_WpH125J_Wincl_MINLO_gammagamma.exactly3lep.root"
+      },
+      {
+        "checksum": "adler32:bf3fdbb0",
+        "size": 137402,
+        "uri": "root://eospublic.cern.ch//eos/opendata/atlas/rucio/opendata/ODEO_FEB2025_v0_exactly3lep_mc_346882.PhH7EG_H7UE_NNPDF30_ggZH125_gammagamma.exactly3lep.root"
+      },
+      {
+        "checksum": "adler32:a58366ed",
+        "size": 653643,
+        "uri": "root://eospublic.cern.ch//eos/opendata/atlas/rucio/opendata/ODEO_FEB2025_v0_exactly3lep_mc_346919.PhPy8EG_A14NNPDF23_NNPDF30ME_ttH125_allhad_tautau_unpol.exactly3lep.root"
+      },
+      {
+        "checksum": "adler32:aa88b32b",
+        "size": 2925440,
+        "uri": "root://eospublic.cern.ch//eos/opendata/atlas/rucio/opendata/ODEO_FEB2025_v0_exactly3lep_mc_346923.PhPy8EG_A14NNPDF23_NNPDF30ME_ttH125_semilep_tautau_unpol.exactly3lep.root"
+      },
+      {
+        "checksum": "adler32:70510534",
+        "size": 6953888,
+        "uri": "root://eospublic.cern.ch//eos/opendata/atlas/rucio/opendata/ODEO_FEB2025_v0_exactly3lep_mc_346927.PhPy8EG_A14NNPDF23_NNPDF30ME_ttH125_dilep_tautau_unpol.exactly3lep.root"
+      },
+      {
+        "checksum": "adler32:c4749b25",
+        "size": 13628438,
+        "uri": "root://eospublic.cern.ch//eos/opendata/atlas/rucio/opendata/ODEO_FEB2025_v0_exactly3lep_mc_364242.Sherpa_222_NNPDF30NNLO_WWW_3l3v_EW6.exactly3lep.root"
+      },
+      {
+        "checksum": "adler32:76fa53e6",
+        "size": 7332176,
+        "uri": "root://eospublic.cern.ch//eos/opendata/atlas/rucio/opendata/ODEO_FEB2025_v0_exactly3lep_mc_364243.Sherpa_222_NNPDF30NNLO_WWZ_4l2v_EW6.exactly3lep.root"
+      },
+      {
+        "checksum": "adler32:22243ddc",
+        "size": 150649,
+        "uri": "root://eospublic.cern.ch//eos/opendata/atlas/rucio/opendata/ODEO_FEB2025_v0_exactly3lep_mc_364244.Sherpa_222_NNPDF30NNLO_WWZ_2l4v_EW6.exactly3lep.root"
+      },
+      {
+        "checksum": "adler32:dcc6d51e",
+        "size": 5908801,
+        "uri": "root://eospublic.cern.ch//eos/opendata/atlas/rucio/opendata/ODEO_FEB2025_v0_exactly3lep_mc_364245.Sherpa_222_NNPDF30NNLO_WZZ_5l1v_EW6.exactly3lep.root"
+      },
+      {
+        "checksum": "adler32:6733585e",
+        "size": 5490603,
+        "uri": "root://eospublic.cern.ch//eos/opendata/atlas/rucio/opendata/ODEO_FEB2025_v0_exactly3lep_mc_364246.Sherpa_222_NNPDF30NNLO_WZZ_3l3v_EW6.exactly3lep.root"
+      },
+      {
+        "checksum": "adler32:81451394",
+        "size": 3535629,
+        "uri": "root://eospublic.cern.ch//eos/opendata/atlas/rucio/opendata/ODEO_FEB2025_v0_exactly3lep_mc_364247.Sherpa_222_NNPDF30NNLO_ZZZ_6l0v_EW6.exactly3lep.root"
+      },
+      {
+        "checksum": "adler32:0a07f78c",
+        "size": 1124390,
+        "uri": "root://eospublic.cern.ch//eos/opendata/atlas/rucio/opendata/ODEO_FEB2025_v0_exactly3lep_mc_364248.Sherpa_222_NNPDF30NNLO_ZZZ_4l2v_EW6.exactly3lep.root"
+      },
+      {
+        "checksum": "adler32:0a7b9fe5",
+        "size": 98896,
+        "uri": "root://eospublic.cern.ch//eos/opendata/atlas/rucio/opendata/ODEO_FEB2025_v0_exactly3lep_mc_364249.Sherpa_222_NNPDF30NNLO_ZZZ_2l4v_EW6.exactly3lep.root"
+      },
+      {
+        "checksum": "adler32:924aa365",
+        "size": 368551,
+        "uri": "root://eospublic.cern.ch//eos/opendata/atlas/rucio/opendata/ODEO_FEB2025_v0_exactly3lep_mc_364336.Sherpa_222_NNPDF30NNLO_WpWpWn_sslvlvjj_EW6.exactly3lep.root"
+      },
+      {
+        "checksum": "adler32:dbb94b9f",
+        "size": 286491,
+        "uri": "root://eospublic.cern.ch//eos/opendata/atlas/rucio/opendata/ODEO_FEB2025_v0_exactly3lep_mc_364337.Sherpa_222_NNPDF30NNLO_WnWnWp_sslvlvjj_EW6.exactly3lep.root"
+      },
+      {
+        "checksum": "adler32:d749815a",
+        "size": 533807,
+        "uri": "root://eospublic.cern.ch//eos/opendata/atlas/rucio/opendata/ODEO_FEB2025_v0_exactly3lep_mc_364338.Sherpa_222_NNPDF30NNLO_WpWpWn_oslvlvjj_EW6.exactly3lep.root"
+      },
+      {
+        "checksum": "adler32:cce4ec4b",
+        "size": 187962,
+        "uri": "root://eospublic.cern.ch//eos/opendata/atlas/rucio/opendata/ODEO_FEB2025_v0_exactly3lep_mc_364339.Sherpa_222_NNPDF30NNLO_WnWnWp_oslvlvjj_EW6.exactly3lep.root"
+      },
+      {
+        "checksum": "adler32:fc99eb91",
+        "size": 387082,
+        "uri": "root://eospublic.cern.ch//eos/opendata/atlas/rucio/opendata/ODEO_FEB2025_v0_exactly3lep_mc_364350.Sherpa_224_NNPDF30NNLO_Diphoton_myy_0_50.exactly3lep.root"
+      },
+      {
+        "checksum": "adler32:e574627d",
+        "size": 3696043,
+        "uri": "root://eospublic.cern.ch//eos/opendata/atlas/rucio/opendata/ODEO_FEB2025_v0_exactly3lep_mc_364351.Sherpa_224_NNPDF30NNLO_Diphoton_myy_50_90.exactly3lep.root"
+      },
+      {
+        "checksum": "adler32:b0a63a53",
+        "size": 1309624,
+        "uri": "root://eospublic.cern.ch//eos/opendata/atlas/rucio/opendata/ODEO_FEB2025_v0_exactly3lep_mc_364352.Sherpa_224_NNPDF30NNLO_Diphoton_myy_90_175.exactly3lep.root"
+      },
+      {
+        "checksum": "adler32:823d1669",
+        "size": 293582,
+        "uri": "root://eospublic.cern.ch//eos/opendata/atlas/rucio/opendata/ODEO_FEB2025_v0_exactly3lep_mc_364353.Sherpa_224_NNPDF30NNLO_Diphoton_myy_175_2000.exactly3lep.root"
+      },
+      {
+        "checksum": "adler32:7a2cc619",
+        "size": 41637,
+        "uri": "root://eospublic.cern.ch//eos/opendata/atlas/rucio/opendata/ODEO_FEB2025_v0_exactly3lep_mc_364354.Sherpa_224_NNPDF30NNLO_Diphoton_myy_2000_E_CMS.exactly3lep.root"
+      },
+      {
+        "checksum": "adler32:e422dc65",
+        "size": 1369737,
+        "uri": "root://eospublic.cern.ch//eos/opendata/atlas/rucio/opendata/ODEO_FEB2025_v0_exactly3lep_mc_364541.Sherpa_222_NNPDF30NNLO_SinglePhoton_pty_17_35.exactly3lep.root"
+      },
+      {
+        "checksum": "adler32:f6fdfe06",
+        "size": 1617101,
+        "uri": "root://eospublic.cern.ch//eos/opendata/atlas/rucio/opendata/ODEO_FEB2025_v0_exactly3lep_mc_364542.Sherpa_222_NNPDF30NNLO_SinglePhoton_pty_35_70.exactly3lep.root"
+      },
+      {
+        "checksum": "adler32:96d2ef82",
+        "size": 1876670,
+        "uri": "root://eospublic.cern.ch//eos/opendata/atlas/rucio/opendata/ODEO_FEB2025_v0_exactly3lep_mc_364543.Sherpa_222_NNPDF30NNLO_SinglePhoton_pty_70_140.exactly3lep.root"
+      },
+      {
+        "checksum": "adler32:6d0ba435",
+        "size": 2594213,
+        "uri": "root://eospublic.cern.ch//eos/opendata/atlas/rucio/opendata/ODEO_FEB2025_v0_exactly3lep_mc_364544.Sherpa_222_NNPDF30NNLO_SinglePhoton_pty_140_280.exactly3lep.root"
+      },
+      {
+        "checksum": "adler32:99f3ba00",
+        "size": 726217,
+        "uri": "root://eospublic.cern.ch//eos/opendata/atlas/rucio/opendata/ODEO_FEB2025_v0_exactly3lep_mc_364545.Sherpa_222_NNPDF30NNLO_SinglePhoton_pty_280_500.exactly3lep.root"
+      },
+      {
+        "checksum": "adler32:db389202",
+        "size": 99201,
+        "uri": "root://eospublic.cern.ch//eos/opendata/atlas/rucio/opendata/ODEO_FEB2025_v0_exactly3lep_mc_364546.Sherpa_222_NNPDF30NNLO_SinglePhoton_pty_500_1000.exactly3lep.root"
+      },
+      {
+        "checksum": "adler32:3cc1d306",
+        "size": 165087,
+        "uri": "root://eospublic.cern.ch//eos/opendata/atlas/rucio/opendata/ODEO_FEB2025_v0_exactly3lep_mc_364547.Sherpa_222_NNPDF30NNLO_SinglePhoton_pty_1000_E_CMS.exactly3lep.root"
+      },
+      {
+        "checksum": "adler32:23b0afa2",
+        "size": 51300,
+        "uri": "root://eospublic.cern.ch//eos/opendata/atlas/rucio/opendata/ODEO_FEB2025_v0_exactly3lep_mc_364700.Pythia8EvtGen_A14NNPDF23LO_jetjet_JZ0WithSW.exactly3lep.root"
+      },
+      {
+        "checksum": "adler32:68fbffee",
+        "size": 147024,
+        "uri": "root://eospublic.cern.ch//eos/opendata/atlas/rucio/opendata/ODEO_FEB2025_v0_exactly3lep_mc_364701.Pythia8EvtGen_A14NNPDF23LO_jetjet_JZ1WithSW.exactly3lep.root"
+      },
+      {
+        "checksum": "adler32:5d33f5c1",
+        "size": 7407682,
+        "uri": "root://eospublic.cern.ch//eos/opendata/atlas/rucio/opendata/ODEO_FEB2025_v0_exactly3lep_mc_364702.Pythia8EvtGen_A14NNPDF23LO_jetjet_JZ2WithSW.exactly3lep.root"
+      },
+      {
+        "checksum": "adler32:8386a95b",
+        "size": 17102300,
+        "uri": "root://eospublic.cern.ch//eos/opendata/atlas/rucio/opendata/ODEO_FEB2025_v0_exactly3lep_mc_364703.Pythia8EvtGen_A14NNPDF23LO_jetjet_JZ3WithSW.exactly3lep.root"
+      },
+      {
+        "checksum": "adler32:2176d51c",
+        "size": 40822714,
+        "uri": "root://eospublic.cern.ch//eos/opendata/atlas/rucio/opendata/ODEO_FEB2025_v0_exactly3lep_mc_364704.Pythia8EvtGen_A14NNPDF23LO_jetjet_JZ4WithSW.exactly3lep.root"
+      },
+      {
+        "checksum": "adler32:c249b5d4",
+        "size": 9154393,
+        "uri": "root://eospublic.cern.ch//eos/opendata/atlas/rucio/opendata/ODEO_FEB2025_v0_exactly3lep_mc_364705.Pythia8EvtGen_A14NNPDF23LO_jetjet_JZ5WithSW.exactly3lep.root"
+      },
+      {
+        "checksum": "adler32:7140344d",
+        "size": 679811,
+        "uri": "root://eospublic.cern.ch//eos/opendata/atlas/rucio/opendata/ODEO_FEB2025_v0_exactly3lep_mc_364706.Pythia8EvtGen_A14NNPDF23LO_jetjet_JZ6WithSW.exactly3lep.root"
+      },
+      {
+        "checksum": "adler32:c1f4fda3",
+        "size": 509635,
+        "uri": "root://eospublic.cern.ch//eos/opendata/atlas/rucio/opendata/ODEO_FEB2025_v0_exactly3lep_mc_364707.Pythia8EvtGen_A14NNPDF23LO_jetjet_JZ7WithSW.exactly3lep.root"
+      },
+      {
+        "checksum": "adler32:3c47222e",
+        "size": 1311484,
+        "uri": "root://eospublic.cern.ch//eos/opendata/atlas/rucio/opendata/ODEO_FEB2025_v0_exactly3lep_mc_364708.Pythia8EvtGen_A14NNPDF23LO_jetjet_JZ8WithSW.exactly3lep.root"
+      },
+      {
+        "checksum": "adler32:2d0708a8",
+        "size": 721927,
+        "uri": "root://eospublic.cern.ch//eos/opendata/atlas/rucio/opendata/ODEO_FEB2025_v0_exactly3lep_mc_364709.Pythia8EvtGen_A14NNPDF23LO_jetjet_JZ9WithSW.exactly3lep.root"
+      },
+      {
+        "checksum": "adler32:cf7b6ef4",
+        "size": 2773772,
+        "uri": "root://eospublic.cern.ch//eos/opendata/atlas/rucio/opendata/ODEO_FEB2025_v0_exactly3lep_mc_364710.Pythia8EvtGen_A14NNPDF23LO_jetjet_JZ10WithSW.exactly3lep.root"
+      },
+      {
+        "checksum": "adler32:ae69e867",
+        "size": 1580856,
+        "uri": "root://eospublic.cern.ch//eos/opendata/atlas/rucio/opendata/ODEO_FEB2025_v0_exactly3lep_mc_364711.Pythia8EvtGen_A14NNPDF23LO_jetjet_JZ11WithSW.exactly3lep.root"
+      },
+      {
+        "checksum": "adler32:cf4124d1",
+        "size": 2437562,
+        "uri": "root://eospublic.cern.ch//eos/opendata/atlas/rucio/opendata/ODEO_FEB2025_v0_exactly3lep_mc_364712.Pythia8EvtGen_A14NNPDF23LO_jetjet_JZ12WithSW.exactly3lep.root"
+      },
+      {
+        "checksum": "adler32:fb54e844",
+        "size": 397741,
+        "uri": "root://eospublic.cern.ch//eos/opendata/atlas/rucio/opendata/ODEO_FEB2025_v0_exactly3lep_mc_375884.MGPy8EG_A14N_GG_ttn1_2000_5000_200.exactly3lep.root"
+      },
+      {
+        "checksum": "adler32:0ce9c562",
+        "size": 36648,
+        "uri": "root://eospublic.cern.ch//eos/opendata/atlas/rucio/opendata/ODEO_FEB2025_v0_exactly3lep_mc_376359.MGPy8EG_A14N23LO_SS_onestepCC_1600_900_200.exactly3lep.root"
+      },
+      {
+        "checksum": "adler32:fcc85fce",
+        "size": 29160,
+        "uri": "root://eospublic.cern.ch//eos/opendata/atlas/rucio/opendata/ODEO_FEB2025_v0_exactly3lep_mc_376518.MadGraphPythia8EvtGen_A14NNPDF23LO_GG_direct_2400_200.exactly3lep.root"
+      },
+      {
+        "checksum": "adler32:b77e521c",
+        "size": 1871611,
+        "uri": "root://eospublic.cern.ch//eos/opendata/atlas/rucio/opendata/ODEO_FEB2025_v0_exactly3lep_mc_392202.MGPy8EG_A14N23LO_C1N2_WZ_500p0_100p0_3L_2L7.exactly3lep.root"
+      },
+      {
+        "checksum": "adler32:fd9c8003",
+        "size": 44054,
+        "uri": "root://eospublic.cern.ch//eos/opendata/atlas/rucio/opendata/ODEO_FEB2025_v0_exactly3lep_mc_394997.MGPy8EG_A14N23LO_SM_N2C1p_105_100_2L2MET75_MadSpin.exactly3lep.root"
+      },
+      {
+        "checksum": "adler32:aef56cdb",
+        "size": 210620,
+        "uri": "root://eospublic.cern.ch//eos/opendata/atlas/rucio/opendata/ODEO_FEB2025_v0_exactly3lep_mc_398384.MGPy8EG_A14N23LO_C1N2N1_GGMHinoZh50_800_noFilter.exactly3lep.root"
+      },
+      {
+        "checksum": "adler32:271f721c",
+        "size": 712901,
+        "uri": "root://eospublic.cern.ch//eos/opendata/atlas/rucio/opendata/ODEO_FEB2025_v0_exactly3lep_mc_410081.MadGraphPythia8EvtGen_A14NNPDF23_ttbarWW.exactly3lep.root"
+      },
+      {
+        "checksum": "adler32:760264ad",
+        "size": 3121653,
+        "uri": "root://eospublic.cern.ch//eos/opendata/atlas/rucio/opendata/ODEO_FEB2025_v0_exactly3lep_mc_410082.MadGraphPythia8EvtGen_A14NNPDF23LO_ttgamma_noallhad.exactly3lep.root"
+      },
+      {
+        "checksum": "adler32:037942c1",
+        "size": 218858,
+        "uri": "root://eospublic.cern.ch//eos/opendata/atlas/rucio/opendata/ODEO_FEB2025_v0_exactly3lep_mc_410087.MadGraphPythia8EvtGen_A14NNPDF23LO_ttgamma_allhad.exactly3lep.root"
+      },
+      {
+        "checksum": "adler32:0571574d",
+        "size": 919642,
+        "uri": "root://eospublic.cern.ch//eos/opendata/atlas/rucio/opendata/ODEO_FEB2025_v0_exactly3lep_mc_410155.aMcAtNloPythia8EvtGen_MEN30NLO_A14N23LO_ttW.exactly3lep.root"
+      },
+      {
+        "checksum": "adler32:5f4e75e6",
+        "size": 344784,
+        "uri": "root://eospublic.cern.ch//eos/opendata/atlas/rucio/opendata/ODEO_FEB2025_v0_exactly3lep_mc_410156.aMcAtNloPythia8EvtGen_MEN30NLO_A14N23LO_ttZnunu.exactly3lep.root"
+      },
+      {
+        "checksum": "adler32:acd16b20",
+        "size": 681858,
+        "uri": "root://eospublic.cern.ch//eos/opendata/atlas/rucio/opendata/ODEO_FEB2025_v0_exactly3lep_mc_410157.aMcAtNloPythia8EvtGen_MEN30NLO_A14N23LO_ttZqq.exactly3lep.root"
+      },
+      {
+        "checksum": "adler32:83b1e34b",
+        "size": 9512535,
+        "uri": "root://eospublic.cern.ch//eos/opendata/atlas/rucio/opendata/ODEO_FEB2025_v0_exactly3lep_mc_410218.aMcAtNloPythia8EvtGen_MEN30NLO_A14N23LO_ttee.exactly3lep.root"
+      },
+      {
+        "checksum": "adler32:7936ada2",
+        "size": 14735713,
+        "uri": "root://eospublic.cern.ch//eos/opendata/atlas/rucio/opendata/ODEO_FEB2025_v0_exactly3lep_mc_410219.aMcAtNloPythia8EvtGen_MEN30NLO_A14N23LO_ttmumu.exactly3lep.root"
+      },
+      {
+        "checksum": "adler32:ead40729",
+        "size": 2751320,
+        "uri": "root://eospublic.cern.ch//eos/opendata/atlas/rucio/opendata/ODEO_FEB2025_v0_exactly3lep_mc_410220.aMcAtNloPythia8EvtGen_MEN30NLO_A14N23LO_tttautau.exactly3lep.root"
+      },
+      {
+        "checksum": "adler32:e18eeb99",
+        "size": 4293847,
+        "uri": "root://eospublic.cern.ch//eos/opendata/atlas/rucio/opendata/ODEO_FEB2025_v0_exactly3lep_mc_410389.MadGraphPythia8EvtGen_A14NNPDF23_ttgamma_nonallhadronic.exactly3lep.root"
+      },
+      {
+        "checksum": "adler32:a0f22739",
+        "size": 3411918,
+        "uri": "root://eospublic.cern.ch//eos/opendata/atlas/rucio/opendata/ODEO_FEB2025_v0_exactly3lep_mc_410395.MGH7EG_H7UE_ttgamma_nonallhadronic.exactly3lep.root"
+      },
+      {
+        "checksum": "adler32:c01b0ee6",
+        "size": 253351,
+        "uri": "root://eospublic.cern.ch//eos/opendata/atlas/rucio/opendata/ODEO_FEB2025_v0_exactly3lep_mc_410396.MGH7EG_H7UE_ttgamma_allhadronic.exactly3lep.root"
+      },
+      {
+        "checksum": "adler32:8545ee71",
+        "size": 3104470,
+        "uri": "root://eospublic.cern.ch//eos/opendata/atlas/rucio/opendata/ODEO_FEB2025_v0_exactly3lep_mc_410408.aMcAtNloPythia8EvtGen_tWZ_Ztoll_minDR1.exactly3lep.root"
+      },
+      {
+        "checksum": "adler32:92deacdd",
+        "size": 134053749,
+        "uri": "root://eospublic.cern.ch//eos/opendata/atlas/rucio/opendata/ODEO_FEB2025_v0_exactly3lep_mc_410470.PhPy8EG_A14_ttbar_hdamp258p75_nonallhad.exactly3lep.root"
+      },
+      {
+        "checksum": "adler32:d84bb055",
+        "size": 8681405,
+        "uri": "root://eospublic.cern.ch//eos/opendata/atlas/rucio/opendata/ODEO_FEB2025_v0_exactly3lep_mc_410471.PhPy8EG_A14_ttbar_hdamp258p75_allhad.exactly3lep.root"
+      },
+      {
+        "checksum": "adler32:58f5ef22",
+        "size": 2005172,
+        "uri": "root://eospublic.cern.ch//eos/opendata/atlas/rucio/opendata/ODEO_FEB2025_v0_exactly3lep_mc_410560.MadGraphPythia8EvtGen_A14_tZ_4fl_tchan_noAllHad.exactly3lep.root"
+      },
+      {
+        "checksum": "adler32:9e6538a9",
+        "size": 211074,
+        "uri": "root://eospublic.cern.ch//eos/opendata/atlas/rucio/opendata/ODEO_FEB2025_v0_exactly3lep_mc_410644.PowhegPythia8EvtGen_A14_singletop_schan_lept_top.exactly3lep.root"
+      },
+      {
+        "checksum": "adler32:9ed97bab",
+        "size": 147859,
+        "uri": "root://eospublic.cern.ch//eos/opendata/atlas/rucio/opendata/ODEO_FEB2025_v0_exactly3lep_mc_410645.PowhegPythia8EvtGen_A14_singletop_schan_lept_antitop.exactly3lep.root"
+      },
+      {
+        "checksum": "adler32:54d92e7f",
+        "size": 2748146,
+        "uri": "root://eospublic.cern.ch//eos/opendata/atlas/rucio/opendata/ODEO_FEB2025_v0_exactly3lep_mc_410658.PhPy8EG_A14_tchan_BW50_lept_top.exactly3lep.root"
+      },
+      {
+        "checksum": "adler32:6abd6b96",
+        "size": 1670982,
+        "uri": "root://eospublic.cern.ch//eos/opendata/atlas/rucio/opendata/ODEO_FEB2025_v0_exactly3lep_mc_410659.PhPy8EG_A14_tchan_BW50_lept_antitop.exactly3lep.root"
+      },
+      {
+        "checksum": "adler32:7c8f1127",
+        "size": 12361543,
+        "uri": "root://eospublic.cern.ch//eos/opendata/atlas/rucio/opendata/ODEO_FEB2025_v0_exactly3lep_mc_411233.PowhegHerwig7EvtGen_tt_hdamp258p75_713_SingleLep.exactly3lep.root"
+      },
+      {
+        "checksum": "adler32:390a0512",
+        "size": 40934924,
+        "uri": "root://eospublic.cern.ch//eos/opendata/atlas/rucio/opendata/ODEO_FEB2025_v0_exactly3lep_mc_411234.PowhegHerwig7EvtGen_tt_hdamp258p75_713_dil.exactly3lep.root"
+      },
+      {
+        "checksum": "adler32:43aa6dab",
+        "size": 10439485,
+        "uri": "root://eospublic.cern.ch//eos/opendata/atlas/rucio/opendata/ODEO_FEB2025_v0_exactly3lep_mc_411316.PowhegHerwig7EvtGen_tt_hdamp258p75_713_allhad.exactly3lep.root"
+      },
+      {
+        "checksum": "adler32:7f6ec847",
+        "size": 5288417,
+        "uri": "root://eospublic.cern.ch//eos/opendata/atlas/rucio/opendata/ODEO_FEB2025_v0_exactly3lep_mc_412043.aMcAtNloPythia8EvtGen_A14NNPDF31_SM4topsNLO.exactly3lep.root"
+      },
+      {
+        "checksum": "adler32:fe8c4be2",
+        "size": 5046167,
+        "uri": "root://eospublic.cern.ch//eos/opendata/atlas/rucio/opendata/ODEO_FEB2025_v0_exactly3lep_mc_412044.aMcAtNloHerwig7EvtGen_H7UE_SM4topsNLO.exactly3lep.root"
+      },
+      {
+        "checksum": "adler32:a63531d9",
+        "size": 122921,
+        "uri": "root://eospublic.cern.ch//eos/opendata/atlas/rucio/opendata/ODEO_FEB2025_v0_exactly3lep_mc_423099.Pythia8EvtGen_A14NNPDF23LO_gammajet_DP8_17.exactly3lep.root"
+      },
+      {
+        "checksum": "adler32:403f3540",
+        "size": 322995,
+        "uri": "root://eospublic.cern.ch//eos/opendata/atlas/rucio/opendata/ODEO_FEB2025_v0_exactly3lep_mc_423100.Pythia8EvtGen_A14NNPDF23LO_gammajet_DP17_35.exactly3lep.root"
+      },
+      {
+        "checksum": "adler32:ea63351d",
+        "size": 417105,
+        "uri": "root://eospublic.cern.ch//eos/opendata/atlas/rucio/opendata/ODEO_FEB2025_v0_exactly3lep_mc_423101.Pythia8EvtGen_A14NNPDF23LO_gammajet_DP35_50.exactly3lep.root"
+      },
+      {
+        "checksum": "adler32:a13bd6a3",
+        "size": 521461,
+        "uri": "root://eospublic.cern.ch//eos/opendata/atlas/rucio/opendata/ODEO_FEB2025_v0_exactly3lep_mc_423102.Pythia8EvtGen_A14NNPDF23LO_gammajet_DP50_70.exactly3lep.root"
+      },
+      {
+        "checksum": "adler32:4b74b3c0",
+        "size": 401245,
+        "uri": "root://eospublic.cern.ch//eos/opendata/atlas/rucio/opendata/ODEO_FEB2025_v0_exactly3lep_mc_423103.Pythia8EvtGen_A14NNPDF23LO_gammajet_DP70_140.exactly3lep.root"
+      },
+      {
+        "checksum": "adler32:52b3bf21",
+        "size": 577995,
+        "uri": "root://eospublic.cern.ch//eos/opendata/atlas/rucio/opendata/ODEO_FEB2025_v0_exactly3lep_mc_423104.Pythia8EvtGen_A14NNPDF23LO_gammajet_DP140_280.exactly3lep.root"
+      },
+      {
+        "checksum": "adler32:e7f2d2db",
+        "size": 679504,
+        "uri": "root://eospublic.cern.ch//eos/opendata/atlas/rucio/opendata/ODEO_FEB2025_v0_exactly3lep_mc_423105.Pythia8EvtGen_A14NNPDF23LO_gammajet_DP280_500.exactly3lep.root"
+      },
+      {
+        "checksum": "adler32:55771081",
+        "size": 120635,
+        "uri": "root://eospublic.cern.ch//eos/opendata/atlas/rucio/opendata/ODEO_FEB2025_v0_exactly3lep_mc_423106.Pythia8EvtGen_A14NNPDF23LO_gammajet_DP500_800.exactly3lep.root"
+      },
+      {
+        "checksum": "adler32:354e25ce",
+        "size": 99709,
+        "uri": "root://eospublic.cern.ch//eos/opendata/atlas/rucio/opendata/ODEO_FEB2025_v0_exactly3lep_mc_423107.Pythia8EvtGen_A14NNPDF23LO_gammajet_DP800_1000.exactly3lep.root"
+      },
+      {
+        "checksum": "adler32:7c3964e0",
+        "size": 141353,
+        "uri": "root://eospublic.cern.ch//eos/opendata/atlas/rucio/opendata/ODEO_FEB2025_v0_exactly3lep_mc_423108.Pythia8EvtGen_A14NNPDF23LO_gammajet_DP1000_1500.exactly3lep.root"
+      },
+      {
+        "checksum": "adler32:de432d4d",
+        "size": 80190,
+        "uri": "root://eospublic.cern.ch//eos/opendata/atlas/rucio/opendata/ODEO_FEB2025_v0_exactly3lep_mc_423109.Pythia8EvtGen_A14NNPDF23LO_gammajet_DP1500_2000.exactly3lep.root"
+      },
+      {
+        "checksum": "adler32:f0ab588c",
+        "size": 69517,
+        "uri": "root://eospublic.cern.ch//eos/opendata/atlas/rucio/opendata/ODEO_FEB2025_v0_exactly3lep_mc_423110.Pythia8EvtGen_A14NNPDF23LO_gammajet_DP2000_2500.exactly3lep.root"
+      },
+      {
+        "checksum": "adler32:4979f322",
+        "size": 132584,
+        "uri": "root://eospublic.cern.ch//eos/opendata/atlas/rucio/opendata/ODEO_FEB2025_v0_exactly3lep_mc_423111.Pythia8EvtGen_A14NNPDF23LO_gammajet_DP2500_3000.exactly3lep.root"
+      },
+      {
+        "checksum": "adler32:1627f5bf",
+        "size": 114678,
+        "uri": "root://eospublic.cern.ch//eos/opendata/atlas/rucio/opendata/ODEO_FEB2025_v0_exactly3lep_mc_423112.Pythia8EvtGen_A14NNPDF23LO_gammajet_DP3000_inf.exactly3lep.root"
+      },
+      {
+        "checksum": "adler32:33dbf5b9",
+        "size": 269438,
+        "uri": "root://eospublic.cern.ch//eos/opendata/atlas/rucio/opendata/ODEO_FEB2025_v0_exactly3lep_mc_448624.MGPy8EG_A14N23LO_TT_higgsinoRPV_1075_700.exactly3lep.root"
+      },
+      {
+        "checksum": "adler32:87183353",
+        "size": 572847,
+        "uri": "root://eospublic.cern.ch//eos/opendata/atlas/rucio/opendata/ODEO_FEB2025_v0_exactly3lep_mc_449595.MGPy8EG_A14N23LO_TT_RPVdirectBL_1400.exactly3lep.root"
+      },
+      {
+        "checksum": "adler32:768cd447",
+        "size": 617851,
+        "uri": "root://eospublic.cern.ch//eos/opendata/atlas/rucio/opendata/ODEO_FEB2025_v0_exactly3lep_mc_450576.PowhegPythia8EvtGen_NNLOPS_nnlo_30_VBFH125_ZZllbb.exactly3lep.root"
+      },
+      {
+        "checksum": "adler32:10c9e160",
+        "size": 614917,
+        "uri": "root://eospublic.cern.ch//eos/opendata/atlas/rucio/opendata/ODEO_FEB2025_v0_exactly3lep_mc_500335.MGH7EG_VBFHWWlvlv.exactly3lep.root"
+      },
+      {
+        "checksum": "adler32:2cb90f25",
+        "size": 343796,
+        "uri": "root://eospublic.cern.ch//eos/opendata/atlas/rucio/opendata/ODEO_FEB2025_v0_exactly3lep_mc_500553.aMCPy8EG_ZH_FxFx_Hyy.exactly3lep.root"
+      },
+      {
+        "checksum": "adler32:2ea9e090",
+        "size": 111631,
+        "uri": "root://eospublic.cern.ch//eos/opendata/atlas/rucio/opendata/ODEO_FEB2025_v0_exactly3lep_mc_500554.aMCPy8EG_WH_FxFx_Hyy.exactly3lep.root"
+      },
+      {
+        "checksum": "adler32:15cddb98",
+        "size": 360685,
+        "uri": "root://eospublic.cern.ch//eos/opendata/atlas/rucio/opendata/ODEO_FEB2025_v0_exactly3lep_mc_500555.aMCPy8EG_ggZH_Hyy.exactly3lep.root"
+      },
+      {
+        "checksum": "adler32:57f1bd53",
+        "size": 54527,
+        "uri": "root://eospublic.cern.ch//eos/opendata/atlas/rucio/opendata/ODEO_FEB2025_v0_exactly3lep_mc_501058.MGPy8EG_StauStauDirect_200p0_1p0_TFilt.exactly3lep.root"
+      },
+      {
+        "checksum": "adler32:bda5a635",
+        "size": 316123,
+        "uri": "root://eospublic.cern.ch//eos/opendata/atlas/rucio/opendata/ODEO_FEB2025_v0_exactly3lep_mc_506098.aMCPy8EG_WpH_FxFx_Htautau.exactly3lep.root"
+      },
+      {
+        "checksum": "adler32:367c1013",
+        "size": 423053,
+        "uri": "root://eospublic.cern.ch//eos/opendata/atlas/rucio/opendata/ODEO_FEB2025_v0_exactly3lep_mc_506099.aMCPy8EG_ZH_FxFx_Htautau.exactly3lep.root"
+      },
+      {
+        "checksum": "adler32:93b96e16",
+        "size": 60064,
+        "uri": "root://eospublic.cern.ch//eos/opendata/atlas/rucio/opendata/ODEO_FEB2025_v0_exactly3lep_mc_506101.aMCH7EG_VBF_Htautauh30h20.exactly3lep.root"
+      },
+      {
+        "checksum": "adler32:0717df35",
+        "size": 645156,
+        "uri": "root://eospublic.cern.ch//eos/opendata/atlas/rucio/opendata/ODEO_FEB2025_v0_exactly3lep_mc_506102.aMCH7EG_VBF_Htautaul13l7.exactly3lep.root"
+      },
+      {
+        "checksum": "adler32:12e5ef11",
+        "size": 95209,
+        "uri": "root://eospublic.cern.ch//eos/opendata/atlas/rucio/opendata/ODEO_FEB2025_v0_exactly3lep_mc_506103.aMCH7EG_VBF_Htautaulp15hm20.exactly3lep.root"
+      },
+      {
+        "checksum": "adler32:7e96f013",
+        "size": 137119,
+        "uri": "root://eospublic.cern.ch//eos/opendata/atlas/rucio/opendata/ODEO_FEB2025_v0_exactly3lep_mc_506104.aMCH7EG_VBF_Htautaulm15hp20.exactly3lep.root"
+      },
+      {
+        "checksum": "adler32:3333e141",
+        "size": 62521,
+        "uri": "root://eospublic.cern.ch//eos/opendata/atlas/rucio/opendata/ODEO_FEB2025_v0_exactly3lep_mc_506811.aMCH7EG_VBF_HC_Hyy.exactly3lep.root"
+      },
+      {
+        "checksum": "adler32:e3e675d9",
+        "size": 38380,
+        "uri": "root://eospublic.cern.ch//eos/opendata/atlas/rucio/opendata/ODEO_FEB2025_v0_exactly3lep_mc_506813.aMCPy8EG_ZH_had_FxFx_Hyy.exactly3lep.root"
+      },
+      {
+        "checksum": "adler32:658ac2b3",
+        "size": 46834,
+        "uri": "root://eospublic.cern.ch//eos/opendata/atlas/rucio/opendata/ODEO_FEB2025_v0_exactly3lep_mc_506814.aMCPy8EG_ggZH_Zhad_Hyy.exactly3lep.root"
+      },
+      {
+        "checksum": "adler32:7d6a7a0d",
+        "size": 78047,
+        "uri": "root://eospublic.cern.ch//eos/opendata/atlas/rucio/opendata/ODEO_FEB2025_v0_exactly3lep_mc_507366.MGPy8EG_A14NNPDF23LO_GGM_N1N2C1_950.exactly3lep.root"
+      },
+      {
+        "checksum": "adler32:3d204886",
+        "size": 881207,
+        "uri": "root://eospublic.cern.ch//eos/opendata/atlas/rucio/opendata/ODEO_FEB2025_v0_exactly3lep_mc_510097.MGPy8EG_A14N23LO_DM_4topscalar_p1000_c1_nonallhad.exactly3lep.root"
+      },
+      {
+        "checksum": "adler32:42c3c2ca",
+        "size": 83801,
+        "uri": "root://eospublic.cern.ch//eos/opendata/atlas/rucio/opendata/ODEO_FEB2025_v0_exactly3lep_mc_523692.MGPy8EG_A14N23LO_TT_tN1_1200_200_MS.exactly3lep.root"
+      },
+      {
+        "checksum": "adler32:dfe62ac5",
+        "size": 1228070,
+        "uri": "root://eospublic.cern.ch//eos/opendata/atlas/rucio/opendata/ODEO_FEB2025_v0_exactly3lep_mc_600017.PhH7EG_H7UE_716_tchan_lept_antitop.exactly3lep.root"
+      },
+      {
+        "checksum": "adler32:eefd1eb0",
+        "size": 2062640,
+        "uri": "root://eospublic.cern.ch//eos/opendata/atlas/rucio/opendata/ODEO_FEB2025_v0_exactly3lep_mc_600018.PhH7EG_H7UE_716_tchan_lept_top.exactly3lep.root"
+      },
+      {
+        "checksum": "adler32:ef91412c",
+        "size": 161048,
+        "uri": "root://eospublic.cern.ch//eos/opendata/atlas/rucio/opendata/ODEO_FEB2025_v0_exactly3lep_mc_600019.PhH7EG_H7UE_716_schan_lept_antitop.exactly3lep.root"
+      },
+      {
+        "checksum": "adler32:e6c99076",
+        "size": 196192,
+        "uri": "root://eospublic.cern.ch//eos/opendata/atlas/rucio/opendata/ODEO_FEB2025_v0_exactly3lep_mc_600020.PhH7EG_H7UE_716_schan_lept_top.exactly3lep.root"
+      },
+      {
+        "checksum": "adler32:742a8d99",
+        "size": 151559,
+        "uri": "root://eospublic.cern.ch//eos/opendata/atlas/rucio/opendata/ODEO_FEB2025_v0_exactly3lep_mc_600565.PhH7EG_ggH125_tautauh30h20_ShowerSys_fix.exactly3lep.root"
+      },
+      {
+        "checksum": "adler32:b7ead8f2",
+        "size": 1674754,
+        "uri": "root://eospublic.cern.ch//eos/opendata/atlas/rucio/opendata/ODEO_FEB2025_v0_exactly3lep_mc_600566.PhH7EG_ggH125_tautaul13l7_ShowerSys_fix.exactly3lep.root"
+      },
+      {
+        "checksum": "adler32:0711a87d",
+        "size": 163954,
+        "uri": "root://eospublic.cern.ch//eos/opendata/atlas/rucio/opendata/ODEO_FEB2025_v0_exactly3lep_mc_600567.PhH7EG_ggH125_ttlp15hm20_ShowerSys_fix.exactly3lep.root"
+      },
+      {
+        "checksum": "adler32:90ef9903",
+        "size": 196983,
+        "uri": "root://eospublic.cern.ch//eos/opendata/atlas/rucio/opendata/ODEO_FEB2025_v0_exactly3lep_mc_600568.PhH7EG_ggH125_ttlm15hp20_ShowerSys_fix.exactly3lep.root"
+      },
+      {
+        "checksum": "adler32:b7fe9303",
+        "size": 61664,
+        "uri": "root://eospublic.cern.ch//eos/opendata/atlas/rucio/opendata/ODEO_FEB2025_v0_exactly3lep_mc_600569.PhH7EG_VBFH125_tautauh30h20_ShowerSys_fix.exactly3lep.root"
+      },
+      {
+        "checksum": "adler32:26b84c0a",
+        "size": 592721,
+        "uri": "root://eospublic.cern.ch//eos/opendata/atlas/rucio/opendata/ODEO_FEB2025_v0_exactly3lep_mc_600570.PhH7EG_VBFH125_tautaul13l7_ShowerSys_fix.exactly3lep.root"
+      },
+      {
+        "checksum": "adler32:54ab0303",
+        "size": 74102,
+        "uri": "root://eospublic.cern.ch//eos/opendata/atlas/rucio/opendata/ODEO_FEB2025_v0_exactly3lep_mc_600571.PhH7EG_VBFH125_tautaulp15hm20_ShowerSys_fix.exactly3lep.root"
+      },
+      {
+        "checksum": "adler32:8a201ad9",
+        "size": 77205,
+        "uri": "root://eospublic.cern.ch//eos/opendata/atlas/rucio/opendata/ODEO_FEB2025_v0_exactly3lep_mc_600572.PhH7EG_VBFH125_tautaulm15hp20_ShowerSys_fix.exactly3lep.root"
+      },
+      {
+        "checksum": "adler32:e62658dd",
+        "size": 192587,
+        "uri": "root://eospublic.cern.ch//eos/opendata/atlas/rucio/opendata/ODEO_FEB2025_v0_exactly3lep_mc_600573.PhH7EG_WmH125J_Winc_MINLO_tt_ShowerSys_fix.exactly3lep.root"
+      },
+      {
+        "checksum": "adler32:46375883",
+        "size": 290683,
+        "uri": "root://eospublic.cern.ch//eos/opendata/atlas/rucio/opendata/ODEO_FEB2025_v0_exactly3lep_mc_600574.PhH7EG_WpH125J_Winc_MINLO_tt_ShowerSys_fix.exactly3lep.root"
+      },
+      {
+        "checksum": "adler32:4a4f6e3c",
+        "size": 609716,
+        "uri": "root://eospublic.cern.ch//eos/opendata/atlas/rucio/opendata/ODEO_FEB2025_v0_exactly3lep_mc_600575.PhH7EG_ZH125J_Zinc_MINLO_tautau_ShowerSys_fix.exactly3lep.root"
+      },
+      {
+        "checksum": "adler32:0330fb1f",
+        "size": 361006,
+        "uri": "root://eospublic.cern.ch//eos/opendata/atlas/rucio/opendata/ODEO_FEB2025_v0_exactly3lep_mc_600686.PhPy8EG_NNPDF3_AZNLO_ggZH125_Htautau_Zinc.exactly3lep.root"
+      },
+      {
+        "checksum": "adler32:238261d3",
+        "size": 4607434,
+        "uri": "root://eospublic.cern.ch//eos/opendata/atlas/rucio/opendata/ODEO_FEB2025_v0_exactly3lep_mc_601352.PhPy8EG_tW_dyn_DR_incl_antitop.exactly3lep.root"
+      },
+      {
+        "checksum": "adler32:bb124a04",
+        "size": 4509907,
+        "uri": "root://eospublic.cern.ch//eos/opendata/atlas/rucio/opendata/ODEO_FEB2025_v0_exactly3lep_mc_601355.PhPy8EG_tW_dyn_DR_incl_top.exactly3lep.root"
+      },
+      {
+        "checksum": "adler32:90e864df",
+        "size": 1391117,
+        "uri": "root://eospublic.cern.ch//eos/opendata/atlas/rucio/opendata/ODEO_FEB2025_v0_exactly3lep_mc_601487.PhPy8EG_A14_tchan_pThard1_lep_antitop.exactly3lep.root"
+      },
+      {
+        "checksum": "adler32:8aea9bfd",
+        "size": 2250053,
+        "uri": "root://eospublic.cern.ch//eos/opendata/atlas/rucio/opendata/ODEO_FEB2025_v0_exactly3lep_mc_601489.PhPy8EG_A14_tchan_pThard1_lep_top.exactly3lep.root"
+      },
+      {
+        "checksum": "adler32:383eb749",
+        "size": 73443117,
+        "uri": "root://eospublic.cern.ch//eos/opendata/atlas/rucio/opendata/ODEO_FEB2025_v0_exactly3lep_mc_601491.PhPy8EG_A14_ttbar_pThard1_dil.exactly3lep.root"
+      },
+      {
+        "checksum": "adler32:95e6b545",
+        "size": 103019,
+        "uri": "root://eospublic.cern.ch//eos/opendata/atlas/rucio/opendata/ODEO_FEB2025_v0_exactly3lep_mc_601495.PhPy8EG_A14_ttbar_pThard1_allhad.exactly3lep.root"
+      },
+      {
+        "checksum": "adler32:a03e6c84",
+        "size": 45298242,
+        "uri": "root://eospublic.cern.ch//eos/opendata/atlas/rucio/opendata/ODEO_FEB2025_v0_exactly3lep_mc_601497.PhPy8EG_A14_ttbar_pThard1_singlelep.exactly3lep.root"
+      },
+      {
+        "checksum": "adler32:ef8552e5",
+        "size": 2790154,
+        "uri": "root://eospublic.cern.ch//eos/opendata/atlas/rucio/opendata/ODEO_FEB2025_v0_exactly3lep_mc_601624.PhPy8EG_tW_DS_dyn_dil_antitop.exactly3lep.root"
+      },
+      {
+        "checksum": "adler32:ef42052c",
+        "size": 4324634,
+        "uri": "root://eospublic.cern.ch//eos/opendata/atlas/rucio/opendata/ODEO_FEB2025_v0_exactly3lep_mc_601627.PhPy8EG_tW_DS_dyn_incl_antitop.exactly3lep.root"
+      },
+      {
+        "checksum": "adler32:4f7d5a8c",
+        "size": 3491577,
+        "uri": "root://eospublic.cern.ch//eos/opendata/atlas/rucio/opendata/ODEO_FEB2025_v0_exactly3lep_mc_601628.PhPy8EG_tW_DS_dyn_dil_top.exactly3lep.root"
+      },
+      {
+        "checksum": "adler32:b8c33895",
+        "size": 4193720,
+        "uri": "root://eospublic.cern.ch//eos/opendata/atlas/rucio/opendata/ODEO_FEB2025_v0_exactly3lep_mc_601631.PhPy8EG_tW_DS_dyn_incl_top.exactly3lep.root"
+      },
+      {
+        "checksum": "adler32:aea59d29",
+        "size": 4529781,
+        "uri": "root://eospublic.cern.ch//eos/opendata/atlas/rucio/opendata/ODEO_FEB2025_v0_exactly3lep_mc_601761.PhPy8EG_tW_dyn_DR_pThard1_incl_top.exactly3lep.root"
+      },
+      {
+        "checksum": "adler32:539fb602",
+        "size": 4573211,
+        "uri": "root://eospublic.cern.ch//eos/opendata/atlas/rucio/opendata/ODEO_FEB2025_v0_exactly3lep_mc_601762.PhPy8EG_tW_dyn_DR_pThard1_incl_antitop.exactly3lep.root"
+      },
+      {
+        "checksum": "adler32:dc2d3d77",
+        "size": 3589950,
+        "uri": "root://eospublic.cern.ch//eos/opendata/atlas/rucio/opendata/ODEO_FEB2025_v0_exactly3lep_mc_601763.PhPy8EG_tW_dyn_DR_pThard1_dil_top.exactly3lep.root"
+      },
+      {
+        "checksum": "adler32:209bfce2",
+        "size": 3621406,
+        "uri": "root://eospublic.cern.ch//eos/opendata/atlas/rucio/opendata/ODEO_FEB2025_v0_exactly3lep_mc_601764.PhPy8EG_tW_dyn_DR_pThard1_dil_antitop.exactly3lep.root"
+      },
+      {
+        "checksum": "adler32:d660fc32",
+        "size": 1547099,
+        "uri": "root://eospublic.cern.ch//eos/opendata/atlas/rucio/opendata/ODEO_FEB2025_v0_exactly3lep_mc_700000.Sh_228_ttW.exactly3lep.root"
+      },
+      {
+        "checksum": "adler32:286482f6",
+        "size": 58679,
+        "uri": "root://eospublic.cern.ch//eos/opendata/atlas/rucio/opendata/ODEO_FEB2025_v0_exactly3lep_mc_700007.Sh_228_yyy_01NLO.exactly3lep.root"
+      },
+      {
+        "checksum": "adler32:3b1513af",
+        "size": 1568690,
+        "uri": "root://eospublic.cern.ch//eos/opendata/atlas/rucio/opendata/ODEO_FEB2025_v0_exactly3lep_mc_700195.Sh_2210_eegammagamma.exactly3lep.root"
+      },
+      {
+        "checksum": "adler32:fb96848a",
+        "size": 2259100,
+        "uri": "root://eospublic.cern.ch//eos/opendata/atlas/rucio/opendata/ODEO_FEB2025_v0_exactly3lep_mc_700196.Sh_2210_mumugammagamma.exactly3lep.root"
+      },
+      {
+        "checksum": "adler32:932ed0fa",
+        "size": 116743,
+        "uri": "root://eospublic.cern.ch//eos/opendata/atlas/rucio/opendata/ODEO_FEB2025_v0_exactly3lep_mc_700197.Sh_2210_tautaugammagamma.exactly3lep.root"
+      },
+      {
+        "checksum": "adler32:e506ddce",
+        "size": 27764,
+        "uri": "root://eospublic.cern.ch//eos/opendata/atlas/rucio/opendata/ODEO_FEB2025_v0_exactly3lep_mc_700198.Sh_2210_nunugammagamma.exactly3lep.root"
+      },
+      {
+        "checksum": "adler32:24097dd4",
+        "size": 153558,
+        "uri": "root://eospublic.cern.ch//eos/opendata/atlas/rucio/opendata/ODEO_FEB2025_v0_exactly3lep_mc_700199.Sh_2210_enugammagamma.exactly3lep.root"
+      },
+      {
+        "checksum": "adler32:1c1a39ff",
+        "size": 153498,
+        "uri": "root://eospublic.cern.ch//eos/opendata/atlas/rucio/opendata/ODEO_FEB2025_v0_exactly3lep_mc_700200.Sh_2210_munugammagamma.exactly3lep.root"
+      },
+      {
+        "checksum": "adler32:56ca7a0a",
+        "size": 68438,
+        "uri": "root://eospublic.cern.ch//eos/opendata/atlas/rucio/opendata/ODEO_FEB2025_v0_exactly3lep_mc_700201.Sh_2210_taunugammagamma.exactly3lep.root"
+      },
+      {
+        "checksum": "adler32:6fa2a325",
+        "size": 71061217,
+        "uri": "root://eospublic.cern.ch//eos/opendata/atlas/rucio/opendata/ODEO_FEB2025_v0_exactly3lep_mc_700320.Sh_2211_Zee_maxHTpTV2_BFilter.exactly3lep.root"
+      },
+      {
+        "checksum": "adler32:2081b96e",
+        "size": 183473539,
+        "uri": "root://eospublic.cern.ch//eos/opendata/atlas/rucio/opendata/ODEO_FEB2025_v0_exactly3lep_mc_700321.Sh_2211_Zee_maxHTpTV2_CFilterBVeto.exactly3lep.root"
+      },
+      {
+        "checksum": "adler32:445b497e",
+        "size": 381774166,
+        "uri": "root://eospublic.cern.ch//eos/opendata/atlas/rucio/opendata/ODEO_FEB2025_v0_exactly3lep_mc_700322.Sh_2211_Zee_maxHTpTV2_CVetoBVeto.exactly3lep.root"
+      },
+      {
+        "checksum": "adler32:3b6e0d9c",
+        "size": 68652571,
+        "uri": "root://eospublic.cern.ch//eos/opendata/atlas/rucio/opendata/ODEO_FEB2025_v0_exactly3lep_mc_700323.Sh_2211_Zmumu_maxHTpTV2_BFilter.exactly3lep.root"
+      },
+      {
+        "checksum": "adler32:03deabf7",
+        "size": 184050961,
+        "uri": "root://eospublic.cern.ch//eos/opendata/atlas/rucio/opendata/ODEO_FEB2025_v0_exactly3lep_mc_700324.Sh_2211_Zmumu_maxHTpTV2_CFilterBVeto.exactly3lep.root"
+      },
+      {
+        "checksum": "adler32:2c4e4137",
+        "size": 386492169,
+        "uri": "root://eospublic.cern.ch//eos/opendata/atlas/rucio/opendata/ODEO_FEB2025_v0_exactly3lep_mc_700325.Sh_2211_Zmumu_maxHTpTV2_CVetoBVeto.exactly3lep.root"
+      },
+      {
+        "checksum": "adler32:b1f63ea3",
+        "size": 687152,
+        "uri": "root://eospublic.cern.ch//eos/opendata/atlas/rucio/opendata/ODEO_FEB2025_v0_exactly3lep_mc_700335.Sh_2211_Znunu_pTV2_BFilter.exactly3lep.root"
+      },
+      {
+        "checksum": "adler32:6771f25f",
+        "size": 1268234,
+        "uri": "root://eospublic.cern.ch//eos/opendata/atlas/rucio/opendata/ODEO_FEB2025_v0_exactly3lep_mc_700336.Sh_2211_Znunu_pTV2_CFilterBVeto.exactly3lep.root"
+      },
+      {
+        "checksum": "adler32:149ddcce",
+        "size": 3400996,
+        "uri": "root://eospublic.cern.ch//eos/opendata/atlas/rucio/opendata/ODEO_FEB2025_v0_exactly3lep_mc_700337.Sh_2211_Znunu_pTV2_CVetoBVeto.exactly3lep.root"
+      },
+      {
+        "checksum": "adler32:d1355092",
+        "size": 29018000,
+        "uri": "root://eospublic.cern.ch//eos/opendata/atlas/rucio/opendata/ODEO_FEB2025_v0_exactly3lep_mc_700338.Sh_2211_Wenu_maxHTpTV2_BFilter.exactly3lep.root"
+      },
+      {
+        "checksum": "adler32:3f72a93e",
+        "size": 103108441,
+        "uri": "root://eospublic.cern.ch//eos/opendata/atlas/rucio/opendata/ODEO_FEB2025_v0_exactly3lep_mc_700339.Sh_2211_Wenu_maxHTpTV2_CFilterBVeto.exactly3lep.root"
+      },
+      {
+        "checksum": "adler32:a67c819d",
+        "size": 63127853,
+        "uri": "root://eospublic.cern.ch//eos/opendata/atlas/rucio/opendata/ODEO_FEB2025_v0_exactly3lep_mc_700340.Sh_2211_Wenu_maxHTpTV2_CVetoBVeto.exactly3lep.root"
+      },
+      {
+        "checksum": "adler32:d2bee54a",
+        "size": 30038155,
+        "uri": "root://eospublic.cern.ch//eos/opendata/atlas/rucio/opendata/ODEO_FEB2025_v0_exactly3lep_mc_700341.Sh_2211_Wmunu_maxHTpTV2_BFilter.exactly3lep.root"
+      },
+      {
+        "checksum": "adler32:347dd3b2",
+        "size": 95751225,
+        "uri": "root://eospublic.cern.ch//eos/opendata/atlas/rucio/opendata/ODEO_FEB2025_v0_exactly3lep_mc_700342.Sh_2211_Wmunu_maxHTpTV2_CFilterBVeto.exactly3lep.root"
+      },
+      {
+        "checksum": "adler32:8ee6d26e",
+        "size": 57598506,
+        "uri": "root://eospublic.cern.ch//eos/opendata/atlas/rucio/opendata/ODEO_FEB2025_v0_exactly3lep_mc_700343.Sh_2211_Wmunu_maxHTpTV2_CVetoBVeto.exactly3lep.root"
+      },
+      {
+        "checksum": "adler32:55e50cdb",
+        "size": 7260468,
+        "uri": "root://eospublic.cern.ch//eos/opendata/atlas/rucio/opendata/ODEO_FEB2025_v0_exactly3lep_mc_700344.Sh_2211_Wtaunu_L_maxHTpTV2_BFilter.exactly3lep.root"
+      },
+      {
+        "checksum": "adler32:815dee19",
+        "size": 17178520,
+        "uri": "root://eospublic.cern.ch//eos/opendata/atlas/rucio/opendata/ODEO_FEB2025_v0_exactly3lep_mc_700345.Sh_2211_Wtaunu_L_maxHTpTV2_CFilterBVeto.exactly3lep.root"
+      },
+      {
+        "checksum": "adler32:6fde1526",
+        "size": 19780908,
+        "uri": "root://eospublic.cern.ch//eos/opendata/atlas/rucio/opendata/ODEO_FEB2025_v0_exactly3lep_mc_700346.Sh_2211_Wtaunu_L_maxHTpTV2_CVetoBVeto.exactly3lep.root"
+      },
+      {
+        "checksum": "adler32:4cf0dc58",
+        "size": 3564752,
+        "uri": "root://eospublic.cern.ch//eos/opendata/atlas/rucio/opendata/ODEO_FEB2025_v0_exactly3lep_mc_700347.Sh_2211_Wtaunu_H_maxHTpTV2_BFilter.exactly3lep.root"
+      },
+      {
+        "checksum": "adler32:b7aefa7a",
+        "size": 2286782,
+        "uri": "root://eospublic.cern.ch//eos/opendata/atlas/rucio/opendata/ODEO_FEB2025_v0_exactly3lep_mc_700348.Sh_2211_Wtaunu_H_maxHTpTV2_CFilterBVeto.exactly3lep.root"
+      },
+      {
+        "checksum": "adler32:2d17e2d5",
+        "size": 8887864,
+        "uri": "root://eospublic.cern.ch//eos/opendata/atlas/rucio/opendata/ODEO_FEB2025_v0_exactly3lep_mc_700349.Sh_2211_Wtaunu_H_maxHTpTV2_CVetoBVeto.exactly3lep.root"
+      },
+      {
+        "checksum": "adler32:a7aeaeba",
+        "size": 193369,
+        "uri": "root://eospublic.cern.ch//eos/opendata/atlas/rucio/opendata/ODEO_FEB2025_v0_exactly3lep_mc_700352.Sh_2211_pTZ100_Zqqgamma.exactly3lep.root"
+      },
+      {
+        "checksum": "adler32:7d8dbecd",
+        "size": 169538,
+        "uri": "root://eospublic.cern.ch//eos/opendata/atlas/rucio/opendata/ODEO_FEB2025_v0_exactly3lep_mc_700353.Sh_2211_pTZ100_Zbbgamma.exactly3lep.root"
+      },
+      {
+        "checksum": "adler32:70d14206",
+        "size": 1028238,
+        "uri": "root://eospublic.cern.ch//eos/opendata/atlas/rucio/opendata/ODEO_FEB2025_v0_exactly3lep_mc_700358.Sh_2211_Zee2jets_Min_N_TChannel.exactly3lep.root"
+      },
+      {
+        "checksum": "adler32:420dcbf9",
+        "size": 871947,
+        "uri": "root://eospublic.cern.ch//eos/opendata/atlas/rucio/opendata/ODEO_FEB2025_v0_exactly3lep_mc_700359.Sh_2211_Zmm2jets_Min_N_TChannel.exactly3lep.root"
+      },
+      {
+        "checksum": "adler32:fb381593",
+        "size": 107869,
+        "uri": "root://eospublic.cern.ch//eos/opendata/atlas/rucio/opendata/ODEO_FEB2025_v0_exactly3lep_mc_700360.Sh_2211_Ztt2jets_Min_N_TChannel.exactly3lep.root"
+      },
+      {
+        "checksum": "adler32:b2b3c531",
+        "size": 58939,
+        "uri": "root://eospublic.cern.ch//eos/opendata/atlas/rucio/opendata/ODEO_FEB2025_v0_exactly3lep_mc_700361.Sh_2211_Znunu2jets_Min_N_TChannel.exactly3lep.root"
+      },
+      {
+        "checksum": "adler32:e5aa8b21",
+        "size": 399705,
+        "uri": "root://eospublic.cern.ch//eos/opendata/atlas/rucio/opendata/ODEO_FEB2025_v0_exactly3lep_mc_700362.Sh_2211_Wenu2jets_Min_N_TChannel.exactly3lep.root"
+      },
+      {
+        "checksum": "adler32:767b53f3",
+        "size": 472955,
+        "uri": "root://eospublic.cern.ch//eos/opendata/atlas/rucio/opendata/ODEO_FEB2025_v0_exactly3lep_mc_700363.Sh_2211_Wmunu2jets_Min_N_TChannel.exactly3lep.root"
+      },
+      {
+        "checksum": "adler32:54192380",
+        "size": 198847,
+        "uri": "root://eospublic.cern.ch//eos/opendata/atlas/rucio/opendata/ODEO_FEB2025_v0_exactly3lep_mc_700364.Sh_2211_Wtaunu2jets_Min_N_TChannel.exactly3lep.root"
+      },
+      {
+        "checksum": "adler32:ca1af905",
+        "size": 72431206,
+        "uri": "root://eospublic.cern.ch//eos/opendata/atlas/rucio/opendata/ODEO_FEB2025_v0_exactly3lep_mc_700398.Sh_2211_mumugamma.exactly3lep.root"
+      },
+      {
+        "checksum": "adler32:b5f58958",
+        "size": 74827714,
+        "uri": "root://eospublic.cern.ch//eos/opendata/atlas/rucio/opendata/ODEO_FEB2025_v0_exactly3lep_mc_700399.Sh_2211_eegamma.exactly3lep.root"
+      },
+      {
+        "checksum": "adler32:f48f8fd4",
+        "size": 7273380,
+        "uri": "root://eospublic.cern.ch//eos/opendata/atlas/rucio/opendata/ODEO_FEB2025_v0_exactly3lep_mc_700400.Sh_2211_tautaugamma.exactly3lep.root"
+      },
+      {
+        "checksum": "adler32:bf8de988",
+        "size": 893950,
+        "uri": "root://eospublic.cern.ch//eos/opendata/atlas/rucio/opendata/ODEO_FEB2025_v0_exactly3lep_mc_700401.Sh_2211_nunugamma.exactly3lep.root"
+      },
+      {
+        "checksum": "adler32:0720d424",
+        "size": 26232259,
+        "uri": "root://eospublic.cern.ch//eos/opendata/atlas/rucio/opendata/ODEO_FEB2025_v0_exactly3lep_mc_700402.Sh_2211_munugamma.exactly3lep.root"
+      },
+      {
+        "checksum": "adler32:0d44bd44",
+        "size": 28140394,
+        "uri": "root://eospublic.cern.ch//eos/opendata/atlas/rucio/opendata/ODEO_FEB2025_v0_exactly3lep_mc_700403.Sh_2211_enugamma.exactly3lep.root"
+      },
+      {
+        "checksum": "adler32:c3a0beb6",
+        "size": 11174284,
+        "uri": "root://eospublic.cern.ch//eos/opendata/atlas/rucio/opendata/ODEO_FEB2025_v0_exactly3lep_mc_700404.Sh_2211_taunugamma.exactly3lep.root"
+      },
+      {
+        "checksum": "adler32:e9ce2186",
+        "size": 51691,
+        "uri": "root://eospublic.cern.ch//eos/opendata/atlas/rucio/opendata/ODEO_FEB2025_v0_exactly3lep_mc_700442.Sh_2211_gamma2jets_pTy140_Min_N_TChannel.exactly3lep.root"
+      },
+      {
+        "checksum": "adler32:6e62a1bb",
+        "size": 5296210,
+        "uri": "root://eospublic.cern.ch//eos/opendata/atlas/rucio/opendata/ODEO_FEB2025_v0_exactly3lep_mc_700467.Sh_2211_Zee_maxHTpTV2_m10_40_pT5_BFilter.exactly3lep.root"
+      },
+      {
+        "checksum": "adler32:46fa9f68",
+        "size": 15397090,
+        "uri": "root://eospublic.cern.ch//eos/opendata/atlas/rucio/opendata/ODEO_FEB2025_v0_exactly3lep_mc_700468.Sh_2211_Zee_maxHTpTV2_m10_40_pT5_CFilterBVeto.exactly3lep.root"
+      },
+      {
+        "checksum": "adler32:f5b99669",
+        "size": 56347533,
+        "uri": "root://eospublic.cern.ch//eos/opendata/atlas/rucio/opendata/ODEO_FEB2025_v0_exactly3lep_mc_700469.Sh_2211_Zee_maxHTpTV2_m10_40_pT5_CVetoBVeto.exactly3lep.root"
+      },
+      {
+        "checksum": "adler32:5e3d21d6",
+        "size": 5666073,
+        "uri": "root://eospublic.cern.ch//eos/opendata/atlas/rucio/opendata/ODEO_FEB2025_v0_exactly3lep_mc_700470.Sh_2211_Zmumu_maxHTpTV2_m10_40_pT5_BFilter.exactly3lep.root"
+      },
+      {
+        "checksum": "adler32:f27f7df1",
+        "size": 14901227,
+        "uri": "root://eospublic.cern.ch//eos/opendata/atlas/rucio/opendata/ODEO_FEB2025_v0_exactly3lep_mc_700471.Sh_2211_Zmumu_maxHTpTV2_m10_40_pT5_CFilterBVeto.exactly3lep.root"
+      },
+      {
+        "checksum": "adler32:238b6c2a",
+        "size": 54952611,
+        "uri": "root://eospublic.cern.ch//eos/opendata/atlas/rucio/opendata/ODEO_FEB2025_v0_exactly3lep_mc_700472.Sh_2211_Zmumu_maxHTpTV2_m10_40_pT5_CVetoBVeto.exactly3lep.root"
+      },
+      {
+        "checksum": "adler32:86a8f10f",
+        "size": 1903815,
+        "uri": "root://eospublic.cern.ch//eos/opendata/atlas/rucio/opendata/ODEO_FEB2025_v0_exactly3lep_mc_700488.Sh_2211_WlvWqq.exactly3lep.root"
+      },
+      {
+        "checksum": "adler32:960e4555",
+        "size": 468425,
+        "uri": "root://eospublic.cern.ch//eos/opendata/atlas/rucio/opendata/ODEO_FEB2025_v0_exactly3lep_mc_700489.Sh_2211_WlvZqq.exactly3lep.root"
+      },
+      {
+        "checksum": "adler32:ba81e7d1",
+        "size": 297689,
+        "uri": "root://eospublic.cern.ch//eos/opendata/atlas/rucio/opendata/ODEO_FEB2025_v0_exactly3lep_mc_700490.Sh_2211_WlvZbb.exactly3lep.root"
+      },
+      {
+        "checksum": "adler32:67b09669",
+        "size": 133483,
+        "uri": "root://eospublic.cern.ch//eos/opendata/atlas/rucio/opendata/ODEO_FEB2025_v0_exactly3lep_mc_700491.Sh_2211_WqqZvv.exactly3lep.root"
+      },
+      {
+        "checksum": "adler32:a570c5ed",
+        "size": 1495213,
+        "uri": "root://eospublic.cern.ch//eos/opendata/atlas/rucio/opendata/ODEO_FEB2025_v0_exactly3lep_mc_700492.Sh_2211_WqqZll.exactly3lep.root"
+      },
+      {
+        "checksum": "adler32:769feec5",
+        "size": 1052743,
+        "uri": "root://eospublic.cern.ch//eos/opendata/atlas/rucio/opendata/ODEO_FEB2025_v0_exactly3lep_mc_700493.Sh_2211_ZqqZll.exactly3lep.root"
+      },
+      {
+        "checksum": "adler32:27153476",
+        "size": 2131612,
+        "uri": "root://eospublic.cern.ch//eos/opendata/atlas/rucio/opendata/ODEO_FEB2025_v0_exactly3lep_mc_700494.Sh_2211_ZbbZll.exactly3lep.root"
+      },
+      {
+        "checksum": "adler32:3edaf6bf",
+        "size": 77965,
+        "uri": "root://eospublic.cern.ch//eos/opendata/atlas/rucio/opendata/ODEO_FEB2025_v0_exactly3lep_mc_700495.Sh_2211_ZqqZvv.exactly3lep.root"
+      },
+      {
+        "checksum": "adler32:d2ea52f5",
+        "size": 46463,
+        "uri": "root://eospublic.cern.ch//eos/opendata/atlas/rucio/opendata/ODEO_FEB2025_v0_exactly3lep_mc_700496.Sh_2211_ZbbZvv.exactly3lep.root"
+      },
+      {
+        "checksum": "adler32:1c7b6e34",
+        "size": 95365,
+        "uri": "root://eospublic.cern.ch//eos/opendata/atlas/rucio/opendata/ODEO_FEB2025_v0_exactly3lep_mc_700507.Sh_2211_pTW140_Wqqgamma.exactly3lep.root"
+      },
+      {
+        "checksum": "adler32:d5afb746",
+        "size": 5714556,
+        "uri": "root://eospublic.cern.ch//eos/opendata/atlas/rucio/opendata/ODEO_FEB2025_v0_exactly3lep_mc_700587.Sh_2212_lllljj.exactly3lep.root"
+      },
+      {
+        "checksum": "adler32:19a0d3bf",
+        "size": 2881594,
+        "uri": "root://eospublic.cern.ch//eos/opendata/atlas/rucio/opendata/ODEO_FEB2025_v0_exactly3lep_mc_700588.Sh_2212_lllvjj.exactly3lep.root"
+      },
+      {
+        "checksum": "adler32:942951b2",
+        "size": 188024,
+        "uri": "root://eospublic.cern.ch//eos/opendata/atlas/rucio/opendata/ODEO_FEB2025_v0_exactly3lep_mc_700589.Sh_2212_llvvjj_os.exactly3lep.root"
+      },
+      {
+        "checksum": "adler32:3eacb0da",
+        "size": 431308,
+        "uri": "root://eospublic.cern.ch//eos/opendata/atlas/rucio/opendata/ODEO_FEB2025_v0_exactly3lep_mc_700590.Sh_2212_llvvjj_ss.exactly3lep.root"
+      },
+      {
+        "checksum": "adler32:02f73d75",
+        "size": 569635,
+        "uri": "root://eospublic.cern.ch//eos/opendata/atlas/rucio/opendata/ODEO_FEB2025_v0_exactly3lep_mc_700591.Sh_2212_lllljj_Int.exactly3lep.root"
+      },
+      {
+        "checksum": "adler32:de8f6226",
+        "size": 1017762,
+        "uri": "root://eospublic.cern.ch//eos/opendata/atlas/rucio/opendata/ODEO_FEB2025_v0_exactly3lep_mc_700592.Sh_2212_lllvjj_Int.exactly3lep.root"
+      },
+      {
+        "checksum": "adler32:70ddbe89",
+        "size": 119169,
+        "uri": "root://eospublic.cern.ch//eos/opendata/atlas/rucio/opendata/ODEO_FEB2025_v0_exactly3lep_mc_700593.Sh_2212_llvvjj_os_Int.exactly3lep.root"
+      },
+      {
+        "checksum": "adler32:f9aedc61",
+        "size": 136679,
+        "uri": "root://eospublic.cern.ch//eos/opendata/atlas/rucio/opendata/ODEO_FEB2025_v0_exactly3lep_mc_700594.Sh_2212_llvvjj_ss_Int.exactly3lep.root"
+      },
+      {
+        "checksum": "adler32:3b0a14ea",
+        "size": 13146802,
+        "uri": "root://eospublic.cern.ch//eos/opendata/atlas/rucio/opendata/ODEO_FEB2025_v0_exactly3lep_mc_700600.Sh_2212_llll.exactly3lep.root"
+      },
+      {
+        "checksum": "adler32:9e21ad02",
+        "size": 25514584,
+        "uri": "root://eospublic.cern.ch//eos/opendata/atlas/rucio/opendata/ODEO_FEB2025_v0_exactly3lep_mc_700601.Sh_2212_lllv.exactly3lep.root"
+      },
+      {
+        "checksum": "adler32:30c15335",
+        "size": 2299535,
+        "uri": "root://eospublic.cern.ch//eos/opendata/atlas/rucio/opendata/ODEO_FEB2025_v0_exactly3lep_mc_700602.Sh_2212_llvv_os.exactly3lep.root"
+      },
+      {
+        "checksum": "adler32:555d864b",
+        "size": 663938,
+        "uri": "root://eospublic.cern.ch//eos/opendata/atlas/rucio/opendata/ODEO_FEB2025_v0_exactly3lep_mc_700603.Sh_2212_llvv_ss.exactly3lep.root"
+      },
+      {
+        "checksum": "adler32:acf7b7dd",
+        "size": 152096,
+        "uri": "root://eospublic.cern.ch//eos/opendata/atlas/rucio/opendata/ODEO_FEB2025_v0_exactly3lep_mc_700604.Sh_2212_lvvv.exactly3lep.root"
+      },
+      {
+        "checksum": "adler32:e13d8dd3",
+        "size": 41249,
+        "uri": "root://eospublic.cern.ch//eos/opendata/atlas/rucio/opendata/ODEO_FEB2025_v0_exactly3lep_mc_700605.Sh_2212_vvvv.exactly3lep.root"
+      },
+      {
+        "checksum": "adler32:fd0b767f",
+        "size": 163871,
+        "uri": "root://eospublic.cern.ch//eos/opendata/atlas/rucio/opendata/ODEO_FEB2025_v0_exactly3lep_mc_700709.Sh_2212_lvgammajj.exactly3lep.root"
+      },
+      {
+        "checksum": "adler32:2961b0fe",
+        "size": 2038497,
+        "uri": "root://eospublic.cern.ch//eos/opendata/atlas/rucio/opendata/ODEO_FEB2025_v0_exactly3lep_mc_700710.Sh_2212_llgammajj.exactly3lep.root"
+      },
+      {
+        "checksum": "adler32:23823d42",
+        "size": 7434753,
+        "uri": "root://eospublic.cern.ch//eos/opendata/atlas/rucio/opendata/ODEO_FEB2025_v0_exactly3lep_mc_700792.Sh_2214_Ztautau_maxHTpTV2_BFilter.exactly3lep.root"
+      },
+      {
+        "checksum": "adler32:22125707",
+        "size": 21556677,
+        "uri": "root://eospublic.cern.ch//eos/opendata/atlas/rucio/opendata/ODEO_FEB2025_v0_exactly3lep_mc_700793.Sh_2214_Ztautau_maxHTpTV2_CFilterBVeto.exactly3lep.root"
+      },
+      {
+        "checksum": "adler32:f72f33fc",
+        "size": 29018302,
+        "uri": "root://eospublic.cern.ch//eos/opendata/atlas/rucio/opendata/ODEO_FEB2025_v0_exactly3lep_mc_700794.Sh_2214_Ztautau_maxHTpTV2_CVetoBVeto.exactly3lep.root"
+      },
+      {
+        "checksum": "adler32:d91b60b1",
+        "size": 5143266,
+        "uri": "root://eospublic.cern.ch//eos/opendata/atlas/rucio/opendata/ODEO_FEB2025_v0_exactly3lep_mc_700843.Sh_2214_Wqq_ptW_200_ECMS.exactly3lep.root"
+      },
+      {
+        "checksum": "adler32:8c141cfa",
+        "size": 1853745,
+        "uri": "root://eospublic.cern.ch//eos/opendata/atlas/rucio/opendata/ODEO_FEB2025_v0_exactly3lep_mc_700849.Sh_2214_Zqq_ptZ_200_ECMS.exactly3lep.root"
+      },
+      {
+        "checksum": "adler32:811f0233",
+        "size": 998264,
+        "uri": "root://eospublic.cern.ch//eos/opendata/atlas/rucio/opendata/ODEO_FEB2025_v0_exactly3lep_mc_700855.Sh_2214_Zbb_ptZ_200_ECMS.exactly3lep.root"
+      },
+      {
+        "checksum": "adler32:495569db",
+        "size": 999016,
+        "uri": "root://eospublic.cern.ch//eos/opendata/atlas/rucio/opendata/ODEO_FEB2025_v0_exactly3lep_mc_700901.Sh_2214_Ztt_maxHTpTV2_Mll10_40_BFilter.exactly3lep.root"
+      },
+      {
+        "checksum": "adler32:cbe9712d",
+        "size": 4208014,
+        "uri": "root://eospublic.cern.ch//eos/opendata/atlas/rucio/opendata/ODEO_FEB2025_v0_exactly3lep_mc_700902.Sh_2214_Ztt_maxHTpTV2_Mll10_40_CFilterBVeto.exactly3lep.root"
+      },
+      {
+        "checksum": "adler32:e5d1cba5",
+        "size": 7240252,
+        "uri": "root://eospublic.cern.ch//eos/opendata/atlas/rucio/opendata/ODEO_FEB2025_v0_exactly3lep_mc_700903.Sh_2214_Ztt_maxHTpTV2_Mll10_40_CVetoBVeto.exactly3lep.root"
+      },
+      {
+        "checksum": "adler32:b16db4e3",
+        "size": 103924,
+        "uri": "root://eospublic.cern.ch//eos/opendata/atlas/rucio/opendata/ODEO_FEB2025_v0_exactly3lep_mc_801976.Py8EG_A14NNPDF23LO_Zprime_NoInt_tautau_SSM3000.exactly3lep.root"
+      },
+      {
+        "checksum": "adler32:33287e2b",
+        "size": 29690,
+        "uri": "root://eospublic.cern.ch//eos/opendata/atlas/rucio/opendata/ODEO_FEB2025_v0_exactly3lep_mc_801978.Py8EG_A14NNPDF23LO_Wprime_taunu_SSM3000.exactly3lep.root"
+      }
+    ],
+    "license": {
+      "attribution": "CC0-1.0"
+    },
+    "methodology": {
+      "description": "<p>These data were created during LS2 as part of a major reprocessing campaign of the Run 2 data. All data were reprocessed using Athena Release 22, and new corresponding MC simulation samples were produced. These data and MC simulation datasets were processed into ROOT ntuple files from the DAOD_PHYSLITE format that is released as open data for research. For the files in this record, the following skimming selection was applied: Exactly three leptons with at least 7 GeV of p<sub>T</sub> (i.e. a leptonically-decaying W+Z boson enhanced selection)"
+    },
+    "publisher": "CERN Open Data Portal",
+    "recid": "93914",
+    "relations": [
+      {
+        "description": "For citing all the Open Data for Education and Outreach from this release, and to find other related datasets, please see",
+        "doi": "10.7483/OPENDATA.ATLAS.B5M9.44TN",
+        "recid": "93910",
+        "title": "ROOT ntuple format 2015-2016 proton-proton Open Data for Education and Outreach from the ATLAS experiment",
+        "type": "isChildOf"
+      }
+    ],
+    "run_period": [
+      "2015",
+      "2016"
+    ],
+    "title": "ATLAS ROOT ntuple format MC simulation, 2015+2016 proton-proton collisions beta release, exactly3lep skim",
+    "type": {
+      "primary": "Dataset",
+      "secondary": [
+        "Simulated"
+      ]
+    },
+    "usage": {
+      "description": "<p> The data and MC simulation provided by the ATLAS experiment in root ntuple format is released under a CC0 license; citation of the data and acknowledgement of the collaboration is requested. This format can be used directly using ROOT or uproot for simple studies and is primarily intended for educational and outreach purposes. <p>Extensive instructions for interacting with the data, as well as documentation of the dataset naming conventions and their contents, are provided on the ATLAS Open Data website linked below. For those interested in implementing a research-quality data analysis, the open data designed for research (also linked below) may be a better starting point. Please be sure to cite the Open Data that you use, in line with the policy below.",
+      "links": [
+        {
+          "description": "ATLAS Open Data Website",
+          "url": "http://opendata.atlas.cern"
+        },
+        {
+          "description": "Resources to understand and use the open data for education and outreach",
+          "url": "https://opendata.atlas.cern/docs/category/13-tev-tutorials-for-education"
+        },
+        {
+          "description": "More about this ntuple format",
+          "url": "https://opendata.atlas.cern/docs/data/for_education/13TeV25_details"
+        },
+        {
+          "description": "Ntuple making framework",
+          "url": "http://gitlab.cern.ch/atlas-outreach-data-tools/physlitetoopendata"
+        },
+        {
+          "description": "Citation policy",
+          "url": "https://opendata.atlas.cern/docs/documentation/ethical_legal/citation_policy"
+        }
+      ]
+    }
+  }
+]

--- a/data/records/atlas-odeo-FEB2025-exactly3lep-mc.json
+++ b/data/records/atlas-odeo-FEB2025-exactly3lep-mc.json
@@ -1939,15 +1939,15 @@
         },
         {
           "description": "Resources to understand and use the open data for education and outreach",
-          "url": "https://opendata.atlas.cern/docs/category/13-tev-tutorials-for-education"
+          "url": "https://opendata.atlas.cern/docs/category/13-tev-2025-beta-release"
         },
         {
           "description": "More about this ntuple format",
-          "url": "https://opendata.atlas.cern/docs/data/for_education/13TeV25_details"
+          "url": "https://opendata.atlas.cern/docs/data/for_education/13TeV25_details#variable-list"
         },
         {
-          "description": "Ntuple making framework",
-          "url": "http://gitlab.cern.ch/atlas-outreach-data-tools/physlitetoopendata"
+          "description": "Ntuple making framework (PhysLiteToOpenData)",
+          "url": "https://doi.org/10.5281/zenodo.15791091"
         },
         {
           "description": "Citation policy",

--- a/data/records/atlas-odeo-FEB2025-exactly4lep-data.json
+++ b/data/records/atlas-odeo-FEB2025-exactly4lep-data.json
@@ -1,0 +1,174 @@
+[
+  {
+    "abstract": {
+      "description": "Run 2 2015+2016 proton-proton collision data beta release, exactly4lep skim from the ATLAS experiment"
+    },
+    "accelerator": "CERN-LHC",
+    "categories": {
+      "source": "ATLAS Collaboration"
+    },
+    "collaboration": {
+      "name": "ATLAS collaboration"
+    },
+    "collections": [
+      "ATLAS-Primary-Datasets"
+    ],
+    "collision_information": {
+      "energy": "13TeV",
+      "type": "pp"
+    },
+    "date_created": [
+      "2015",
+      "2016"
+    ],
+    "date_published": "2025",
+    "date_reprocessed": "2020",
+    "distribution": {
+      "formats": [
+        "root"
+      ],
+      "number_events": 1362611,
+      "number_files": 16,
+      "size": 581985898
+    },
+    "doi": "10.7483/OPENDATA.ATLAS.3ATL.Q9Z2",
+    "experiment": [
+      "ATLAS"
+    ],
+    "files": [
+      {
+        "checksum": "adler32:35ffb644",
+        "size": 2219662,
+        "uri": "root://eospublic.cern.ch//eos/opendata/atlas/rucio/opendata/ODEO_FEB2025_v0_exactly4lep_data15_periodD.exactly4lep.root"
+      },
+      {
+        "checksum": "adler32:11aff768",
+        "size": 12275933,
+        "uri": "root://eospublic.cern.ch//eos/opendata/atlas/rucio/opendata/ODEO_FEB2025_v0_exactly4lep_data15_periodE.exactly4lep.root"
+      },
+      {
+        "checksum": "adler32:73d2fb5c",
+        "size": 8484460,
+        "uri": "root://eospublic.cern.ch//eos/opendata/atlas/rucio/opendata/ODEO_FEB2025_v0_exactly4lep_data15_periodF.exactly4lep.root"
+      },
+      {
+        "checksum": "adler32:5d44fbe9",
+        "size": 17643965,
+        "uri": "root://eospublic.cern.ch//eos/opendata/atlas/rucio/opendata/ODEO_FEB2025_v0_exactly4lep_data15_periodG.exactly4lep.root"
+      },
+      {
+        "checksum": "adler32:db4aab41",
+        "size": 5414463,
+        "uri": "root://eospublic.cern.ch//eos/opendata/atlas/rucio/opendata/ODEO_FEB2025_v0_exactly4lep_data15_periodH.exactly4lep.root"
+      },
+      {
+        "checksum": "adler32:c41e0bbb",
+        "size": 32441129,
+        "uri": "root://eospublic.cern.ch//eos/opendata/atlas/rucio/opendata/ODEO_FEB2025_v0_exactly4lep_data15_periodJ.exactly4lep.root"
+      },
+      {
+        "checksum": "adler32:97e978aa",
+        "size": 15023271,
+        "uri": "root://eospublic.cern.ch//eos/opendata/atlas/rucio/opendata/ODEO_FEB2025_v0_exactly4lep_data16_periodA.exactly4lep.root"
+      },
+      {
+        "checksum": "adler32:6f875e38",
+        "size": 29991093,
+        "uri": "root://eospublic.cern.ch//eos/opendata/atlas/rucio/opendata/ODEO_FEB2025_v0_exactly4lep_data16_periodB.exactly4lep.root"
+      },
+      {
+        "checksum": "adler32:7668a69a",
+        "size": 38856748,
+        "uri": "root://eospublic.cern.ch//eos/opendata/atlas/rucio/opendata/ODEO_FEB2025_v0_exactly4lep_data16_periodC.exactly4lep.root"
+      },
+      {
+        "checksum": "adler32:d2c053e3",
+        "size": 74725823,
+        "uri": "root://eospublic.cern.ch//eos/opendata/atlas/rucio/opendata/ODEO_FEB2025_v0_exactly4lep_data16_periodD.exactly4lep.root"
+      },
+      {
+        "checksum": "adler32:aaa7f39a",
+        "size": 23061480,
+        "uri": "root://eospublic.cern.ch//eos/opendata/atlas/rucio/opendata/ODEO_FEB2025_v0_exactly4lep_data16_periodE.exactly4lep.root"
+      },
+      {
+        "checksum": "adler32:454d66ec",
+        "size": 50022281,
+        "uri": "root://eospublic.cern.ch//eos/opendata/atlas/rucio/opendata/ODEO_FEB2025_v0_exactly4lep_data16_periodF.exactly4lep.root"
+      },
+      {
+        "checksum": "adler32:1c237c0f",
+        "size": 55416187,
+        "uri": "root://eospublic.cern.ch//eos/opendata/atlas/rucio/opendata/ODEO_FEB2025_v0_exactly4lep_data16_periodG.exactly4lep.root"
+      },
+      {
+        "checksum": "adler32:6350ad14",
+        "size": 84692319,
+        "uri": "root://eospublic.cern.ch//eos/opendata/atlas/rucio/opendata/ODEO_FEB2025_v0_exactly4lep_data16_periodI.exactly4lep.root"
+      },
+      {
+        "checksum": "adler32:91eb8edb",
+        "size": 34518175,
+        "uri": "root://eospublic.cern.ch//eos/opendata/atlas/rucio/opendata/ODEO_FEB2025_v0_exactly4lep_data16_periodK.exactly4lep.root"
+      },
+      {
+        "checksum": "adler32:e8bb20ab",
+        "size": 97198909,
+        "uri": "root://eospublic.cern.ch//eos/opendata/atlas/rucio/opendata/ODEO_FEB2025_v0_exactly4lep_data16_periodL.exactly4lep.root"
+      }
+    ],
+    "license": {
+      "attribution": "CC0-1.0"
+    },
+    "methodology": {
+      "description": "<p>These data were created during LS2 as part of a major reprocessing campaign of the Run 2 data. All data were reprocessed using Athena Release 22, and new corresponding MC simulation samples were produced. These data and MC simulation datasets were processed into ROOT ntuple files from the DAOD_PHYSLITE format that is released as open data for research. For the files in this record, the following skimming selection was applied: Exactly four leptons with at least 7 GeV of p<sub>T</sub> (i.e. a leptonically-decaying ZZ boson or Higgs to four leptons enhanced selection)"
+    },
+    "publisher": "CERN Open Data Portal",
+    "recid": "93924",
+    "relations": [
+      {
+        "description": "For citing all the Open Data for Education and Outreach from this release, and to find other related datasets, please see",
+        "doi": "10.7483/OPENDATA.ATLAS.B5M9.44TN",
+        "recid": "93910",
+        "title": "ROOT ntuple format 2015-2016 proton-proton Open Data for Education and Outreach from the ATLAS experiment",
+        "type": "isChildOf"
+      }
+    ],
+    "run_period": [
+      "2015",
+      "2016"
+    ],
+    "title": "ATLAS ROOT ntuple format Run 2 2015+2016 proton-proton collision data beta release, exactly4lep skim",
+    "type": {
+      "primary": "Dataset",
+      "secondary": [
+        "Collision"
+      ]
+    },
+    "usage": {
+      "description": "<p> The data and MC simulation provided by the ATLAS experiment in root ntuple format is released under a CC0 license; citation of the data and acknowledgement of the collaboration is requested. This format can be used directly using ROOT or uproot for simple studies and is primarily intended for educational and outreach purposes. <p>Extensive instructions for interacting with the data, as well as documentation of the dataset naming conventions and their contents, are provided on the ATLAS Open Data website linked below. For those interested in implementing a research-quality data analysis, the open data designed for research (also linked below) may be a better starting point. Please be sure to cite the Open Data that you use, in line with the policy below.",
+      "links": [
+        {
+          "description": "ATLAS Open Data Website",
+          "url": "http://opendata.atlas.cern"
+        },
+        {
+          "description": "Resources to understand and use the open data for education and outreach",
+          "url": "https://opendata.atlas.cern/docs/category/13-tev-tutorials-for-education"
+        },
+        {
+          "description": "More about this ntuple format",
+          "url": "https://opendata.atlas.cern/docs/data/for_education/13TeV25_details"
+        },
+        {
+          "description": "Ntuple making framework",
+          "url": "http://gitlab.cern.ch/atlas-outreach-data-tools/physlitetoopendata"
+        },
+        {
+          "description": "Citation policy",
+          "url": "https://opendata.atlas.cern/docs/documentation/ethical_legal/citation_policy"
+        }
+      ]
+    }
+  }
+]

--- a/data/records/atlas-odeo-FEB2025-exactly4lep-data.json
+++ b/data/records/atlas-odeo-FEB2025-exactly4lep-data.json
@@ -154,15 +154,15 @@
         },
         {
           "description": "Resources to understand and use the open data for education and outreach",
-          "url": "https://opendata.atlas.cern/docs/category/13-tev-tutorials-for-education"
+          "url": "https://opendata.atlas.cern/docs/category/13-tev-2025-beta-release"
         },
         {
           "description": "More about this ntuple format",
-          "url": "https://opendata.atlas.cern/docs/data/for_education/13TeV25_details"
+          "url": "https://opendata.atlas.cern/docs/data/for_education/13TeV25_details#variable-list"
         },
         {
-          "description": "Ntuple making framework",
-          "url": "http://gitlab.cern.ch/atlas-outreach-data-tools/physlitetoopendata"
+          "description": "Ntuple making framework (PhysLiteToOpenData)",
+          "url": "https://doi.org/10.5281/zenodo.15791091"
         },
         {
           "description": "Citation policy",

--- a/data/records/atlas-odeo-FEB2025-exactly4lep-mc.json
+++ b/data/records/atlas-odeo-FEB2025-exactly4lep-mc.json
@@ -1939,15 +1939,15 @@
         },
         {
           "description": "Resources to understand and use the open data for education and outreach",
-          "url": "https://opendata.atlas.cern/docs/category/13-tev-tutorials-for-education"
+          "url": "https://opendata.atlas.cern/docs/category/13-tev-2025-beta-release"
         },
         {
           "description": "More about this ntuple format",
-          "url": "https://opendata.atlas.cern/docs/data/for_education/13TeV25_details"
+          "url": "https://opendata.atlas.cern/docs/data/for_education/13TeV25_details#variable-list"
         },
         {
-          "description": "Ntuple making framework",
-          "url": "http://gitlab.cern.ch/atlas-outreach-data-tools/physlitetoopendata"
+          "description": "Ntuple making framework (PhysLiteToOpenData)",
+          "url": "https://doi.org/10.5281/zenodo.15791091"
         },
         {
           "description": "Citation policy",

--- a/data/records/atlas-odeo-FEB2025-exactly4lep-mc.json
+++ b/data/records/atlas-odeo-FEB2025-exactly4lep-mc.json
@@ -1,0 +1,1959 @@
+[
+  {
+    "abstract": {
+      "description": "MC simulation, 2015+2016 proton-proton collisions beta release, exactly4lep skim from the ATLAS experiment"
+    },
+    "accelerator": "CERN-LHC",
+    "categories": {
+      "source": "ATLAS Collaboration"
+    },
+    "collaboration": {
+      "name": "ATLAS collaboration"
+    },
+    "collections": [
+      "ATLAS-Primary-Datasets"
+    ],
+    "collision_information": {
+      "energy": "13TeV",
+      "type": "pp"
+    },
+    "date_created": [
+      "2015",
+      "2016"
+    ],
+    "date_published": "2025",
+    "date_reprocessed": "2020",
+    "distribution": {
+      "formats": [
+        "root"
+      ],
+      "number_events": 1404912,
+      "number_files": 373,
+      "size": 894129031
+    },
+    "doi": "10.7483/OPENDATA.ATLAS.XNPI.CX93",
+    "experiment": [
+      "ATLAS"
+    ],
+    "files": [
+      {
+        "checksum": "adler32:b066b542",
+        "size": 38946,
+        "uri": "root://eospublic.cern.ch//eos/opendata/atlas/rucio/opendata/ODEO_FEB2025_v0_exactly4lep_mc_301204.Pythia8EvtGen_A14MSTW2008LO_Zprime_NoInt_ee_SSM3000.exactly4lep.root"
+      },
+      {
+        "checksum": "adler32:9560e69a",
+        "size": 43732,
+        "uri": "root://eospublic.cern.ch//eos/opendata/atlas/rucio/opendata/ODEO_FEB2025_v0_exactly4lep_mc_301209.Pythia8EvtGen_A14MSTW2008LO_Zprime_NoInt_mumu_SSM3000.exactly4lep.root"
+      },
+      {
+        "checksum": "adler32:5c409448",
+        "size": 26178,
+        "uri": "root://eospublic.cern.ch//eos/opendata/atlas/rucio/opendata/ODEO_FEB2025_v0_exactly4lep_mc_301243.Pythia8EvtGen_A14NNPDF23LO_Wprime_enu_SSM3000.exactly4lep.root"
+      },
+      {
+        "checksum": "adler32:29864ecb",
+        "size": 26049,
+        "uri": "root://eospublic.cern.ch//eos/opendata/atlas/rucio/opendata/ODEO_FEB2025_v0_exactly4lep_mc_301247.Pythia8EvtGen_A14NNPDF23LO_Wprime_munu_SSM3000.exactly4lep.root"
+      },
+      {
+        "checksum": "adler32:4a36c62b",
+        "size": 83370,
+        "uri": "root://eospublic.cern.ch//eos/opendata/atlas/rucio/opendata/ODEO_FEB2025_v0_exactly4lep_mc_301333.Pythia8EvtGen_A14NNPDF23LO_zprime3000_tt.exactly4lep.root"
+      },
+      {
+        "checksum": "adler32:3063520a",
+        "size": 32166,
+        "uri": "root://eospublic.cern.ch//eos/opendata/atlas/rucio/opendata/ODEO_FEB2025_v0_exactly4lep_mc_301826.Pythia8EvtGen_A14NNPDF23LO_Wprime_qq_3000.exactly4lep.root"
+      },
+      {
+        "checksum": "adler32:d8db4878",
+        "size": 33731,
+        "uri": "root://eospublic.cern.ch//eos/opendata/atlas/rucio/opendata/ODEO_FEB2025_v0_exactly4lep_mc_301928.Pythia8EvtGen_A14NNPDF23LO_Zprimebb3000.exactly4lep.root"
+      },
+      {
+        "checksum": "adler32:81cac6aa",
+        "size": 394289,
+        "uri": "root://eospublic.cern.ch//eos/opendata/atlas/rucio/opendata/ODEO_FEB2025_v0_exactly4lep_mc_302520.Pythia8EvtGen_A14NNPDF23LO_2DP20_Mass_55_100.exactly4lep.root"
+      },
+      {
+        "checksum": "adler32:0e139586",
+        "size": 73864,
+        "uri": "root://eospublic.cern.ch//eos/opendata/atlas/rucio/opendata/ODEO_FEB2025_v0_exactly4lep_mc_302521.Pythia8EvtGen_A14NNPDF23LO_2DP20_Mass_100_160.exactly4lep.root"
+      },
+      {
+        "checksum": "adler32:7bdf9f05",
+        "size": 26159,
+        "uri": "root://eospublic.cern.ch//eos/opendata/atlas/rucio/opendata/ODEO_FEB2025_v0_exactly4lep_mc_302522.Pythia8EvtGen_A14NNPDF23LO_2DP20_Mass_160_250.exactly4lep.root"
+      },
+      {
+        "checksum": "adler32:7c709dc2",
+        "size": 1395,
+        "uri": "root://eospublic.cern.ch//eos/opendata/atlas/rucio/opendata/ODEO_FEB2025_v0_exactly4lep_mc_302523.Pythia8EvtGen_A14NNPDF23LO_2DP20_Mass_250_400.exactly4lep.root"
+      },
+      {
+        "checksum": "adler32:4ac39e86",
+        "size": 1395,
+        "uri": "root://eospublic.cern.ch//eos/opendata/atlas/rucio/opendata/ODEO_FEB2025_v0_exactly4lep_mc_302524.Pythia8EvtGen_A14NNPDF23LO_2DP20_Mass_400_650.exactly4lep.root"
+      },
+      {
+        "checksum": "adler32:bd88a000",
+        "size": 1403,
+        "uri": "root://eospublic.cern.ch//eos/opendata/atlas/rucio/opendata/ODEO_FEB2025_v0_exactly4lep_mc_302525.Pythia8EvtGen_A14NNPDF23LO_2DP20_Mass_650_1000.exactly4lep.root"
+      },
+      {
+        "checksum": "adler32:f0ff350c",
+        "size": 38254,
+        "uri": "root://eospublic.cern.ch//eos/opendata/atlas/rucio/opendata/ODEO_FEB2025_v0_exactly4lep_mc_302526.Pythia8EvtGen_A14NNPDF23LO_2DP20_Mass_1000_1500.exactly4lep.root"
+      },
+      {
+        "checksum": "adler32:4c15a1fc",
+        "size": 1411,
+        "uri": "root://eospublic.cern.ch//eos/opendata/atlas/rucio/opendata/ODEO_FEB2025_v0_exactly4lep_mc_302527.Pythia8EvtGen_A14NNPDF23LO_2DP20_Mass_1500_2000.exactly4lep.root"
+      },
+      {
+        "checksum": "adler32:4fdaa244",
+        "size": 1411,
+        "uri": "root://eospublic.cern.ch//eos/opendata/atlas/rucio/opendata/ODEO_FEB2025_v0_exactly4lep_mc_302528.Pythia8EvtGen_A14NNPDF23LO_2DP20_Mass_2000_2500.exactly4lep.root"
+      },
+      {
+        "checksum": "adler32:46639f94",
+        "size": 1411,
+        "uri": "root://eospublic.cern.ch//eos/opendata/atlas/rucio/opendata/ODEO_FEB2025_v0_exactly4lep_mc_302529.Pythia8EvtGen_A14NNPDF23LO_2DP20_Mass_2500_3000.exactly4lep.root"
+      },
+      {
+        "checksum": "adler32:54069a4b",
+        "size": 27407,
+        "uri": "root://eospublic.cern.ch//eos/opendata/atlas/rucio/opendata/ODEO_FEB2025_v0_exactly4lep_mc_302530.Pythia8EvtGen_A14NNPDF23LO_2DP20_Mass_3000_3500.exactly4lep.root"
+      },
+      {
+        "checksum": "adler32:520f9be5",
+        "size": 27382,
+        "uri": "root://eospublic.cern.ch//eos/opendata/atlas/rucio/opendata/ODEO_FEB2025_v0_exactly4lep_mc_302531.Pythia8EvtGen_A14NNPDF23LO_2DP20_Mass_3500_4000.exactly4lep.root"
+      },
+      {
+        "checksum": "adler32:08eb32d2",
+        "size": 27260,
+        "uri": "root://eospublic.cern.ch//eos/opendata/atlas/rucio/opendata/ODEO_FEB2025_v0_exactly4lep_mc_302532.Pythia8EvtGen_A14NNPDF23LO_2DP20_Mass_4000_4500.exactly4lep.root"
+      },
+      {
+        "checksum": "adler32:7b54a0a2",
+        "size": 1411,
+        "uri": "root://eospublic.cern.ch//eos/opendata/atlas/rucio/opendata/ODEO_FEB2025_v0_exactly4lep_mc_302533.Pythia8EvtGen_A14NNPDF23LO_2DP20_Mass_4500_5000.exactly4lep.root"
+      },
+      {
+        "checksum": "adler32:03a74a17",
+        "size": 40871,
+        "uri": "root://eospublic.cern.ch//eos/opendata/atlas/rucio/opendata/ODEO_FEB2025_v0_exactly4lep_mc_302534.Pythia8EvtGen_A14NNPDF23LO_2DP20_Mass_5000_inf.exactly4lep.root"
+      },
+      {
+        "checksum": "adler32:a632da04",
+        "size": 69511,
+        "uri": "root://eospublic.cern.ch//eos/opendata/atlas/rucio/opendata/ODEO_FEB2025_v0_exactly4lep_mc_302733.MadGraphPythia8EvtGen_A14NNPDF23LO_WpL_tblep_M3000.exactly4lep.root"
+      },
+      {
+        "checksum": "adler32:84f27cd5",
+        "size": 138097,
+        "uri": "root://eospublic.cern.ch//eos/opendata/atlas/rucio/opendata/ODEO_FEB2025_v0_exactly4lep_mc_304014.MadGraphPythia8EvtGen_A14NNPDF23_3top_SM.exactly4lep.root"
+      },
+      {
+        "checksum": "adler32:44dcbe1e",
+        "size": 45945,
+        "uri": "root://eospublic.cern.ch//eos/opendata/atlas/rucio/opendata/ODEO_FEB2025_v0_exactly4lep_mc_306149.MadGraphPythia8EvtGen_A14NNPDF23LO_WpL_tbhad_M3000.exactly4lep.root"
+      },
+      {
+        "checksum": "adler32:48de805d",
+        "size": 26156,
+        "uri": "root://eospublic.cern.ch//eos/opendata/atlas/rucio/opendata/ODEO_FEB2025_v0_exactly4lep_mc_311490.PowhegPy8EG_A14N23LO_DMA_500_700_gq0p25.exactly4lep.root"
+      },
+      {
+        "checksum": "adler32:e45ee39f",
+        "size": 1624694,
+        "uri": "root://eospublic.cern.ch//eos/opendata/atlas/rucio/opendata/ODEO_FEB2025_v0_exactly4lep_mc_312613.aMcAtNloPy8EG_A14N30NLO_LQd_gstML_0p3_nonallhad_M1000.exactly4lep.root"
+      },
+      {
+        "checksum": "adler32:d4b1d26e",
+        "size": 1499,
+        "uri": "root://eospublic.cern.ch//eos/opendata/atlas/rucio/opendata/ODEO_FEB2025_v0_exactly4lep_mc_341456.PowhegPythia8EvtGen_CT10_AZNLO_ZH125J_MINLO_veveWWlvqq_VpT.exactly4lep.root"
+      },
+      {
+        "checksum": "adler32:38bdd9b2",
+        "size": 1515,
+        "uri": "root://eospublic.cern.ch//eos/opendata/atlas/rucio/opendata/ODEO_FEB2025_v0_exactly4lep_mc_341458.PowhegPythia8EvtGen_CT10_AZNLO_ZH125J_MINLO_vmuvmuWWlvqq_VpT.exactly4lep.root"
+      },
+      {
+        "checksum": "adler32:8c91cae5",
+        "size": 26203,
+        "uri": "root://eospublic.cern.ch//eos/opendata/atlas/rucio/opendata/ODEO_FEB2025_v0_exactly4lep_mc_341460.PowhegPy8EG_CT10_AZNLO_ZH125J_MINLO_vtauvtauWWlvqq_VpT.exactly4lep.root"
+      },
+      {
+        "checksum": "adler32:cfd25937",
+        "size": 26169,
+        "uri": "root://eospublic.cern.ch//eos/opendata/atlas/rucio/opendata/ODEO_FEB2025_v0_exactly4lep_mc_343981.PowhegPythia8EvtGen_NNLOPS_nnlo_30_ggH125_gamgam.exactly4lep.root"
+      },
+      {
+        "checksum": "adler32:668bb59f",
+        "size": 12052764,
+        "uri": "root://eospublic.cern.ch//eos/opendata/atlas/rucio/opendata/ODEO_FEB2025_v0_exactly4lep_mc_344158.aMcAtNloPythia8EvtGen_A14NNPDF23LO_ppx0_FxFx_Np012_SM.exactly4lep.root"
+      },
+      {
+        "checksum": "adler32:e3a2fc9e",
+        "size": 27204,
+        "uri": "root://eospublic.cern.ch//eos/opendata/atlas/rucio/opendata/ODEO_FEB2025_v0_exactly4lep_mc_345056.PowhegPythia8EvtGen_NNPDF3_AZNLO_ZH125J_MINLO_vvbb_VpT.exactly4lep.root"
+      },
+      {
+        "checksum": "adler32:790cf5de",
+        "size": 26360,
+        "uri": "root://eospublic.cern.ch//eos/opendata/atlas/rucio/opendata/ODEO_FEB2025_v0_exactly4lep_mc_345058.PowhegPythia8EvtGen_NNPDF3_AZNLO_ggZH125_vvbb.exactly4lep.root"
+      },
+      {
+        "checksum": "adler32:c675b786",
+        "size": 182051943,
+        "uri": "root://eospublic.cern.ch//eos/opendata/atlas/rucio/opendata/ODEO_FEB2025_v0_exactly4lep_mc_345060.PowhegPythia8EvtGen_NNLOPS_nnlo_30_ggH125_ZZ4l.exactly4lep.root"
+      },
+      {
+        "checksum": "adler32:7d32fdf2",
+        "size": 40346,
+        "uri": "root://eospublic.cern.ch//eos/opendata/atlas/rucio/opendata/ODEO_FEB2025_v0_exactly4lep_mc_345061.PowhegPythia8EvtGen_NNPDF3_AZNLO_ggZH125_HgamgamZinc.exactly4lep.root"
+      },
+      {
+        "checksum": "adler32:2b0f1ac2",
+        "size": 3534681,
+        "uri": "root://eospublic.cern.ch//eos/opendata/atlas/rucio/opendata/ODEO_FEB2025_v0_exactly4lep_mc_345066.PowhegPythia8EvtGen_NNPDF3_AZNLO_ggZH125_ZZ4lepZinc.exactly4lep.root"
+      },
+      {
+        "checksum": "adler32:15009f62",
+        "size": 59635,
+        "uri": "root://eospublic.cern.ch//eos/opendata/atlas/rucio/opendata/ODEO_FEB2025_v0_exactly4lep_mc_345097.PowhegPythia8EvtGen_NNLOPS_nnlo_30_ggH125_mumu.exactly4lep.root"
+      },
+      {
+        "checksum": "adler32:6f2965e0",
+        "size": 710803,
+        "uri": "root://eospublic.cern.ch//eos/opendata/atlas/rucio/opendata/ODEO_FEB2025_v0_exactly4lep_mc_345098.PowhegPythia8EvtGen_NNPDF3_AZNLO_ggZH125_Hmumu_Zinc.exactly4lep.root"
+      },
+      {
+        "checksum": "adler32:75d6d537",
+        "size": 631193,
+        "uri": "root://eospublic.cern.ch//eos/opendata/atlas/rucio/opendata/ODEO_FEB2025_v0_exactly4lep_mc_345103.PowhegPythia8EvtGen_NNPDF30_AZNLO_ZH125J_Hmumu_Zincl_MINLO.exactly4lep.root"
+      },
+      {
+        "checksum": "adler32:23fbd484",
+        "size": 71696,
+        "uri": "root://eospublic.cern.ch//eos/opendata/atlas/rucio/opendata/ODEO_FEB2025_v0_exactly4lep_mc_345104.PowhegPythia8EvtGen_NNPDF30_AZNLO_WpH125J_Hmumu_Wincl_MINLO.exactly4lep.root"
+      },
+      {
+        "checksum": "adler32:8dfe1d42",
+        "size": 60202,
+        "uri": "root://eospublic.cern.ch//eos/opendata/atlas/rucio/opendata/ODEO_FEB2025_v0_exactly4lep_mc_345105.PowhegPythia8EvtGen_NNPDF30_AZNLO_WmH125J_Hmumu_Wincl_MINLO.exactly4lep.root"
+      },
+      {
+        "checksum": "adler32:58ec59bf",
+        "size": 64271,
+        "uri": "root://eospublic.cern.ch//eos/opendata/atlas/rucio/opendata/ODEO_FEB2025_v0_exactly4lep_mc_345106.PowhegPythia8EvtGen_NNPDF30_AZNLOCTEQ6L1_VBFH125_mumu.exactly4lep.root"
+      },
+      {
+        "checksum": "adler32:862847aa",
+        "size": 27326,
+        "uri": "root://eospublic.cern.ch//eos/opendata/atlas/rucio/opendata/ODEO_FEB2025_v0_exactly4lep_mc_345112.PowhegPythia8EvtGen_NNPDF3_AZNLO_ZH125J_MINLO_vvcc_VpT.exactly4lep.root"
+      },
+      {
+        "checksum": "adler32:dfe0acac",
+        "size": 1395,
+        "uri": "root://eospublic.cern.ch//eos/opendata/atlas/rucio/opendata/ODEO_FEB2025_v0_exactly4lep_mc_345114.PowhegPythia8EvtGen_NNPDF3_AZNLO_ggZH125_vvcc.exactly4lep.root"
+      },
+      {
+        "checksum": "adler32:c50d5aec",
+        "size": 66770,
+        "uri": "root://eospublic.cern.ch//eos/opendata/atlas/rucio/opendata/ODEO_FEB2025_v0_exactly4lep_mc_345120.PowhegPy8EG_NNLOPS_nnlo_30_ggH125_tautaul13l7.exactly4lep.root"
+      },
+      {
+        "checksum": "adler32:394501c5",
+        "size": 39528,
+        "uri": "root://eospublic.cern.ch//eos/opendata/atlas/rucio/opendata/ODEO_FEB2025_v0_exactly4lep_mc_345121.PowhegPy8EG_NNLOPS_nnlo_30_ggH125_tautaulm15hp20.exactly4lep.root"
+      },
+      {
+        "checksum": "adler32:8913b26a",
+        "size": 1419,
+        "uri": "root://eospublic.cern.ch//eos/opendata/atlas/rucio/opendata/ODEO_FEB2025_v0_exactly4lep_mc_345122.PowhegPy8EG_NNLOPS_nnlo_30_ggH125_tautaulp15hm20.exactly4lep.root"
+      },
+      {
+        "checksum": "adler32:a0a497b2",
+        "size": 26153,
+        "uri": "root://eospublic.cern.ch//eos/opendata/atlas/rucio/opendata/ODEO_FEB2025_v0_exactly4lep_mc_345123.PowhegPy8EG_NNLOPS_nnlo_30_ggH125_tautauh30h20.exactly4lep.root"
+      },
+      {
+        "checksum": "adler32:6e36809c",
+        "size": 294192,
+        "uri": "root://eospublic.cern.ch//eos/opendata/atlas/rucio/opendata/ODEO_FEB2025_v0_exactly4lep_mc_345124.PowhegPy8EG_NNLOPS_nnlo_30_ggH125_etau_filt.exactly4lep.root"
+      },
+      {
+        "checksum": "adler32:e3c7a3d7",
+        "size": 301704,
+        "uri": "root://eospublic.cern.ch//eos/opendata/atlas/rucio/opendata/ODEO_FEB2025_v0_exactly4lep_mc_345125.PowhegPy8EG_NNLOPS_nnlo_30_ggH125_mutau_filt.exactly4lep.root"
+      },
+      {
+        "checksum": "adler32:a5862918",
+        "size": 27306,
+        "uri": "root://eospublic.cern.ch//eos/opendata/atlas/rucio/opendata/ODEO_FEB2025_v0_exactly4lep_mc_345211.PowhegPy8EG_NNPDF30_AZNLO_WmH125J_Winc_MINLO_tautau.exactly4lep.root"
+      },
+      {
+        "checksum": "adler32:01d953f9",
+        "size": 28209,
+        "uri": "root://eospublic.cern.ch//eos/opendata/atlas/rucio/opendata/ODEO_FEB2025_v0_exactly4lep_mc_345212.PowhegPy8EG_NNPDF30_AZNLO_WpH125J_Winc_MINLO_tautau.exactly4lep.root"
+      },
+      {
+        "checksum": "adler32:ee7b4fc3",
+        "size": 43764,
+        "uri": "root://eospublic.cern.ch//eos/opendata/atlas/rucio/opendata/ODEO_FEB2025_v0_exactly4lep_mc_345213.PowhegPy8EG_NNPDF30_AZNLO_WmH125J_Winc_MINLO_etau.exactly4lep.root"
+      },
+      {
+        "checksum": "adler32:1418c433",
+        "size": 57647,
+        "uri": "root://eospublic.cern.ch//eos/opendata/atlas/rucio/opendata/ODEO_FEB2025_v0_exactly4lep_mc_345214.PowhegPy8EG_NNPDF30_AZNLO_WpH125J_Winc_MINLO_etau.exactly4lep.root"
+      },
+      {
+        "checksum": "adler32:6735bd8b",
+        "size": 41924,
+        "uri": "root://eospublic.cern.ch//eos/opendata/atlas/rucio/opendata/ODEO_FEB2025_v0_exactly4lep_mc_345215.PowhegPy8EG_NNPDF30_AZNLO_WmH125J_Winc_MINLO_mutau.exactly4lep.root"
+      },
+      {
+        "checksum": "adler32:f916da08",
+        "size": 63408,
+        "uri": "root://eospublic.cern.ch//eos/opendata/atlas/rucio/opendata/ODEO_FEB2025_v0_exactly4lep_mc_345216.PowhegPy8EG_NNPDF30_AZNLO_WpH125J_Winc_MINLO_mutau.exactly4lep.root"
+      },
+      {
+        "checksum": "adler32:2af809a4",
+        "size": 76136,
+        "uri": "root://eospublic.cern.ch//eos/opendata/atlas/rucio/opendata/ODEO_FEB2025_v0_exactly4lep_mc_345217.PowhegPy8EG_NNPDF30_AZNLO_ZH125J_Zinc_MINLO_tautau.exactly4lep.root"
+      },
+      {
+        "checksum": "adler32:89ebf0d5",
+        "size": 312812,
+        "uri": "root://eospublic.cern.ch//eos/opendata/atlas/rucio/opendata/ODEO_FEB2025_v0_exactly4lep_mc_345218.PowhegPy8EG_NNPDF30_AZNLO_ZH125J_Zinc_MINLO_etau.exactly4lep.root"
+      },
+      {
+        "checksum": "adler32:1baae141",
+        "size": 234712,
+        "uri": "root://eospublic.cern.ch//eos/opendata/atlas/rucio/opendata/ODEO_FEB2025_v0_exactly4lep_mc_345219.PowhegPy8EG_NNPDF30_AZNLO_ZH125J_Zinc_MINLO_mutau.exactly4lep.root"
+      },
+      {
+        "checksum": "adler32:57e43a77",
+        "size": 940510,
+        "uri": "root://eospublic.cern.ch//eos/opendata/atlas/rucio/opendata/ODEO_FEB2025_v0_exactly4lep_mc_345316.PowhegPythia8EvtGen_NNLOPS_nnlo_30_ggH125_Zy_Zll.exactly4lep.root"
+      },
+      {
+        "checksum": "adler32:df52b3a1",
+        "size": 77187,
+        "uri": "root://eospublic.cern.ch//eos/opendata/atlas/rucio/opendata/ODEO_FEB2025_v0_exactly4lep_mc_345317.PowhegPythia8EvtGen_NNPDF30_AZNLO_WmH125J_Hyy_Wincl_MINLO.exactly4lep.root"
+      },
+      {
+        "checksum": "adler32:8344db85",
+        "size": 43026,
+        "uri": "root://eospublic.cern.ch//eos/opendata/atlas/rucio/opendata/ODEO_FEB2025_v0_exactly4lep_mc_345318.PowhegPythia8EvtGen_NNPDF30_AZNLO_WpH125J_Hyy_Wincl_MINLO.exactly4lep.root"
+      },
+      {
+        "checksum": "adler32:5fb07846",
+        "size": 55131,
+        "uri": "root://eospublic.cern.ch//eos/opendata/atlas/rucio/opendata/ODEO_FEB2025_v0_exactly4lep_mc_345319.PowhegPythia8EvtGen_NNPDF30_AZNLO_ZH125J_Hyy_Zincl_MINLO.exactly4lep.root"
+      },
+      {
+        "checksum": "adler32:7da30290",
+        "size": 95772,
+        "uri": "root://eospublic.cern.ch//eos/opendata/atlas/rucio/opendata/ODEO_FEB2025_v0_exactly4lep_mc_345320.PowhegPythia8EvtGen_NNPDF30_AZNLO_WmH125J_HZy_Wincl_MINLO.exactly4lep.root"
+      },
+      {
+        "checksum": "adler32:c49030d6",
+        "size": 85924,
+        "uri": "root://eospublic.cern.ch//eos/opendata/atlas/rucio/opendata/ODEO_FEB2025_v0_exactly4lep_mc_345321.PowhegPythia8EvtGen_NNPDF30_AZNLO_WpH125J_HZy_Wincl_MINLO.exactly4lep.root"
+      },
+      {
+        "checksum": "adler32:35526be4",
+        "size": 438141,
+        "uri": "root://eospublic.cern.ch//eos/opendata/atlas/rucio/opendata/ODEO_FEB2025_v0_exactly4lep_mc_345322.PowhegPythia8EvtGen_NNPDF30_AZNLO_ZH125J_HZy_Zincl_MINLO.exactly4lep.root"
+      },
+      {
+        "checksum": "adler32:541be71a",
+        "size": 50663,
+        "uri": "root://eospublic.cern.ch//eos/opendata/atlas/rucio/opendata/ODEO_FEB2025_v0_exactly4lep_mc_345324.PowhegPythia8EvtGen_NNLOPS_NN30_ggH125_WWlvlv_EF_15_5.exactly4lep.root"
+      },
+      {
+        "checksum": "adler32:42c9d81b",
+        "size": 85279,
+        "uri": "root://eospublic.cern.ch//eos/opendata/atlas/rucio/opendata/ODEO_FEB2025_v0_exactly4lep_mc_345325.PowhegPythia8EvtGen_NNPDF3_AZNLO_WpH125J_MINLO_qqWWlvlv.exactly4lep.root"
+      },
+      {
+        "checksum": "adler32:fbfac2e9",
+        "size": 97064,
+        "uri": "root://eospublic.cern.ch//eos/opendata/atlas/rucio/opendata/ODEO_FEB2025_v0_exactly4lep_mc_345433.PowhegPythia8EvtGen_NNPDF3_AZNLO_WmH125J_MINLO_qqWWlvlv.exactly4lep.root"
+      },
+      {
+        "checksum": "adler32:65b12425",
+        "size": 30389,
+        "uri": "root://eospublic.cern.ch//eos/opendata/atlas/rucio/opendata/ODEO_FEB2025_v0_exactly4lep_mc_345445.PowhegPythia8EvtGen_NNPDF3_AZNLO_ZH125J_MINLO_vvWWlvlv.exactly4lep.root"
+      },
+      {
+        "checksum": "adler32:d47ac112",
+        "size": 1451,
+        "uri": "root://eospublic.cern.ch//eos/opendata/atlas/rucio/opendata/ODEO_FEB2025_v0_exactly4lep_mc_345596.PowhegPythia8EvtGen_NNPDF3_AZNLO_ggZH125_Zinc_HZZinv.exactly4lep.root"
+      },
+      {
+        "checksum": "adler32:d21b97fe",
+        "size": 82742,
+        "uri": "root://eospublic.cern.ch//eos/opendata/atlas/rucio/opendata/ODEO_FEB2025_v0_exactly4lep_mc_345697.MadGraphPythia8EvtGen_AZNLOCTEQ6L1_ggfhtautaullNp2.exactly4lep.root"
+      },
+      {
+        "checksum": "adler32:548532c8",
+        "size": 57357,
+        "uri": "root://eospublic.cern.ch//eos/opendata/atlas/rucio/opendata/ODEO_FEB2025_v0_exactly4lep_mc_345698.MadGraphPythia8EvtGen_AZNLOCTEQ6L1_ggfhtautaulhNp2.exactly4lep.root"
+      },
+      {
+        "checksum": "adler32:8afadfcb",
+        "size": 26260,
+        "uri": "root://eospublic.cern.ch//eos/opendata/atlas/rucio/opendata/ODEO_FEB2025_v0_exactly4lep_mc_345699.MadGraphPythia8EvtGen_AZNLOCTEQ6L1_ggfhtautauhhNp2.exactly4lep.root"
+      },
+      {
+        "checksum": "adler32:e2c87c47",
+        "size": 471269,
+        "uri": "root://eospublic.cern.ch//eos/opendata/atlas/rucio/opendata/ODEO_FEB2025_v0_exactly4lep_mc_345833.PowhegPythia8EvtGen_NNPDF30_AZNLOCTEQ6L1_VBFH125_Zllgam.exactly4lep.root"
+      },
+      {
+        "checksum": "adler32:98987d64",
+        "size": 42734,
+        "uri": "root://eospublic.cern.ch//eos/opendata/atlas/rucio/opendata/ODEO_FEB2025_v0_exactly4lep_mc_345834.PowhegPythia8EvtGen_NNPDF30_AZNLOCTEQ6L1_VBFH125_gamstargam.exactly4lep.root"
+      },
+      {
+        "checksum": "adler32:532f7026",
+        "size": 622147,
+        "uri": "root://eospublic.cern.ch//eos/opendata/atlas/rucio/opendata/ODEO_FEB2025_v0_exactly4lep_mc_345876.PowhegPythia8EvtGen_NNPDF30_AZNLO_ZH125J_Hee__Zincl_MINLO.exactly4lep.root"
+      },
+      {
+        "checksum": "adler32:3d8acc2f",
+        "size": 51061,
+        "uri": "root://eospublic.cern.ch//eos/opendata/atlas/rucio/opendata/ODEO_FEB2025_v0_exactly4lep_mc_345877.PowhegPythia8EvtGen_NNPDF30_AZNLO_WpH125J_Hee_Wincl_MINLO.exactly4lep.root"
+      },
+      {
+        "checksum": "adler32:d6d84137",
+        "size": 55063,
+        "uri": "root://eospublic.cern.ch//eos/opendata/atlas/rucio/opendata/ODEO_FEB2025_v0_exactly4lep_mc_345878.PowhegPythia8EvtGen_NNPDF30_AZNLO_WmH125J_Hee_Wincl_MINLO.exactly4lep.root"
+      },
+      {
+        "checksum": "adler32:c86b4dd0",
+        "size": 40279,
+        "uri": "root://eospublic.cern.ch//eos/opendata/atlas/rucio/opendata/ODEO_FEB2025_v0_exactly4lep_mc_345944.aMcAtNloPy8EG_A14NNPDF23LO_ppx0yy_FxFx_Np012_SM.exactly4lep.root"
+      },
+      {
+        "checksum": "adler32:26a626cf",
+        "size": 89242,
+        "uri": "root://eospublic.cern.ch//eos/opendata/atlas/rucio/opendata/ODEO_FEB2025_v0_exactly4lep_mc_345948.PowhegPy8EG_NNPDF30_AZNLOCTEQ6L1_VBFH125_WWlvlv.exactly4lep.root"
+      },
+      {
+        "checksum": "adler32:7efe2bf8",
+        "size": 41342,
+        "uri": "root://eospublic.cern.ch//eos/opendata/atlas/rucio/opendata/ODEO_FEB2025_v0_exactly4lep_mc_345949.PowhegPythia8EvtGen_NNPDF30_AZNLOCTEQ6L1_VBFH125_bb.exactly4lep.root"
+      },
+      {
+        "checksum": "adler32:fc813666",
+        "size": 76793,
+        "uri": "root://eospublic.cern.ch//eos/opendata/atlas/rucio/opendata/ODEO_FEB2025_v0_exactly4lep_mc_345961.PowhegPythia8EvtGen_NNLOPS_nnlo_30_ggH125_gamstargam.exactly4lep.root"
+      },
+      {
+        "checksum": "adler32:162c12b6",
+        "size": 56948,
+        "uri": "root://eospublic.cern.ch//eos/opendata/atlas/rucio/opendata/ODEO_FEB2025_v0_exactly4lep_mc_345963.PowhegPythia8EvtGen_NNPDF30_AZNLO_WmH125J_Hgamstargam_MINLO.exactly4lep.root"
+      },
+      {
+        "checksum": "adler32:e18b02c8",
+        "size": 48983,
+        "uri": "root://eospublic.cern.ch//eos/opendata/atlas/rucio/opendata/ODEO_FEB2025_v0_exactly4lep_mc_345964.PowhegPythia8EvtGen_NNPDF30_AZNLO_WpH125J_Hgamstargam_MINLO.exactly4lep.root"
+      },
+      {
+        "checksum": "adler32:0bf25805",
+        "size": 200282,
+        "uri": "root://eospublic.cern.ch//eos/opendata/atlas/rucio/opendata/ODEO_FEB2025_v0_exactly4lep_mc_345965.PowhegPythia8EvtGen_NNPDF30_AZNLO_ZH125J_Hgamstargam_MINLO.exactly4lep.root"
+      },
+      {
+        "checksum": "adler32:91c31d58",
+        "size": 35133,
+        "uri": "root://eospublic.cern.ch//eos/opendata/atlas/rucio/opendata/ODEO_FEB2025_v0_exactly4lep_mc_346188.aMcAtNloPythia8EvtGen_tHjb125_4fl_gamgam.exactly4lep.root"
+      },
+      {
+        "checksum": "adler32:362e084a",
+        "size": 94869,
+        "uri": "root://eospublic.cern.ch//eos/opendata/atlas/rucio/opendata/ODEO_FEB2025_v0_exactly4lep_mc_346189.aMcAtNloPythia8EvtGen_ttH_gamgam.exactly4lep.root"
+      },
+      {
+        "checksum": "adler32:57d78512",
+        "size": 64743,
+        "uri": "root://eospublic.cern.ch//eos/opendata/atlas/rucio/opendata/ODEO_FEB2025_v0_exactly4lep_mc_346190.PowhegPy8EG_NNPDF30_AZNLOCTEQ6L1_VBFH125_tautaul13l7.exactly4lep.root"
+      },
+      {
+        "checksum": "adler32:101f4218",
+        "size": 39672,
+        "uri": "root://eospublic.cern.ch//eos/opendata/atlas/rucio/opendata/ODEO_FEB2025_v0_exactly4lep_mc_346191.PowhegPy8EG_NNPDF30_AZNLOCTEQ6L1_VBFH125_tautaulm15hp20.exactly4lep.root"
+      },
+      {
+        "checksum": "adler32:d3fbf7db",
+        "size": 26268,
+        "uri": "root://eospublic.cern.ch//eos/opendata/atlas/rucio/opendata/ODEO_FEB2025_v0_exactly4lep_mc_346192.PowhegPy8EG_NNPDF30_AZNLOCTEQ6L1_VBFH125_tautaulp15hm20.exactly4lep.root"
+      },
+      {
+        "checksum": "adler32:5b06b7ba",
+        "size": 1459,
+        "uri": "root://eospublic.cern.ch//eos/opendata/atlas/rucio/opendata/ODEO_FEB2025_v0_exactly4lep_mc_346193.PowhegPy8EG_NNPDF30_AZNLOCTEQ6L1_VBFH125_tautauh30h20.exactly4lep.root"
+      },
+      {
+        "checksum": "adler32:3559e2b7",
+        "size": 92507,
+        "uri": "root://eospublic.cern.ch//eos/opendata/atlas/rucio/opendata/ODEO_FEB2025_v0_exactly4lep_mc_346194.PowhegPy8EG_NNPDF30_AZNLOCTEQ6L1_VBFH125_etau_filt.exactly4lep.root"
+      },
+      {
+        "checksum": "adler32:af00e425",
+        "size": 86118,
+        "uri": "root://eospublic.cern.ch//eos/opendata/atlas/rucio/opendata/ODEO_FEB2025_v0_exactly4lep_mc_346195.PowhegPy8EG_NNPDF30_AZNLOCTEQ6L1_VBFH125_mutau_filt.exactly4lep.root"
+      },
+      {
+        "checksum": "adler32:2e372d84",
+        "size": 2240787,
+        "uri": "root://eospublic.cern.ch//eos/opendata/atlas/rucio/opendata/ODEO_FEB2025_v0_exactly4lep_mc_346198.PhPy8EG_A14NNPDF23_NNPDF30ME_ttH125_Zgam.exactly4lep.root"
+      },
+      {
+        "checksum": "adler32:803997f3",
+        "size": 27334,
+        "uri": "root://eospublic.cern.ch//eos/opendata/atlas/rucio/opendata/ODEO_FEB2025_v0_exactly4lep_mc_346214.PowhegPy8EG_NNPDF30_AZNLOCTEQ6L1_VBFH125_gamgam.exactly4lep.root"
+      },
+      {
+        "checksum": "adler32:d15f96aa",
+        "size": 40376446,
+        "uri": "root://eospublic.cern.ch//eos/opendata/atlas/rucio/opendata/ODEO_FEB2025_v0_exactly4lep_mc_346228.PowhegPy8EG_NNPDF30_AZNLOCTEQ6L1_VBFH125_ZZ4lep_notau.exactly4lep.root"
+      },
+      {
+        "checksum": "adler32:bc64bb1e",
+        "size": 65117,
+        "uri": "root://eospublic.cern.ch//eos/opendata/atlas/rucio/opendata/ODEO_FEB2025_v0_exactly4lep_mc_346310.PowhegPythia8EvtGen_NNPDF30_AZNLO_ZH125J_Zincl_H_incl_MINLO.exactly4lep.root"
+      },
+      {
+        "checksum": "adler32:1f9104fa",
+        "size": 29402,
+        "uri": "root://eospublic.cern.ch//eos/opendata/atlas/rucio/opendata/ODEO_FEB2025_v0_exactly4lep_mc_346311.PowhegPythia8EvtGen_NNPDF30_AZNLO_WpH125J_Wincl_H_incl_MINLO.exactly4lep.root"
+      },
+      {
+        "checksum": "adler32:1cd8b9f6",
+        "size": 29245,
+        "uri": "root://eospublic.cern.ch//eos/opendata/atlas/rucio/opendata/ODEO_FEB2025_v0_exactly4lep_mc_346312.PowhegPythia8EvtGen_NNPDF30_AZNLO_WmH125J_Wincl_H_incl_MINLO.exactly4lep.root"
+      },
+      {
+        "checksum": "adler32:92c7bb84",
+        "size": 70861,
+        "uri": "root://eospublic.cern.ch//eos/opendata/atlas/rucio/opendata/ODEO_FEB2025_v0_exactly4lep_mc_346317.PowhegPy8EG_NNPDF30_AZNLOCTEQ6L1_VBFH125_incl.exactly4lep.root"
+      },
+      {
+        "checksum": "adler32:f5a68974",
+        "size": 5028335,
+        "uri": "root://eospublic.cern.ch//eos/opendata/atlas/rucio/opendata/ODEO_FEB2025_v0_exactly4lep_mc_346340.PowhegPy8EG_A14NNPDF23_NNPDF30ME_ttH125_ZZ4l_allhad.exactly4lep.root"
+      },
+      {
+        "checksum": "adler32:8e7fc86f",
+        "size": 6732775,
+        "uri": "root://eospublic.cern.ch//eos/opendata/atlas/rucio/opendata/ODEO_FEB2025_v0_exactly4lep_mc_346341.PowhegPy8EG_A14NNPDF23_NNPDF30ME_ttH125_ZZ4l_semilep.exactly4lep.root"
+      },
+      {
+        "checksum": "adler32:27d3b85a",
+        "size": 5886203,
+        "uri": "root://eospublic.cern.ch//eos/opendata/atlas/rucio/opendata/ODEO_FEB2025_v0_exactly4lep_mc_346342.PowhegPy8EG_A14NNPDF23_NNPDF30ME_ttH125_ZZ4l_dilep.exactly4lep.root"
+      },
+      {
+        "checksum": "adler32:807b019e",
+        "size": 69974,
+        "uri": "root://eospublic.cern.ch//eos/opendata/atlas/rucio/opendata/ODEO_FEB2025_v0_exactly4lep_mc_346343.PhPy8EG_A14NNPDF23_NNPDF30ME_ttH125_allhad.exactly4lep.root"
+      },
+      {
+        "checksum": "adler32:52e8ef67",
+        "size": 124311,
+        "uri": "root://eospublic.cern.ch//eos/opendata/atlas/rucio/opendata/ODEO_FEB2025_v0_exactly4lep_mc_346344.PhPy8EG_A14NNPDF23_NNPDF30ME_ttH125_semilep.exactly4lep.root"
+      },
+      {
+        "checksum": "adler32:794ac9d9",
+        "size": 1153469,
+        "uri": "root://eospublic.cern.ch//eos/opendata/atlas/rucio/opendata/ODEO_FEB2025_v0_exactly4lep_mc_346345.PhPy8EG_A14NNPDF23_NNPDF30ME_ttH125_dilep.exactly4lep.root"
+      },
+      {
+        "checksum": "adler32:324f3fc4",
+        "size": 27195,
+        "uri": "root://eospublic.cern.ch//eos/opendata/atlas/rucio/opendata/ODEO_FEB2025_v0_exactly4lep_mc_346398.PowhegHerwig7EvtGen_NNPDF3_AZNLO_ZH125J_MINLO_vvbb_VpT.exactly4lep.root"
+      },
+      {
+        "checksum": "adler32:356bb18e",
+        "size": 1403,
+        "uri": "root://eospublic.cern.ch//eos/opendata/atlas/rucio/opendata/ODEO_FEB2025_v0_exactly4lep_mc_346400.PowhegHerwig7EvtGen_NNPDF3_AZNLO_ggZH125J_vvbb.exactly4lep.root"
+      },
+      {
+        "checksum": "adler32:493bab57",
+        "size": 2530320,
+        "uri": "root://eospublic.cern.ch//eos/opendata/atlas/rucio/opendata/ODEO_FEB2025_v0_exactly4lep_mc_346414.aMcAtNloPythia8EvtGen_tHjb125_4fl_ZZ4l.exactly4lep.root"
+      },
+      {
+        "checksum": "adler32:4aa5a6c4",
+        "size": 109981157,
+        "uri": "root://eospublic.cern.ch//eos/opendata/atlas/rucio/opendata/ODEO_FEB2025_v0_exactly4lep_mc_346446.PhH7EG_H7UE_NNLOPS_nnlo_30_ggH125_ZZ4l_noTau.exactly4lep.root"
+      },
+      {
+        "checksum": "adler32:4eaea691",
+        "size": 40557159,
+        "uri": "root://eospublic.cern.ch//eos/opendata/atlas/rucio/opendata/ODEO_FEB2025_v0_exactly4lep_mc_346447.PhH7EG_H7UE_NNPDF30_VBFH125_ZZ4lep_noTau.exactly4lep.root"
+      },
+      {
+        "checksum": "adler32:316f3060",
+        "size": 6110541,
+        "uri": "root://eospublic.cern.ch//eos/opendata/atlas/rucio/opendata/ODEO_FEB2025_v0_exactly4lep_mc_346448.PhH7EG_H7UE_NNPDF30_ZH125J_Zincl_MINLO.exactly4lep.root"
+      },
+      {
+        "checksum": "adler32:f3d7a8d7",
+        "size": 4817026,
+        "uri": "root://eospublic.cern.ch//eos/opendata/atlas/rucio/opendata/ODEO_FEB2025_v0_exactly4lep_mc_346449.PhH7EG_H7UE_NNPDF30_WpH125J_Wincl_MINLO.exactly4lep.root"
+      },
+      {
+        "checksum": "adler32:230cff56",
+        "size": 2605389,
+        "uri": "root://eospublic.cern.ch//eos/opendata/atlas/rucio/opendata/ODEO_FEB2025_v0_exactly4lep_mc_346450.PhH7EG_H7UE_NNPDF30_WmH125J_Wincl_MINLO.exactly4lep.root"
+      },
+      {
+        "checksum": "adler32:10d70d98",
+        "size": 3371282,
+        "uri": "root://eospublic.cern.ch//eos/opendata/atlas/rucio/opendata/ODEO_FEB2025_v0_exactly4lep_mc_346451.PhH7EG_H7UE_NNPDF3_ggZH125_ZZ4lepZinc.exactly4lep.root"
+      },
+      {
+        "checksum": "adler32:2f073269",
+        "size": 5070435,
+        "uri": "root://eospublic.cern.ch//eos/opendata/atlas/rucio/opendata/ODEO_FEB2025_v0_exactly4lep_mc_346452.PhH7EG_H7UE_NNPDF30ME_ttH125_ZZ4l_allhad_noTau.exactly4lep.root"
+      },
+      {
+        "checksum": "adler32:47e8fb90",
+        "size": 6721638,
+        "uri": "root://eospublic.cern.ch//eos/opendata/atlas/rucio/opendata/ODEO_FEB2025_v0_exactly4lep_mc_346453.PhH7EG_H7UE_NNPDF30ME_ttH125_ZZ4l_semilep_noTau.exactly4lep.root"
+      },
+      {
+        "checksum": "adler32:2225e6f3",
+        "size": 5937606,
+        "uri": "root://eospublic.cern.ch//eos/opendata/atlas/rucio/opendata/ODEO_FEB2025_v0_exactly4lep_mc_346454.PhH7EG_H7UE_NNPDF30ME_ttH125_ZZ4l_dilep_noTau.exactly4lep.root"
+      },
+      {
+        "checksum": "adler32:8965530b",
+        "size": 50659,
+        "uri": "root://eospublic.cern.ch//eos/opendata/atlas/rucio/opendata/ODEO_FEB2025_v0_exactly4lep_mc_346486.aMcAtNloPythia8EvtGen_tWH125_yy.exactly4lep.root"
+      },
+      {
+        "checksum": "adler32:db9a71f5",
+        "size": 3411159,
+        "uri": "root://eospublic.cern.ch//eos/opendata/atlas/rucio/opendata/ODEO_FEB2025_v0_exactly4lep_mc_346511.aMcAtNloPythia8EvtGen_tWH125_ZZ4l.exactly4lep.root"
+      },
+      {
+        "checksum": "adler32:2168cf5e",
+        "size": 359957,
+        "uri": "root://eospublic.cern.ch//eos/opendata/atlas/rucio/opendata/ODEO_FEB2025_v0_exactly4lep_mc_346524.PowhegPythia8EvtGen_NNPDF3_AZNLO_ggZH125J_MINLO_ZinclWWlvlv.exactly4lep.root"
+      },
+      {
+        "checksum": "adler32:b69fe4b1",
+        "size": 160922,
+        "uri": "root://eospublic.cern.ch//eos/opendata/atlas/rucio/opendata/ODEO_FEB2025_v0_exactly4lep_mc_346525.PowhegPythia8EvtGen_A14NNPDF23_NNPDF30ME_ttH125_gamgam.exactly4lep.root"
+      },
+      {
+        "checksum": "adler32:832251b9",
+        "size": 148094,
+        "uri": "root://eospublic.cern.ch//eos/opendata/atlas/rucio/opendata/ODEO_FEB2025_v0_exactly4lep_mc_346526.PowhegHerwig7EvtGen_H7UE_NNPDF30ME_ttH125_gamgam.exactly4lep.root"
+      },
+      {
+        "checksum": "adler32:98a4c486",
+        "size": 1459,
+        "uri": "root://eospublic.cern.ch//eos/opendata/atlas/rucio/opendata/ODEO_FEB2025_v0_exactly4lep_mc_346588.PowhegPythia8EvtGen_NNLOPS_nnlo_30_ggH125_ZZ4nu_MET75.exactly4lep.root"
+      },
+      {
+        "checksum": "adler32:ffad9dc2",
+        "size": 109274,
+        "uri": "root://eospublic.cern.ch//eos/opendata/atlas/rucio/opendata/ODEO_FEB2025_v0_exactly4lep_mc_346601.aMcAtNloHerwig7EvtGen_MEN30NLO_ttH125_gamgam.exactly4lep.root"
+      },
+      {
+        "checksum": "adler32:29cf1de7",
+        "size": 29983,
+        "uri": "root://eospublic.cern.ch//eos/opendata/atlas/rucio/opendata/ODEO_FEB2025_v0_exactly4lep_mc_346602.aMcAtNloHerwig7EvtGen_MEN30NLO_tHjb125_gamgam.exactly4lep.root"
+      },
+      {
+        "checksum": "adler32:4a16cf5e",
+        "size": 1491,
+        "uri": "root://eospublic.cern.ch//eos/opendata/atlas/rucio/opendata/ODEO_FEB2025_v0_exactly4lep_mc_346605.PowhegPythia8EvtGen_NNPDF30_AZNLO_WpH125J_WinclHinv_MET75.exactly4lep.root"
+      },
+      {
+        "checksum": "adler32:596fcf22",
+        "size": 1491,
+        "uri": "root://eospublic.cern.ch//eos/opendata/atlas/rucio/opendata/ODEO_FEB2025_v0_exactly4lep_mc_346606.PowhegPythia8EvtGen_NNPDF30_AZNLO_WmH125J_WinclHinv_MET75.exactly4lep.root"
+      },
+      {
+        "checksum": "adler32:ffee8405",
+        "size": 27482,
+        "uri": "root://eospublic.cern.ch//eos/opendata/atlas/rucio/opendata/ODEO_FEB2025_v0_exactly4lep_mc_346607.PowhegPythia8EvtGen_NNPDF30_AZNLO_ZH125J_ZinclHinv_MET75.exactly4lep.root"
+      },
+      {
+        "checksum": "adler32:7eb46e29",
+        "size": 91857,
+        "uri": "root://eospublic.cern.ch//eos/opendata/atlas/rucio/opendata/ODEO_FEB2025_v0_exactly4lep_mc_346632.PowhegPy8EG_A14NNPDF23_NNPDF30ME_ttH125_ZZ4nu_semilep.exactly4lep.root"
+      },
+      {
+        "checksum": "adler32:26969bba",
+        "size": 44729,
+        "uri": "root://eospublic.cern.ch//eos/opendata/atlas/rucio/opendata/ODEO_FEB2025_v0_exactly4lep_mc_346633.PowhegPy8EG_A14NNPDF23_NNPDF30ME_ttH125_ZZ4nu_allhad.exactly4lep.root"
+      },
+      {
+        "checksum": "adler32:48d05d96",
+        "size": 78536,
+        "uri": "root://eospublic.cern.ch//eos/opendata/atlas/rucio/opendata/ODEO_FEB2025_v0_exactly4lep_mc_346634.PowhegPy8EG_A14NNPDF23_NNPDF30ME_ttH125_ZZ4nu_dilep.exactly4lep.root"
+      },
+      {
+        "checksum": "adler32:0938f171",
+        "size": 8788738,
+        "uri": "root://eospublic.cern.ch//eos/opendata/atlas/rucio/opendata/ODEO_FEB2025_v0_exactly4lep_mc_346645.PowhegPythia8EvtGen_NNPDF30_AZNLO_ZH125J_Zincl_MINLO_shw.exactly4lep.root"
+      },
+      {
+        "checksum": "adler32:ee184fc7",
+        "size": 4949584,
+        "uri": "root://eospublic.cern.ch//eos/opendata/atlas/rucio/opendata/ODEO_FEB2025_v0_exactly4lep_mc_346646.PowhegPythia8EvtGen_NNPDF30_AZNLO_WpH125J_Wincl_MINLO_shw.exactly4lep.root"
+      },
+      {
+        "checksum": "adler32:29a04d41",
+        "size": 2700623,
+        "uri": "root://eospublic.cern.ch//eos/opendata/atlas/rucio/opendata/ODEO_FEB2025_v0_exactly4lep_mc_346647.PowhegPythia8EvtGen_NNPDF30_AZNLO_WmH125J_Wincl_MINLO_shw.exactly4lep.root"
+      },
+      {
+        "checksum": "adler32:d83e7bba",
+        "size": 40790,
+        "uri": "root://eospublic.cern.ch//eos/opendata/atlas/rucio/opendata/ODEO_FEB2025_v0_exactly4lep_mc_346726.PowhegHerwig7EvtGen_NNPDF3_AZNLO_ZH125J_MINLO_vvcc_VpT.exactly4lep.root"
+      },
+      {
+        "checksum": "adler32:c7c9b28c",
+        "size": 1403,
+        "uri": "root://eospublic.cern.ch//eos/opendata/atlas/rucio/opendata/ODEO_FEB2025_v0_exactly4lep_mc_346728.PowhegHerwig7EvtGen_NNPDF3_AZNLO_ggZH125J_vvcc.exactly4lep.root"
+      },
+      {
+        "checksum": "adler32:b0689f60",
+        "size": 126775,
+        "uri": "root://eospublic.cern.ch//eos/opendata/atlas/rucio/opendata/ODEO_FEB2025_v0_exactly4lep_mc_346797.PhH7EG_H7UE_NNLOPS_nnlo_30_ggH125_gamgam.exactly4lep.root"
+      },
+      {
+        "checksum": "adler32:48c3b9ab",
+        "size": 268006,
+        "uri": "root://eospublic.cern.ch//eos/opendata/atlas/rucio/opendata/ODEO_FEB2025_v0_exactly4lep_mc_346802.PhH7EG_NNLOPS_nnlo_30_ggH125_WWlvlv_noTau.exactly4lep.root"
+      },
+      {
+        "checksum": "adler32:c2bcf1aa",
+        "size": 59451,
+        "uri": "root://eospublic.cern.ch//eos/opendata/atlas/rucio/opendata/ODEO_FEB2025_v0_exactly4lep_mc_346877.PhH7EG_NNPDF30_VBFH125_WWlvlv.exactly4lep.root"
+      },
+      {
+        "checksum": "adler32:a8e68bca",
+        "size": 1331,
+        "uri": "root://eospublic.cern.ch//eos/opendata/atlas/rucio/opendata/ODEO_FEB2025_v0_exactly4lep_mc_346878.PhH7EG_H7UE_NNPDF30_VBF125_gammagamma.exactly4lep.root"
+      },
+      {
+        "checksum": "adler32:19876d7a",
+        "size": 51363,
+        "uri": "root://eospublic.cern.ch//eos/opendata/atlas/rucio/opendata/ODEO_FEB2025_v0_exactly4lep_mc_346879.PhH7EG_H7UE_NNPDF30_ZH125J_Zincl_MINLO_gammagamma.exactly4lep.root"
+      },
+      {
+        "checksum": "adler32:a75ecb89",
+        "size": 28309,
+        "uri": "root://eospublic.cern.ch//eos/opendata/atlas/rucio/opendata/ODEO_FEB2025_v0_exactly4lep_mc_346880.PhH7EG_H7UE_NNPDF30_WmH125J_Wincl_MINLO_gammagamma.exactly4lep.root"
+      },
+      {
+        "checksum": "adler32:9e29b432",
+        "size": 29174,
+        "uri": "root://eospublic.cern.ch//eos/opendata/atlas/rucio/opendata/ODEO_FEB2025_v0_exactly4lep_mc_346881.PhH7EG_H7UE_NNPDF30_WpH125J_Wincl_MINLO_gammagamma.exactly4lep.root"
+      },
+      {
+        "checksum": "adler32:68b2875a",
+        "size": 35017,
+        "uri": "root://eospublic.cern.ch//eos/opendata/atlas/rucio/opendata/ODEO_FEB2025_v0_exactly4lep_mc_346882.PhH7EG_H7UE_NNPDF30_ggZH125_gammagamma.exactly4lep.root"
+      },
+      {
+        "checksum": "adler32:1b7aac14",
+        "size": 116153,
+        "uri": "root://eospublic.cern.ch//eos/opendata/atlas/rucio/opendata/ODEO_FEB2025_v0_exactly4lep_mc_346919.PhPy8EG_A14NNPDF23_NNPDF30ME_ttH125_allhad_tautau_unpol.exactly4lep.root"
+      },
+      {
+        "checksum": "adler32:33a4ee40",
+        "size": 319720,
+        "uri": "root://eospublic.cern.ch//eos/opendata/atlas/rucio/opendata/ODEO_FEB2025_v0_exactly4lep_mc_346923.PhPy8EG_A14NNPDF23_NNPDF30ME_ttH125_semilep_tautau_unpol.exactly4lep.root"
+      },
+      {
+        "checksum": "adler32:0053b4f7",
+        "size": 1189386,
+        "uri": "root://eospublic.cern.ch//eos/opendata/atlas/rucio/opendata/ODEO_FEB2025_v0_exactly4lep_mc_346927.PhPy8EG_A14NNPDF23_NNPDF30ME_ttH125_dilep_tautau_unpol.exactly4lep.root"
+      },
+      {
+        "checksum": "adler32:0bd818b8",
+        "size": 309516,
+        "uri": "root://eospublic.cern.ch//eos/opendata/atlas/rucio/opendata/ODEO_FEB2025_v0_exactly4lep_mc_364242.Sherpa_222_NNPDF30NNLO_WWW_3l3v_EW6.exactly4lep.root"
+      },
+      {
+        "checksum": "adler32:4e75c48c",
+        "size": 3733703,
+        "uri": "root://eospublic.cern.ch//eos/opendata/atlas/rucio/opendata/ODEO_FEB2025_v0_exactly4lep_mc_364243.Sherpa_222_NNPDF30NNLO_WWZ_4l2v_EW6.exactly4lep.root"
+      },
+      {
+        "checksum": "adler32:f7fd042f",
+        "size": 31332,
+        "uri": "root://eospublic.cern.ch//eos/opendata/atlas/rucio/opendata/ODEO_FEB2025_v0_exactly4lep_mc_364244.Sherpa_222_NNPDF30NNLO_WWZ_2l4v_EW6.exactly4lep.root"
+      },
+      {
+        "checksum": "adler32:8c4fc43b",
+        "size": 4741689,
+        "uri": "root://eospublic.cern.ch//eos/opendata/atlas/rucio/opendata/ODEO_FEB2025_v0_exactly4lep_mc_364245.Sherpa_222_NNPDF30NNLO_WZZ_5l1v_EW6.exactly4lep.root"
+      },
+      {
+        "checksum": "adler32:5139e65a",
+        "size": 147437,
+        "uri": "root://eospublic.cern.ch//eos/opendata/atlas/rucio/opendata/ODEO_FEB2025_v0_exactly4lep_mc_364246.Sherpa_222_NNPDF30NNLO_WZZ_3l3v_EW6.exactly4lep.root"
+      },
+      {
+        "checksum": "adler32:54c9613c",
+        "size": 4058180,
+        "uri": "root://eospublic.cern.ch//eos/opendata/atlas/rucio/opendata/ODEO_FEB2025_v0_exactly4lep_mc_364247.Sherpa_222_NNPDF30NNLO_ZZZ_6l0v_EW6.exactly4lep.root"
+      },
+      {
+        "checksum": "adler32:0955d692",
+        "size": 926028,
+        "uri": "root://eospublic.cern.ch//eos/opendata/atlas/rucio/opendata/ODEO_FEB2025_v0_exactly4lep_mc_364248.Sherpa_222_NNPDF30NNLO_ZZZ_4l2v_EW6.exactly4lep.root"
+      },
+      {
+        "checksum": "adler32:0d18afba",
+        "size": 27956,
+        "uri": "root://eospublic.cern.ch//eos/opendata/atlas/rucio/opendata/ODEO_FEB2025_v0_exactly4lep_mc_364249.Sherpa_222_NNPDF30NNLO_ZZZ_2l4v_EW6.exactly4lep.root"
+      },
+      {
+        "checksum": "adler32:0ea641b0",
+        "size": 44210,
+        "uri": "root://eospublic.cern.ch//eos/opendata/atlas/rucio/opendata/ODEO_FEB2025_v0_exactly4lep_mc_364336.Sherpa_222_NNPDF30NNLO_WpWpWn_sslvlvjj_EW6.exactly4lep.root"
+      },
+      {
+        "checksum": "adler32:96d8b6df",
+        "size": 44868,
+        "uri": "root://eospublic.cern.ch//eos/opendata/atlas/rucio/opendata/ODEO_FEB2025_v0_exactly4lep_mc_364337.Sherpa_222_NNPDF30NNLO_WnWnWp_sslvlvjj_EW6.exactly4lep.root"
+      },
+      {
+        "checksum": "adler32:8de1ee41",
+        "size": 41676,
+        "uri": "root://eospublic.cern.ch//eos/opendata/atlas/rucio/opendata/ODEO_FEB2025_v0_exactly4lep_mc_364338.Sherpa_222_NNPDF30NNLO_WpWpWn_oslvlvjj_EW6.exactly4lep.root"
+      },
+      {
+        "checksum": "adler32:df56185e",
+        "size": 33515,
+        "uri": "root://eospublic.cern.ch//eos/opendata/atlas/rucio/opendata/ODEO_FEB2025_v0_exactly4lep_mc_364339.Sherpa_222_NNPDF30NNLO_WnWnWp_oslvlvjj_EW6.exactly4lep.root"
+      },
+      {
+        "checksum": "adler32:047a3961",
+        "size": 170919,
+        "uri": "root://eospublic.cern.ch//eos/opendata/atlas/rucio/opendata/ODEO_FEB2025_v0_exactly4lep_mc_364350.Sherpa_224_NNPDF30NNLO_Diphoton_myy_0_50.exactly4lep.root"
+      },
+      {
+        "checksum": "adler32:9b61c354",
+        "size": 1470732,
+        "uri": "root://eospublic.cern.ch//eos/opendata/atlas/rucio/opendata/ODEO_FEB2025_v0_exactly4lep_mc_364351.Sherpa_224_NNPDF30NNLO_Diphoton_myy_50_90.exactly4lep.root"
+      },
+      {
+        "checksum": "adler32:e536cdbf",
+        "size": 377949,
+        "uri": "root://eospublic.cern.ch//eos/opendata/atlas/rucio/opendata/ODEO_FEB2025_v0_exactly4lep_mc_364352.Sherpa_224_NNPDF30NNLO_Diphoton_myy_90_175.exactly4lep.root"
+      },
+      {
+        "checksum": "adler32:2bf48308",
+        "size": 78676,
+        "uri": "root://eospublic.cern.ch//eos/opendata/atlas/rucio/opendata/ODEO_FEB2025_v0_exactly4lep_mc_364353.Sherpa_224_NNPDF30NNLO_Diphoton_myy_175_2000.exactly4lep.root"
+      },
+      {
+        "checksum": "adler32:34abf259",
+        "size": 26209,
+        "uri": "root://eospublic.cern.ch//eos/opendata/atlas/rucio/opendata/ODEO_FEB2025_v0_exactly4lep_mc_364354.Sherpa_224_NNPDF30NNLO_Diphoton_myy_2000_E_CMS.exactly4lep.root"
+      },
+      {
+        "checksum": "adler32:984fc4ee",
+        "size": 62049,
+        "uri": "root://eospublic.cern.ch//eos/opendata/atlas/rucio/opendata/ODEO_FEB2025_v0_exactly4lep_mc_364541.Sherpa_222_NNPDF30NNLO_SinglePhoton_pty_17_35.exactly4lep.root"
+      },
+      {
+        "checksum": "adler32:353e13d3",
+        "size": 74255,
+        "uri": "root://eospublic.cern.ch//eos/opendata/atlas/rucio/opendata/ODEO_FEB2025_v0_exactly4lep_mc_364542.Sherpa_222_NNPDF30NNLO_SinglePhoton_pty_35_70.exactly4lep.root"
+      },
+      {
+        "checksum": "adler32:226c488b",
+        "size": 292910,
+        "uri": "root://eospublic.cern.ch//eos/opendata/atlas/rucio/opendata/ODEO_FEB2025_v0_exactly4lep_mc_364543.Sherpa_222_NNPDF30NNLO_SinglePhoton_pty_70_140.exactly4lep.root"
+      },
+      {
+        "checksum": "adler32:66492f3d",
+        "size": 916391,
+        "uri": "root://eospublic.cern.ch//eos/opendata/atlas/rucio/opendata/ODEO_FEB2025_v0_exactly4lep_mc_364544.Sherpa_222_NNPDF30NNLO_SinglePhoton_pty_140_280.exactly4lep.root"
+      },
+      {
+        "checksum": "adler32:66ceed52",
+        "size": 299348,
+        "uri": "root://eospublic.cern.ch//eos/opendata/atlas/rucio/opendata/ODEO_FEB2025_v0_exactly4lep_mc_364545.Sherpa_222_NNPDF30NNLO_SinglePhoton_pty_280_500.exactly4lep.root"
+      },
+      {
+        "checksum": "adler32:f1831782",
+        "size": 41500,
+        "uri": "root://eospublic.cern.ch//eos/opendata/atlas/rucio/opendata/ODEO_FEB2025_v0_exactly4lep_mc_364546.Sherpa_222_NNPDF30NNLO_SinglePhoton_pty_500_1000.exactly4lep.root"
+      },
+      {
+        "checksum": "adler32:ae6baf53",
+        "size": 54824,
+        "uri": "root://eospublic.cern.ch//eos/opendata/atlas/rucio/opendata/ODEO_FEB2025_v0_exactly4lep_mc_364547.Sherpa_222_NNPDF30NNLO_SinglePhoton_pty_1000_E_CMS.exactly4lep.root"
+      },
+      {
+        "checksum": "adler32:600fa70e",
+        "size": 1379,
+        "uri": "root://eospublic.cern.ch//eos/opendata/atlas/rucio/opendata/ODEO_FEB2025_v0_exactly4lep_mc_364700.Pythia8EvtGen_A14NNPDF23LO_jetjet_JZ0WithSW.exactly4lep.root"
+      },
+      {
+        "checksum": "adler32:03e0e2f1",
+        "size": 26171,
+        "uri": "root://eospublic.cern.ch//eos/opendata/atlas/rucio/opendata/ODEO_FEB2025_v0_exactly4lep_mc_364701.Pythia8EvtGen_A14NNPDF23LO_jetjet_JZ1WithSW.exactly4lep.root"
+      },
+      {
+        "checksum": "adler32:8d899f5e",
+        "size": 845049,
+        "uri": "root://eospublic.cern.ch//eos/opendata/atlas/rucio/opendata/ODEO_FEB2025_v0_exactly4lep_mc_364702.Pythia8EvtGen_A14NNPDF23LO_jetjet_JZ2WithSW.exactly4lep.root"
+      },
+      {
+        "checksum": "adler32:ea351e89",
+        "size": 6762338,
+        "uri": "root://eospublic.cern.ch//eos/opendata/atlas/rucio/opendata/ODEO_FEB2025_v0_exactly4lep_mc_364703.Pythia8EvtGen_A14NNPDF23LO_jetjet_JZ3WithSW.exactly4lep.root"
+      },
+      {
+        "checksum": "adler32:7db24e39",
+        "size": 11556229,
+        "uri": "root://eospublic.cern.ch//eos/opendata/atlas/rucio/opendata/ODEO_FEB2025_v0_exactly4lep_mc_364704.Pythia8EvtGen_A14NNPDF23LO_jetjet_JZ4WithSW.exactly4lep.root"
+      },
+      {
+        "checksum": "adler32:69e3f3a5",
+        "size": 2255471,
+        "uri": "root://eospublic.cern.ch//eos/opendata/atlas/rucio/opendata/ODEO_FEB2025_v0_exactly4lep_mc_364705.Pythia8EvtGen_A14NNPDF23LO_jetjet_JZ5WithSW.exactly4lep.root"
+      },
+      {
+        "checksum": "adler32:5212fafe",
+        "size": 152074,
+        "uri": "root://eospublic.cern.ch//eos/opendata/atlas/rucio/opendata/ODEO_FEB2025_v0_exactly4lep_mc_364706.Pythia8EvtGen_A14NNPDF23LO_jetjet_JZ6WithSW.exactly4lep.root"
+      },
+      {
+        "checksum": "adler32:21be56bf",
+        "size": 130469,
+        "uri": "root://eospublic.cern.ch//eos/opendata/atlas/rucio/opendata/ODEO_FEB2025_v0_exactly4lep_mc_364707.Pythia8EvtGen_A14NNPDF23LO_jetjet_JZ7WithSW.exactly4lep.root"
+      },
+      {
+        "checksum": "adler32:9a0772eb",
+        "size": 266091,
+        "uri": "root://eospublic.cern.ch//eos/opendata/atlas/rucio/opendata/ODEO_FEB2025_v0_exactly4lep_mc_364708.Pythia8EvtGen_A14NNPDF23LO_jetjet_JZ8WithSW.exactly4lep.root"
+      },
+      {
+        "checksum": "adler32:07bb95de",
+        "size": 184332,
+        "uri": "root://eospublic.cern.ch//eos/opendata/atlas/rucio/opendata/ODEO_FEB2025_v0_exactly4lep_mc_364709.Pythia8EvtGen_A14NNPDF23LO_jetjet_JZ9WithSW.exactly4lep.root"
+      },
+      {
+        "checksum": "adler32:47a4e4ce",
+        "size": 632035,
+        "uri": "root://eospublic.cern.ch//eos/opendata/atlas/rucio/opendata/ODEO_FEB2025_v0_exactly4lep_mc_364710.Pythia8EvtGen_A14NNPDF23LO_jetjet_JZ10WithSW.exactly4lep.root"
+      },
+      {
+        "checksum": "adler32:fb469448",
+        "size": 383636,
+        "uri": "root://eospublic.cern.ch//eos/opendata/atlas/rucio/opendata/ODEO_FEB2025_v0_exactly4lep_mc_364711.Pythia8EvtGen_A14NNPDF23LO_jetjet_JZ11WithSW.exactly4lep.root"
+      },
+      {
+        "checksum": "adler32:a39d1551",
+        "size": 617917,
+        "uri": "root://eospublic.cern.ch//eos/opendata/atlas/rucio/opendata/ODEO_FEB2025_v0_exactly4lep_mc_364712.Pythia8EvtGen_A14NNPDF23LO_jetjet_JZ12WithSW.exactly4lep.root"
+      },
+      {
+        "checksum": "adler32:5d822078",
+        "size": 107088,
+        "uri": "root://eospublic.cern.ch//eos/opendata/atlas/rucio/opendata/ODEO_FEB2025_v0_exactly4lep_mc_375884.MGPy8EG_A14N_GG_ttn1_2000_5000_200.exactly4lep.root"
+      },
+      {
+        "checksum": "adler32:ceb31d16",
+        "size": 31346,
+        "uri": "root://eospublic.cern.ch//eos/opendata/atlas/rucio/opendata/ODEO_FEB2025_v0_exactly4lep_mc_376359.MGPy8EG_A14N23LO_SS_onestepCC_1600_900_200.exactly4lep.root"
+      },
+      {
+        "checksum": "adler32:70d38b38",
+        "size": 28980,
+        "uri": "root://eospublic.cern.ch//eos/opendata/atlas/rucio/opendata/ODEO_FEB2025_v0_exactly4lep_mc_376518.MadGraphPythia8EvtGen_A14NNPDF23LO_GG_direct_2400_200.exactly4lep.root"
+      },
+      {
+        "checksum": "adler32:0efa6856",
+        "size": 74911,
+        "uri": "root://eospublic.cern.ch//eos/opendata/atlas/rucio/opendata/ODEO_FEB2025_v0_exactly4lep_mc_392202.MGPy8EG_A14N23LO_C1N2_WZ_500p0_100p0_3L_2L7.exactly4lep.root"
+      },
+      {
+        "checksum": "adler32:603ca7fe",
+        "size": 1435,
+        "uri": "root://eospublic.cern.ch//eos/opendata/atlas/rucio/opendata/ODEO_FEB2025_v0_exactly4lep_mc_394997.MGPy8EG_A14N23LO_SM_N2C1p_105_100_2L2MET75_MadSpin.exactly4lep.root"
+      },
+      {
+        "checksum": "adler32:b0d90ebd",
+        "size": 65209,
+        "uri": "root://eospublic.cern.ch//eos/opendata/atlas/rucio/opendata/ODEO_FEB2025_v0_exactly4lep_mc_398384.MGPy8EG_A14N23LO_C1N2N1_GGMHinoZh50_800_noFilter.exactly4lep.root"
+      },
+      {
+        "checksum": "adler32:bf44ae21",
+        "size": 123430,
+        "uri": "root://eospublic.cern.ch//eos/opendata/atlas/rucio/opendata/ODEO_FEB2025_v0_exactly4lep_mc_410081.MadGraphPythia8EvtGen_A14NNPDF23_ttbarWW.exactly4lep.root"
+      },
+      {
+        "checksum": "adler32:7f22f008",
+        "size": 443189,
+        "uri": "root://eospublic.cern.ch//eos/opendata/atlas/rucio/opendata/ODEO_FEB2025_v0_exactly4lep_mc_410082.MadGraphPythia8EvtGen_A14NNPDF23LO_ttgamma_noallhad.exactly4lep.root"
+      },
+      {
+        "checksum": "adler32:79b71d5b",
+        "size": 77607,
+        "uri": "root://eospublic.cern.ch//eos/opendata/atlas/rucio/opendata/ODEO_FEB2025_v0_exactly4lep_mc_410087.MadGraphPythia8EvtGen_A14NNPDF23LO_ttgamma_allhad.exactly4lep.root"
+      },
+      {
+        "checksum": "adler32:c5b3bc30",
+        "size": 128712,
+        "uri": "root://eospublic.cern.ch//eos/opendata/atlas/rucio/opendata/ODEO_FEB2025_v0_exactly4lep_mc_410155.aMcAtNloPythia8EvtGen_MEN30NLO_A14N23LO_ttW.exactly4lep.root"
+      },
+      {
+        "checksum": "adler32:3c90d037",
+        "size": 73312,
+        "uri": "root://eospublic.cern.ch//eos/opendata/atlas/rucio/opendata/ODEO_FEB2025_v0_exactly4lep_mc_410156.aMcAtNloPythia8EvtGen_MEN30NLO_A14N23LO_ttZnunu.exactly4lep.root"
+      },
+      {
+        "checksum": "adler32:087b4881",
+        "size": 118048,
+        "uri": "root://eospublic.cern.ch//eos/opendata/atlas/rucio/opendata/ODEO_FEB2025_v0_exactly4lep_mc_410157.aMcAtNloPythia8EvtGen_MEN30NLO_A14N23LO_ttZqq.exactly4lep.root"
+      },
+      {
+        "checksum": "adler32:f39f16c6",
+        "size": 1738794,
+        "uri": "root://eospublic.cern.ch//eos/opendata/atlas/rucio/opendata/ODEO_FEB2025_v0_exactly4lep_mc_410218.aMcAtNloPythia8EvtGen_MEN30NLO_A14N23LO_ttee.exactly4lep.root"
+      },
+      {
+        "checksum": "adler32:526eda69",
+        "size": 2790490,
+        "uri": "root://eospublic.cern.ch//eos/opendata/atlas/rucio/opendata/ODEO_FEB2025_v0_exactly4lep_mc_410219.aMcAtNloPythia8EvtGen_MEN30NLO_A14N23LO_ttmumu.exactly4lep.root"
+      },
+      {
+        "checksum": "adler32:80de36a0",
+        "size": 413384,
+        "uri": "root://eospublic.cern.ch//eos/opendata/atlas/rucio/opendata/ODEO_FEB2025_v0_exactly4lep_mc_410220.aMcAtNloPythia8EvtGen_MEN30NLO_A14N23LO_tttautau.exactly4lep.root"
+      },
+      {
+        "checksum": "adler32:d49fcdc3",
+        "size": 526703,
+        "uri": "root://eospublic.cern.ch//eos/opendata/atlas/rucio/opendata/ODEO_FEB2025_v0_exactly4lep_mc_410389.MadGraphPythia8EvtGen_A14NNPDF23_ttgamma_nonallhadronic.exactly4lep.root"
+      },
+      {
+        "checksum": "adler32:b79d8e58",
+        "size": 455108,
+        "uri": "root://eospublic.cern.ch//eos/opendata/atlas/rucio/opendata/ODEO_FEB2025_v0_exactly4lep_mc_410395.MGH7EG_H7UE_ttgamma_nonallhadronic.exactly4lep.root"
+      },
+      {
+        "checksum": "adler32:a814503f",
+        "size": 100688,
+        "uri": "root://eospublic.cern.ch//eos/opendata/atlas/rucio/opendata/ODEO_FEB2025_v0_exactly4lep_mc_410396.MGH7EG_H7UE_ttgamma_allhadronic.exactly4lep.root"
+      },
+      {
+        "checksum": "adler32:27289a7b",
+        "size": 576333,
+        "uri": "root://eospublic.cern.ch//eos/opendata/atlas/rucio/opendata/ODEO_FEB2025_v0_exactly4lep_mc_410408.aMcAtNloPythia8EvtGen_tWZ_Ztoll_minDR1.exactly4lep.root"
+      },
+      {
+        "checksum": "adler32:20d1c6da",
+        "size": 16255158,
+        "uri": "root://eospublic.cern.ch//eos/opendata/atlas/rucio/opendata/ODEO_FEB2025_v0_exactly4lep_mc_410470.PhPy8EG_A14_ttbar_hdamp258p75_nonallhad.exactly4lep.root"
+      },
+      {
+        "checksum": "adler32:db468364",
+        "size": 2837258,
+        "uri": "root://eospublic.cern.ch//eos/opendata/atlas/rucio/opendata/ODEO_FEB2025_v0_exactly4lep_mc_410471.PhPy8EG_A14_ttbar_hdamp258p75_allhad.exactly4lep.root"
+      },
+      {
+        "checksum": "adler32:d2fa2c92",
+        "size": 183601,
+        "uri": "root://eospublic.cern.ch//eos/opendata/atlas/rucio/opendata/ODEO_FEB2025_v0_exactly4lep_mc_410560.MadGraphPythia8EvtGen_A14_tZ_4fl_tchan_noAllHad.exactly4lep.root"
+      },
+      {
+        "checksum": "adler32:418d5e4a",
+        "size": 57479,
+        "uri": "root://eospublic.cern.ch//eos/opendata/atlas/rucio/opendata/ODEO_FEB2025_v0_exactly4lep_mc_410644.PowhegPythia8EvtGen_A14_singletop_schan_lept_top.exactly4lep.root"
+      },
+      {
+        "checksum": "adler32:4b81e9b0",
+        "size": 44531,
+        "uri": "root://eospublic.cern.ch//eos/opendata/atlas/rucio/opendata/ODEO_FEB2025_v0_exactly4lep_mc_410645.PowhegPythia8EvtGen_A14_singletop_schan_lept_antitop.exactly4lep.root"
+      },
+      {
+        "checksum": "adler32:edc6e0ec",
+        "size": 687943,
+        "uri": "root://eospublic.cern.ch//eos/opendata/atlas/rucio/opendata/ODEO_FEB2025_v0_exactly4lep_mc_410658.PhPy8EG_A14_tchan_BW50_lept_top.exactly4lep.root"
+      },
+      {
+        "checksum": "adler32:452600dc",
+        "size": 395209,
+        "uri": "root://eospublic.cern.ch//eos/opendata/atlas/rucio/opendata/ODEO_FEB2025_v0_exactly4lep_mc_410659.PhPy8EG_A14_tchan_BW50_lept_antitop.exactly4lep.root"
+      },
+      {
+        "checksum": "adler32:7a49d7b1",
+        "size": 2198850,
+        "uri": "root://eospublic.cern.ch//eos/opendata/atlas/rucio/opendata/ODEO_FEB2025_v0_exactly4lep_mc_411233.PowhegHerwig7EvtGen_tt_hdamp258p75_713_SingleLep.exactly4lep.root"
+      },
+      {
+        "checksum": "adler32:5de270ce",
+        "size": 3403061,
+        "uri": "root://eospublic.cern.ch//eos/opendata/atlas/rucio/opendata/ODEO_FEB2025_v0_exactly4lep_mc_411234.PowhegHerwig7EvtGen_tt_hdamp258p75_713_dil.exactly4lep.root"
+      },
+      {
+        "checksum": "adler32:70ef0c58",
+        "size": 3443270,
+        "uri": "root://eospublic.cern.ch//eos/opendata/atlas/rucio/opendata/ODEO_FEB2025_v0_exactly4lep_mc_411316.PowhegHerwig7EvtGen_tt_hdamp258p75_713_allhad.exactly4lep.root"
+      },
+      {
+        "checksum": "adler32:77567e79",
+        "size": 943776,
+        "uri": "root://eospublic.cern.ch//eos/opendata/atlas/rucio/opendata/ODEO_FEB2025_v0_exactly4lep_mc_412043.aMcAtNloPythia8EvtGen_A14NNPDF31_SM4topsNLO.exactly4lep.root"
+      },
+      {
+        "checksum": "adler32:94742d96",
+        "size": 875228,
+        "uri": "root://eospublic.cern.ch//eos/opendata/atlas/rucio/opendata/ODEO_FEB2025_v0_exactly4lep_mc_412044.aMcAtNloHerwig7EvtGen_H7UE_SM4topsNLO.exactly4lep.root"
+      },
+      {
+        "checksum": "adler32:855ba370",
+        "size": 1371,
+        "uri": "root://eospublic.cern.ch//eos/opendata/atlas/rucio/opendata/ODEO_FEB2025_v0_exactly4lep_mc_423099.Pythia8EvtGen_A14NNPDF23LO_gammajet_DP8_17.exactly4lep.root"
+      },
+      {
+        "checksum": "adler32:cd62a4f4",
+        "size": 1379,
+        "uri": "root://eospublic.cern.ch//eos/opendata/atlas/rucio/opendata/ODEO_FEB2025_v0_exactly4lep_mc_423100.Pythia8EvtGen_A14NNPDF23LO_gammajet_DP17_35.exactly4lep.root"
+      },
+      {
+        "checksum": "adler32:20b7eea0",
+        "size": 51526,
+        "uri": "root://eospublic.cern.ch//eos/opendata/atlas/rucio/opendata/ODEO_FEB2025_v0_exactly4lep_mc_423101.Pythia8EvtGen_A14NNPDF23LO_gammajet_DP35_50.exactly4lep.root"
+      },
+      {
+        "checksum": "adler32:b87b8c5d",
+        "size": 98207,
+        "uri": "root://eospublic.cern.ch//eos/opendata/atlas/rucio/opendata/ODEO_FEB2025_v0_exactly4lep_mc_423102.Pythia8EvtGen_A14NNPDF23LO_gammajet_DP50_70.exactly4lep.root"
+      },
+      {
+        "checksum": "adler32:b365514a",
+        "size": 124242,
+        "uri": "root://eospublic.cern.ch//eos/opendata/atlas/rucio/opendata/ODEO_FEB2025_v0_exactly4lep_mc_423103.Pythia8EvtGen_A14NNPDF23LO_gammajet_DP70_140.exactly4lep.root"
+      },
+      {
+        "checksum": "adler32:f0c95c6c",
+        "size": 182509,
+        "uri": "root://eospublic.cern.ch//eos/opendata/atlas/rucio/opendata/ODEO_FEB2025_v0_exactly4lep_mc_423104.Pythia8EvtGen_A14NNPDF23LO_gammajet_DP140_280.exactly4lep.root"
+      },
+      {
+        "checksum": "adler32:46675eb8",
+        "size": 276561,
+        "uri": "root://eospublic.cern.ch//eos/opendata/atlas/rucio/opendata/ODEO_FEB2025_v0_exactly4lep_mc_423105.Pythia8EvtGen_A14NNPDF23LO_gammajet_DP280_500.exactly4lep.root"
+      },
+      {
+        "checksum": "adler32:972e4831",
+        "size": 49368,
+        "uri": "root://eospublic.cern.ch//eos/opendata/atlas/rucio/opendata/ODEO_FEB2025_v0_exactly4lep_mc_423106.Pythia8EvtGen_A14NNPDF23LO_gammajet_DP500_800.exactly4lep.root"
+      },
+      {
+        "checksum": "adler32:be54523a",
+        "size": 43727,
+        "uri": "root://eospublic.cern.ch//eos/opendata/atlas/rucio/opendata/ODEO_FEB2025_v0_exactly4lep_mc_423107.Pythia8EvtGen_A14NNPDF23LO_gammajet_DP800_1000.exactly4lep.root"
+      },
+      {
+        "checksum": "adler32:ebbf7e96",
+        "size": 59619,
+        "uri": "root://eospublic.cern.ch//eos/opendata/atlas/rucio/opendata/ODEO_FEB2025_v0_exactly4lep_mc_423108.Pythia8EvtGen_A14NNPDF23LO_gammajet_DP1000_1500.exactly4lep.root"
+      },
+      {
+        "checksum": "adler32:70c8ae95",
+        "size": 31866,
+        "uri": "root://eospublic.cern.ch//eos/opendata/atlas/rucio/opendata/ODEO_FEB2025_v0_exactly4lep_mc_423109.Pythia8EvtGen_A14NNPDF23LO_gammajet_DP1500_2000.exactly4lep.root"
+      },
+      {
+        "checksum": "adler32:6bd65532",
+        "size": 32092,
+        "uri": "root://eospublic.cern.ch//eos/opendata/atlas/rucio/opendata/ODEO_FEB2025_v0_exactly4lep_mc_423110.Pythia8EvtGen_A14NNPDF23LO_gammajet_DP2000_2500.exactly4lep.root"
+      },
+      {
+        "checksum": "adler32:80a85334",
+        "size": 44286,
+        "uri": "root://eospublic.cern.ch//eos/opendata/atlas/rucio/opendata/ODEO_FEB2025_v0_exactly4lep_mc_423111.Pythia8EvtGen_A14NNPDF23LO_gammajet_DP2500_3000.exactly4lep.root"
+      },
+      {
+        "checksum": "adler32:43eaa3ce",
+        "size": 45208,
+        "uri": "root://eospublic.cern.ch//eos/opendata/atlas/rucio/opendata/ODEO_FEB2025_v0_exactly4lep_mc_423112.Pythia8EvtGen_A14NNPDF23LO_gammajet_DP3000_inf.exactly4lep.root"
+      },
+      {
+        "checksum": "adler32:f9bd1a9e",
+        "size": 72421,
+        "uri": "root://eospublic.cern.ch//eos/opendata/atlas/rucio/opendata/ODEO_FEB2025_v0_exactly4lep_mc_448624.MGPy8EG_A14N23LO_TT_higgsinoRPV_1075_700.exactly4lep.root"
+      },
+      {
+        "checksum": "adler32:ef33af0b",
+        "size": 132393,
+        "uri": "root://eospublic.cern.ch//eos/opendata/atlas/rucio/opendata/ODEO_FEB2025_v0_exactly4lep_mc_449595.MGPy8EG_A14N23LO_TT_RPVdirectBL_1400.exactly4lep.root"
+      },
+      {
+        "checksum": "adler32:d0fbff98",
+        "size": 60945,
+        "uri": "root://eospublic.cern.ch//eos/opendata/atlas/rucio/opendata/ODEO_FEB2025_v0_exactly4lep_mc_450576.PowhegPythia8EvtGen_NNLOPS_nnlo_30_VBFH125_ZZllbb.exactly4lep.root"
+      },
+      {
+        "checksum": "adler32:be793c6d",
+        "size": 66114,
+        "uri": "root://eospublic.cern.ch//eos/opendata/atlas/rucio/opendata/ODEO_FEB2025_v0_exactly4lep_mc_500335.MGH7EG_VBFHWWlvlv.exactly4lep.root"
+      },
+      {
+        "checksum": "adler32:693815a6",
+        "size": 61289,
+        "uri": "root://eospublic.cern.ch//eos/opendata/atlas/rucio/opendata/ODEO_FEB2025_v0_exactly4lep_mc_500553.aMCPy8EG_ZH_FxFx_Hyy.exactly4lep.root"
+      },
+      {
+        "checksum": "adler32:d9c61968",
+        "size": 28063,
+        "uri": "root://eospublic.cern.ch//eos/opendata/atlas/rucio/opendata/ODEO_FEB2025_v0_exactly4lep_mc_500554.aMCPy8EG_WH_FxFx_Hyy.exactly4lep.root"
+      },
+      {
+        "checksum": "adler32:a105117f",
+        "size": 67862,
+        "uri": "root://eospublic.cern.ch//eos/opendata/atlas/rucio/opendata/ODEO_FEB2025_v0_exactly4lep_mc_500555.aMCPy8EG_ggZH_Hyy.exactly4lep.root"
+      },
+      {
+        "checksum": "adler32:4ad81cbd",
+        "size": 28912,
+        "uri": "root://eospublic.cern.ch//eos/opendata/atlas/rucio/opendata/ODEO_FEB2025_v0_exactly4lep_mc_501058.MGPy8EG_StauStauDirect_200p0_1p0_TFilt.exactly4lep.root"
+      },
+      {
+        "checksum": "adler32:65731b1c",
+        "size": 43849,
+        "uri": "root://eospublic.cern.ch//eos/opendata/atlas/rucio/opendata/ODEO_FEB2025_v0_exactly4lep_mc_506098.aMCPy8EG_WpH_FxFx_Htautau.exactly4lep.root"
+      },
+      {
+        "checksum": "adler32:edae6cdc",
+        "size": 83966,
+        "uri": "root://eospublic.cern.ch//eos/opendata/atlas/rucio/opendata/ODEO_FEB2025_v0_exactly4lep_mc_506099.aMCPy8EG_ZH_FxFx_Htautau.exactly4lep.root"
+      },
+      {
+        "checksum": "adler32:9a646ecf",
+        "size": 1235,
+        "uri": "root://eospublic.cern.ch//eos/opendata/atlas/rucio/opendata/ODEO_FEB2025_v0_exactly4lep_mc_506101.aMCH7EG_VBF_Htautauh30h20.exactly4lep.root"
+      },
+      {
+        "checksum": "adler32:1ac4894b",
+        "size": 83369,
+        "uri": "root://eospublic.cern.ch//eos/opendata/atlas/rucio/opendata/ODEO_FEB2025_v0_exactly4lep_mc_506102.aMCH7EG_VBF_Htautaul13l7.exactly4lep.root"
+      },
+      {
+        "checksum": "adler32:2e7b4ed9",
+        "size": 26003,
+        "uri": "root://eospublic.cern.ch//eos/opendata/atlas/rucio/opendata/ODEO_FEB2025_v0_exactly4lep_mc_506103.aMCH7EG_VBF_Htautaulp15hm20.exactly4lep.root"
+      },
+      {
+        "checksum": "adler32:8612eb3c",
+        "size": 44757,
+        "uri": "root://eospublic.cern.ch//eos/opendata/atlas/rucio/opendata/ODEO_FEB2025_v0_exactly4lep_mc_506104.aMCH7EG_VBF_Htautaulm15hp20.exactly4lep.root"
+      },
+      {
+        "checksum": "adler32:46d0da29",
+        "size": 26997,
+        "uri": "root://eospublic.cern.ch//eos/opendata/atlas/rucio/opendata/ODEO_FEB2025_v0_exactly4lep_mc_506811.aMCH7EG_VBF_HC_Hyy.exactly4lep.root"
+      },
+      {
+        "checksum": "adler32:629b6679",
+        "size": 28229,
+        "uri": "root://eospublic.cern.ch//eos/opendata/atlas/rucio/opendata/ODEO_FEB2025_v0_exactly4lep_mc_506813.aMCPy8EG_ZH_had_FxFx_Hyy.exactly4lep.root"
+      },
+      {
+        "checksum": "adler32:60566f53",
+        "size": 1211,
+        "uri": "root://eospublic.cern.ch//eos/opendata/atlas/rucio/opendata/ODEO_FEB2025_v0_exactly4lep_mc_506814.aMCPy8EG_ggZH_Zhad_Hyy.exactly4lep.root"
+      },
+      {
+        "checksum": "adler32:7e6fa17d",
+        "size": 33346,
+        "uri": "root://eospublic.cern.ch//eos/opendata/atlas/rucio/opendata/ODEO_FEB2025_v0_exactly4lep_mc_507366.MGPy8EG_A14NNPDF23LO_GGM_N1N2C1_950.exactly4lep.root"
+      },
+      {
+        "checksum": "adler32:4257f3eb",
+        "size": 195254,
+        "uri": "root://eospublic.cern.ch//eos/opendata/atlas/rucio/opendata/ODEO_FEB2025_v0_exactly4lep_mc_510097.MGPy8EG_A14N23LO_DM_4topscalar_p1000_c1_nonallhad.exactly4lep.root"
+      },
+      {
+        "checksum": "adler32:1b4d23cb",
+        "size": 37452,
+        "uri": "root://eospublic.cern.ch//eos/opendata/atlas/rucio/opendata/ODEO_FEB2025_v0_exactly4lep_mc_523692.MGPy8EG_A14N23LO_TT_tN1_1200_200_MS.exactly4lep.root"
+      },
+      {
+        "checksum": "adler32:233bcfb3",
+        "size": 331267,
+        "uri": "root://eospublic.cern.ch//eos/opendata/atlas/rucio/opendata/ODEO_FEB2025_v0_exactly4lep_mc_600017.PhH7EG_H7UE_716_tchan_lept_antitop.exactly4lep.root"
+      },
+      {
+        "checksum": "adler32:c0bd572a",
+        "size": 551369,
+        "uri": "root://eospublic.cern.ch//eos/opendata/atlas/rucio/opendata/ODEO_FEB2025_v0_exactly4lep_mc_600018.PhH7EG_H7UE_716_tchan_lept_top.exactly4lep.root"
+      },
+      {
+        "checksum": "adler32:7e08137d",
+        "size": 49157,
+        "uri": "root://eospublic.cern.ch//eos/opendata/atlas/rucio/opendata/ODEO_FEB2025_v0_exactly4lep_mc_600019.PhH7EG_H7UE_716_schan_lept_antitop.exactly4lep.root"
+      },
+      {
+        "checksum": "adler32:7d9888e6",
+        "size": 48921,
+        "uri": "root://eospublic.cern.ch//eos/opendata/atlas/rucio/opendata/ODEO_FEB2025_v0_exactly4lep_mc_600020.PhH7EG_H7UE_716_schan_lept_top.exactly4lep.root"
+      },
+      {
+        "checksum": "adler32:e0389c56",
+        "size": 1355,
+        "uri": "root://eospublic.cern.ch//eos/opendata/atlas/rucio/opendata/ODEO_FEB2025_v0_exactly4lep_mc_600565.PhH7EG_ggH125_tautauh30h20_ShowerSys_fix.exactly4lep.root"
+      },
+      {
+        "checksum": "adler32:e39d55c8",
+        "size": 200204,
+        "uri": "root://eospublic.cern.ch//eos/opendata/atlas/rucio/opendata/ODEO_FEB2025_v0_exactly4lep_mc_600566.PhH7EG_ggH125_tautaul13l7_ShowerSys_fix.exactly4lep.root"
+      },
+      {
+        "checksum": "adler32:a6531249",
+        "size": 50524,
+        "uri": "root://eospublic.cern.ch//eos/opendata/atlas/rucio/opendata/ODEO_FEB2025_v0_exactly4lep_mc_600567.PhH7EG_ggH125_ttlp15hm20_ShowerSys_fix.exactly4lep.root"
+      },
+      {
+        "checksum": "adler32:b05ea8f1",
+        "size": 40341,
+        "uri": "root://eospublic.cern.ch//eos/opendata/atlas/rucio/opendata/ODEO_FEB2025_v0_exactly4lep_mc_600568.PhH7EG_ggH125_ttlm15hp20_ShowerSys_fix.exactly4lep.root"
+      },
+      {
+        "checksum": "adler32:3cbe8a50",
+        "size": 26102,
+        "uri": "root://eospublic.cern.ch//eos/opendata/atlas/rucio/opendata/ODEO_FEB2025_v0_exactly4lep_mc_600569.PhH7EG_VBFH125_tautauh30h20_ShowerSys_fix.exactly4lep.root"
+      },
+      {
+        "checksum": "adler32:375dc8d7",
+        "size": 75829,
+        "uri": "root://eospublic.cern.ch//eos/opendata/atlas/rucio/opendata/ODEO_FEB2025_v0_exactly4lep_mc_600570.PhH7EG_VBFH125_tautaul13l7_ShowerSys_fix.exactly4lep.root"
+      },
+      {
+        "checksum": "adler32:be2b2164",
+        "size": 27326,
+        "uri": "root://eospublic.cern.ch//eos/opendata/atlas/rucio/opendata/ODEO_FEB2025_v0_exactly4lep_mc_600571.PhH7EG_VBFH125_tautaulp15hm20_ShowerSys_fix.exactly4lep.root"
+      },
+      {
+        "checksum": "adler32:4abd0bfb",
+        "size": 27244,
+        "uri": "root://eospublic.cern.ch//eos/opendata/atlas/rucio/opendata/ODEO_FEB2025_v0_exactly4lep_mc_600572.PhH7EG_VBFH125_tautaulm15hp20_ShowerSys_fix.exactly4lep.root"
+      },
+      {
+        "checksum": "adler32:5326047e",
+        "size": 29969,
+        "uri": "root://eospublic.cern.ch//eos/opendata/atlas/rucio/opendata/ODEO_FEB2025_v0_exactly4lep_mc_600573.PhH7EG_WmH125J_Winc_MINLO_tt_ShowerSys_fix.exactly4lep.root"
+      },
+      {
+        "checksum": "adler32:e9861be3",
+        "size": 44302,
+        "uri": "root://eospublic.cern.ch//eos/opendata/atlas/rucio/opendata/ODEO_FEB2025_v0_exactly4lep_mc_600574.PhH7EG_WpH125J_Winc_MINLO_tt_ShowerSys_fix.exactly4lep.root"
+      },
+      {
+        "checksum": "adler32:b5c7a86b",
+        "size": 115637,
+        "uri": "root://eospublic.cern.ch//eos/opendata/atlas/rucio/opendata/ODEO_FEB2025_v0_exactly4lep_mc_600575.PhH7EG_ZH125J_Zinc_MINLO_tautau_ShowerSys_fix.exactly4lep.root"
+      },
+      {
+        "checksum": "adler32:e2e3151b",
+        "size": 75185,
+        "uri": "root://eospublic.cern.ch//eos/opendata/atlas/rucio/opendata/ODEO_FEB2025_v0_exactly4lep_mc_600686.PhPy8EG_NNPDF3_AZNLO_ggZH125_Htautau_Zinc.exactly4lep.root"
+      },
+      {
+        "checksum": "adler32:1f176a9c",
+        "size": 842023,
+        "uri": "root://eospublic.cern.ch//eos/opendata/atlas/rucio/opendata/ODEO_FEB2025_v0_exactly4lep_mc_601352.PhPy8EG_tW_dyn_DR_incl_antitop.exactly4lep.root"
+      },
+      {
+        "checksum": "adler32:c3515583",
+        "size": 822637,
+        "uri": "root://eospublic.cern.ch//eos/opendata/atlas/rucio/opendata/ODEO_FEB2025_v0_exactly4lep_mc_601355.PhPy8EG_tW_dyn_DR_incl_top.exactly4lep.root"
+      },
+      {
+        "checksum": "adler32:db10eb6e",
+        "size": 348229,
+        "uri": "root://eospublic.cern.ch//eos/opendata/atlas/rucio/opendata/ODEO_FEB2025_v0_exactly4lep_mc_601487.PhPy8EG_A14_tchan_pThard1_lep_antitop.exactly4lep.root"
+      },
+      {
+        "checksum": "adler32:b06df8c0",
+        "size": 558937,
+        "uri": "root://eospublic.cern.ch//eos/opendata/atlas/rucio/opendata/ODEO_FEB2025_v0_exactly4lep_mc_601489.PhPy8EG_A14_tchan_pThard1_lep_top.exactly4lep.root"
+      },
+      {
+        "checksum": "adler32:64872fec",
+        "size": 6067725,
+        "uri": "root://eospublic.cern.ch//eos/opendata/atlas/rucio/opendata/ODEO_FEB2025_v0_exactly4lep_mc_601491.PhPy8EG_A14_ttbar_pThard1_dil.exactly4lep.root"
+      },
+      {
+        "checksum": "adler32:14bf4315",
+        "size": 55515,
+        "uri": "root://eospublic.cern.ch//eos/opendata/atlas/rucio/opendata/ODEO_FEB2025_v0_exactly4lep_mc_601495.PhPy8EG_A14_ttbar_pThard1_allhad.exactly4lep.root"
+      },
+      {
+        "checksum": "adler32:83eca2ab",
+        "size": 8053103,
+        "uri": "root://eospublic.cern.ch//eos/opendata/atlas/rucio/opendata/ODEO_FEB2025_v0_exactly4lep_mc_601497.PhPy8EG_A14_ttbar_pThard1_singlelep.exactly4lep.root"
+      },
+      {
+        "checksum": "adler32:bab846f5",
+        "size": 229701,
+        "uri": "root://eospublic.cern.ch//eos/opendata/atlas/rucio/opendata/ODEO_FEB2025_v0_exactly4lep_mc_601624.PhPy8EG_tW_DS_dyn_dil_antitop.exactly4lep.root"
+      },
+      {
+        "checksum": "adler32:8a45a7fb",
+        "size": 755443,
+        "uri": "root://eospublic.cern.ch//eos/opendata/atlas/rucio/opendata/ODEO_FEB2025_v0_exactly4lep_mc_601627.PhPy8EG_tW_DS_dyn_incl_antitop.exactly4lep.root"
+      },
+      {
+        "checksum": "adler32:b3989a72",
+        "size": 268101,
+        "uri": "root://eospublic.cern.ch//eos/opendata/atlas/rucio/opendata/ODEO_FEB2025_v0_exactly4lep_mc_601628.PhPy8EG_tW_DS_dyn_dil_top.exactly4lep.root"
+      },
+      {
+        "checksum": "adler32:37d40719",
+        "size": 724657,
+        "uri": "root://eospublic.cern.ch//eos/opendata/atlas/rucio/opendata/ODEO_FEB2025_v0_exactly4lep_mc_601631.PhPy8EG_tW_DS_dyn_incl_top.exactly4lep.root"
+      },
+      {
+        "checksum": "adler32:5caa38ac",
+        "size": 775594,
+        "uri": "root://eospublic.cern.ch//eos/opendata/atlas/rucio/opendata/ODEO_FEB2025_v0_exactly4lep_mc_601761.PhPy8EG_tW_dyn_DR_pThard1_incl_top.exactly4lep.root"
+      },
+      {
+        "checksum": "adler32:cc89ce80",
+        "size": 788744,
+        "uri": "root://eospublic.cern.ch//eos/opendata/atlas/rucio/opendata/ODEO_FEB2025_v0_exactly4lep_mc_601762.PhPy8EG_tW_dyn_DR_pThard1_incl_antitop.exactly4lep.root"
+      },
+      {
+        "checksum": "adler32:e545bb26",
+        "size": 275225,
+        "uri": "root://eospublic.cern.ch//eos/opendata/atlas/rucio/opendata/ODEO_FEB2025_v0_exactly4lep_mc_601763.PhPy8EG_tW_dyn_DR_pThard1_dil_top.exactly4lep.root"
+      },
+      {
+        "checksum": "adler32:8efdcf44",
+        "size": 300337,
+        "uri": "root://eospublic.cern.ch//eos/opendata/atlas/rucio/opendata/ODEO_FEB2025_v0_exactly4lep_mc_601764.PhPy8EG_tW_dyn_DR_pThard1_dil_antitop.exactly4lep.root"
+      },
+      {
+        "checksum": "adler32:cad1ce77",
+        "size": 200983,
+        "uri": "root://eospublic.cern.ch//eos/opendata/atlas/rucio/opendata/ODEO_FEB2025_v0_exactly4lep_mc_700000.Sh_228_ttW.exactly4lep.root"
+      },
+      {
+        "checksum": "adler32:d194b7ac",
+        "size": 25936,
+        "uri": "root://eospublic.cern.ch//eos/opendata/atlas/rucio/opendata/ODEO_FEB2025_v0_exactly4lep_mc_700007.Sh_228_yyy_01NLO.exactly4lep.root"
+      },
+      {
+        "checksum": "adler32:522aadf9",
+        "size": 142133,
+        "uri": "root://eospublic.cern.ch//eos/opendata/atlas/rucio/opendata/ODEO_FEB2025_v0_exactly4lep_mc_700195.Sh_2210_eegammagamma.exactly4lep.root"
+      },
+      {
+        "checksum": "adler32:656eefd7",
+        "size": 229707,
+        "uri": "root://eospublic.cern.ch//eos/opendata/atlas/rucio/opendata/ODEO_FEB2025_v0_exactly4lep_mc_700196.Sh_2210_mumugammagamma.exactly4lep.root"
+      },
+      {
+        "checksum": "adler32:304c7705",
+        "size": 29024,
+        "uri": "root://eospublic.cern.ch//eos/opendata/atlas/rucio/opendata/ODEO_FEB2025_v0_exactly4lep_mc_700197.Sh_2210_tautaugammagamma.exactly4lep.root"
+      },
+      {
+        "checksum": "adler32:4e1872d3",
+        "size": 1211,
+        "uri": "root://eospublic.cern.ch//eos/opendata/atlas/rucio/opendata/ODEO_FEB2025_v0_exactly4lep_mc_700198.Sh_2210_nunugammagamma.exactly4lep.root"
+      },
+      {
+        "checksum": "adler32:53d4bf9c",
+        "size": 46041,
+        "uri": "root://eospublic.cern.ch//eos/opendata/atlas/rucio/opendata/ODEO_FEB2025_v0_exactly4lep_mc_700199.Sh_2210_enugammagamma.exactly4lep.root"
+      },
+      {
+        "checksum": "adler32:5a3a08ba",
+        "size": 44756,
+        "uri": "root://eospublic.cern.ch//eos/opendata/atlas/rucio/opendata/ODEO_FEB2025_v0_exactly4lep_mc_700200.Sh_2210_munugammagamma.exactly4lep.root"
+      },
+      {
+        "checksum": "adler32:f459d7a6",
+        "size": 37889,
+        "uri": "root://eospublic.cern.ch//eos/opendata/atlas/rucio/opendata/ODEO_FEB2025_v0_exactly4lep_mc_700201.Sh_2210_taunugammagamma.exactly4lep.root"
+      },
+      {
+        "checksum": "adler32:1f833f2c",
+        "size": 6833147,
+        "uri": "root://eospublic.cern.ch//eos/opendata/atlas/rucio/opendata/ODEO_FEB2025_v0_exactly4lep_mc_700320.Sh_2211_Zee_maxHTpTV2_BFilter.exactly4lep.root"
+      },
+      {
+        "checksum": "adler32:8368baab",
+        "size": 19683661,
+        "uri": "root://eospublic.cern.ch//eos/opendata/atlas/rucio/opendata/ODEO_FEB2025_v0_exactly4lep_mc_700321.Sh_2211_Zee_maxHTpTV2_CFilterBVeto.exactly4lep.root"
+      },
+      {
+        "checksum": "adler32:f3056800",
+        "size": 34195062,
+        "uri": "root://eospublic.cern.ch//eos/opendata/atlas/rucio/opendata/ODEO_FEB2025_v0_exactly4lep_mc_700322.Sh_2211_Zee_maxHTpTV2_CVetoBVeto.exactly4lep.root"
+      },
+      {
+        "checksum": "adler32:eebd221b",
+        "size": 6521212,
+        "uri": "root://eospublic.cern.ch//eos/opendata/atlas/rucio/opendata/ODEO_FEB2025_v0_exactly4lep_mc_700323.Sh_2211_Zmumu_maxHTpTV2_BFilter.exactly4lep.root"
+      },
+      {
+        "checksum": "adler32:2d3e872e",
+        "size": 19546630,
+        "uri": "root://eospublic.cern.ch//eos/opendata/atlas/rucio/opendata/ODEO_FEB2025_v0_exactly4lep_mc_700324.Sh_2211_Zmumu_maxHTpTV2_CFilterBVeto.exactly4lep.root"
+      },
+      {
+        "checksum": "adler32:4516abfe",
+        "size": 35789917,
+        "uri": "root://eospublic.cern.ch//eos/opendata/atlas/rucio/opendata/ODEO_FEB2025_v0_exactly4lep_mc_700325.Sh_2211_Zmumu_maxHTpTV2_CVetoBVeto.exactly4lep.root"
+      },
+      {
+        "checksum": "adler32:839dacf5",
+        "size": 220664,
+        "uri": "root://eospublic.cern.ch//eos/opendata/atlas/rucio/opendata/ODEO_FEB2025_v0_exactly4lep_mc_700335.Sh_2211_Znunu_pTV2_BFilter.exactly4lep.root"
+      },
+      {
+        "checksum": "adler32:dbf0556c",
+        "size": 372932,
+        "uri": "root://eospublic.cern.ch//eos/opendata/atlas/rucio/opendata/ODEO_FEB2025_v0_exactly4lep_mc_700336.Sh_2211_Znunu_pTV2_CFilterBVeto.exactly4lep.root"
+      },
+      {
+        "checksum": "adler32:d8d17f3b",
+        "size": 688743,
+        "uri": "root://eospublic.cern.ch//eos/opendata/atlas/rucio/opendata/ODEO_FEB2025_v0_exactly4lep_mc_700337.Sh_2211_Znunu_pTV2_CVetoBVeto.exactly4lep.root"
+      },
+      {
+        "checksum": "adler32:542a23c6",
+        "size": 5870875,
+        "uri": "root://eospublic.cern.ch//eos/opendata/atlas/rucio/opendata/ODEO_FEB2025_v0_exactly4lep_mc_700338.Sh_2211_Wenu_maxHTpTV2_BFilter.exactly4lep.root"
+      },
+      {
+        "checksum": "adler32:582f3427",
+        "size": 18688945,
+        "uri": "root://eospublic.cern.ch//eos/opendata/atlas/rucio/opendata/ODEO_FEB2025_v0_exactly4lep_mc_700339.Sh_2211_Wenu_maxHTpTV2_CFilterBVeto.exactly4lep.root"
+      },
+      {
+        "checksum": "adler32:5919f8db",
+        "size": 14084976,
+        "uri": "root://eospublic.cern.ch//eos/opendata/atlas/rucio/opendata/ODEO_FEB2025_v0_exactly4lep_mc_700340.Sh_2211_Wenu_maxHTpTV2_CVetoBVeto.exactly4lep.root"
+      },
+      {
+        "checksum": "adler32:2b459a39",
+        "size": 6140940,
+        "uri": "root://eospublic.cern.ch//eos/opendata/atlas/rucio/opendata/ODEO_FEB2025_v0_exactly4lep_mc_700341.Sh_2211_Wmunu_maxHTpTV2_BFilter.exactly4lep.root"
+      },
+      {
+        "checksum": "adler32:e3ce7ba3",
+        "size": 17351108,
+        "uri": "root://eospublic.cern.ch//eos/opendata/atlas/rucio/opendata/ODEO_FEB2025_v0_exactly4lep_mc_700342.Sh_2211_Wmunu_maxHTpTV2_CFilterBVeto.exactly4lep.root"
+      },
+      {
+        "checksum": "adler32:7a32d554",
+        "size": 13332159,
+        "uri": "root://eospublic.cern.ch//eos/opendata/atlas/rucio/opendata/ODEO_FEB2025_v0_exactly4lep_mc_700343.Sh_2211_Wmunu_maxHTpTV2_CVetoBVeto.exactly4lep.root"
+      },
+      {
+        "checksum": "adler32:42ac2eb0",
+        "size": 1689361,
+        "uri": "root://eospublic.cern.ch//eos/opendata/atlas/rucio/opendata/ODEO_FEB2025_v0_exactly4lep_mc_700344.Sh_2211_Wtaunu_L_maxHTpTV2_BFilter.exactly4lep.root"
+      },
+      {
+        "checksum": "adler32:c319812c",
+        "size": 5489179,
+        "uri": "root://eospublic.cern.ch//eos/opendata/atlas/rucio/opendata/ODEO_FEB2025_v0_exactly4lep_mc_700345.Sh_2211_Wtaunu_L_maxHTpTV2_CFilterBVeto.exactly4lep.root"
+      },
+      {
+        "checksum": "adler32:1f8d2fbc",
+        "size": 7307621,
+        "uri": "root://eospublic.cern.ch//eos/opendata/atlas/rucio/opendata/ODEO_FEB2025_v0_exactly4lep_mc_700346.Sh_2211_Wtaunu_L_maxHTpTV2_CVetoBVeto.exactly4lep.root"
+      },
+      {
+        "checksum": "adler32:657360b3",
+        "size": 1400900,
+        "uri": "root://eospublic.cern.ch//eos/opendata/atlas/rucio/opendata/ODEO_FEB2025_v0_exactly4lep_mc_700347.Sh_2211_Wtaunu_H_maxHTpTV2_BFilter.exactly4lep.root"
+      },
+      {
+        "checksum": "adler32:1f798f3c",
+        "size": 765068,
+        "uri": "root://eospublic.cern.ch//eos/opendata/atlas/rucio/opendata/ODEO_FEB2025_v0_exactly4lep_mc_700348.Sh_2211_Wtaunu_H_maxHTpTV2_CFilterBVeto.exactly4lep.root"
+      },
+      {
+        "checksum": "adler32:a29ac634",
+        "size": 2779176,
+        "uri": "root://eospublic.cern.ch//eos/opendata/atlas/rucio/opendata/ODEO_FEB2025_v0_exactly4lep_mc_700349.Sh_2211_Wtaunu_H_maxHTpTV2_CVetoBVeto.exactly4lep.root"
+      },
+      {
+        "checksum": "adler32:a2c88bd6",
+        "size": 88952,
+        "uri": "root://eospublic.cern.ch//eos/opendata/atlas/rucio/opendata/ODEO_FEB2025_v0_exactly4lep_mc_700352.Sh_2211_pTZ100_Zqqgamma.exactly4lep.root"
+      },
+      {
+        "checksum": "adler32:68affdd8",
+        "size": 65768,
+        "uri": "root://eospublic.cern.ch//eos/opendata/atlas/rucio/opendata/ODEO_FEB2025_v0_exactly4lep_mc_700353.Sh_2211_pTZ100_Zbbgamma.exactly4lep.root"
+      },
+      {
+        "checksum": "adler32:4ed9e802",
+        "size": 111269,
+        "uri": "root://eospublic.cern.ch//eos/opendata/atlas/rucio/opendata/ODEO_FEB2025_v0_exactly4lep_mc_700358.Sh_2211_Zee2jets_Min_N_TChannel.exactly4lep.root"
+      },
+      {
+        "checksum": "adler32:f0f8b3c4",
+        "size": 96086,
+        "uri": "root://eospublic.cern.ch//eos/opendata/atlas/rucio/opendata/ODEO_FEB2025_v0_exactly4lep_mc_700359.Sh_2211_Zmm2jets_Min_N_TChannel.exactly4lep.root"
+      },
+      {
+        "checksum": "adler32:3a2e725a",
+        "size": 44347,
+        "uri": "root://eospublic.cern.ch//eos/opendata/atlas/rucio/opendata/ODEO_FEB2025_v0_exactly4lep_mc_700360.Sh_2211_Ztt2jets_Min_N_TChannel.exactly4lep.root"
+      },
+      {
+        "checksum": "adler32:ae9e7f3b",
+        "size": 25885,
+        "uri": "root://eospublic.cern.ch//eos/opendata/atlas/rucio/opendata/ODEO_FEB2025_v0_exactly4lep_mc_700361.Sh_2211_Znunu2jets_Min_N_TChannel.exactly4lep.root"
+      },
+      {
+        "checksum": "adler32:1da2a39b",
+        "size": 147164,
+        "uri": "root://eospublic.cern.ch//eos/opendata/atlas/rucio/opendata/ODEO_FEB2025_v0_exactly4lep_mc_700362.Sh_2211_Wenu2jets_Min_N_TChannel.exactly4lep.root"
+      },
+      {
+        "checksum": "adler32:2fd9f448",
+        "size": 172325,
+        "uri": "root://eospublic.cern.ch//eos/opendata/atlas/rucio/opendata/ODEO_FEB2025_v0_exactly4lep_mc_700363.Sh_2211_Wmunu2jets_Min_N_TChannel.exactly4lep.root"
+      },
+      {
+        "checksum": "adler32:763c39e4",
+        "size": 50104,
+        "uri": "root://eospublic.cern.ch//eos/opendata/atlas/rucio/opendata/ODEO_FEB2025_v0_exactly4lep_mc_700364.Sh_2211_Wtaunu2jets_Min_N_TChannel.exactly4lep.root"
+      },
+      {
+        "checksum": "adler32:f628bb64",
+        "size": 6692961,
+        "uri": "root://eospublic.cern.ch//eos/opendata/atlas/rucio/opendata/ODEO_FEB2025_v0_exactly4lep_mc_700398.Sh_2211_mumugamma.exactly4lep.root"
+      },
+      {
+        "checksum": "adler32:712c14bb",
+        "size": 7167123,
+        "uri": "root://eospublic.cern.ch//eos/opendata/atlas/rucio/opendata/ODEO_FEB2025_v0_exactly4lep_mc_700399.Sh_2211_eegamma.exactly4lep.root"
+      },
+      {
+        "checksum": "adler32:9dc028db",
+        "size": 1666688,
+        "uri": "root://eospublic.cern.ch//eos/opendata/atlas/rucio/opendata/ODEO_FEB2025_v0_exactly4lep_mc_700400.Sh_2211_tautaugamma.exactly4lep.root"
+      },
+      {
+        "checksum": "adler32:844d8bbe",
+        "size": 285129,
+        "uri": "root://eospublic.cern.ch//eos/opendata/atlas/rucio/opendata/ODEO_FEB2025_v0_exactly4lep_mc_700401.Sh_2211_nunugamma.exactly4lep.root"
+      },
+      {
+        "checksum": "adler32:f351696e",
+        "size": 5424474,
+        "uri": "root://eospublic.cern.ch//eos/opendata/atlas/rucio/opendata/ODEO_FEB2025_v0_exactly4lep_mc_700402.Sh_2211_munugamma.exactly4lep.root"
+      },
+      {
+        "checksum": "adler32:c57049f2",
+        "size": 5548065,
+        "uri": "root://eospublic.cern.ch//eos/opendata/atlas/rucio/opendata/ODEO_FEB2025_v0_exactly4lep_mc_700403.Sh_2211_enugamma.exactly4lep.root"
+      },
+      {
+        "checksum": "adler32:53cb8706",
+        "size": 3523998,
+        "uri": "root://eospublic.cern.ch//eos/opendata/atlas/rucio/opendata/ODEO_FEB2025_v0_exactly4lep_mc_700404.Sh_2211_taunugamma.exactly4lep.root"
+      },
+      {
+        "checksum": "adler32:ae617baf",
+        "size": 26114,
+        "uri": "root://eospublic.cern.ch//eos/opendata/atlas/rucio/opendata/ODEO_FEB2025_v0_exactly4lep_mc_700442.Sh_2211_gamma2jets_pTy140_Min_N_TChannel.exactly4lep.root"
+      },
+      {
+        "checksum": "adler32:6cd5d8db",
+        "size": 588259,
+        "uri": "root://eospublic.cern.ch//eos/opendata/atlas/rucio/opendata/ODEO_FEB2025_v0_exactly4lep_mc_700467.Sh_2211_Zee_maxHTpTV2_m10_40_pT5_BFilter.exactly4lep.root"
+      },
+      {
+        "checksum": "adler32:0b2da63f",
+        "size": 1752906,
+        "uri": "root://eospublic.cern.ch//eos/opendata/atlas/rucio/opendata/ODEO_FEB2025_v0_exactly4lep_mc_700468.Sh_2211_Zee_maxHTpTV2_m10_40_pT5_CFilterBVeto.exactly4lep.root"
+      },
+      {
+        "checksum": "adler32:049936b2",
+        "size": 8413815,
+        "uri": "root://eospublic.cern.ch//eos/opendata/atlas/rucio/opendata/ODEO_FEB2025_v0_exactly4lep_mc_700469.Sh_2211_Zee_maxHTpTV2_m10_40_pT5_CVetoBVeto.exactly4lep.root"
+      },
+      {
+        "checksum": "adler32:afc80365",
+        "size": 555782,
+        "uri": "root://eospublic.cern.ch//eos/opendata/atlas/rucio/opendata/ODEO_FEB2025_v0_exactly4lep_mc_700470.Sh_2211_Zmumu_maxHTpTV2_m10_40_pT5_BFilter.exactly4lep.root"
+      },
+      {
+        "checksum": "adler32:c2c67dff",
+        "size": 1707319,
+        "uri": "root://eospublic.cern.ch//eos/opendata/atlas/rucio/opendata/ODEO_FEB2025_v0_exactly4lep_mc_700471.Sh_2211_Zmumu_maxHTpTV2_m10_40_pT5_CFilterBVeto.exactly4lep.root"
+      },
+      {
+        "checksum": "adler32:3fb8dcba",
+        "size": 8549262,
+        "uri": "root://eospublic.cern.ch//eos/opendata/atlas/rucio/opendata/ODEO_FEB2025_v0_exactly4lep_mc_700472.Sh_2211_Zmumu_maxHTpTV2_m10_40_pT5_CVetoBVeto.exactly4lep.root"
+      },
+      {
+        "checksum": "adler32:51d13a93",
+        "size": 616185,
+        "uri": "root://eospublic.cern.ch//eos/opendata/atlas/rucio/opendata/ODEO_FEB2025_v0_exactly4lep_mc_700488.Sh_2211_WlvWqq.exactly4lep.root"
+      },
+      {
+        "checksum": "adler32:84aafc2c",
+        "size": 163497,
+        "uri": "root://eospublic.cern.ch//eos/opendata/atlas/rucio/opendata/ODEO_FEB2025_v0_exactly4lep_mc_700489.Sh_2211_WlvZqq.exactly4lep.root"
+      },
+      {
+        "checksum": "adler32:58e5432b",
+        "size": 70910,
+        "uri": "root://eospublic.cern.ch//eos/opendata/atlas/rucio/opendata/ODEO_FEB2025_v0_exactly4lep_mc_700490.Sh_2211_WlvZbb.exactly4lep.root"
+      },
+      {
+        "checksum": "adler32:748cebc9",
+        "size": 37637,
+        "uri": "root://eospublic.cern.ch//eos/opendata/atlas/rucio/opendata/ODEO_FEB2025_v0_exactly4lep_mc_700491.Sh_2211_WqqZvv.exactly4lep.root"
+      },
+      {
+        "checksum": "adler32:c937d7c5",
+        "size": 181807,
+        "uri": "root://eospublic.cern.ch//eos/opendata/atlas/rucio/opendata/ODEO_FEB2025_v0_exactly4lep_mc_700492.Sh_2211_WqqZll.exactly4lep.root"
+      },
+      {
+        "checksum": "adler32:86b75396",
+        "size": 120594,
+        "uri": "root://eospublic.cern.ch//eos/opendata/atlas/rucio/opendata/ODEO_FEB2025_v0_exactly4lep_mc_700493.Sh_2211_ZqqZll.exactly4lep.root"
+      },
+      {
+        "checksum": "adler32:974a91f9",
+        "size": 197371,
+        "uri": "root://eospublic.cern.ch//eos/opendata/atlas/rucio/opendata/ODEO_FEB2025_v0_exactly4lep_mc_700494.Sh_2211_ZbbZll.exactly4lep.root"
+      },
+      {
+        "checksum": "adler32:0671d6ab",
+        "size": 37961,
+        "uri": "root://eospublic.cern.ch//eos/opendata/atlas/rucio/opendata/ODEO_FEB2025_v0_exactly4lep_mc_700495.Sh_2211_ZqqZvv.exactly4lep.root"
+      },
+      {
+        "checksum": "adler32:b9567164",
+        "size": 26032,
+        "uri": "root://eospublic.cern.ch//eos/opendata/atlas/rucio/opendata/ODEO_FEB2025_v0_exactly4lep_mc_700496.Sh_2211_ZbbZvv.exactly4lep.root"
+      },
+      {
+        "checksum": "adler32:0e0c7f28",
+        "size": 46472,
+        "uri": "root://eospublic.cern.ch//eos/opendata/atlas/rucio/opendata/ODEO_FEB2025_v0_exactly4lep_mc_700507.Sh_2211_pTW140_Wqqgamma.exactly4lep.root"
+      },
+      {
+        "checksum": "adler32:72dd2afb",
+        "size": 2705560,
+        "uri": "root://eospublic.cern.ch//eos/opendata/atlas/rucio/opendata/ODEO_FEB2025_v0_exactly4lep_mc_700587.Sh_2212_lllljj.exactly4lep.root"
+      },
+      {
+        "checksum": "adler32:364e5803",
+        "size": 99084,
+        "uri": "root://eospublic.cern.ch//eos/opendata/atlas/rucio/opendata/ODEO_FEB2025_v0_exactly4lep_mc_700588.Sh_2212_lllvjj.exactly4lep.root"
+      },
+      {
+        "checksum": "adler32:1bfe59f3",
+        "size": 32778,
+        "uri": "root://eospublic.cern.ch//eos/opendata/atlas/rucio/opendata/ODEO_FEB2025_v0_exactly4lep_mc_700589.Sh_2212_llvvjj_os.exactly4lep.root"
+      },
+      {
+        "checksum": "adler32:6e70e120",
+        "size": 72145,
+        "uri": "root://eospublic.cern.ch//eos/opendata/atlas/rucio/opendata/ODEO_FEB2025_v0_exactly4lep_mc_700590.Sh_2212_llvvjj_ss.exactly4lep.root"
+      },
+      {
+        "checksum": "adler32:ff3c00b2",
+        "size": 175418,
+        "uri": "root://eospublic.cern.ch//eos/opendata/atlas/rucio/opendata/ODEO_FEB2025_v0_exactly4lep_mc_700591.Sh_2212_lllljj_Int.exactly4lep.root"
+      },
+      {
+        "checksum": "adler32:222e1a44",
+        "size": 54069,
+        "uri": "root://eospublic.cern.ch//eos/opendata/atlas/rucio/opendata/ODEO_FEB2025_v0_exactly4lep_mc_700592.Sh_2212_lllvjj_Int.exactly4lep.root"
+      },
+      {
+        "checksum": "adler32:c2b16939",
+        "size": 35809,
+        "uri": "root://eospublic.cern.ch//eos/opendata/atlas/rucio/opendata/ODEO_FEB2025_v0_exactly4lep_mc_700593.Sh_2212_llvvjj_os_Int.exactly4lep.root"
+      },
+      {
+        "checksum": "adler32:0d222560",
+        "size": 41544,
+        "uri": "root://eospublic.cern.ch//eos/opendata/atlas/rucio/opendata/ODEO_FEB2025_v0_exactly4lep_mc_700594.Sh_2212_llvvjj_ss_Int.exactly4lep.root"
+      },
+      {
+        "checksum": "adler32:1a80cedf",
+        "size": 5407367,
+        "uri": "root://eospublic.cern.ch//eos/opendata/atlas/rucio/opendata/ODEO_FEB2025_v0_exactly4lep_mc_700600.Sh_2212_llll.exactly4lep.root"
+      },
+      {
+        "checksum": "adler32:ed78d13f",
+        "size": 753532,
+        "uri": "root://eospublic.cern.ch//eos/opendata/atlas/rucio/opendata/ODEO_FEB2025_v0_exactly4lep_mc_700601.Sh_2212_lllv.exactly4lep.root"
+      },
+      {
+        "checksum": "adler32:7d160018",
+        "size": 290493,
+        "uri": "root://eospublic.cern.ch//eos/opendata/atlas/rucio/opendata/ODEO_FEB2025_v0_exactly4lep_mc_700602.Sh_2212_llvv_os.exactly4lep.root"
+      },
+      {
+        "checksum": "adler32:e2abbb15",
+        "size": 98995,
+        "uri": "root://eospublic.cern.ch//eos/opendata/atlas/rucio/opendata/ODEO_FEB2025_v0_exactly4lep_mc_700603.Sh_2212_llvv_ss.exactly4lep.root"
+      },
+      {
+        "checksum": "adler32:4d7ff076",
+        "size": 66414,
+        "uri": "root://eospublic.cern.ch//eos/opendata/atlas/rucio/opendata/ODEO_FEB2025_v0_exactly4lep_mc_700604.Sh_2212_lvvv.exactly4lep.root"
+      },
+      {
+        "checksum": "adler32:62c75413",
+        "size": 1131,
+        "uri": "root://eospublic.cern.ch//eos/opendata/atlas/rucio/opendata/ODEO_FEB2025_v0_exactly4lep_mc_700605.Sh_2212_vvvv.exactly4lep.root"
+      },
+      {
+        "checksum": "adler32:7b7b4ee5",
+        "size": 46412,
+        "uri": "root://eospublic.cern.ch//eos/opendata/atlas/rucio/opendata/ODEO_FEB2025_v0_exactly4lep_mc_700709.Sh_2212_lvgammajj.exactly4lep.root"
+      },
+      {
+        "checksum": "adler32:b39778bc",
+        "size": 227322,
+        "uri": "root://eospublic.cern.ch//eos/opendata/atlas/rucio/opendata/ODEO_FEB2025_v0_exactly4lep_mc_700710.Sh_2212_llgammajj.exactly4lep.root"
+      },
+      {
+        "checksum": "adler32:b738fbd7",
+        "size": 1566887,
+        "uri": "root://eospublic.cern.ch//eos/opendata/atlas/rucio/opendata/ODEO_FEB2025_v0_exactly4lep_mc_700792.Sh_2214_Ztautau_maxHTpTV2_BFilter.exactly4lep.root"
+      },
+      {
+        "checksum": "adler32:44749784",
+        "size": 5766328,
+        "uri": "root://eospublic.cern.ch//eos/opendata/atlas/rucio/opendata/ODEO_FEB2025_v0_exactly4lep_mc_700793.Sh_2214_Ztautau_maxHTpTV2_CFilterBVeto.exactly4lep.root"
+      },
+      {
+        "checksum": "adler32:af45959f",
+        "size": 8999594,
+        "uri": "root://eospublic.cern.ch//eos/opendata/atlas/rucio/opendata/ODEO_FEB2025_v0_exactly4lep_mc_700794.Sh_2214_Ztautau_maxHTpTV2_CVetoBVeto.exactly4lep.root"
+      },
+      {
+        "checksum": "adler32:7e875a6c",
+        "size": 1998651,
+        "uri": "root://eospublic.cern.ch//eos/opendata/atlas/rucio/opendata/ODEO_FEB2025_v0_exactly4lep_mc_700843.Sh_2214_Wqq_ptW_200_ECMS.exactly4lep.root"
+      },
+      {
+        "checksum": "adler32:0f802d30",
+        "size": 714440,
+        "uri": "root://eospublic.cern.ch//eos/opendata/atlas/rucio/opendata/ODEO_FEB2025_v0_exactly4lep_mc_700849.Sh_2214_Zqq_ptZ_200_ECMS.exactly4lep.root"
+      },
+      {
+        "checksum": "adler32:3b3389e5",
+        "size": 306293,
+        "uri": "root://eospublic.cern.ch//eos/opendata/atlas/rucio/opendata/ODEO_FEB2025_v0_exactly4lep_mc_700855.Sh_2214_Zbb_ptZ_200_ECMS.exactly4lep.root"
+      },
+      {
+        "checksum": "adler32:43093d61",
+        "size": 322239,
+        "uri": "root://eospublic.cern.ch//eos/opendata/atlas/rucio/opendata/ODEO_FEB2025_v0_exactly4lep_mc_700901.Sh_2214_Ztt_maxHTpTV2_Mll10_40_BFilter.exactly4lep.root"
+      },
+      {
+        "checksum": "adler32:68f76d47",
+        "size": 1472970,
+        "uri": "root://eospublic.cern.ch//eos/opendata/atlas/rucio/opendata/ODEO_FEB2025_v0_exactly4lep_mc_700902.Sh_2214_Ztt_maxHTpTV2_Mll10_40_CFilterBVeto.exactly4lep.root"
+      },
+      {
+        "checksum": "adler32:8acff842",
+        "size": 2302333,
+        "uri": "root://eospublic.cern.ch//eos/opendata/atlas/rucio/opendata/ODEO_FEB2025_v0_exactly4lep_mc_700903.Sh_2214_Ztt_maxHTpTV2_Mll10_40_CVetoBVeto.exactly4lep.root"
+      },
+      {
+        "checksum": "adler32:4aac9eea",
+        "size": 35213,
+        "uri": "root://eospublic.cern.ch//eos/opendata/atlas/rucio/opendata/ODEO_FEB2025_v0_exactly4lep_mc_801976.Py8EG_A14NNPDF23LO_Zprime_NoInt_tautau_SSM3000.exactly4lep.root"
+      },
+      {
+        "checksum": "adler32:fdaa8f36",
+        "size": 1347,
+        "uri": "root://eospublic.cern.ch//eos/opendata/atlas/rucio/opendata/ODEO_FEB2025_v0_exactly4lep_mc_801978.Py8EG_A14NNPDF23LO_Wprime_taunu_SSM3000.exactly4lep.root"
+      }
+    ],
+    "license": {
+      "attribution": "CC0-1.0"
+    },
+    "methodology": {
+      "description": "<p>These data were created during LS2 as part of a major reprocessing campaign of the Run 2 data. All data were reprocessed using Athena Release 22, and new corresponding MC simulation samples were produced. These data and MC simulation datasets were processed into ROOT ntuple files from the DAOD_PHYSLITE format that is released as open data for research. For the files in this record, the following skimming selection was applied: Exactly four leptons with at least 7 GeV of p<sub>T</sub> (i.e. a leptonically-decaying ZZ boson or Higgs to four leptons enhanced selection)"
+    },
+    "publisher": "CERN Open Data Portal",
+    "recid": "93928",
+    "relations": [
+      {
+        "description": "For citing all the Open Data for Education and Outreach from this release, and to find other related datasets, please see",
+        "doi": "10.7483/OPENDATA.ATLAS.B5M9.44TN",
+        "recid": "93910",
+        "title": "ROOT ntuple format 2015-2016 proton-proton Open Data for Education and Outreach from the ATLAS experiment",
+        "type": "isChildOf"
+      }
+    ],
+    "run_period": [
+      "2015",
+      "2016"
+    ],
+    "title": "ATLAS ROOT ntuple format MC simulation, 2015+2016 proton-proton collisions beta release, exactly4lep skim",
+    "type": {
+      "primary": "Dataset",
+      "secondary": [
+        "Simulated"
+      ]
+    },
+    "usage": {
+      "description": "<p> The data and MC simulation provided by the ATLAS experiment in root ntuple format is released under a CC0 license; citation of the data and acknowledgement of the collaboration is requested. This format can be used directly using ROOT or uproot for simple studies and is primarily intended for educational and outreach purposes. <p>Extensive instructions for interacting with the data, as well as documentation of the dataset naming conventions and their contents, are provided on the ATLAS Open Data website linked below. For those interested in implementing a research-quality data analysis, the open data designed for research (also linked below) may be a better starting point. Please be sure to cite the Open Data that you use, in line with the policy below.",
+      "links": [
+        {
+          "description": "ATLAS Open Data Website",
+          "url": "http://opendata.atlas.cern"
+        },
+        {
+          "description": "Resources to understand and use the open data for education and outreach",
+          "url": "https://opendata.atlas.cern/docs/category/13-tev-tutorials-for-education"
+        },
+        {
+          "description": "More about this ntuple format",
+          "url": "https://opendata.atlas.cern/docs/data/for_education/13TeV25_details"
+        },
+        {
+          "description": "Ntuple making framework",
+          "url": "http://gitlab.cern.ch/atlas-outreach-data-tools/physlitetoopendata"
+        },
+        {
+          "description": "Citation policy",
+          "url": "https://opendata.atlas.cern/docs/documentation/ethical_legal/citation_policy"
+        }
+      ]
+    }
+  }
+]

--- a/data/records/atlas-odeo-FEB2025-gamgam-data.json
+++ b/data/records/atlas-odeo-FEB2025-gamgam-data.json
@@ -1,0 +1,174 @@
+[
+  {
+    "abstract": {
+      "description": "Run 2 2015+2016 proton-proton collision data beta release, GamGam skim from the ATLAS experiment"
+    },
+    "accelerator": "CERN-LHC",
+    "categories": {
+      "source": "ATLAS Collaboration"
+    },
+    "collaboration": {
+      "name": "ATLAS collaboration"
+    },
+    "collections": [
+      "ATLAS-Primary-Datasets"
+    ],
+    "collision_information": {
+      "energy": "13TeV",
+      "type": "pp"
+    },
+    "date_created": [
+      "2015",
+      "2016"
+    ],
+    "date_published": "2025",
+    "date_reprocessed": "2020",
+    "distribution": {
+      "formats": [
+        "root"
+      ],
+      "number_events": 36564144,
+      "number_files": 16,
+      "size": 9861498743
+    },
+    "doi": "10.7483/OPENDATA.ATLAS.GYRR.GRP3",
+    "experiment": [
+      "ATLAS"
+    ],
+    "files": [
+      {
+        "checksum": "adler32:037f48e7",
+        "size": 17541818,
+        "uri": "root://eospublic.cern.ch//eos/opendata/atlas/rucio/opendata/ODEO_FEB2025_v0_GamGam_data15_periodD.GamGam.root"
+      },
+      {
+        "checksum": "adler32:5b6c774b",
+        "size": 141975625,
+        "uri": "root://eospublic.cern.ch//eos/opendata/atlas/rucio/opendata/ODEO_FEB2025_v0_GamGam_data15_periodE.GamGam.root"
+      },
+      {
+        "checksum": "adler32:20353e70",
+        "size": 95022340,
+        "uri": "root://eospublic.cern.ch//eos/opendata/atlas/rucio/opendata/ODEO_FEB2025_v0_GamGam_data15_periodF.GamGam.root"
+      },
+      {
+        "checksum": "adler32:28691bde",
+        "size": 221345638,
+        "uri": "root://eospublic.cern.ch//eos/opendata/atlas/rucio/opendata/ODEO_FEB2025_v0_GamGam_data15_periodG.GamGam.root"
+      },
+      {
+        "checksum": "adler32:ed5cef5b",
+        "size": 74522772,
+        "uri": "root://eospublic.cern.ch//eos/opendata/atlas/rucio/opendata/ODEO_FEB2025_v0_GamGam_data15_periodH.GamGam.root"
+      },
+      {
+        "checksum": "adler32:231ad87f",
+        "size": 408883172,
+        "uri": "root://eospublic.cern.ch//eos/opendata/atlas/rucio/opendata/ODEO_FEB2025_v0_GamGam_data15_periodJ.GamGam.root"
+      },
+      {
+        "checksum": "adler32:3d20136e",
+        "size": 165726034,
+        "uri": "root://eospublic.cern.ch//eos/opendata/atlas/rucio/opendata/ODEO_FEB2025_v0_GamGam_data16_periodA.GamGam.root"
+      },
+      {
+        "checksum": "adler32:b97b371c",
+        "size": 508021080,
+        "uri": "root://eospublic.cern.ch//eos/opendata/atlas/rucio/opendata/ODEO_FEB2025_v0_GamGam_data16_periodB.GamGam.root"
+      },
+      {
+        "checksum": "adler32:490c71d5",
+        "size": 636876354,
+        "uri": "root://eospublic.cern.ch//eos/opendata/atlas/rucio/opendata/ODEO_FEB2025_v0_GamGam_data16_periodC.GamGam.root"
+      },
+      {
+        "checksum": "adler32:818cd37a",
+        "size": 1273874265,
+        "uri": "root://eospublic.cern.ch//eos/opendata/atlas/rucio/opendata/ODEO_FEB2025_v0_GamGam_data16_periodD.GamGam.root"
+      },
+      {
+        "checksum": "adler32:6aaa8cb0",
+        "size": 409839207,
+        "uri": "root://eospublic.cern.ch//eos/opendata/atlas/rucio/opendata/ODEO_FEB2025_v0_GamGam_data16_periodE.GamGam.root"
+      },
+      {
+        "checksum": "adler32:eee689ae",
+        "size": 940511987,
+        "uri": "root://eospublic.cern.ch//eos/opendata/atlas/rucio/opendata/ODEO_FEB2025_v0_GamGam_data16_periodF.GamGam.root"
+      },
+      {
+        "checksum": "adler32:782471db",
+        "size": 1055927491,
+        "uri": "root://eospublic.cern.ch//eos/opendata/atlas/rucio/opendata/ODEO_FEB2025_v0_GamGam_data16_periodG.GamGam.root"
+      },
+      {
+        "checksum": "adler32:3b9297d4",
+        "size": 1602459069,
+        "uri": "root://eospublic.cern.ch//eos/opendata/atlas/rucio/opendata/ODEO_FEB2025_v0_GamGam_data16_periodI.GamGam.root"
+      },
+      {
+        "checksum": "adler32:cbcb3944",
+        "size": 605960864,
+        "uri": "root://eospublic.cern.ch//eos/opendata/atlas/rucio/opendata/ODEO_FEB2025_v0_GamGam_data16_periodK.GamGam.root"
+      },
+      {
+        "checksum": "adler32:96d47683",
+        "size": 1703011027,
+        "uri": "root://eospublic.cern.ch//eos/opendata/atlas/rucio/opendata/ODEO_FEB2025_v0_GamGam_data16_periodL.GamGam.root"
+      }
+    ],
+    "license": {
+      "attribution": "CC0-1.0"
+    },
+    "methodology": {
+      "description": "<p>These data were created during LS2 as part of a major reprocessing campaign of the Run 2 data. All data were reprocessed using Athena Release 22, and new corresponding MC simulation samples were produced. These data and MC simulation datasets were processed into ROOT ntuple files from the DAOD_PHYSLITE format that is released as open data for research. For the files in this record, the following skimming selection was applied: At least two photons with at least 25 GeV of p<sub>T</sub> each (i.e. a Higgs boson decaying to two photons enhanced selection)"
+    },
+    "publisher": "CERN Open Data Portal",
+    "recid": "93915",
+    "relations": [
+      {
+        "description": "For citing all the Open Data for Education and Outreach from this release, and to find other related datasets, please see",
+        "doi": "10.7483/OPENDATA.ATLAS.B5M9.44TN",
+        "recid": "93910",
+        "title": "ROOT ntuple format 2015-2016 proton-proton Open Data for Education and Outreach from the ATLAS experiment",
+        "type": "isChildOf"
+      }
+    ],
+    "run_period": [
+      "2015",
+      "2016"
+    ],
+    "title": "ATLAS ROOT ntuple format Run 2 2015+2016 proton-proton collision data beta release, GamGam skim",
+    "type": {
+      "primary": "Dataset",
+      "secondary": [
+        "Collision"
+      ]
+    },
+    "usage": {
+      "description": "<p> The data and MC simulation provided by the ATLAS experiment in root ntuple format is released under a CC0 license; citation of the data and acknowledgement of the collaboration is requested. This format can be used directly using ROOT or uproot for simple studies and is primarily intended for educational and outreach purposes. <p>Extensive instructions for interacting with the data, as well as documentation of the dataset naming conventions and their contents, are provided on the ATLAS Open Data website linked below. For those interested in implementing a research-quality data analysis, the open data designed for research (also linked below) may be a better starting point. Please be sure to cite the Open Data that you use, in line with the policy below.",
+      "links": [
+        {
+          "description": "ATLAS Open Data Website",
+          "url": "http://opendata.atlas.cern"
+        },
+        {
+          "description": "Resources to understand and use the open data for education and outreach",
+          "url": "https://opendata.atlas.cern/docs/category/13-tev-tutorials-for-education"
+        },
+        {
+          "description": "More about this ntuple format",
+          "url": "https://opendata.atlas.cern/docs/data/for_education/13TeV25_details"
+        },
+        {
+          "description": "Ntuple making framework",
+          "url": "http://gitlab.cern.ch/atlas-outreach-data-tools/physlitetoopendata"
+        },
+        {
+          "description": "Citation policy",
+          "url": "https://opendata.atlas.cern/docs/documentation/ethical_legal/citation_policy"
+        }
+      ]
+    }
+  }
+]

--- a/data/records/atlas-odeo-FEB2025-gamgam-data.json
+++ b/data/records/atlas-odeo-FEB2025-gamgam-data.json
@@ -154,15 +154,15 @@
         },
         {
           "description": "Resources to understand and use the open data for education and outreach",
-          "url": "https://opendata.atlas.cern/docs/category/13-tev-tutorials-for-education"
+          "url": "https://opendata.atlas.cern/docs/category/13-tev-2025-beta-release"
         },
         {
           "description": "More about this ntuple format",
-          "url": "https://opendata.atlas.cern/docs/data/for_education/13TeV25_details"
+          "url": "https://opendata.atlas.cern/docs/data/for_education/13TeV25_details#variable-list"
         },
         {
-          "description": "Ntuple making framework",
-          "url": "http://gitlab.cern.ch/atlas-outreach-data-tools/physlitetoopendata"
+          "description": "Ntuple making framework (PhysLiteToOpenData)",
+          "url": "https://doi.org/10.5281/zenodo.15791091"
         },
         {
           "description": "Citation policy",

--- a/data/records/atlas-odeo-FEB2025-gamgam-mc.json
+++ b/data/records/atlas-odeo-FEB2025-gamgam-mc.json
@@ -1939,15 +1939,15 @@
         },
         {
           "description": "Resources to understand and use the open data for education and outreach",
-          "url": "https://opendata.atlas.cern/docs/category/13-tev-tutorials-for-education"
+          "url": "https://opendata.atlas.cern/docs/category/13-tev-2025-beta-release"
         },
         {
           "description": "More about this ntuple format",
-          "url": "https://opendata.atlas.cern/docs/data/for_education/13TeV25_details"
+          "url": "https://opendata.atlas.cern/docs/data/for_education/13TeV25_details#variable-list"
         },
         {
-          "description": "Ntuple making framework",
-          "url": "http://gitlab.cern.ch/atlas-outreach-data-tools/physlitetoopendata"
+          "description": "Ntuple making framework (PhysLiteToOpenData)",
+          "url": "https://doi.org/10.5281/zenodo.15791091"
         },
         {
           "description": "Citation policy",

--- a/data/records/atlas-odeo-FEB2025-gamgam-mc.json
+++ b/data/records/atlas-odeo-FEB2025-gamgam-mc.json
@@ -1,0 +1,1959 @@
+[
+  {
+    "abstract": {
+      "description": "MC simulation, 2015+2016 proton-proton collisions beta release, GamGam skim from the ATLAS experiment"
+    },
+    "accelerator": "CERN-LHC",
+    "categories": {
+      "source": "ATLAS Collaboration"
+    },
+    "collaboration": {
+      "name": "ATLAS collaboration"
+    },
+    "collections": [
+      "ATLAS-Primary-Datasets"
+    ],
+    "collision_information": {
+      "energy": "13TeV",
+      "type": "pp"
+    },
+    "date_created": [
+      "2015",
+      "2016"
+    ],
+    "date_published": "2025",
+    "date_reprocessed": "2020",
+    "distribution": {
+      "formats": [
+        "root"
+      ],
+      "number_events": 12120657,
+      "number_files": 373,
+      "size": 4895835241
+    },
+    "doi": "10.7483/OPENDATA.ATLAS.IMZO.7U52",
+    "experiment": [
+      "ATLAS"
+    ],
+    "files": [
+      {
+        "checksum": "adler32:a006cda6",
+        "size": 84148,
+        "uri": "root://eospublic.cern.ch//eos/opendata/atlas/rucio/opendata/ODEO_FEB2025_v0_GamGam_mc_301204.Pythia8EvtGen_A14MSTW2008LO_Zprime_NoInt_ee_SSM3000.GamGam.root"
+      },
+      {
+        "checksum": "adler32:ea8a7d79",
+        "size": 51361,
+        "uri": "root://eospublic.cern.ch//eos/opendata/atlas/rucio/opendata/ODEO_FEB2025_v0_GamGam_mc_301209.Pythia8EvtGen_A14MSTW2008LO_Zprime_NoInt_mumu_SSM3000.GamGam.root"
+      },
+      {
+        "checksum": "adler32:08706f3d",
+        "size": 36998,
+        "uri": "root://eospublic.cern.ch//eos/opendata/atlas/rucio/opendata/ODEO_FEB2025_v0_GamGam_mc_301243.Pythia8EvtGen_A14NNPDF23LO_Wprime_enu_SSM3000.GamGam.root"
+      },
+      {
+        "checksum": "adler32:38d0552d",
+        "size": 32427,
+        "uri": "root://eospublic.cern.ch//eos/opendata/atlas/rucio/opendata/ODEO_FEB2025_v0_GamGam_mc_301247.Pythia8EvtGen_A14NNPDF23LO_Wprime_munu_SSM3000.GamGam.root"
+      },
+      {
+        "checksum": "adler32:14b5fe5a",
+        "size": 347634,
+        "uri": "root://eospublic.cern.ch//eos/opendata/atlas/rucio/opendata/ODEO_FEB2025_v0_GamGam_mc_301333.Pythia8EvtGen_A14NNPDF23LO_zprime3000_tt.GamGam.root"
+      },
+      {
+        "checksum": "adler32:a44fc6a1",
+        "size": 95100,
+        "uri": "root://eospublic.cern.ch//eos/opendata/atlas/rucio/opendata/ODEO_FEB2025_v0_GamGam_mc_301826.Pythia8EvtGen_A14NNPDF23LO_Wprime_qq_3000.GamGam.root"
+      },
+      {
+        "checksum": "adler32:2d6bc3e0",
+        "size": 98349,
+        "uri": "root://eospublic.cern.ch//eos/opendata/atlas/rucio/opendata/ODEO_FEB2025_v0_GamGam_mc_301928.Pythia8EvtGen_A14NNPDF23LO_Zprimebb3000.GamGam.root"
+      },
+      {
+        "checksum": "adler32:5c7f0ecf",
+        "size": 322658547,
+        "uri": "root://eospublic.cern.ch//eos/opendata/atlas/rucio/opendata/ODEO_FEB2025_v0_GamGam_mc_302520.Pythia8EvtGen_A14NNPDF23LO_2DP20_Mass_55_100.GamGam.root"
+      },
+      {
+        "checksum": "adler32:b43248ea",
+        "size": 110755804,
+        "uri": "root://eospublic.cern.ch//eos/opendata/atlas/rucio/opendata/ODEO_FEB2025_v0_GamGam_mc_302521.Pythia8EvtGen_A14NNPDF23LO_2DP20_Mass_100_160.GamGam.root"
+      },
+      {
+        "checksum": "adler32:29b766d2",
+        "size": 35876133,
+        "uri": "root://eospublic.cern.ch//eos/opendata/atlas/rucio/opendata/ODEO_FEB2025_v0_GamGam_mc_302522.Pythia8EvtGen_A14NNPDF23LO_2DP20_Mass_160_250.GamGam.root"
+      },
+      {
+        "checksum": "adler32:4814f1d7",
+        "size": 18223555,
+        "uri": "root://eospublic.cern.ch//eos/opendata/atlas/rucio/opendata/ODEO_FEB2025_v0_GamGam_mc_302523.Pythia8EvtGen_A14NNPDF23LO_2DP20_Mass_250_400.GamGam.root"
+      },
+      {
+        "checksum": "adler32:d7154fb9",
+        "size": 41327857,
+        "uri": "root://eospublic.cern.ch//eos/opendata/atlas/rucio/opendata/ODEO_FEB2025_v0_GamGam_mc_302524.Pythia8EvtGen_A14NNPDF23LO_2DP20_Mass_400_650.GamGam.root"
+      },
+      {
+        "checksum": "adler32:dd6d8630",
+        "size": 16487702,
+        "uri": "root://eospublic.cern.ch//eos/opendata/atlas/rucio/opendata/ODEO_FEB2025_v0_GamGam_mc_302525.Pythia8EvtGen_A14NNPDF23LO_2DP20_Mass_650_1000.GamGam.root"
+      },
+      {
+        "checksum": "adler32:bd012f49",
+        "size": 33537960,
+        "uri": "root://eospublic.cern.ch//eos/opendata/atlas/rucio/opendata/ODEO_FEB2025_v0_GamGam_mc_302526.Pythia8EvtGen_A14NNPDF23LO_2DP20_Mass_1000_1500.GamGam.root"
+      },
+      {
+        "checksum": "adler32:fad3104c",
+        "size": 32943130,
+        "uri": "root://eospublic.cern.ch//eos/opendata/atlas/rucio/opendata/ODEO_FEB2025_v0_GamGam_mc_302527.Pythia8EvtGen_A14NNPDF23LO_2DP20_Mass_1500_2000.GamGam.root"
+      },
+      {
+        "checksum": "adler32:69cc5b14",
+        "size": 45138209,
+        "uri": "root://eospublic.cern.ch//eos/opendata/atlas/rucio/opendata/ODEO_FEB2025_v0_GamGam_mc_302528.Pythia8EvtGen_A14NNPDF23LO_2DP20_Mass_2000_2500.GamGam.root"
+      },
+      {
+        "checksum": "adler32:b0bbd659",
+        "size": 29077221,
+        "uri": "root://eospublic.cern.ch//eos/opendata/atlas/rucio/opendata/ODEO_FEB2025_v0_GamGam_mc_302529.Pythia8EvtGen_A14NNPDF23LO_2DP20_Mass_2500_3000.GamGam.root"
+      },
+      {
+        "checksum": "adler32:eead54ba",
+        "size": 45968139,
+        "uri": "root://eospublic.cern.ch//eos/opendata/atlas/rucio/opendata/ODEO_FEB2025_v0_GamGam_mc_302530.Pythia8EvtGen_A14NNPDF23LO_2DP20_Mass_3000_3500.GamGam.root"
+      },
+      {
+        "checksum": "adler32:1ad4590b",
+        "size": 20620763,
+        "uri": "root://eospublic.cern.ch//eos/opendata/atlas/rucio/opendata/ODEO_FEB2025_v0_GamGam_mc_302531.Pythia8EvtGen_A14NNPDF23LO_2DP20_Mass_3500_4000.GamGam.root"
+      },
+      {
+        "checksum": "adler32:86dc3d31",
+        "size": 34475394,
+        "uri": "root://eospublic.cern.ch//eos/opendata/atlas/rucio/opendata/ODEO_FEB2025_v0_GamGam_mc_302532.Pythia8EvtGen_A14NNPDF23LO_2DP20_Mass_4000_4500.GamGam.root"
+      },
+      {
+        "checksum": "adler32:851e8bdd",
+        "size": 13511612,
+        "uri": "root://eospublic.cern.ch//eos/opendata/atlas/rucio/opendata/ODEO_FEB2025_v0_GamGam_mc_302533.Pythia8EvtGen_A14NNPDF23LO_2DP20_Mass_4500_5000.GamGam.root"
+      },
+      {
+        "checksum": "adler32:36405a8f",
+        "size": 31881489,
+        "uri": "root://eospublic.cern.ch//eos/opendata/atlas/rucio/opendata/ODEO_FEB2025_v0_GamGam_mc_302534.Pythia8EvtGen_A14NNPDF23LO_2DP20_Mass_5000_inf.GamGam.root"
+      },
+      {
+        "checksum": "adler32:8969a507",
+        "size": 178583,
+        "uri": "root://eospublic.cern.ch//eos/opendata/atlas/rucio/opendata/ODEO_FEB2025_v0_GamGam_mc_302733.MadGraphPythia8EvtGen_A14NNPDF23LO_WpL_tblep_M3000.GamGam.root"
+      },
+      {
+        "checksum": "adler32:96224315",
+        "size": 166444,
+        "uri": "root://eospublic.cern.ch//eos/opendata/atlas/rucio/opendata/ODEO_FEB2025_v0_GamGam_mc_304014.MadGraphPythia8EvtGen_A14NNPDF23_3top_SM.GamGam.root"
+      },
+      {
+        "checksum": "adler32:54e3f4ab",
+        "size": 296200,
+        "uri": "root://eospublic.cern.ch//eos/opendata/atlas/rucio/opendata/ODEO_FEB2025_v0_GamGam_mc_306149.MadGraphPythia8EvtGen_A14NNPDF23LO_WpL_tbhad_M3000.GamGam.root"
+      },
+      {
+        "checksum": "adler32:b2c398c4",
+        "size": 52783,
+        "uri": "root://eospublic.cern.ch//eos/opendata/atlas/rucio/opendata/ODEO_FEB2025_v0_GamGam_mc_311490.PowhegPy8EG_A14N23LO_DMA_500_700_gq0p25.GamGam.root"
+      },
+      {
+        "checksum": "adler32:f617f98a",
+        "size": 229118,
+        "uri": "root://eospublic.cern.ch//eos/opendata/atlas/rucio/opendata/ODEO_FEB2025_v0_GamGam_mc_312613.aMcAtNloPy8EG_A14N30NLO_LQd_gstML_0p3_nonallhad_M1000.GamGam.root"
+      },
+      {
+        "checksum": "adler32:99884a88",
+        "size": 33049,
+        "uri": "root://eospublic.cern.ch//eos/opendata/atlas/rucio/opendata/ODEO_FEB2025_v0_GamGam_mc_341456.PowhegPythia8EvtGen_CT10_AZNLO_ZH125J_MINLO_veveWWlvqq_VpT.GamGam.root"
+      },
+      {
+        "checksum": "adler32:73e76787",
+        "size": 39308,
+        "uri": "root://eospublic.cern.ch//eos/opendata/atlas/rucio/opendata/ODEO_FEB2025_v0_GamGam_mc_341458.PowhegPythia8EvtGen_CT10_AZNLO_ZH125J_MINLO_vmuvmuWWlvqq_VpT.GamGam.root"
+      },
+      {
+        "checksum": "adler32:db175ec2",
+        "size": 35236,
+        "uri": "root://eospublic.cern.ch//eos/opendata/atlas/rucio/opendata/ODEO_FEB2025_v0_GamGam_mc_341460.PowhegPy8EG_CT10_AZNLO_ZH125J_MINLO_vtauvtauWWlvqq_VpT.GamGam.root"
+      },
+      {
+        "checksum": "adler32:3e3f0a3b",
+        "size": 32086416,
+        "uri": "root://eospublic.cern.ch//eos/opendata/atlas/rucio/opendata/ODEO_FEB2025_v0_GamGam_mc_343981.PowhegPythia8EvtGen_NNLOPS_nnlo_30_ggH125_gamgam.GamGam.root"
+      },
+      {
+        "checksum": "adler32:19e9229f",
+        "size": 96637,
+        "uri": "root://eospublic.cern.ch//eos/opendata/atlas/rucio/opendata/ODEO_FEB2025_v0_GamGam_mc_344158.aMcAtNloPythia8EvtGen_A14NNPDF23LO_ppx0_FxFx_Np012_SM.GamGam.root"
+      },
+      {
+        "checksum": "adler32:f1e71f18",
+        "size": 55017,
+        "uri": "root://eospublic.cern.ch//eos/opendata/atlas/rucio/opendata/ODEO_FEB2025_v0_GamGam_mc_345056.PowhegPythia8EvtGen_NNPDF3_AZNLO_ZH125J_MINLO_vvbb_VpT.GamGam.root"
+      },
+      {
+        "checksum": "adler32:da266081",
+        "size": 54417,
+        "uri": "root://eospublic.cern.ch//eos/opendata/atlas/rucio/opendata/ODEO_FEB2025_v0_GamGam_mc_345058.PowhegPythia8EvtGen_NNPDF3_AZNLO_ggZH125_vvbb.GamGam.root"
+      },
+      {
+        "checksum": "adler32:971a35bc",
+        "size": 981395,
+        "uri": "root://eospublic.cern.ch//eos/opendata/atlas/rucio/opendata/ODEO_FEB2025_v0_GamGam_mc_345060.PowhegPythia8EvtGen_NNLOPS_nnlo_30_ggH125_ZZ4l.GamGam.root"
+      },
+      {
+        "checksum": "adler32:f08477df",
+        "size": 9713372,
+        "uri": "root://eospublic.cern.ch//eos/opendata/atlas/rucio/opendata/ODEO_FEB2025_v0_GamGam_mc_345061.PowhegPythia8EvtGen_NNPDF3_AZNLO_ggZH125_HgamgamZinc.GamGam.root"
+      },
+      {
+        "checksum": "adler32:af0db673",
+        "size": 90508,
+        "uri": "root://eospublic.cern.ch//eos/opendata/atlas/rucio/opendata/ODEO_FEB2025_v0_GamGam_mc_345066.PowhegPythia8EvtGen_NNPDF3_AZNLO_ggZH125_ZZ4lepZinc.GamGam.root"
+      },
+      {
+        "checksum": "adler32:9e7741b6",
+        "size": 41870,
+        "uri": "root://eospublic.cern.ch//eos/opendata/atlas/rucio/opendata/ODEO_FEB2025_v0_GamGam_mc_345097.PowhegPythia8EvtGen_NNLOPS_nnlo_30_ggH125_mumu.GamGam.root"
+      },
+      {
+        "checksum": "adler32:0f0195fe",
+        "size": 43294,
+        "uri": "root://eospublic.cern.ch//eos/opendata/atlas/rucio/opendata/ODEO_FEB2025_v0_GamGam_mc_345098.PowhegPythia8EvtGen_NNPDF3_AZNLO_ggZH125_Hmumu_Zinc.GamGam.root"
+      },
+      {
+        "checksum": "adler32:415ca64e",
+        "size": 35531,
+        "uri": "root://eospublic.cern.ch//eos/opendata/atlas/rucio/opendata/ODEO_FEB2025_v0_GamGam_mc_345103.PowhegPythia8EvtGen_NNPDF30_AZNLO_ZH125J_Hmumu_Zincl_MINLO.GamGam.root"
+      },
+      {
+        "checksum": "adler32:20b92d31",
+        "size": 33396,
+        "uri": "root://eospublic.cern.ch//eos/opendata/atlas/rucio/opendata/ODEO_FEB2025_v0_GamGam_mc_345104.PowhegPythia8EvtGen_NNPDF30_AZNLO_WpH125J_Hmumu_Wincl_MINLO.GamGam.root"
+      },
+      {
+        "checksum": "adler32:d6274bce",
+        "size": 33344,
+        "uri": "root://eospublic.cern.ch//eos/opendata/atlas/rucio/opendata/ODEO_FEB2025_v0_GamGam_mc_345105.PowhegPythia8EvtGen_NNPDF30_AZNLO_WmH125J_Hmumu_Wincl_MINLO.GamGam.root"
+      },
+      {
+        "checksum": "adler32:95d150c0",
+        "size": 52677,
+        "uri": "root://eospublic.cern.ch//eos/opendata/atlas/rucio/opendata/ODEO_FEB2025_v0_GamGam_mc_345106.PowhegPythia8EvtGen_NNPDF30_AZNLOCTEQ6L1_VBFH125_mumu.GamGam.root"
+      },
+      {
+        "checksum": "adler32:96755db4",
+        "size": 60997,
+        "uri": "root://eospublic.cern.ch//eos/opendata/atlas/rucio/opendata/ODEO_FEB2025_v0_GamGam_mc_345112.PowhegPythia8EvtGen_NNPDF3_AZNLO_ZH125J_MINLO_vvcc_VpT.GamGam.root"
+      },
+      {
+        "checksum": "adler32:219e7d3d",
+        "size": 37874,
+        "uri": "root://eospublic.cern.ch//eos/opendata/atlas/rucio/opendata/ODEO_FEB2025_v0_GamGam_mc_345114.PowhegPythia8EvtGen_NNPDF3_AZNLO_ggZH125_vvcc.GamGam.root"
+      },
+      {
+        "checksum": "adler32:154fca64",
+        "size": 57593,
+        "uri": "root://eospublic.cern.ch//eos/opendata/atlas/rucio/opendata/ODEO_FEB2025_v0_GamGam_mc_345120.PowhegPy8EG_NNLOPS_nnlo_30_ggH125_tautaul13l7.GamGam.root"
+      },
+      {
+        "checksum": "adler32:ac433d0d",
+        "size": 115527,
+        "uri": "root://eospublic.cern.ch//eos/opendata/atlas/rucio/opendata/ODEO_FEB2025_v0_GamGam_mc_345121.PowhegPy8EG_NNLOPS_nnlo_30_ggH125_tautaulm15hp20.GamGam.root"
+      },
+      {
+        "checksum": "adler32:9b614676",
+        "size": 158305,
+        "uri": "root://eospublic.cern.ch//eos/opendata/atlas/rucio/opendata/ODEO_FEB2025_v0_GamGam_mc_345122.PowhegPy8EG_NNLOPS_nnlo_30_ggH125_tautaulp15hm20.GamGam.root"
+      },
+      {
+        "checksum": "adler32:4d7aa2ab",
+        "size": 452420,
+        "uri": "root://eospublic.cern.ch//eos/opendata/atlas/rucio/opendata/ODEO_FEB2025_v0_GamGam_mc_345123.PowhegPy8EG_NNLOPS_nnlo_30_ggH125_tautauh30h20.GamGam.root"
+      },
+      {
+        "checksum": "adler32:673f1e07",
+        "size": 1287501,
+        "uri": "root://eospublic.cern.ch//eos/opendata/atlas/rucio/opendata/ODEO_FEB2025_v0_GamGam_mc_345124.PowhegPy8EG_NNLOPS_nnlo_30_ggH125_etau_filt.GamGam.root"
+      },
+      {
+        "checksum": "adler32:d446c1b1",
+        "size": 548196,
+        "uri": "root://eospublic.cern.ch//eos/opendata/atlas/rucio/opendata/ODEO_FEB2025_v0_GamGam_mc_345125.PowhegPy8EG_NNLOPS_nnlo_30_ggH125_mutau_filt.GamGam.root"
+      },
+      {
+        "checksum": "adler32:86662094",
+        "size": 69059,
+        "uri": "root://eospublic.cern.ch//eos/opendata/atlas/rucio/opendata/ODEO_FEB2025_v0_GamGam_mc_345211.PowhegPy8EG_NNPDF30_AZNLO_WmH125J_Winc_MINLO_tautau.GamGam.root"
+      },
+      {
+        "checksum": "adler32:8dc1b7d1",
+        "size": 92977,
+        "uri": "root://eospublic.cern.ch//eos/opendata/atlas/rucio/opendata/ODEO_FEB2025_v0_GamGam_mc_345212.PowhegPy8EG_NNPDF30_AZNLO_WpH125J_Winc_MINLO_tautau.GamGam.root"
+      },
+      {
+        "checksum": "adler32:9e0654ec",
+        "size": 90561,
+        "uri": "root://eospublic.cern.ch//eos/opendata/atlas/rucio/opendata/ODEO_FEB2025_v0_GamGam_mc_345213.PowhegPy8EG_NNPDF30_AZNLO_WmH125J_Winc_MINLO_etau.GamGam.root"
+      },
+      {
+        "checksum": "adler32:1be04d78",
+        "size": 154776,
+        "uri": "root://eospublic.cern.ch//eos/opendata/atlas/rucio/opendata/ODEO_FEB2025_v0_GamGam_mc_345214.PowhegPy8EG_NNPDF30_AZNLO_WpH125J_Winc_MINLO_etau.GamGam.root"
+      },
+      {
+        "checksum": "adler32:e564e3d8",
+        "size": 55775,
+        "uri": "root://eospublic.cern.ch//eos/opendata/atlas/rucio/opendata/ODEO_FEB2025_v0_GamGam_mc_345215.PowhegPy8EG_NNPDF30_AZNLO_WmH125J_Winc_MINLO_mutau.GamGam.root"
+      },
+      {
+        "checksum": "adler32:2b811211",
+        "size": 81484,
+        "uri": "root://eospublic.cern.ch//eos/opendata/atlas/rucio/opendata/ODEO_FEB2025_v0_GamGam_mc_345216.PowhegPy8EG_NNPDF30_AZNLO_WpH125J_Winc_MINLO_mutau.GamGam.root"
+      },
+      {
+        "checksum": "adler32:72c5df4a",
+        "size": 133017,
+        "uri": "root://eospublic.cern.ch//eos/opendata/atlas/rucio/opendata/ODEO_FEB2025_v0_GamGam_mc_345217.PowhegPy8EG_NNPDF30_AZNLO_ZH125J_Zinc_MINLO_tautau.GamGam.root"
+      },
+      {
+        "checksum": "adler32:bfeeb02d",
+        "size": 139441,
+        "uri": "root://eospublic.cern.ch//eos/opendata/atlas/rucio/opendata/ODEO_FEB2025_v0_GamGam_mc_345218.PowhegPy8EG_NNPDF30_AZNLO_ZH125J_Zinc_MINLO_etau.GamGam.root"
+      },
+      {
+        "checksum": "adler32:a9d362b7",
+        "size": 74268,
+        "uri": "root://eospublic.cern.ch//eos/opendata/atlas/rucio/opendata/ODEO_FEB2025_v0_GamGam_mc_345219.PowhegPy8EG_NNPDF30_AZNLO_ZH125J_Zinc_MINLO_mutau.GamGam.root"
+      },
+      {
+        "checksum": "adler32:35d211c4",
+        "size": 3929243,
+        "uri": "root://eospublic.cern.ch//eos/opendata/atlas/rucio/opendata/ODEO_FEB2025_v0_GamGam_mc_345316.PowhegPythia8EvtGen_NNLOPS_nnlo_30_ggH125_Zy_Zll.GamGam.root"
+      },
+      {
+        "checksum": "adler32:dafbc675",
+        "size": 42229740,
+        "uri": "root://eospublic.cern.ch//eos/opendata/atlas/rucio/opendata/ODEO_FEB2025_v0_GamGam_mc_345317.PowhegPythia8EvtGen_NNPDF30_AZNLO_WmH125J_Hyy_Wincl_MINLO.GamGam.root"
+      },
+      {
+        "checksum": "adler32:09255474",
+        "size": 20950650,
+        "uri": "root://eospublic.cern.ch//eos/opendata/atlas/rucio/opendata/ODEO_FEB2025_v0_GamGam_mc_345318.PowhegPythia8EvtGen_NNPDF30_AZNLO_WpH125J_Hyy_Wincl_MINLO.GamGam.root"
+      },
+      {
+        "checksum": "adler32:73e37d64",
+        "size": 14484826,
+        "uri": "root://eospublic.cern.ch//eos/opendata/atlas/rucio/opendata/ODEO_FEB2025_v0_GamGam_mc_345319.PowhegPythia8EvtGen_NNPDF30_AZNLO_ZH125J_Hyy_Zincl_MINLO.GamGam.root"
+      },
+      {
+        "checksum": "adler32:170e6907",
+        "size": 261238,
+        "uri": "root://eospublic.cern.ch//eos/opendata/atlas/rucio/opendata/ODEO_FEB2025_v0_GamGam_mc_345320.PowhegPythia8EvtGen_NNPDF30_AZNLO_WmH125J_HZy_Wincl_MINLO.GamGam.root"
+      },
+      {
+        "checksum": "adler32:480e4dc7",
+        "size": 228520,
+        "uri": "root://eospublic.cern.ch//eos/opendata/atlas/rucio/opendata/ODEO_FEB2025_v0_GamGam_mc_345321.PowhegPythia8EvtGen_NNPDF30_AZNLO_WpH125J_HZy_Wincl_MINLO.GamGam.root"
+      },
+      {
+        "checksum": "adler32:afd6eef0",
+        "size": 457123,
+        "uri": "root://eospublic.cern.ch//eos/opendata/atlas/rucio/opendata/ODEO_FEB2025_v0_GamGam_mc_345322.PowhegPythia8EvtGen_NNPDF30_AZNLO_ZH125J_HZy_Zincl_MINLO.GamGam.root"
+      },
+      {
+        "checksum": "adler32:9957a659",
+        "size": 51406,
+        "uri": "root://eospublic.cern.ch//eos/opendata/atlas/rucio/opendata/ODEO_FEB2025_v0_GamGam_mc_345324.PowhegPythia8EvtGen_NNLOPS_NN30_ggH125_WWlvlv_EF_15_5.GamGam.root"
+      },
+      {
+        "checksum": "adler32:1924a1d1",
+        "size": 74140,
+        "uri": "root://eospublic.cern.ch//eos/opendata/atlas/rucio/opendata/ODEO_FEB2025_v0_GamGam_mc_345325.PowhegPythia8EvtGen_NNPDF3_AZNLO_WpH125J_MINLO_qqWWlvlv.GamGam.root"
+      },
+      {
+        "checksum": "adler32:5d53e2ca",
+        "size": 82957,
+        "uri": "root://eospublic.cern.ch//eos/opendata/atlas/rucio/opendata/ODEO_FEB2025_v0_GamGam_mc_345433.PowhegPythia8EvtGen_NNPDF3_AZNLO_WmH125J_MINLO_qqWWlvlv.GamGam.root"
+      },
+      {
+        "checksum": "adler32:22172904",
+        "size": 41858,
+        "uri": "root://eospublic.cern.ch//eos/opendata/atlas/rucio/opendata/ODEO_FEB2025_v0_GamGam_mc_345445.PowhegPythia8EvtGen_NNPDF3_AZNLO_ZH125J_MINLO_vvWWlvlv.GamGam.root"
+      },
+      {
+        "checksum": "adler32:3b4279a7",
+        "size": 34691,
+        "uri": "root://eospublic.cern.ch//eos/opendata/atlas/rucio/opendata/ODEO_FEB2025_v0_GamGam_mc_345596.PowhegPythia8EvtGen_NNPDF3_AZNLO_ggZH125_Zinc_HZZinv.GamGam.root"
+      },
+      {
+        "checksum": "adler32:28d1344b",
+        "size": 93146,
+        "uri": "root://eospublic.cern.ch//eos/opendata/atlas/rucio/opendata/ODEO_FEB2025_v0_GamGam_mc_345697.MadGraphPythia8EvtGen_AZNLOCTEQ6L1_ggfhtautaullNp2.GamGam.root"
+      },
+      {
+        "checksum": "adler32:d734f83b",
+        "size": 342711,
+        "uri": "root://eospublic.cern.ch//eos/opendata/atlas/rucio/opendata/ODEO_FEB2025_v0_GamGam_mc_345698.MadGraphPythia8EvtGen_AZNLOCTEQ6L1_ggfhtautaulhNp2.GamGam.root"
+      },
+      {
+        "checksum": "adler32:fd0ded64",
+        "size": 841890,
+        "uri": "root://eospublic.cern.ch//eos/opendata/atlas/rucio/opendata/ODEO_FEB2025_v0_GamGam_mc_345699.MadGraphPythia8EvtGen_AZNLOCTEQ6L1_ggfhtautauhhNp2.GamGam.root"
+      },
+      {
+        "checksum": "adler32:d23dfc5e",
+        "size": 3033729,
+        "uri": "root://eospublic.cern.ch//eos/opendata/atlas/rucio/opendata/ODEO_FEB2025_v0_GamGam_mc_345833.PowhegPythia8EvtGen_NNPDF30_AZNLOCTEQ6L1_VBFH125_Zllgam.GamGam.root"
+      },
+      {
+        "checksum": "adler32:90febcab",
+        "size": 846746,
+        "uri": "root://eospublic.cern.ch//eos/opendata/atlas/rucio/opendata/ODEO_FEB2025_v0_GamGam_mc_345834.PowhegPythia8EvtGen_NNPDF30_AZNLOCTEQ6L1_VBFH125_gamstargam.GamGam.root"
+      },
+      {
+        "checksum": "adler32:d0ed5ea2",
+        "size": 102572,
+        "uri": "root://eospublic.cern.ch//eos/opendata/atlas/rucio/opendata/ODEO_FEB2025_v0_GamGam_mc_345876.PowhegPythia8EvtGen_NNPDF30_AZNLO_ZH125J_Hee__Zincl_MINLO.GamGam.root"
+      },
+      {
+        "checksum": "adler32:f03c7881",
+        "size": 68179,
+        "uri": "root://eospublic.cern.ch//eos/opendata/atlas/rucio/opendata/ODEO_FEB2025_v0_GamGam_mc_345877.PowhegPythia8EvtGen_NNPDF30_AZNLO_WpH125J_Hee_Wincl_MINLO.GamGam.root"
+      },
+      {
+        "checksum": "adler32:43d3f311",
+        "size": 65185,
+        "uri": "root://eospublic.cern.ch//eos/opendata/atlas/rucio/opendata/ODEO_FEB2025_v0_GamGam_mc_345878.PowhegPythia8EvtGen_NNPDF30_AZNLO_WmH125J_Hee_Wincl_MINLO.GamGam.root"
+      },
+      {
+        "checksum": "adler32:794c04a9",
+        "size": 33681962,
+        "uri": "root://eospublic.cern.ch//eos/opendata/atlas/rucio/opendata/ODEO_FEB2025_v0_GamGam_mc_345944.aMcAtNloPy8EG_A14NNPDF23LO_ppx0yy_FxFx_Np012_SM.GamGam.root"
+      },
+      {
+        "checksum": "adler32:8cf2e78f",
+        "size": 95369,
+        "uri": "root://eospublic.cern.ch//eos/opendata/atlas/rucio/opendata/ODEO_FEB2025_v0_GamGam_mc_345948.PowhegPy8EG_NNPDF30_AZNLOCTEQ6L1_VBFH125_WWlvlv.GamGam.root"
+      },
+      {
+        "checksum": "adler32:5718018e",
+        "size": 65834,
+        "uri": "root://eospublic.cern.ch//eos/opendata/atlas/rucio/opendata/ODEO_FEB2025_v0_GamGam_mc_345949.PowhegPythia8EvtGen_NNPDF30_AZNLOCTEQ6L1_VBFH125_bb.GamGam.root"
+      },
+      {
+        "checksum": "adler32:ede405d3",
+        "size": 1551546,
+        "uri": "root://eospublic.cern.ch//eos/opendata/atlas/rucio/opendata/ODEO_FEB2025_v0_GamGam_mc_345961.PowhegPythia8EvtGen_NNLOPS_nnlo_30_ggH125_gamstargam.GamGam.root"
+      },
+      {
+        "checksum": "adler32:0eae6359",
+        "size": 472803,
+        "uri": "root://eospublic.cern.ch//eos/opendata/atlas/rucio/opendata/ODEO_FEB2025_v0_GamGam_mc_345963.PowhegPythia8EvtGen_NNPDF30_AZNLO_WmH125J_Hgamstargam_MINLO.GamGam.root"
+      },
+      {
+        "checksum": "adler32:a2bf201a",
+        "size": 441646,
+        "uri": "root://eospublic.cern.ch//eos/opendata/atlas/rucio/opendata/ODEO_FEB2025_v0_GamGam_mc_345964.PowhegPythia8EvtGen_NNPDF30_AZNLO_WpH125J_Hgamstargam_MINLO.GamGam.root"
+      },
+      {
+        "checksum": "adler32:2c76d535",
+        "size": 894750,
+        "uri": "root://eospublic.cern.ch//eos/opendata/atlas/rucio/opendata/ODEO_FEB2025_v0_GamGam_mc_345965.PowhegPythia8EvtGen_NNPDF30_AZNLO_ZH125J_Hgamstargam_MINLO.GamGam.root"
+      },
+      {
+        "checksum": "adler32:4d6e182c",
+        "size": 9650055,
+        "uri": "root://eospublic.cern.ch//eos/opendata/atlas/rucio/opendata/ODEO_FEB2025_v0_GamGam_mc_346188.aMcAtNloPythia8EvtGen_tHjb125_4fl_gamgam.GamGam.root"
+      },
+      {
+        "checksum": "adler32:b07e479c",
+        "size": 18883614,
+        "uri": "root://eospublic.cern.ch//eos/opendata/atlas/rucio/opendata/ODEO_FEB2025_v0_GamGam_mc_346189.aMcAtNloPythia8EvtGen_ttH_gamgam.GamGam.root"
+      },
+      {
+        "checksum": "adler32:45458365",
+        "size": 85783,
+        "uri": "root://eospublic.cern.ch//eos/opendata/atlas/rucio/opendata/ODEO_FEB2025_v0_GamGam_mc_346190.PowhegPy8EG_NNPDF30_AZNLOCTEQ6L1_VBFH125_tautaul13l7.GamGam.root"
+      },
+      {
+        "checksum": "adler32:4c04da58",
+        "size": 128007,
+        "uri": "root://eospublic.cern.ch//eos/opendata/atlas/rucio/opendata/ODEO_FEB2025_v0_GamGam_mc_346191.PowhegPy8EG_NNPDF30_AZNLOCTEQ6L1_VBFH125_tautaulm15hp20.GamGam.root"
+      },
+      {
+        "checksum": "adler32:dda83945",
+        "size": 129227,
+        "uri": "root://eospublic.cern.ch//eos/opendata/atlas/rucio/opendata/ODEO_FEB2025_v0_GamGam_mc_346192.PowhegPy8EG_NNPDF30_AZNLOCTEQ6L1_VBFH125_tautaulp15hm20.GamGam.root"
+      },
+      {
+        "checksum": "adler32:fa77f13b",
+        "size": 305085,
+        "uri": "root://eospublic.cern.ch//eos/opendata/atlas/rucio/opendata/ODEO_FEB2025_v0_GamGam_mc_346193.PowhegPy8EG_NNPDF30_AZNLOCTEQ6L1_VBFH125_tautauh30h20.GamGam.root"
+      },
+      {
+        "checksum": "adler32:ff9bb8fd",
+        "size": 465247,
+        "uri": "root://eospublic.cern.ch//eos/opendata/atlas/rucio/opendata/ODEO_FEB2025_v0_GamGam_mc_346194.PowhegPy8EG_NNPDF30_AZNLOCTEQ6L1_VBFH125_etau_filt.GamGam.root"
+      },
+      {
+        "checksum": "adler32:3ce83bc4",
+        "size": 179492,
+        "uri": "root://eospublic.cern.ch//eos/opendata/atlas/rucio/opendata/ODEO_FEB2025_v0_GamGam_mc_346195.PowhegPy8EG_NNPDF30_AZNLOCTEQ6L1_VBFH125_mutau_filt.GamGam.root"
+      },
+      {
+        "checksum": "adler32:08a69761",
+        "size": 2679917,
+        "uri": "root://eospublic.cern.ch//eos/opendata/atlas/rucio/opendata/ODEO_FEB2025_v0_GamGam_mc_346198.PhPy8EG_A14NNPDF23_NNPDF30ME_ttH125_Zgam.GamGam.root"
+      },
+      {
+        "checksum": "adler32:52f61c51",
+        "size": 14414350,
+        "uri": "root://eospublic.cern.ch//eos/opendata/atlas/rucio/opendata/ODEO_FEB2025_v0_GamGam_mc_346214.PowhegPy8EG_NNPDF30_AZNLOCTEQ6L1_VBFH125_gamgam.GamGam.root"
+      },
+      {
+        "checksum": "adler32:1bd03fc5",
+        "size": 291801,
+        "uri": "root://eospublic.cern.ch//eos/opendata/atlas/rucio/opendata/ODEO_FEB2025_v0_GamGam_mc_346228.PowhegPy8EG_NNPDF30_AZNLOCTEQ6L1_VBFH125_ZZ4lep_notau.GamGam.root"
+      },
+      {
+        "checksum": "adler32:7f5c3008",
+        "size": 109467,
+        "uri": "root://eospublic.cern.ch//eos/opendata/atlas/rucio/opendata/ODEO_FEB2025_v0_GamGam_mc_346310.PowhegPythia8EvtGen_NNPDF30_AZNLO_ZH125J_Zincl_H_incl_MINLO.GamGam.root"
+      },
+      {
+        "checksum": "adler32:3be14683",
+        "size": 61137,
+        "uri": "root://eospublic.cern.ch//eos/opendata/atlas/rucio/opendata/ODEO_FEB2025_v0_GamGam_mc_346311.PowhegPythia8EvtGen_NNPDF30_AZNLO_WpH125J_Wincl_H_incl_MINLO.GamGam.root"
+      },
+      {
+        "checksum": "adler32:fd852a3f",
+        "size": 72804,
+        "uri": "root://eospublic.cern.ch//eos/opendata/atlas/rucio/opendata/ODEO_FEB2025_v0_GamGam_mc_346312.PowhegPythia8EvtGen_NNPDF30_AZNLO_WmH125J_Wincl_H_incl_MINLO.GamGam.root"
+      },
+      {
+        "checksum": "adler32:76cf0b7f",
+        "size": 242802,
+        "uri": "root://eospublic.cern.ch//eos/opendata/atlas/rucio/opendata/ODEO_FEB2025_v0_GamGam_mc_346317.PowhegPy8EG_NNPDF30_AZNLOCTEQ6L1_VBFH125_incl.GamGam.root"
+      },
+      {
+        "checksum": "adler32:c6c3a4ad",
+        "size": 132503,
+        "uri": "root://eospublic.cern.ch//eos/opendata/atlas/rucio/opendata/ODEO_FEB2025_v0_GamGam_mc_346340.PowhegPy8EG_A14NNPDF23_NNPDF30ME_ttH125_ZZ4l_allhad.GamGam.root"
+      },
+      {
+        "checksum": "adler32:db7c13c8",
+        "size": 116681,
+        "uri": "root://eospublic.cern.ch//eos/opendata/atlas/rucio/opendata/ODEO_FEB2025_v0_GamGam_mc_346341.PowhegPy8EG_A14NNPDF23_NNPDF30ME_ttH125_ZZ4l_semilep.GamGam.root"
+      },
+      {
+        "checksum": "adler32:30ee2275",
+        "size": 90578,
+        "uri": "root://eospublic.cern.ch//eos/opendata/atlas/rucio/opendata/ODEO_FEB2025_v0_GamGam_mc_346342.PowhegPy8EG_A14NNPDF23_NNPDF30ME_ttH125_ZZ4l_dilep.GamGam.root"
+      },
+      {
+        "checksum": "adler32:5daada0f",
+        "size": 388697,
+        "uri": "root://eospublic.cern.ch//eos/opendata/atlas/rucio/opendata/ODEO_FEB2025_v0_GamGam_mc_346343.PhPy8EG_A14NNPDF23_NNPDF30ME_ttH125_allhad.GamGam.root"
+      },
+      {
+        "checksum": "adler32:ac7171ec",
+        "size": 269954,
+        "uri": "root://eospublic.cern.ch//eos/opendata/atlas/rucio/opendata/ODEO_FEB2025_v0_GamGam_mc_346344.PhPy8EG_A14NNPDF23_NNPDF30ME_ttH125_semilep.GamGam.root"
+      },
+      {
+        "checksum": "adler32:1ebbe9a7",
+        "size": 511677,
+        "uri": "root://eospublic.cern.ch//eos/opendata/atlas/rucio/opendata/ODEO_FEB2025_v0_GamGam_mc_346345.PhPy8EG_A14NNPDF23_NNPDF30ME_ttH125_dilep.GamGam.root"
+      },
+      {
+        "checksum": "adler32:f3ddb6cf",
+        "size": 37991,
+        "uri": "root://eospublic.cern.ch//eos/opendata/atlas/rucio/opendata/ODEO_FEB2025_v0_GamGam_mc_346398.PowhegHerwig7EvtGen_NNPDF3_AZNLO_ZH125J_MINLO_vvbb_VpT.GamGam.root"
+      },
+      {
+        "checksum": "adler32:6b207a63",
+        "size": 52007,
+        "uri": "root://eospublic.cern.ch//eos/opendata/atlas/rucio/opendata/ODEO_FEB2025_v0_GamGam_mc_346400.PowhegHerwig7EvtGen_NNPDF3_AZNLO_ggZH125J_vvbb.GamGam.root"
+      },
+      {
+        "checksum": "adler32:d195307c",
+        "size": 77497,
+        "uri": "root://eospublic.cern.ch//eos/opendata/atlas/rucio/opendata/ODEO_FEB2025_v0_GamGam_mc_346414.aMcAtNloPythia8EvtGen_tHjb125_4fl_ZZ4l.GamGam.root"
+      },
+      {
+        "checksum": "adler32:af051a0b",
+        "size": 593065,
+        "uri": "root://eospublic.cern.ch//eos/opendata/atlas/rucio/opendata/ODEO_FEB2025_v0_GamGam_mc_346446.PhH7EG_H7UE_NNLOPS_nnlo_30_ggH125_ZZ4l_noTau.GamGam.root"
+      },
+      {
+        "checksum": "adler32:2f63b101",
+        "size": 266702,
+        "uri": "root://eospublic.cern.ch//eos/opendata/atlas/rucio/opendata/ODEO_FEB2025_v0_GamGam_mc_346447.PhH7EG_H7UE_NNPDF30_VBFH125_ZZ4lep_noTau.GamGam.root"
+      },
+      {
+        "checksum": "adler32:3e3ecd4b",
+        "size": 131820,
+        "uri": "root://eospublic.cern.ch//eos/opendata/atlas/rucio/opendata/ODEO_FEB2025_v0_GamGam_mc_346448.PhH7EG_H7UE_NNPDF30_ZH125J_Zincl_MINLO.GamGam.root"
+      },
+      {
+        "checksum": "adler32:f8fe74cd",
+        "size": 118451,
+        "uri": "root://eospublic.cern.ch//eos/opendata/atlas/rucio/opendata/ODEO_FEB2025_v0_GamGam_mc_346449.PhH7EG_H7UE_NNPDF30_WpH125J_Wincl_MINLO.GamGam.root"
+      },
+      {
+        "checksum": "adler32:b2788624",
+        "size": 63314,
+        "uri": "root://eospublic.cern.ch//eos/opendata/atlas/rucio/opendata/ODEO_FEB2025_v0_GamGam_mc_346450.PhH7EG_H7UE_NNPDF30_WmH125J_Wincl_MINLO.GamGam.root"
+      },
+      {
+        "checksum": "adler32:89b7946b",
+        "size": 73914,
+        "uri": "root://eospublic.cern.ch//eos/opendata/atlas/rucio/opendata/ODEO_FEB2025_v0_GamGam_mc_346451.PhH7EG_H7UE_NNPDF3_ggZH125_ZZ4lepZinc.GamGam.root"
+      },
+      {
+        "checksum": "adler32:194ab820",
+        "size": 113934,
+        "uri": "root://eospublic.cern.ch//eos/opendata/atlas/rucio/opendata/ODEO_FEB2025_v0_GamGam_mc_346452.PhH7EG_H7UE_NNPDF30ME_ttH125_ZZ4l_allhad_noTau.GamGam.root"
+      },
+      {
+        "checksum": "adler32:d7ab2b25",
+        "size": 98065,
+        "uri": "root://eospublic.cern.ch//eos/opendata/atlas/rucio/opendata/ODEO_FEB2025_v0_GamGam_mc_346453.PhH7EG_H7UE_NNPDF30ME_ttH125_ZZ4l_semilep_noTau.GamGam.root"
+      },
+      {
+        "checksum": "adler32:ebe5574e",
+        "size": 86338,
+        "uri": "root://eospublic.cern.ch//eos/opendata/atlas/rucio/opendata/ODEO_FEB2025_v0_GamGam_mc_346454.PhH7EG_H7UE_NNPDF30ME_ttH125_ZZ4l_dilep_noTau.GamGam.root"
+      },
+      {
+        "checksum": "adler32:baf66db3",
+        "size": 10229225,
+        "uri": "root://eospublic.cern.ch//eos/opendata/atlas/rucio/opendata/ODEO_FEB2025_v0_GamGam_mc_346486.aMcAtNloPythia8EvtGen_tWH125_yy.GamGam.root"
+      },
+      {
+        "checksum": "adler32:120c8832",
+        "size": 119898,
+        "uri": "root://eospublic.cern.ch//eos/opendata/atlas/rucio/opendata/ODEO_FEB2025_v0_GamGam_mc_346511.aMcAtNloPythia8EvtGen_tWH125_ZZ4l.GamGam.root"
+      },
+      {
+        "checksum": "adler32:02bd3a91",
+        "size": 53639,
+        "uri": "root://eospublic.cern.ch//eos/opendata/atlas/rucio/opendata/ODEO_FEB2025_v0_GamGam_mc_346524.PowhegPythia8EvtGen_NNPDF3_AZNLO_ggZH125J_MINLO_ZinclWWlvlv.GamGam.root"
+      },
+      {
+        "checksum": "adler32:7f1227ff",
+        "size": 41246308,
+        "uri": "root://eospublic.cern.ch//eos/opendata/atlas/rucio/opendata/ODEO_FEB2025_v0_GamGam_mc_346525.PowhegPythia8EvtGen_A14NNPDF23_NNPDF30ME_ttH125_gamgam.GamGam.root"
+      },
+      {
+        "checksum": "adler32:d579be64",
+        "size": 46609889,
+        "uri": "root://eospublic.cern.ch//eos/opendata/atlas/rucio/opendata/ODEO_FEB2025_v0_GamGam_mc_346526.PowhegHerwig7EvtGen_H7UE_NNPDF30ME_ttH125_gamgam.GamGam.root"
+      },
+      {
+        "checksum": "adler32:dd07e1ee",
+        "size": 47389,
+        "uri": "root://eospublic.cern.ch//eos/opendata/atlas/rucio/opendata/ODEO_FEB2025_v0_GamGam_mc_346588.PowhegPythia8EvtGen_NNLOPS_nnlo_30_ggH125_ZZ4nu_MET75.GamGam.root"
+      },
+      {
+        "checksum": "adler32:e54676c7",
+        "size": 32842543,
+        "uri": "root://eospublic.cern.ch//eos/opendata/atlas/rucio/opendata/ODEO_FEB2025_v0_GamGam_mc_346601.aMcAtNloHerwig7EvtGen_MEN30NLO_ttH125_gamgam.GamGam.root"
+      },
+      {
+        "checksum": "adler32:00e6e530",
+        "size": 9747796,
+        "uri": "root://eospublic.cern.ch//eos/opendata/atlas/rucio/opendata/ODEO_FEB2025_v0_GamGam_mc_346602.aMcAtNloHerwig7EvtGen_MEN30NLO_tHjb125_gamgam.GamGam.root"
+      },
+      {
+        "checksum": "adler32:c70ef5d4",
+        "size": 57686,
+        "uri": "root://eospublic.cern.ch//eos/opendata/atlas/rucio/opendata/ODEO_FEB2025_v0_GamGam_mc_346605.PowhegPythia8EvtGen_NNPDF30_AZNLO_WpH125J_WinclHinv_MET75.GamGam.root"
+      },
+      {
+        "checksum": "adler32:9483dcf0",
+        "size": 57574,
+        "uri": "root://eospublic.cern.ch//eos/opendata/atlas/rucio/opendata/ODEO_FEB2025_v0_GamGam_mc_346606.PowhegPythia8EvtGen_NNPDF30_AZNLO_WmH125J_WinclHinv_MET75.GamGam.root"
+      },
+      {
+        "checksum": "adler32:c6c9e8d7",
+        "size": 66769,
+        "uri": "root://eospublic.cern.ch//eos/opendata/atlas/rucio/opendata/ODEO_FEB2025_v0_GamGam_mc_346607.PowhegPythia8EvtGen_NNPDF30_AZNLO_ZH125J_ZinclHinv_MET75.GamGam.root"
+      },
+      {
+        "checksum": "adler32:cb4a357a",
+        "size": 218575,
+        "uri": "root://eospublic.cern.ch//eos/opendata/atlas/rucio/opendata/ODEO_FEB2025_v0_GamGam_mc_346632.PowhegPy8EG_A14NNPDF23_NNPDF30ME_ttH125_ZZ4nu_semilep.GamGam.root"
+      },
+      {
+        "checksum": "adler32:2d6d462d",
+        "size": 183360,
+        "uri": "root://eospublic.cern.ch//eos/opendata/atlas/rucio/opendata/ODEO_FEB2025_v0_GamGam_mc_346633.PowhegPy8EG_A14NNPDF23_NNPDF30ME_ttH125_ZZ4nu_allhad.GamGam.root"
+      },
+      {
+        "checksum": "adler32:1000c134",
+        "size": 62338,
+        "uri": "root://eospublic.cern.ch//eos/opendata/atlas/rucio/opendata/ODEO_FEB2025_v0_GamGam_mc_346634.PowhegPy8EG_A14NNPDF23_NNPDF30ME_ttH125_ZZ4nu_dilep.GamGam.root"
+      },
+      {
+        "checksum": "adler32:f0472c11",
+        "size": 177873,
+        "uri": "root://eospublic.cern.ch//eos/opendata/atlas/rucio/opendata/ODEO_FEB2025_v0_GamGam_mc_346645.PowhegPythia8EvtGen_NNPDF30_AZNLO_ZH125J_Zincl_MINLO_shw.GamGam.root"
+      },
+      {
+        "checksum": "adler32:bb5c2af8",
+        "size": 120552,
+        "uri": "root://eospublic.cern.ch//eos/opendata/atlas/rucio/opendata/ODEO_FEB2025_v0_GamGam_mc_346646.PowhegPythia8EvtGen_NNPDF30_AZNLO_WpH125J_Wincl_MINLO_shw.GamGam.root"
+      },
+      {
+        "checksum": "adler32:f10d1c48",
+        "size": 66131,
+        "uri": "root://eospublic.cern.ch//eos/opendata/atlas/rucio/opendata/ODEO_FEB2025_v0_GamGam_mc_346647.PowhegPythia8EvtGen_NNPDF30_AZNLO_WmH125J_Wincl_MINLO_shw.GamGam.root"
+      },
+      {
+        "checksum": "adler32:95382641",
+        "size": 67276,
+        "uri": "root://eospublic.cern.ch//eos/opendata/atlas/rucio/opendata/ODEO_FEB2025_v0_GamGam_mc_346726.PowhegHerwig7EvtGen_NNPDF3_AZNLO_ZH125J_MINLO_vvcc_VpT.GamGam.root"
+      },
+      {
+        "checksum": "adler32:64d6fbc2",
+        "size": 32182,
+        "uri": "root://eospublic.cern.ch//eos/opendata/atlas/rucio/opendata/ODEO_FEB2025_v0_GamGam_mc_346728.PowhegHerwig7EvtGen_NNPDF3_AZNLO_ggZH125J_vvcc.GamGam.root"
+      },
+      {
+        "checksum": "adler32:c89c7181",
+        "size": 353422181,
+        "uri": "root://eospublic.cern.ch//eos/opendata/atlas/rucio/opendata/ODEO_FEB2025_v0_GamGam_mc_346797.PhH7EG_H7UE_NNLOPS_nnlo_30_ggH125_gamgam.GamGam.root"
+      },
+      {
+        "checksum": "adler32:eaa73282",
+        "size": 285825,
+        "uri": "root://eospublic.cern.ch//eos/opendata/atlas/rucio/opendata/ODEO_FEB2025_v0_GamGam_mc_346802.PhH7EG_NNLOPS_nnlo_30_ggH125_WWlvlv_noTau.GamGam.root"
+      },
+      {
+        "checksum": "adler32:b6282619",
+        "size": 65630,
+        "uri": "root://eospublic.cern.ch//eos/opendata/atlas/rucio/opendata/ODEO_FEB2025_v0_GamGam_mc_346877.PhH7EG_NNPDF30_VBFH125_WWlvlv.GamGam.root"
+      },
+      {
+        "checksum": "adler32:1c5f8229",
+        "size": 63222028,
+        "uri": "root://eospublic.cern.ch//eos/opendata/atlas/rucio/opendata/ODEO_FEB2025_v0_GamGam_mc_346878.PhH7EG_H7UE_NNPDF30_VBF125_gammagamma.GamGam.root"
+      },
+      {
+        "checksum": "adler32:eb8f8a90",
+        "size": 19249360,
+        "uri": "root://eospublic.cern.ch//eos/opendata/atlas/rucio/opendata/ODEO_FEB2025_v0_GamGam_mc_346879.PhH7EG_H7UE_NNPDF30_ZH125J_Zincl_MINLO_gammagamma.GamGam.root"
+      },
+      {
+        "checksum": "adler32:87e5e824",
+        "size": 10283123,
+        "uri": "root://eospublic.cern.ch//eos/opendata/atlas/rucio/opendata/ODEO_FEB2025_v0_GamGam_mc_346880.PhH7EG_H7UE_NNPDF30_WmH125J_Wincl_MINLO_gammagamma.GamGam.root"
+      },
+      {
+        "checksum": "adler32:1e6b9d55",
+        "size": 18523976,
+        "uri": "root://eospublic.cern.ch//eos/opendata/atlas/rucio/opendata/ODEO_FEB2025_v0_GamGam_mc_346881.PhH7EG_H7UE_NNPDF30_WpH125J_Wincl_MINLO_gammagamma.GamGam.root"
+      },
+      {
+        "checksum": "adler32:fed3e4d2",
+        "size": 10242700,
+        "uri": "root://eospublic.cern.ch//eos/opendata/atlas/rucio/opendata/ODEO_FEB2025_v0_GamGam_mc_346882.PhH7EG_H7UE_NNPDF30_ggZH125_gammagamma.GamGam.root"
+      },
+      {
+        "checksum": "adler32:d92e2288",
+        "size": 749468,
+        "uri": "root://eospublic.cern.ch//eos/opendata/atlas/rucio/opendata/ODEO_FEB2025_v0_GamGam_mc_346919.PhPy8EG_A14NNPDF23_NNPDF30ME_ttH125_allhad_tautau_unpol.GamGam.root"
+      },
+      {
+        "checksum": "adler32:61ef4d7c",
+        "size": 573701,
+        "uri": "root://eospublic.cern.ch//eos/opendata/atlas/rucio/opendata/ODEO_FEB2025_v0_GamGam_mc_346923.PhPy8EG_A14NNPDF23_NNPDF30ME_ttH125_semilep_tautau_unpol.GamGam.root"
+      },
+      {
+        "checksum": "adler32:882f220a",
+        "size": 373342,
+        "uri": "root://eospublic.cern.ch//eos/opendata/atlas/rucio/opendata/ODEO_FEB2025_v0_GamGam_mc_346927.PhPy8EG_A14NNPDF23_NNPDF30ME_ttH125_dilep_tautau_unpol.GamGam.root"
+      },
+      {
+        "checksum": "adler32:1e1e8f7e",
+        "size": 163738,
+        "uri": "root://eospublic.cern.ch//eos/opendata/atlas/rucio/opendata/ODEO_FEB2025_v0_GamGam_mc_364242.Sherpa_222_NNPDF30NNLO_WWW_3l3v_EW6.GamGam.root"
+      },
+      {
+        "checksum": "adler32:cb252276",
+        "size": 103504,
+        "uri": "root://eospublic.cern.ch//eos/opendata/atlas/rucio/opendata/ODEO_FEB2025_v0_GamGam_mc_364243.Sherpa_222_NNPDF30NNLO_WWZ_4l2v_EW6.GamGam.root"
+      },
+      {
+        "checksum": "adler32:ba9be47b",
+        "size": 48705,
+        "uri": "root://eospublic.cern.ch//eos/opendata/atlas/rucio/opendata/ODEO_FEB2025_v0_GamGam_mc_364244.Sherpa_222_NNPDF30NNLO_WWZ_2l4v_EW6.GamGam.root"
+      },
+      {
+        "checksum": "adler32:0cbf45da",
+        "size": 149051,
+        "uri": "root://eospublic.cern.ch//eos/opendata/atlas/rucio/opendata/ODEO_FEB2025_v0_GamGam_mc_364245.Sherpa_222_NNPDF30NNLO_WZZ_5l1v_EW6.GamGam.root"
+      },
+      {
+        "checksum": "adler32:9af686e1",
+        "size": 84311,
+        "uri": "root://eospublic.cern.ch//eos/opendata/atlas/rucio/opendata/ODEO_FEB2025_v0_GamGam_mc_364246.Sherpa_222_NNPDF30NNLO_WZZ_3l3v_EW6.GamGam.root"
+      },
+      {
+        "checksum": "adler32:3c89a355",
+        "size": 143626,
+        "uri": "root://eospublic.cern.ch//eos/opendata/atlas/rucio/opendata/ODEO_FEB2025_v0_GamGam_mc_364247.Sherpa_222_NNPDF30NNLO_ZZZ_6l0v_EW6.GamGam.root"
+      },
+      {
+        "checksum": "adler32:53f1cf44",
+        "size": 45350,
+        "uri": "root://eospublic.cern.ch//eos/opendata/atlas/rucio/opendata/ODEO_FEB2025_v0_GamGam_mc_364248.Sherpa_222_NNPDF30NNLO_ZZZ_4l2v_EW6.GamGam.root"
+      },
+      {
+        "checksum": "adler32:b1b98432",
+        "size": 38380,
+        "uri": "root://eospublic.cern.ch//eos/opendata/atlas/rucio/opendata/ODEO_FEB2025_v0_GamGam_mc_364249.Sherpa_222_NNPDF30NNLO_ZZZ_2l4v_EW6.GamGam.root"
+      },
+      {
+        "checksum": "adler32:88e4a471",
+        "size": 53974,
+        "uri": "root://eospublic.cern.ch//eos/opendata/atlas/rucio/opendata/ODEO_FEB2025_v0_GamGam_mc_364336.Sherpa_222_NNPDF30NNLO_WpWpWn_sslvlvjj_EW6.GamGam.root"
+      },
+      {
+        "checksum": "adler32:cb655069",
+        "size": 52185,
+        "uri": "root://eospublic.cern.ch//eos/opendata/atlas/rucio/opendata/ODEO_FEB2025_v0_GamGam_mc_364337.Sherpa_222_NNPDF30NNLO_WnWnWp_sslvlvjj_EW6.GamGam.root"
+      },
+      {
+        "checksum": "adler32:05f5873c",
+        "size": 38631,
+        "uri": "root://eospublic.cern.ch//eos/opendata/atlas/rucio/opendata/ODEO_FEB2025_v0_GamGam_mc_364338.Sherpa_222_NNPDF30NNLO_WpWpWn_oslvlvjj_EW6.GamGam.root"
+      },
+      {
+        "checksum": "adler32:a91c4bda",
+        "size": 32404,
+        "uri": "root://eospublic.cern.ch//eos/opendata/atlas/rucio/opendata/ODEO_FEB2025_v0_GamGam_mc_364339.Sherpa_222_NNPDF30NNLO_WnWnWp_oslvlvjj_EW6.GamGam.root"
+      },
+      {
+        "checksum": "adler32:5523af6c",
+        "size": 22446105,
+        "uri": "root://eospublic.cern.ch//eos/opendata/atlas/rucio/opendata/ODEO_FEB2025_v0_GamGam_mc_364350.Sherpa_224_NNPDF30NNLO_Diphoton_myy_0_50.GamGam.root"
+      },
+      {
+        "checksum": "adler32:055b8450",
+        "size": 790847676,
+        "uri": "root://eospublic.cern.ch//eos/opendata/atlas/rucio/opendata/ODEO_FEB2025_v0_GamGam_mc_364351.Sherpa_224_NNPDF30NNLO_Diphoton_myy_50_90.GamGam.root"
+      },
+      {
+        "checksum": "adler32:19c3d623",
+        "size": 590212105,
+        "uri": "root://eospublic.cern.ch//eos/opendata/atlas/rucio/opendata/ODEO_FEB2025_v0_GamGam_mc_364352.Sherpa_224_NNPDF30NNLO_Diphoton_myy_90_175.GamGam.root"
+      },
+      {
+        "checksum": "adler32:8805c6c2",
+        "size": 154379338,
+        "uri": "root://eospublic.cern.ch//eos/opendata/atlas/rucio/opendata/ODEO_FEB2025_v0_GamGam_mc_364353.Sherpa_224_NNPDF30NNLO_Diphoton_myy_175_2000.GamGam.root"
+      },
+      {
+        "checksum": "adler32:a7e3889b",
+        "size": 9248148,
+        "uri": "root://eospublic.cern.ch//eos/opendata/atlas/rucio/opendata/ODEO_FEB2025_v0_GamGam_mc_364354.Sherpa_224_NNPDF30NNLO_Diphoton_myy_2000_E_CMS.GamGam.root"
+      },
+      {
+        "checksum": "adler32:7eb76aa3",
+        "size": 2636599,
+        "uri": "root://eospublic.cern.ch//eos/opendata/atlas/rucio/opendata/ODEO_FEB2025_v0_GamGam_mc_364541.Sherpa_222_NNPDF30NNLO_SinglePhoton_pty_17_35.GamGam.root"
+      },
+      {
+        "checksum": "adler32:714a180e",
+        "size": 13588675,
+        "uri": "root://eospublic.cern.ch//eos/opendata/atlas/rucio/opendata/ODEO_FEB2025_v0_GamGam_mc_364542.Sherpa_222_NNPDF30NNLO_SinglePhoton_pty_35_70.GamGam.root"
+      },
+      {
+        "checksum": "adler32:b13dd66e",
+        "size": 30470136,
+        "uri": "root://eospublic.cern.ch//eos/opendata/atlas/rucio/opendata/ODEO_FEB2025_v0_GamGam_mc_364543.Sherpa_222_NNPDF30NNLO_SinglePhoton_pty_70_140.GamGam.root"
+      },
+      {
+        "checksum": "adler32:09a8faec",
+        "size": 54880174,
+        "uri": "root://eospublic.cern.ch//eos/opendata/atlas/rucio/opendata/ODEO_FEB2025_v0_GamGam_mc_364544.Sherpa_222_NNPDF30NNLO_SinglePhoton_pty_140_280.GamGam.root"
+      },
+      {
+        "checksum": "adler32:2a80d92a",
+        "size": 16295191,
+        "uri": "root://eospublic.cern.ch//eos/opendata/atlas/rucio/opendata/ODEO_FEB2025_v0_GamGam_mc_364545.Sherpa_222_NNPDF30NNLO_SinglePhoton_pty_280_500.GamGam.root"
+      },
+      {
+        "checksum": "adler32:8186da41",
+        "size": 1900036,
+        "uri": "root://eospublic.cern.ch//eos/opendata/atlas/rucio/opendata/ODEO_FEB2025_v0_GamGam_mc_364546.Sherpa_222_NNPDF30NNLO_SinglePhoton_pty_500_1000.GamGam.root"
+      },
+      {
+        "checksum": "adler32:971fc920",
+        "size": 3482652,
+        "uri": "root://eospublic.cern.ch//eos/opendata/atlas/rucio/opendata/ODEO_FEB2025_v0_GamGam_mc_364547.Sherpa_222_NNPDF30NNLO_SinglePhoton_pty_1000_E_CMS.GamGam.root"
+      },
+      {
+        "checksum": "adler32:f356c38f",
+        "size": 157867,
+        "uri": "root://eospublic.cern.ch//eos/opendata/atlas/rucio/opendata/ODEO_FEB2025_v0_GamGam_mc_364700.Pythia8EvtGen_A14NNPDF23LO_jetjet_JZ0WithSW.GamGam.root"
+      },
+      {
+        "checksum": "adler32:dc9e3e09",
+        "size": 424012,
+        "uri": "root://eospublic.cern.ch//eos/opendata/atlas/rucio/opendata/ODEO_FEB2025_v0_GamGam_mc_364701.Pythia8EvtGen_A14NNPDF23LO_jetjet_JZ1WithSW.GamGam.root"
+      },
+      {
+        "checksum": "adler32:a77d416a",
+        "size": 9935487,
+        "uri": "root://eospublic.cern.ch//eos/opendata/atlas/rucio/opendata/ODEO_FEB2025_v0_GamGam_mc_364702.Pythia8EvtGen_A14NNPDF23LO_jetjet_JZ2WithSW.GamGam.root"
+      },
+      {
+        "checksum": "adler32:0fa91a05",
+        "size": 29827274,
+        "uri": "root://eospublic.cern.ch//eos/opendata/atlas/rucio/opendata/ODEO_FEB2025_v0_GamGam_mc_364703.Pythia8EvtGen_A14NNPDF23LO_jetjet_JZ3WithSW.GamGam.root"
+      },
+      {
+        "checksum": "adler32:4866ecf7",
+        "size": 121373672,
+        "uri": "root://eospublic.cern.ch//eos/opendata/atlas/rucio/opendata/ODEO_FEB2025_v0_GamGam_mc_364704.Pythia8EvtGen_A14NNPDF23LO_jetjet_JZ4WithSW.GamGam.root"
+      },
+      {
+        "checksum": "adler32:8f778341",
+        "size": 36059660,
+        "uri": "root://eospublic.cern.ch//eos/opendata/atlas/rucio/opendata/ODEO_FEB2025_v0_GamGam_mc_364705.Pythia8EvtGen_A14NNPDF23LO_jetjet_JZ5WithSW.GamGam.root"
+      },
+      {
+        "checksum": "adler32:0ed9d0ad",
+        "size": 2855027,
+        "uri": "root://eospublic.cern.ch//eos/opendata/atlas/rucio/opendata/ODEO_FEB2025_v0_GamGam_mc_364706.Pythia8EvtGen_A14NNPDF23LO_jetjet_JZ6WithSW.GamGam.root"
+      },
+      {
+        "checksum": "adler32:406d0a42",
+        "size": 2206465,
+        "uri": "root://eospublic.cern.ch//eos/opendata/atlas/rucio/opendata/ODEO_FEB2025_v0_GamGam_mc_364707.Pythia8EvtGen_A14NNPDF23LO_jetjet_JZ7WithSW.GamGam.root"
+      },
+      {
+        "checksum": "adler32:d8a18790",
+        "size": 5291552,
+        "uri": "root://eospublic.cern.ch//eos/opendata/atlas/rucio/opendata/ODEO_FEB2025_v0_GamGam_mc_364708.Pythia8EvtGen_A14NNPDF23LO_jetjet_JZ8WithSW.GamGam.root"
+      },
+      {
+        "checksum": "adler32:c382bc50",
+        "size": 2598413,
+        "uri": "root://eospublic.cern.ch//eos/opendata/atlas/rucio/opendata/ODEO_FEB2025_v0_GamGam_mc_364709.Pythia8EvtGen_A14NNPDF23LO_jetjet_JZ9WithSW.GamGam.root"
+      },
+      {
+        "checksum": "adler32:912791c0",
+        "size": 8564967,
+        "uri": "root://eospublic.cern.ch//eos/opendata/atlas/rucio/opendata/ODEO_FEB2025_v0_GamGam_mc_364710.Pythia8EvtGen_A14NNPDF23LO_jetjet_JZ10WithSW.GamGam.root"
+      },
+      {
+        "checksum": "adler32:4f5eacb8",
+        "size": 3989416,
+        "uri": "root://eospublic.cern.ch//eos/opendata/atlas/rucio/opendata/ODEO_FEB2025_v0_GamGam_mc_364711.Pythia8EvtGen_A14NNPDF23LO_jetjet_JZ11WithSW.GamGam.root"
+      },
+      {
+        "checksum": "adler32:ca12bd30",
+        "size": 4852271,
+        "uri": "root://eospublic.cern.ch//eos/opendata/atlas/rucio/opendata/ODEO_FEB2025_v0_GamGam_mc_364712.Pythia8EvtGen_A14NNPDF23LO_jetjet_JZ12WithSW.GamGam.root"
+      },
+      {
+        "checksum": "adler32:b9d2c692",
+        "size": 189833,
+        "uri": "root://eospublic.cern.ch//eos/opendata/atlas/rucio/opendata/ODEO_FEB2025_v0_GamGam_mc_375884.MGPy8EG_A14N_GG_ttn1_2000_5000_200.GamGam.root"
+      },
+      {
+        "checksum": "adler32:adfe2065",
+        "size": 54304,
+        "uri": "root://eospublic.cern.ch//eos/opendata/atlas/rucio/opendata/ODEO_FEB2025_v0_GamGam_mc_376359.MGPy8EG_A14N23LO_SS_onestepCC_1600_900_200.GamGam.root"
+      },
+      {
+        "checksum": "adler32:5ad2e39b",
+        "size": 61430,
+        "uri": "root://eospublic.cern.ch//eos/opendata/atlas/rucio/opendata/ODEO_FEB2025_v0_GamGam_mc_376518.MadGraphPythia8EvtGen_A14NNPDF23LO_GG_direct_2400_200.GamGam.root"
+      },
+      {
+        "checksum": "adler32:cbef38e9",
+        "size": 41235,
+        "uri": "root://eospublic.cern.ch//eos/opendata/atlas/rucio/opendata/ODEO_FEB2025_v0_GamGam_mc_392202.MGPy8EG_A14N23LO_C1N2_WZ_500p0_100p0_3L_2L7.GamGam.root"
+      },
+      {
+        "checksum": "adler32:f778246f",
+        "size": 30408,
+        "uri": "root://eospublic.cern.ch//eos/opendata/atlas/rucio/opendata/ODEO_FEB2025_v0_GamGam_mc_394997.MGPy8EG_A14N23LO_SM_N2C1p_105_100_2L2MET75_MadSpin.GamGam.root"
+      },
+      {
+        "checksum": "adler32:2d539ccb",
+        "size": 129185,
+        "uri": "root://eospublic.cern.ch//eos/opendata/atlas/rucio/opendata/ODEO_FEB2025_v0_GamGam_mc_398384.MGPy8EG_A14N23LO_C1N2N1_GGMHinoZh50_800_noFilter.GamGam.root"
+      },
+      {
+        "checksum": "adler32:e47c9e3c",
+        "size": 133060,
+        "uri": "root://eospublic.cern.ch//eos/opendata/atlas/rucio/opendata/ODEO_FEB2025_v0_GamGam_mc_410081.MadGraphPythia8EvtGen_A14NNPDF23_ttbarWW.GamGam.root"
+      },
+      {
+        "checksum": "adler32:a605093b",
+        "size": 4567090,
+        "uri": "root://eospublic.cern.ch//eos/opendata/atlas/rucio/opendata/ODEO_FEB2025_v0_GamGam_mc_410082.MadGraphPythia8EvtGen_A14NNPDF23LO_ttgamma_noallhad.GamGam.root"
+      },
+      {
+        "checksum": "adler32:fe3a9f96",
+        "size": 2949440,
+        "uri": "root://eospublic.cern.ch//eos/opendata/atlas/rucio/opendata/ODEO_FEB2025_v0_GamGam_mc_410087.MadGraphPythia8EvtGen_A14NNPDF23LO_ttgamma_allhad.GamGam.root"
+      },
+      {
+        "checksum": "adler32:4b809781",
+        "size": 246639,
+        "uri": "root://eospublic.cern.ch//eos/opendata/atlas/rucio/opendata/ODEO_FEB2025_v0_GamGam_mc_410155.aMcAtNloPythia8EvtGen_MEN30NLO_A14N23LO_ttW.GamGam.root"
+      },
+      {
+        "checksum": "adler32:6aecf16f",
+        "size": 183430,
+        "uri": "root://eospublic.cern.ch//eos/opendata/atlas/rucio/opendata/ODEO_FEB2025_v0_GamGam_mc_410156.aMcAtNloPythia8EvtGen_MEN30NLO_A14N23LO_ttZnunu.GamGam.root"
+      },
+      {
+        "checksum": "adler32:8d648083",
+        "size": 400929,
+        "uri": "root://eospublic.cern.ch//eos/opendata/atlas/rucio/opendata/ODEO_FEB2025_v0_GamGam_mc_410157.aMcAtNloPythia8EvtGen_MEN30NLO_A14N23LO_ttZqq.GamGam.root"
+      },
+      {
+        "checksum": "adler32:1d7f58a2",
+        "size": 300205,
+        "uri": "root://eospublic.cern.ch//eos/opendata/atlas/rucio/opendata/ODEO_FEB2025_v0_GamGam_mc_410218.aMcAtNloPythia8EvtGen_MEN30NLO_A14N23LO_ttee.GamGam.root"
+      },
+      {
+        "checksum": "adler32:75c99781",
+        "size": 228585,
+        "uri": "root://eospublic.cern.ch//eos/opendata/atlas/rucio/opendata/ODEO_FEB2025_v0_GamGam_mc_410219.aMcAtNloPythia8EvtGen_MEN30NLO_A14N23LO_ttmumu.GamGam.root"
+      },
+      {
+        "checksum": "adler32:cf3a412d",
+        "size": 660449,
+        "uri": "root://eospublic.cern.ch//eos/opendata/atlas/rucio/opendata/ODEO_FEB2025_v0_GamGam_mc_410220.aMcAtNloPythia8EvtGen_MEN30NLO_A14N23LO_tttautau.GamGam.root"
+      },
+      {
+        "checksum": "adler32:ab2709cb",
+        "size": 5744715,
+        "uri": "root://eospublic.cern.ch//eos/opendata/atlas/rucio/opendata/ODEO_FEB2025_v0_GamGam_mc_410389.MadGraphPythia8EvtGen_A14NNPDF23_ttgamma_nonallhadronic.GamGam.root"
+      },
+      {
+        "checksum": "adler32:b0d8956f",
+        "size": 4674832,
+        "uri": "root://eospublic.cern.ch//eos/opendata/atlas/rucio/opendata/ODEO_FEB2025_v0_GamGam_mc_410395.MGH7EG_H7UE_ttgamma_nonallhadronic.GamGam.root"
+      },
+      {
+        "checksum": "adler32:596cc48d",
+        "size": 3055039,
+        "uri": "root://eospublic.cern.ch//eos/opendata/atlas/rucio/opendata/ODEO_FEB2025_v0_GamGam_mc_410396.MGH7EG_H7UE_ttgamma_allhadronic.GamGam.root"
+      },
+      {
+        "checksum": "adler32:e90d5c25",
+        "size": 108956,
+        "uri": "root://eospublic.cern.ch//eos/opendata/atlas/rucio/opendata/ODEO_FEB2025_v0_GamGam_mc_410408.aMcAtNloPythia8EvtGen_tWZ_Ztoll_minDR1.GamGam.root"
+      },
+      {
+        "checksum": "adler32:20e85910",
+        "size": 29155514,
+        "uri": "root://eospublic.cern.ch//eos/opendata/atlas/rucio/opendata/ODEO_FEB2025_v0_GamGam_mc_410470.PhPy8EG_A14_ttbar_hdamp258p75_nonallhad.GamGam.root"
+      },
+      {
+        "checksum": "adler32:aa82f8a8",
+        "size": 16444498,
+        "uri": "root://eospublic.cern.ch//eos/opendata/atlas/rucio/opendata/ODEO_FEB2025_v0_GamGam_mc_410471.PhPy8EG_A14_ttbar_hdamp258p75_allhad.GamGam.root"
+      },
+      {
+        "checksum": "adler32:0ace4278",
+        "size": 149267,
+        "uri": "root://eospublic.cern.ch//eos/opendata/atlas/rucio/opendata/ODEO_FEB2025_v0_GamGam_mc_410560.MadGraphPythia8EvtGen_A14_tZ_4fl_tchan_noAllHad.GamGam.root"
+      },
+      {
+        "checksum": "adler32:ea00971a",
+        "size": 90124,
+        "uri": "root://eospublic.cern.ch//eos/opendata/atlas/rucio/opendata/ODEO_FEB2025_v0_GamGam_mc_410644.PowhegPythia8EvtGen_A14_singletop_schan_lept_top.GamGam.root"
+      },
+      {
+        "checksum": "adler32:8964240d",
+        "size": 63828,
+        "uri": "root://eospublic.cern.ch//eos/opendata/atlas/rucio/opendata/ODEO_FEB2025_v0_GamGam_mc_410645.PowhegPythia8EvtGen_A14_singletop_schan_lept_antitop.GamGam.root"
+      },
+      {
+        "checksum": "adler32:41b23ab6",
+        "size": 1222382,
+        "uri": "root://eospublic.cern.ch//eos/opendata/atlas/rucio/opendata/ODEO_FEB2025_v0_GamGam_mc_410658.PhPy8EG_A14_tchan_BW50_lept_top.GamGam.root"
+      },
+      {
+        "checksum": "adler32:b1239b8b",
+        "size": 727113,
+        "uri": "root://eospublic.cern.ch//eos/opendata/atlas/rucio/opendata/ODEO_FEB2025_v0_GamGam_mc_410659.PhPy8EG_A14_tchan_BW50_lept_antitop.GamGam.root"
+      },
+      {
+        "checksum": "adler32:d7da08ad",
+        "size": 5219093,
+        "uri": "root://eospublic.cern.ch//eos/opendata/atlas/rucio/opendata/ODEO_FEB2025_v0_GamGam_mc_411233.PowhegHerwig7EvtGen_tt_hdamp258p75_713_SingleLep.GamGam.root"
+      },
+      {
+        "checksum": "adler32:2655f48f",
+        "size": 2531677,
+        "uri": "root://eospublic.cern.ch//eos/opendata/atlas/rucio/opendata/ODEO_FEB2025_v0_GamGam_mc_411234.PowhegHerwig7EvtGen_tt_hdamp258p75_713_dil.GamGam.root"
+      },
+      {
+        "checksum": "adler32:1f165899",
+        "size": 18065635,
+        "uri": "root://eospublic.cern.ch//eos/opendata/atlas/rucio/opendata/ODEO_FEB2025_v0_GamGam_mc_411316.PowhegHerwig7EvtGen_tt_hdamp258p75_713_allhad.GamGam.root"
+      },
+      {
+        "checksum": "adler32:01291736",
+        "size": 1022167,
+        "uri": "root://eospublic.cern.ch//eos/opendata/atlas/rucio/opendata/ODEO_FEB2025_v0_GamGam_mc_412043.aMcAtNloPythia8EvtGen_A14NNPDF31_SM4topsNLO.GamGam.root"
+      },
+      {
+        "checksum": "adler32:4cc22eb2",
+        "size": 713669,
+        "uri": "root://eospublic.cern.ch//eos/opendata/atlas/rucio/opendata/ODEO_FEB2025_v0_GamGam_mc_412044.aMcAtNloHerwig7EvtGen_H7UE_SM4topsNLO.GamGam.root"
+      },
+      {
+        "checksum": "adler32:978f42cb",
+        "size": 51968,
+        "uri": "root://eospublic.cern.ch//eos/opendata/atlas/rucio/opendata/ODEO_FEB2025_v0_GamGam_mc_423099.Pythia8EvtGen_A14NNPDF23LO_gammajet_DP8_17.GamGam.root"
+      },
+      {
+        "checksum": "adler32:87615d93",
+        "size": 839297,
+        "uri": "root://eospublic.cern.ch//eos/opendata/atlas/rucio/opendata/ODEO_FEB2025_v0_GamGam_mc_423100.Pythia8EvtGen_A14NNPDF23LO_gammajet_DP17_35.GamGam.root"
+      },
+      {
+        "checksum": "adler32:1b78ade8",
+        "size": 4586627,
+        "uri": "root://eospublic.cern.ch//eos/opendata/atlas/rucio/opendata/ODEO_FEB2025_v0_GamGam_mc_423101.Pythia8EvtGen_A14NNPDF23LO_gammajet_DP35_50.GamGam.root"
+      },
+      {
+        "checksum": "adler32:1c1a3991",
+        "size": 10124108,
+        "uri": "root://eospublic.cern.ch//eos/opendata/atlas/rucio/opendata/ODEO_FEB2025_v0_GamGam_mc_423102.Pythia8EvtGen_A14NNPDF23LO_gammajet_DP50_70.GamGam.root"
+      },
+      {
+        "checksum": "adler32:5bf96f22",
+        "size": 10489108,
+        "uri": "root://eospublic.cern.ch//eos/opendata/atlas/rucio/opendata/ODEO_FEB2025_v0_GamGam_mc_423103.Pythia8EvtGen_A14NNPDF23LO_gammajet_DP70_140.GamGam.root"
+      },
+      {
+        "checksum": "adler32:118b6d27",
+        "size": 18263805,
+        "uri": "root://eospublic.cern.ch//eos/opendata/atlas/rucio/opendata/ODEO_FEB2025_v0_GamGam_mc_423104.Pythia8EvtGen_A14NNPDF23LO_gammajet_DP140_280.GamGam.root"
+      },
+      {
+        "checksum": "adler32:1d0bc94e",
+        "size": 21704422,
+        "uri": "root://eospublic.cern.ch//eos/opendata/atlas/rucio/opendata/ODEO_FEB2025_v0_GamGam_mc_423105.Pythia8EvtGen_A14NNPDF23LO_gammajet_DP280_500.GamGam.root"
+      },
+      {
+        "checksum": "adler32:49a76788",
+        "size": 3491821,
+        "uri": "root://eospublic.cern.ch//eos/opendata/atlas/rucio/opendata/ODEO_FEB2025_v0_GamGam_mc_423106.Pythia8EvtGen_A14NNPDF23LO_gammajet_DP500_800.GamGam.root"
+      },
+      {
+        "checksum": "adler32:c84ef90c",
+        "size": 2558562,
+        "uri": "root://eospublic.cern.ch//eos/opendata/atlas/rucio/opendata/ODEO_FEB2025_v0_GamGam_mc_423107.Pythia8EvtGen_A14NNPDF23LO_gammajet_DP800_1000.GamGam.root"
+      },
+      {
+        "checksum": "adler32:7594ab5e",
+        "size": 3829343,
+        "uri": "root://eospublic.cern.ch//eos/opendata/atlas/rucio/opendata/ODEO_FEB2025_v0_GamGam_mc_423108.Pythia8EvtGen_A14NNPDF23LO_gammajet_DP1000_1500.GamGam.root"
+      },
+      {
+        "checksum": "adler32:80ee2a9c",
+        "size": 1606772,
+        "uri": "root://eospublic.cern.ch//eos/opendata/atlas/rucio/opendata/ODEO_FEB2025_v0_GamGam_mc_423109.Pythia8EvtGen_A14NNPDF23LO_gammajet_DP1500_2000.GamGam.root"
+      },
+      {
+        "checksum": "adler32:e52285d6",
+        "size": 1292874,
+        "uri": "root://eospublic.cern.ch//eos/opendata/atlas/rucio/opendata/ODEO_FEB2025_v0_GamGam_mc_423110.Pythia8EvtGen_A14NNPDF23LO_gammajet_DP2000_2500.GamGam.root"
+      },
+      {
+        "checksum": "adler32:6fa10ef8",
+        "size": 2264143,
+        "uri": "root://eospublic.cern.ch//eos/opendata/atlas/rucio/opendata/ODEO_FEB2025_v0_GamGam_mc_423111.Pythia8EvtGen_A14NNPDF23LO_gammajet_DP2500_3000.GamGam.root"
+      },
+      {
+        "checksum": "adler32:97015115",
+        "size": 1655884,
+        "uri": "root://eospublic.cern.ch//eos/opendata/atlas/rucio/opendata/ODEO_FEB2025_v0_GamGam_mc_423112.Pythia8EvtGen_A14NNPDF23LO_gammajet_DP3000_inf.GamGam.root"
+      },
+      {
+        "checksum": "adler32:5c60c210",
+        "size": 146871,
+        "uri": "root://eospublic.cern.ch//eos/opendata/atlas/rucio/opendata/ODEO_FEB2025_v0_GamGam_mc_448624.MGPy8EG_A14N23LO_TT_higgsinoRPV_1075_700.GamGam.root"
+      },
+      {
+        "checksum": "adler32:fbfd491e",
+        "size": 160677,
+        "uri": "root://eospublic.cern.ch//eos/opendata/atlas/rucio/opendata/ODEO_FEB2025_v0_GamGam_mc_449595.MGPy8EG_A14N23LO_TT_RPVdirectBL_1400.GamGam.root"
+      },
+      {
+        "checksum": "adler32:1153e22b",
+        "size": 45318,
+        "uri": "root://eospublic.cern.ch//eos/opendata/atlas/rucio/opendata/ODEO_FEB2025_v0_GamGam_mc_450576.PowhegPythia8EvtGen_NNLOPS_nnlo_30_VBFH125_ZZllbb.GamGam.root"
+      },
+      {
+        "checksum": "adler32:22829913",
+        "size": 85241,
+        "uri": "root://eospublic.cern.ch//eos/opendata/atlas/rucio/opendata/ODEO_FEB2025_v0_GamGam_mc_500335.MGH7EG_VBFHWWlvlv.GamGam.root"
+      },
+      {
+        "checksum": "adler32:dd9065d6",
+        "size": 9167538,
+        "uri": "root://eospublic.cern.ch//eos/opendata/atlas/rucio/opendata/ODEO_FEB2025_v0_GamGam_mc_500553.aMCPy8EG_ZH_FxFx_Hyy.GamGam.root"
+      },
+      {
+        "checksum": "adler32:0f163660",
+        "size": 7512799,
+        "uri": "root://eospublic.cern.ch//eos/opendata/atlas/rucio/opendata/ODEO_FEB2025_v0_GamGam_mc_500554.aMCPy8EG_WH_FxFx_Hyy.GamGam.root"
+      },
+      {
+        "checksum": "adler32:6ea24d29",
+        "size": 9649395,
+        "uri": "root://eospublic.cern.ch//eos/opendata/atlas/rucio/opendata/ODEO_FEB2025_v0_GamGam_mc_500555.aMCPy8EG_ggZH_Hyy.GamGam.root"
+      },
+      {
+        "checksum": "adler32:348cb05c",
+        "size": 155966,
+        "uri": "root://eospublic.cern.ch//eos/opendata/atlas/rucio/opendata/ODEO_FEB2025_v0_GamGam_mc_501058.MGPy8EG_StauStauDirect_200p0_1p0_TFilt.GamGam.root"
+      },
+      {
+        "checksum": "adler32:cf0ba331",
+        "size": 148970,
+        "uri": "root://eospublic.cern.ch//eos/opendata/atlas/rucio/opendata/ODEO_FEB2025_v0_GamGam_mc_506098.aMCPy8EG_WpH_FxFx_Htautau.GamGam.root"
+      },
+      {
+        "checksum": "adler32:6fb00389",
+        "size": 109129,
+        "uri": "root://eospublic.cern.ch//eos/opendata/atlas/rucio/opendata/ODEO_FEB2025_v0_GamGam_mc_506099.aMCPy8EG_ZH_FxFx_Htautau.GamGam.root"
+      },
+      {
+        "checksum": "adler32:8b53596d",
+        "size": 450798,
+        "uri": "root://eospublic.cern.ch//eos/opendata/atlas/rucio/opendata/ODEO_FEB2025_v0_GamGam_mc_506101.aMCH7EG_VBF_Htautauh30h20.GamGam.root"
+      },
+      {
+        "checksum": "adler32:f802f504",
+        "size": 106515,
+        "uri": "root://eospublic.cern.ch//eos/opendata/atlas/rucio/opendata/ODEO_FEB2025_v0_GamGam_mc_506102.aMCH7EG_VBF_Htautaul13l7.GamGam.root"
+      },
+      {
+        "checksum": "adler32:d8416da5",
+        "size": 164428,
+        "uri": "root://eospublic.cern.ch//eos/opendata/atlas/rucio/opendata/ODEO_FEB2025_v0_GamGam_mc_506103.aMCH7EG_VBF_Htautaulp15hm20.GamGam.root"
+      },
+      {
+        "checksum": "adler32:7a5c0bde",
+        "size": 228666,
+        "uri": "root://eospublic.cern.ch//eos/opendata/atlas/rucio/opendata/ODEO_FEB2025_v0_GamGam_mc_506104.aMCH7EG_VBF_Htautaulm15hp20.GamGam.root"
+      },
+      {
+        "checksum": "adler32:dd07866c",
+        "size": 28447493,
+        "uri": "root://eospublic.cern.ch//eos/opendata/atlas/rucio/opendata/ODEO_FEB2025_v0_GamGam_mc_506811.aMCH7EG_VBF_HC_Hyy.GamGam.root"
+      },
+      {
+        "checksum": "adler32:fcfc408e",
+        "size": 7526501,
+        "uri": "root://eospublic.cern.ch//eos/opendata/atlas/rucio/opendata/ODEO_FEB2025_v0_GamGam_mc_506813.aMCPy8EG_ZH_had_FxFx_Hyy.GamGam.root"
+      },
+      {
+        "checksum": "adler32:9397b098",
+        "size": 10002571,
+        "uri": "root://eospublic.cern.ch//eos/opendata/atlas/rucio/opendata/ODEO_FEB2025_v0_GamGam_mc_506814.aMCPy8EG_ggZH_Zhad_Hyy.GamGam.root"
+      },
+      {
+        "checksum": "adler32:655edf25",
+        "size": 430573,
+        "uri": "root://eospublic.cern.ch//eos/opendata/atlas/rucio/opendata/ODEO_FEB2025_v0_GamGam_mc_507366.MGPy8EG_A14NNPDF23LO_GGM_N1N2C1_950.GamGam.root"
+      },
+      {
+        "checksum": "adler32:2f97d730",
+        "size": 173088,
+        "uri": "root://eospublic.cern.ch//eos/opendata/atlas/rucio/opendata/ODEO_FEB2025_v0_GamGam_mc_510097.MGPy8EG_A14N23LO_DM_4topscalar_p1000_c1_nonallhad.GamGam.root"
+      },
+      {
+        "checksum": "adler32:3771b125",
+        "size": 82965,
+        "uri": "root://eospublic.cern.ch//eos/opendata/atlas/rucio/opendata/ODEO_FEB2025_v0_GamGam_mc_523692.MGPy8EG_A14N23LO_TT_tN1_1200_200_MS.GamGam.root"
+      },
+      {
+        "checksum": "adler32:ce7cbe46",
+        "size": 517052,
+        "uri": "root://eospublic.cern.ch//eos/opendata/atlas/rucio/opendata/ODEO_FEB2025_v0_GamGam_mc_600017.PhH7EG_H7UE_716_tchan_lept_antitop.GamGam.root"
+      },
+      {
+        "checksum": "adler32:eef489a3",
+        "size": 892266,
+        "uri": "root://eospublic.cern.ch//eos/opendata/atlas/rucio/opendata/ODEO_FEB2025_v0_GamGam_mc_600018.PhH7EG_H7UE_716_tchan_lept_top.GamGam.root"
+      },
+      {
+        "checksum": "adler32:9e074e20",
+        "size": 63204,
+        "uri": "root://eospublic.cern.ch//eos/opendata/atlas/rucio/opendata/ODEO_FEB2025_v0_GamGam_mc_600019.PhH7EG_H7UE_716_schan_lept_antitop.GamGam.root"
+      },
+      {
+        "checksum": "adler32:28f545b5",
+        "size": 81599,
+        "uri": "root://eospublic.cern.ch//eos/opendata/atlas/rucio/opendata/ODEO_FEB2025_v0_GamGam_mc_600020.PhH7EG_H7UE_716_schan_lept_top.GamGam.root"
+      },
+      {
+        "checksum": "adler32:089baf36",
+        "size": 1567801,
+        "uri": "root://eospublic.cern.ch//eos/opendata/atlas/rucio/opendata/ODEO_FEB2025_v0_GamGam_mc_600565.PhH7EG_ggH125_tautauh30h20_ShowerSys_fix.GamGam.root"
+      },
+      {
+        "checksum": "adler32:de607f2d",
+        "size": 226783,
+        "uri": "root://eospublic.cern.ch//eos/opendata/atlas/rucio/opendata/ODEO_FEB2025_v0_GamGam_mc_600566.PhH7EG_ggH125_tautaul13l7_ShowerSys_fix.GamGam.root"
+      },
+      {
+        "checksum": "adler32:a57d9c2f",
+        "size": 271444,
+        "uri": "root://eospublic.cern.ch//eos/opendata/atlas/rucio/opendata/ODEO_FEB2025_v0_GamGam_mc_600567.PhH7EG_ggH125_ttlp15hm20_ShowerSys_fix.GamGam.root"
+      },
+      {
+        "checksum": "adler32:6dcfa90f",
+        "size": 277792,
+        "uri": "root://eospublic.cern.ch//eos/opendata/atlas/rucio/opendata/ODEO_FEB2025_v0_GamGam_mc_600568.PhH7EG_ggH125_ttlm15hp20_ShowerSys_fix.GamGam.root"
+      },
+      {
+        "checksum": "adler32:db6f91d7",
+        "size": 589075,
+        "uri": "root://eospublic.cern.ch//eos/opendata/atlas/rucio/opendata/ODEO_FEB2025_v0_GamGam_mc_600569.PhH7EG_VBFH125_tautauh30h20_ShowerSys_fix.GamGam.root"
+      },
+      {
+        "checksum": "adler32:406e50ec",
+        "size": 103733,
+        "uri": "root://eospublic.cern.ch//eos/opendata/atlas/rucio/opendata/ODEO_FEB2025_v0_GamGam_mc_600570.PhH7EG_VBFH125_tautaul13l7_ShowerSys_fix.GamGam.root"
+      },
+      {
+        "checksum": "adler32:93c18a66",
+        "size": 123019,
+        "uri": "root://eospublic.cern.ch//eos/opendata/atlas/rucio/opendata/ODEO_FEB2025_v0_GamGam_mc_600571.PhH7EG_VBFH125_tautaulp15hm20_ShowerSys_fix.GamGam.root"
+      },
+      {
+        "checksum": "adler32:b9a67508",
+        "size": 116483,
+        "uri": "root://eospublic.cern.ch//eos/opendata/atlas/rucio/opendata/ODEO_FEB2025_v0_GamGam_mc_600572.PhH7EG_VBFH125_tautaulm15hp20_ShowerSys_fix.GamGam.root"
+      },
+      {
+        "checksum": "adler32:1f7936ba",
+        "size": 100313,
+        "uri": "root://eospublic.cern.ch//eos/opendata/atlas/rucio/opendata/ODEO_FEB2025_v0_GamGam_mc_600573.PhH7EG_WmH125J_Winc_MINLO_tt_ShowerSys_fix.GamGam.root"
+      },
+      {
+        "checksum": "adler32:0789ccf0",
+        "size": 137725,
+        "uri": "root://eospublic.cern.ch//eos/opendata/atlas/rucio/opendata/ODEO_FEB2025_v0_GamGam_mc_600574.PhH7EG_WpH125J_Winc_MINLO_tt_ShowerSys_fix.GamGam.root"
+      },
+      {
+        "checksum": "adler32:f30b1d38",
+        "size": 152981,
+        "uri": "root://eospublic.cern.ch//eos/opendata/atlas/rucio/opendata/ODEO_FEB2025_v0_GamGam_mc_600575.PhH7EG_ZH125J_Zinc_MINLO_tautau_ShowerSys_fix.GamGam.root"
+      },
+      {
+        "checksum": "adler32:5204b334",
+        "size": 106061,
+        "uri": "root://eospublic.cern.ch//eos/opendata/atlas/rucio/opendata/ODEO_FEB2025_v0_GamGam_mc_600686.PhPy8EG_NNPDF3_AZNLO_ggZH125_Htautau_Zinc.GamGam.root"
+      },
+      {
+        "checksum": "adler32:d3f48987",
+        "size": 1996010,
+        "uri": "root://eospublic.cern.ch//eos/opendata/atlas/rucio/opendata/ODEO_FEB2025_v0_GamGam_mc_601352.PhPy8EG_tW_dyn_DR_incl_antitop.GamGam.root"
+      },
+      {
+        "checksum": "adler32:adac1e81",
+        "size": 1985122,
+        "uri": "root://eospublic.cern.ch//eos/opendata/atlas/rucio/opendata/ODEO_FEB2025_v0_GamGam_mc_601355.PhPy8EG_tW_dyn_DR_incl_top.GamGam.root"
+      },
+      {
+        "checksum": "adler32:04f6a6dc",
+        "size": 619167,
+        "uri": "root://eospublic.cern.ch//eos/opendata/atlas/rucio/opendata/ODEO_FEB2025_v0_GamGam_mc_601487.PhPy8EG_A14_tchan_pThard1_lep_antitop.GamGam.root"
+      },
+      {
+        "checksum": "adler32:05017fe0",
+        "size": 927990,
+        "uri": "root://eospublic.cern.ch//eos/opendata/atlas/rucio/opendata/ODEO_FEB2025_v0_GamGam_mc_601489.PhPy8EG_A14_tchan_pThard1_lep_top.GamGam.root"
+      },
+      {
+        "checksum": "adler32:75746773",
+        "size": 4655717,
+        "uri": "root://eospublic.cern.ch//eos/opendata/atlas/rucio/opendata/ODEO_FEB2025_v0_GamGam_mc_601491.PhPy8EG_A14_ttbar_pThard1_dil.GamGam.root"
+      },
+      {
+        "checksum": "adler32:16b86503",
+        "size": 172845,
+        "uri": "root://eospublic.cern.ch//eos/opendata/atlas/rucio/opendata/ODEO_FEB2025_v0_GamGam_mc_601495.PhPy8EG_A14_ttbar_pThard1_allhad.GamGam.root"
+      },
+      {
+        "checksum": "adler32:e188919a",
+        "size": 20906238,
+        "uri": "root://eospublic.cern.ch//eos/opendata/atlas/rucio/opendata/ODEO_FEB2025_v0_GamGam_mc_601497.PhPy8EG_A14_ttbar_pThard1_singlelep.GamGam.root"
+      },
+      {
+        "checksum": "adler32:7ecffb63",
+        "size": 211378,
+        "uri": "root://eospublic.cern.ch//eos/opendata/atlas/rucio/opendata/ODEO_FEB2025_v0_GamGam_mc_601624.PhPy8EG_tW_DS_dyn_dil_antitop.GamGam.root"
+      },
+      {
+        "checksum": "adler32:25f78f23",
+        "size": 1785928,
+        "uri": "root://eospublic.cern.ch//eos/opendata/atlas/rucio/opendata/ODEO_FEB2025_v0_GamGam_mc_601627.PhPy8EG_tW_DS_dyn_incl_antitop.GamGam.root"
+      },
+      {
+        "checksum": "adler32:ffaafca6",
+        "size": 256243,
+        "uri": "root://eospublic.cern.ch//eos/opendata/atlas/rucio/opendata/ODEO_FEB2025_v0_GamGam_mc_601628.PhPy8EG_tW_DS_dyn_dil_top.GamGam.root"
+      },
+      {
+        "checksum": "adler32:6c26c9ef",
+        "size": 1719543,
+        "uri": "root://eospublic.cern.ch//eos/opendata/atlas/rucio/opendata/ODEO_FEB2025_v0_GamGam_mc_601631.PhPy8EG_tW_DS_dyn_incl_top.GamGam.root"
+      },
+      {
+        "checksum": "adler32:9cd3c70a",
+        "size": 1922919,
+        "uri": "root://eospublic.cern.ch//eos/opendata/atlas/rucio/opendata/ODEO_FEB2025_v0_GamGam_mc_601761.PhPy8EG_tW_dyn_DR_pThard1_incl_top.GamGam.root"
+      },
+      {
+        "checksum": "adler32:8589404b",
+        "size": 1956720,
+        "uri": "root://eospublic.cern.ch//eos/opendata/atlas/rucio/opendata/ODEO_FEB2025_v0_GamGam_mc_601762.PhPy8EG_tW_dyn_DR_pThard1_incl_antitop.GamGam.root"
+      },
+      {
+        "checksum": "adler32:93654e83",
+        "size": 267256,
+        "uri": "root://eospublic.cern.ch//eos/opendata/atlas/rucio/opendata/ODEO_FEB2025_v0_GamGam_mc_601763.PhPy8EG_tW_dyn_DR_pThard1_dil_top.GamGam.root"
+      },
+      {
+        "checksum": "adler32:071aebec",
+        "size": 264986,
+        "uri": "root://eospublic.cern.ch//eos/opendata/atlas/rucio/opendata/ODEO_FEB2025_v0_GamGam_mc_601764.PhPy8EG_tW_dyn_DR_pThard1_dil_antitop.GamGam.root"
+      },
+      {
+        "checksum": "adler32:5ed74ce2",
+        "size": 260180,
+        "uri": "root://eospublic.cern.ch//eos/opendata/atlas/rucio/opendata/ODEO_FEB2025_v0_GamGam_mc_700000.Sh_228_ttW.GamGam.root"
+      },
+      {
+        "checksum": "adler32:5a974996",
+        "size": 10759701,
+        "uri": "root://eospublic.cern.ch//eos/opendata/atlas/rucio/opendata/ODEO_FEB2025_v0_GamGam_mc_700007.Sh_228_yyy_01NLO.GamGam.root"
+      },
+      {
+        "checksum": "adler32:8c6892a2",
+        "size": 3092716,
+        "uri": "root://eospublic.cern.ch//eos/opendata/atlas/rucio/opendata/ODEO_FEB2025_v0_GamGam_mc_700195.Sh_2210_eegammagamma.GamGam.root"
+      },
+      {
+        "checksum": "adler32:75cc5ab8",
+        "size": 3949716,
+        "uri": "root://eospublic.cern.ch//eos/opendata/atlas/rucio/opendata/ODEO_FEB2025_v0_GamGam_mc_700196.Sh_2210_mumugammagamma.GamGam.root"
+      },
+      {
+        "checksum": "adler32:3193c59d",
+        "size": 2403771,
+        "uri": "root://eospublic.cern.ch//eos/opendata/atlas/rucio/opendata/ODEO_FEB2025_v0_GamGam_mc_700197.Sh_2210_tautaugammagamma.GamGam.root"
+      },
+      {
+        "checksum": "adler32:16ce9eb0",
+        "size": 1101813,
+        "uri": "root://eospublic.cern.ch//eos/opendata/atlas/rucio/opendata/ODEO_FEB2025_v0_GamGam_mc_700198.Sh_2210_nunugammagamma.GamGam.root"
+      },
+      {
+        "checksum": "adler32:4f8faca8",
+        "size": 2593176,
+        "uri": "root://eospublic.cern.ch//eos/opendata/atlas/rucio/opendata/ODEO_FEB2025_v0_GamGam_mc_700199.Sh_2210_enugammagamma.GamGam.root"
+      },
+      {
+        "checksum": "adler32:c7bfe108",
+        "size": 2265110,
+        "uri": "root://eospublic.cern.ch//eos/opendata/atlas/rucio/opendata/ODEO_FEB2025_v0_GamGam_mc_700200.Sh_2210_munugammagamma.GamGam.root"
+      },
+      {
+        "checksum": "adler32:8b6261c0",
+        "size": 2819275,
+        "uri": "root://eospublic.cern.ch//eos/opendata/atlas/rucio/opendata/ODEO_FEB2025_v0_GamGam_mc_700201.Sh_2210_taunugammagamma.GamGam.root"
+      },
+      {
+        "checksum": "adler32:dab67a3c",
+        "size": 7434887,
+        "uri": "root://eospublic.cern.ch//eos/opendata/atlas/rucio/opendata/ODEO_FEB2025_v0_GamGam_mc_700320.Sh_2211_Zee_maxHTpTV2_BFilter.GamGam.root"
+      },
+      {
+        "checksum": "adler32:10306fca",
+        "size": 34071216,
+        "uri": "root://eospublic.cern.ch//eos/opendata/atlas/rucio/opendata/ODEO_FEB2025_v0_GamGam_mc_700321.Sh_2211_Zee_maxHTpTV2_CFilterBVeto.GamGam.root"
+      },
+      {
+        "checksum": "adler32:c98a9eb1",
+        "size": 101468845,
+        "uri": "root://eospublic.cern.ch//eos/opendata/atlas/rucio/opendata/ODEO_FEB2025_v0_GamGam_mc_700322.Sh_2211_Zee_maxHTpTV2_CVetoBVeto.GamGam.root"
+      },
+      {
+        "checksum": "adler32:caa153bd",
+        "size": 2623471,
+        "uri": "root://eospublic.cern.ch//eos/opendata/atlas/rucio/opendata/ODEO_FEB2025_v0_GamGam_mc_700323.Sh_2211_Zmumu_maxHTpTV2_BFilter.GamGam.root"
+      },
+      {
+        "checksum": "adler32:782b0529",
+        "size": 11833293,
+        "uri": "root://eospublic.cern.ch//eos/opendata/atlas/rucio/opendata/ODEO_FEB2025_v0_GamGam_mc_700324.Sh_2211_Zmumu_maxHTpTV2_CFilterBVeto.GamGam.root"
+      },
+      {
+        "checksum": "adler32:0ca88bea",
+        "size": 27529612,
+        "uri": "root://eospublic.cern.ch//eos/opendata/atlas/rucio/opendata/ODEO_FEB2025_v0_GamGam_mc_700325.Sh_2211_Zmumu_maxHTpTV2_CVetoBVeto.GamGam.root"
+      },
+      {
+        "checksum": "adler32:a01392cb",
+        "size": 837665,
+        "uri": "root://eospublic.cern.ch//eos/opendata/atlas/rucio/opendata/ODEO_FEB2025_v0_GamGam_mc_700335.Sh_2211_Znunu_pTV2_BFilter.GamGam.root"
+      },
+      {
+        "checksum": "adler32:f52abb7a",
+        "size": 1830990,
+        "uri": "root://eospublic.cern.ch//eos/opendata/atlas/rucio/opendata/ODEO_FEB2025_v0_GamGam_mc_700336.Sh_2211_Znunu_pTV2_CFilterBVeto.GamGam.root"
+      },
+      {
+        "checksum": "adler32:08ef5500",
+        "size": 5170397,
+        "uri": "root://eospublic.cern.ch//eos/opendata/atlas/rucio/opendata/ODEO_FEB2025_v0_GamGam_mc_700337.Sh_2211_Znunu_pTV2_CVetoBVeto.GamGam.root"
+      },
+      {
+        "checksum": "adler32:477bc033",
+        "size": 16068549,
+        "uri": "root://eospublic.cern.ch//eos/opendata/atlas/rucio/opendata/ODEO_FEB2025_v0_GamGam_mc_700338.Sh_2211_Wenu_maxHTpTV2_BFilter.GamGam.root"
+      },
+      {
+        "checksum": "adler32:d15f08a1",
+        "size": 72363831,
+        "uri": "root://eospublic.cern.ch//eos/opendata/atlas/rucio/opendata/ODEO_FEB2025_v0_GamGam_mc_700339.Sh_2211_Wenu_maxHTpTV2_CFilterBVeto.GamGam.root"
+      },
+      {
+        "checksum": "adler32:ef0e5536",
+        "size": 70442097,
+        "uri": "root://eospublic.cern.ch//eos/opendata/atlas/rucio/opendata/ODEO_FEB2025_v0_GamGam_mc_700340.Sh_2211_Wenu_maxHTpTV2_CVetoBVeto.GamGam.root"
+      },
+      {
+        "checksum": "adler32:0c7ce0e9",
+        "size": 11437672,
+        "uri": "root://eospublic.cern.ch//eos/opendata/atlas/rucio/opendata/ODEO_FEB2025_v0_GamGam_mc_700341.Sh_2211_Wmunu_maxHTpTV2_BFilter.GamGam.root"
+      },
+      {
+        "checksum": "adler32:2950ce3c",
+        "size": 38815736,
+        "uri": "root://eospublic.cern.ch//eos/opendata/atlas/rucio/opendata/ODEO_FEB2025_v0_GamGam_mc_700342.Sh_2211_Wmunu_maxHTpTV2_CFilterBVeto.GamGam.root"
+      },
+      {
+        "checksum": "adler32:54cf793f",
+        "size": 34703397,
+        "uri": "root://eospublic.cern.ch//eos/opendata/atlas/rucio/opendata/ODEO_FEB2025_v0_GamGam_mc_700343.Sh_2211_Wmunu_maxHTpTV2_CVetoBVeto.GamGam.root"
+      },
+      {
+        "checksum": "adler32:bc24d21c",
+        "size": 4307705,
+        "uri": "root://eospublic.cern.ch//eos/opendata/atlas/rucio/opendata/ODEO_FEB2025_v0_GamGam_mc_700344.Sh_2211_Wtaunu_L_maxHTpTV2_BFilter.GamGam.root"
+      },
+      {
+        "checksum": "adler32:5044e665",
+        "size": 12697521,
+        "uri": "root://eospublic.cern.ch//eos/opendata/atlas/rucio/opendata/ODEO_FEB2025_v0_GamGam_mc_700345.Sh_2211_Wtaunu_L_maxHTpTV2_CFilterBVeto.GamGam.root"
+      },
+      {
+        "checksum": "adler32:8f11a74b",
+        "size": 19995117,
+        "uri": "root://eospublic.cern.ch//eos/opendata/atlas/rucio/opendata/ODEO_FEB2025_v0_GamGam_mc_700346.Sh_2211_Wtaunu_L_maxHTpTV2_CVetoBVeto.GamGam.root"
+      },
+      {
+        "checksum": "adler32:e99e77cb",
+        "size": 6850452,
+        "uri": "root://eospublic.cern.ch//eos/opendata/atlas/rucio/opendata/ODEO_FEB2025_v0_GamGam_mc_700347.Sh_2211_Wtaunu_H_maxHTpTV2_BFilter.GamGam.root"
+      },
+      {
+        "checksum": "adler32:77f12aba",
+        "size": 4639695,
+        "uri": "root://eospublic.cern.ch//eos/opendata/atlas/rucio/opendata/ODEO_FEB2025_v0_GamGam_mc_700348.Sh_2211_Wtaunu_H_maxHTpTV2_CFilterBVeto.GamGam.root"
+      },
+      {
+        "checksum": "adler32:f8128a42",
+        "size": 23133476,
+        "uri": "root://eospublic.cern.ch//eos/opendata/atlas/rucio/opendata/ODEO_FEB2025_v0_GamGam_mc_700349.Sh_2211_Wtaunu_H_maxHTpTV2_CVetoBVeto.GamGam.root"
+      },
+      {
+        "checksum": "adler32:d6afb081",
+        "size": 3489493,
+        "uri": "root://eospublic.cern.ch//eos/opendata/atlas/rucio/opendata/ODEO_FEB2025_v0_GamGam_mc_700352.Sh_2211_pTZ100_Zqqgamma.GamGam.root"
+      },
+      {
+        "checksum": "adler32:2d422574",
+        "size": 1398124,
+        "uri": "root://eospublic.cern.ch//eos/opendata/atlas/rucio/opendata/ODEO_FEB2025_v0_GamGam_mc_700353.Sh_2211_pTZ100_Zbbgamma.GamGam.root"
+      },
+      {
+        "checksum": "adler32:b314dde2",
+        "size": 235950,
+        "uri": "root://eospublic.cern.ch//eos/opendata/atlas/rucio/opendata/ODEO_FEB2025_v0_GamGam_mc_700358.Sh_2211_Zee2jets_Min_N_TChannel.GamGam.root"
+      },
+      {
+        "checksum": "adler32:d5011a32",
+        "size": 59454,
+        "uri": "root://eospublic.cern.ch//eos/opendata/atlas/rucio/opendata/ODEO_FEB2025_v0_GamGam_mc_700359.Sh_2211_Zmm2jets_Min_N_TChannel.GamGam.root"
+      },
+      {
+        "checksum": "adler32:ccfca80c",
+        "size": 160350,
+        "uri": "root://eospublic.cern.ch//eos/opendata/atlas/rucio/opendata/ODEO_FEB2025_v0_GamGam_mc_700360.Sh_2211_Ztt2jets_Min_N_TChannel.GamGam.root"
+      },
+      {
+        "checksum": "adler32:42a9972e",
+        "size": 91291,
+        "uri": "root://eospublic.cern.ch//eos/opendata/atlas/rucio/opendata/ODEO_FEB2025_v0_GamGam_mc_700361.Sh_2211_Znunu2jets_Min_N_TChannel.GamGam.root"
+      },
+      {
+        "checksum": "adler32:8d248d48",
+        "size": 395470,
+        "uri": "root://eospublic.cern.ch//eos/opendata/atlas/rucio/opendata/ODEO_FEB2025_v0_GamGam_mc_700362.Sh_2211_Wenu2jets_Min_N_TChannel.GamGam.root"
+      },
+      {
+        "checksum": "adler32:9d77adba",
+        "size": 260163,
+        "uri": "root://eospublic.cern.ch//eos/opendata/atlas/rucio/opendata/ODEO_FEB2025_v0_GamGam_mc_700363.Sh_2211_Wmunu2jets_Min_N_TChannel.GamGam.root"
+      },
+      {
+        "checksum": "adler32:d8025cba",
+        "size": 302977,
+        "uri": "root://eospublic.cern.ch//eos/opendata/atlas/rucio/opendata/ODEO_FEB2025_v0_GamGam_mc_700364.Sh_2211_Wtaunu2jets_Min_N_TChannel.GamGam.root"
+      },
+      {
+        "checksum": "adler32:2034fdb5",
+        "size": 9859420,
+        "uri": "root://eospublic.cern.ch//eos/opendata/atlas/rucio/opendata/ODEO_FEB2025_v0_GamGam_mc_700398.Sh_2211_mumugamma.GamGam.root"
+      },
+      {
+        "checksum": "adler32:ac799a34",
+        "size": 41330361,
+        "uri": "root://eospublic.cern.ch//eos/opendata/atlas/rucio/opendata/ODEO_FEB2025_v0_GamGam_mc_700399.Sh_2211_eegamma.GamGam.root"
+      },
+      {
+        "checksum": "adler32:22fe45d9",
+        "size": 38504841,
+        "uri": "root://eospublic.cern.ch//eos/opendata/atlas/rucio/opendata/ODEO_FEB2025_v0_GamGam_mc_700400.Sh_2211_tautaugamma.GamGam.root"
+      },
+      {
+        "checksum": "adler32:c7dbc630",
+        "size": 7466417,
+        "uri": "root://eospublic.cern.ch//eos/opendata/atlas/rucio/opendata/ODEO_FEB2025_v0_GamGam_mc_700401.Sh_2211_nunugamma.GamGam.root"
+      },
+      {
+        "checksum": "adler32:c6e899bf",
+        "size": 40042314,
+        "uri": "root://eospublic.cern.ch//eos/opendata/atlas/rucio/opendata/ODEO_FEB2025_v0_GamGam_mc_700402.Sh_2211_munugamma.GamGam.root"
+      },
+      {
+        "checksum": "adler32:38143612",
+        "size": 88618957,
+        "uri": "root://eospublic.cern.ch//eos/opendata/atlas/rucio/opendata/ODEO_FEB2025_v0_GamGam_mc_700403.Sh_2211_enugamma.GamGam.root"
+      },
+      {
+        "checksum": "adler32:80380691",
+        "size": 77479192,
+        "uri": "root://eospublic.cern.ch//eos/opendata/atlas/rucio/opendata/ODEO_FEB2025_v0_GamGam_mc_700404.Sh_2211_taunugamma.GamGam.root"
+      },
+      {
+        "checksum": "adler32:af0dc19e",
+        "size": 1096281,
+        "uri": "root://eospublic.cern.ch//eos/opendata/atlas/rucio/opendata/ODEO_FEB2025_v0_GamGam_mc_700442.Sh_2211_gamma2jets_pTy140_Min_N_TChannel.GamGam.root"
+      },
+      {
+        "checksum": "adler32:4c667973",
+        "size": 497680,
+        "uri": "root://eospublic.cern.ch//eos/opendata/atlas/rucio/opendata/ODEO_FEB2025_v0_GamGam_mc_700467.Sh_2211_Zee_maxHTpTV2_m10_40_pT5_BFilter.GamGam.root"
+      },
+      {
+        "checksum": "adler32:67c1960f",
+        "size": 1937617,
+        "uri": "root://eospublic.cern.ch//eos/opendata/atlas/rucio/opendata/ODEO_FEB2025_v0_GamGam_mc_700468.Sh_2211_Zee_maxHTpTV2_m10_40_pT5_CFilterBVeto.GamGam.root"
+      },
+      {
+        "checksum": "adler32:9882781f",
+        "size": 12771816,
+        "uri": "root://eospublic.cern.ch//eos/opendata/atlas/rucio/opendata/ODEO_FEB2025_v0_GamGam_mc_700469.Sh_2211_Zee_maxHTpTV2_m10_40_pT5_CVetoBVeto.GamGam.root"
+      },
+      {
+        "checksum": "adler32:2b970990",
+        "size": 376217,
+        "uri": "root://eospublic.cern.ch//eos/opendata/atlas/rucio/opendata/ODEO_FEB2025_v0_GamGam_mc_700470.Sh_2211_Zmumu_maxHTpTV2_m10_40_pT5_BFilter.GamGam.root"
+      },
+      {
+        "checksum": "adler32:defd6ca7",
+        "size": 1271464,
+        "uri": "root://eospublic.cern.ch//eos/opendata/atlas/rucio/opendata/ODEO_FEB2025_v0_GamGam_mc_700471.Sh_2211_Zmumu_maxHTpTV2_m10_40_pT5_CFilterBVeto.GamGam.root"
+      },
+      {
+        "checksum": "adler32:292efe79",
+        "size": 8419320,
+        "uri": "root://eospublic.cern.ch//eos/opendata/atlas/rucio/opendata/ODEO_FEB2025_v0_GamGam_mc_700472.Sh_2211_Zmumu_maxHTpTV2_m10_40_pT5_CVetoBVeto.GamGam.root"
+      },
+      {
+        "checksum": "adler32:430caf99",
+        "size": 1764247,
+        "uri": "root://eospublic.cern.ch//eos/opendata/atlas/rucio/opendata/ODEO_FEB2025_v0_GamGam_mc_700488.Sh_2211_WlvWqq.GamGam.root"
+      },
+      {
+        "checksum": "adler32:01961db6",
+        "size": 446426,
+        "uri": "root://eospublic.cern.ch//eos/opendata/atlas/rucio/opendata/ODEO_FEB2025_v0_GamGam_mc_700489.Sh_2211_WlvZqq.GamGam.root"
+      },
+      {
+        "checksum": "adler32:6eec27bf",
+        "size": 122668,
+        "uri": "root://eospublic.cern.ch//eos/opendata/atlas/rucio/opendata/ODEO_FEB2025_v0_GamGam_mc_700490.Sh_2211_WlvZbb.GamGam.root"
+      },
+      {
+        "checksum": "adler32:55ab04fa",
+        "size": 217712,
+        "uri": "root://eospublic.cern.ch//eos/opendata/atlas/rucio/opendata/ODEO_FEB2025_v0_GamGam_mc_700491.Sh_2211_WqqZvv.GamGam.root"
+      },
+      {
+        "checksum": "adler32:8d5b26e5",
+        "size": 313077,
+        "uri": "root://eospublic.cern.ch//eos/opendata/atlas/rucio/opendata/ODEO_FEB2025_v0_GamGam_mc_700492.Sh_2211_WqqZll.GamGam.root"
+      },
+      {
+        "checksum": "adler32:eff6c4aa",
+        "size": 209761,
+        "uri": "root://eospublic.cern.ch//eos/opendata/atlas/rucio/opendata/ODEO_FEB2025_v0_GamGam_mc_700493.Sh_2211_ZqqZll.GamGam.root"
+      },
+      {
+        "checksum": "adler32:ecdf4a65",
+        "size": 172338,
+        "uri": "root://eospublic.cern.ch//eos/opendata/atlas/rucio/opendata/ODEO_FEB2025_v0_GamGam_mc_700494.Sh_2211_ZbbZll.GamGam.root"
+      },
+      {
+        "checksum": "adler32:b1242d56",
+        "size": 105147,
+        "uri": "root://eospublic.cern.ch//eos/opendata/atlas/rucio/opendata/ODEO_FEB2025_v0_GamGam_mc_700495.Sh_2211_ZqqZvv.GamGam.root"
+      },
+      {
+        "checksum": "adler32:4f07f19a",
+        "size": 48957,
+        "uri": "root://eospublic.cern.ch//eos/opendata/atlas/rucio/opendata/ODEO_FEB2025_v0_GamGam_mc_700496.Sh_2211_ZbbZvv.GamGam.root"
+      },
+      {
+        "checksum": "adler32:3e4dc8d6",
+        "size": 2435197,
+        "uri": "root://eospublic.cern.ch//eos/opendata/atlas/rucio/opendata/ODEO_FEB2025_v0_GamGam_mc_700507.Sh_2211_pTW140_Wqqgamma.GamGam.root"
+      },
+      {
+        "checksum": "adler32:fabbe8bf",
+        "size": 126441,
+        "uri": "root://eospublic.cern.ch//eos/opendata/atlas/rucio/opendata/ODEO_FEB2025_v0_GamGam_mc_700587.Sh_2212_lllljj.GamGam.root"
+      },
+      {
+        "checksum": "adler32:fefd01db",
+        "size": 68353,
+        "uri": "root://eospublic.cern.ch//eos/opendata/atlas/rucio/opendata/ODEO_FEB2025_v0_GamGam_mc_700588.Sh_2212_lllvjj.GamGam.root"
+      },
+      {
+        "checksum": "adler32:c4024554",
+        "size": 50986,
+        "uri": "root://eospublic.cern.ch//eos/opendata/atlas/rucio/opendata/ODEO_FEB2025_v0_GamGam_mc_700589.Sh_2212_llvvjj_os.GamGam.root"
+      },
+      {
+        "checksum": "adler32:f3a611d5",
+        "size": 89086,
+        "uri": "root://eospublic.cern.ch//eos/opendata/atlas/rucio/opendata/ODEO_FEB2025_v0_GamGam_mc_700590.Sh_2212_llvvjj_ss.GamGam.root"
+      },
+      {
+        "checksum": "adler32:0d909dd1",
+        "size": 39645,
+        "uri": "root://eospublic.cern.ch//eos/opendata/atlas/rucio/opendata/ODEO_FEB2025_v0_GamGam_mc_700591.Sh_2212_lllljj_Int.GamGam.root"
+      },
+      {
+        "checksum": "adler32:90a30525",
+        "size": 46840,
+        "uri": "root://eospublic.cern.ch//eos/opendata/atlas/rucio/opendata/ODEO_FEB2025_v0_GamGam_mc_700592.Sh_2212_lllvjj_Int.GamGam.root"
+      },
+      {
+        "checksum": "adler32:d2af582e",
+        "size": 41912,
+        "uri": "root://eospublic.cern.ch//eos/opendata/atlas/rucio/opendata/ODEO_FEB2025_v0_GamGam_mc_700593.Sh_2212_llvvjj_os_Int.GamGam.root"
+      },
+      {
+        "checksum": "adler32:34460581",
+        "size": 45724,
+        "uri": "root://eospublic.cern.ch//eos/opendata/atlas/rucio/opendata/ODEO_FEB2025_v0_GamGam_mc_700594.Sh_2212_llvvjj_ss_Int.GamGam.root"
+      },
+      {
+        "checksum": "adler32:4ced02ee",
+        "size": 189117,
+        "uri": "root://eospublic.cern.ch//eos/opendata/atlas/rucio/opendata/ODEO_FEB2025_v0_GamGam_mc_700600.Sh_2212_llll.GamGam.root"
+      },
+      {
+        "checksum": "adler32:214eafa5",
+        "size": 351329,
+        "uri": "root://eospublic.cern.ch//eos/opendata/atlas/rucio/opendata/ODEO_FEB2025_v0_GamGam_mc_700601.Sh_2212_lllv.GamGam.root"
+      },
+      {
+        "checksum": "adler32:38f0c319",
+        "size": 472126,
+        "uri": "root://eospublic.cern.ch//eos/opendata/atlas/rucio/opendata/ODEO_FEB2025_v0_GamGam_mc_700602.Sh_2212_llvv_os.GamGam.root"
+      },
+      {
+        "checksum": "adler32:202fccef",
+        "size": 151301,
+        "uri": "root://eospublic.cern.ch//eos/opendata/atlas/rucio/opendata/ODEO_FEB2025_v0_GamGam_mc_700603.Sh_2212_llvv_ss.GamGam.root"
+      },
+      {
+        "checksum": "adler32:236419e1",
+        "size": 129226,
+        "uri": "root://eospublic.cern.ch//eos/opendata/atlas/rucio/opendata/ODEO_FEB2025_v0_GamGam_mc_700604.Sh_2212_lvvv.GamGam.root"
+      },
+      {
+        "checksum": "adler32:86a93617",
+        "size": 47392,
+        "uri": "root://eospublic.cern.ch//eos/opendata/atlas/rucio/opendata/ODEO_FEB2025_v0_GamGam_mc_700605.Sh_2212_vvvv.GamGam.root"
+      },
+      {
+        "checksum": "adler32:60ec13ee",
+        "size": 475014,
+        "uri": "root://eospublic.cern.ch//eos/opendata/atlas/rucio/opendata/ODEO_FEB2025_v0_GamGam_mc_700709.Sh_2212_lvgammajj.GamGam.root"
+      },
+      {
+        "checksum": "adler32:587d97a1",
+        "size": 1097022,
+        "uri": "root://eospublic.cern.ch//eos/opendata/atlas/rucio/opendata/ODEO_FEB2025_v0_GamGam_mc_700710.Sh_2212_llgammajj.GamGam.root"
+      },
+      {
+        "checksum": "adler32:300c4766",
+        "size": 6015924,
+        "uri": "root://eospublic.cern.ch//eos/opendata/atlas/rucio/opendata/ODEO_FEB2025_v0_GamGam_mc_700792.Sh_2214_Ztautau_maxHTpTV2_BFilter.GamGam.root"
+      },
+      {
+        "checksum": "adler32:dca1f964",
+        "size": 27637719,
+        "uri": "root://eospublic.cern.ch//eos/opendata/atlas/rucio/opendata/ODEO_FEB2025_v0_GamGam_mc_700793.Sh_2214_Ztautau_maxHTpTV2_CFilterBVeto.GamGam.root"
+      },
+      {
+        "checksum": "adler32:00c0a728",
+        "size": 49155995,
+        "uri": "root://eospublic.cern.ch//eos/opendata/atlas/rucio/opendata/ODEO_FEB2025_v0_GamGam_mc_700794.Sh_2214_Ztautau_maxHTpTV2_CVetoBVeto.GamGam.root"
+      },
+      {
+        "checksum": "adler32:79cd8feb",
+        "size": 11618735,
+        "uri": "root://eospublic.cern.ch//eos/opendata/atlas/rucio/opendata/ODEO_FEB2025_v0_GamGam_mc_700843.Sh_2214_Wqq_ptW_200_ECMS.GamGam.root"
+      },
+      {
+        "checksum": "adler32:5be4553b",
+        "size": 4091482,
+        "uri": "root://eospublic.cern.ch//eos/opendata/atlas/rucio/opendata/ODEO_FEB2025_v0_GamGam_mc_700849.Sh_2214_Zqq_ptZ_200_ECMS.GamGam.root"
+      },
+      {
+        "checksum": "adler32:94273f7e",
+        "size": 1232657,
+        "uri": "root://eospublic.cern.ch//eos/opendata/atlas/rucio/opendata/ODEO_FEB2025_v0_GamGam_mc_700855.Sh_2214_Zbb_ptZ_200_ECMS.GamGam.root"
+      },
+      {
+        "checksum": "adler32:1cc7ce26",
+        "size": 852483,
+        "uri": "root://eospublic.cern.ch//eos/opendata/atlas/rucio/opendata/ODEO_FEB2025_v0_GamGam_mc_700901.Sh_2214_Ztt_maxHTpTV2_Mll10_40_BFilter.GamGam.root"
+      },
+      {
+        "checksum": "adler32:faca30a2",
+        "size": 4613721,
+        "uri": "root://eospublic.cern.ch//eos/opendata/atlas/rucio/opendata/ODEO_FEB2025_v0_GamGam_mc_700902.Sh_2214_Ztt_maxHTpTV2_Mll10_40_CFilterBVeto.GamGam.root"
+      },
+      {
+        "checksum": "adler32:9c4d1aef",
+        "size": 9853769,
+        "uri": "root://eospublic.cern.ch//eos/opendata/atlas/rucio/opendata/ODEO_FEB2025_v0_GamGam_mc_700903.Sh_2214_Ztt_maxHTpTV2_Mll10_40_CVetoBVeto.GamGam.root"
+      },
+      {
+        "checksum": "adler32:15df0d3d",
+        "size": 193600,
+        "uri": "root://eospublic.cern.ch//eos/opendata/atlas/rucio/opendata/ODEO_FEB2025_v0_GamGam_mc_801976.Py8EG_A14NNPDF23LO_Zprime_NoInt_tautau_SSM3000.GamGam.root"
+      },
+      {
+        "checksum": "adler32:8857bddc",
+        "size": 42053,
+        "uri": "root://eospublic.cern.ch//eos/opendata/atlas/rucio/opendata/ODEO_FEB2025_v0_GamGam_mc_801978.Py8EG_A14NNPDF23LO_Wprime_taunu_SSM3000.GamGam.root"
+      }
+    ],
+    "license": {
+      "attribution": "CC0-1.0"
+    },
+    "methodology": {
+      "description": "<p>These data were created during LS2 as part of a major reprocessing campaign of the Run 2 data. All data were reprocessed using Athena Release 22, and new corresponding MC simulation samples were produced. These data and MC simulation datasets were processed into ROOT ntuple files from the DAOD_PHYSLITE format that is released as open data for research. For the files in this record, the following skimming selection was applied: At least two photons with at least 25 GeV of p<sub>T</sub> each (i.e. a Higgs boson decaying to two photons enhanced selection)"
+    },
+    "publisher": "CERN Open Data Portal",
+    "recid": "93922",
+    "relations": [
+      {
+        "description": "For citing all the Open Data for Education and Outreach from this release, and to find other related datasets, please see",
+        "doi": "10.7483/OPENDATA.ATLAS.B5M9.44TN",
+        "recid": "93910",
+        "title": "ROOT ntuple format 2015-2016 proton-proton Open Data for Education and Outreach from the ATLAS experiment",
+        "type": "isChildOf"
+      }
+    ],
+    "run_period": [
+      "2015",
+      "2016"
+    ],
+    "title": "ATLAS ROOT ntuple format MC simulation, 2015+2016 proton-proton collisions beta release, GamGam skim",
+    "type": {
+      "primary": "Dataset",
+      "secondary": [
+        "Simulated"
+      ]
+    },
+    "usage": {
+      "description": "<p> The data and MC simulation provided by the ATLAS experiment in root ntuple format is released under a CC0 license; citation of the data and acknowledgement of the collaboration is requested. This format can be used directly using ROOT or uproot for simple studies and is primarily intended for educational and outreach purposes. <p>Extensive instructions for interacting with the data, as well as documentation of the dataset naming conventions and their contents, are provided on the ATLAS Open Data website linked below. For those interested in implementing a research-quality data analysis, the open data designed for research (also linked below) may be a better starting point. Please be sure to cite the Open Data that you use, in line with the policy below.",
+      "links": [
+        {
+          "description": "ATLAS Open Data Website",
+          "url": "http://opendata.atlas.cern"
+        },
+        {
+          "description": "Resources to understand and use the open data for education and outreach",
+          "url": "https://opendata.atlas.cern/docs/category/13-tev-tutorials-for-education"
+        },
+        {
+          "description": "More about this ntuple format",
+          "url": "https://opendata.atlas.cern/docs/data/for_education/13TeV25_details"
+        },
+        {
+          "description": "Ntuple making framework",
+          "url": "http://gitlab.cern.ch/atlas-outreach-data-tools/physlitetoopendata"
+        },
+        {
+          "description": "Citation policy",
+          "url": "https://opendata.atlas.cern/docs/documentation/ethical_legal/citation_policy"
+        }
+      ]
+    }
+  }
+]

--- a/data/records/atlas-odeo-FEB2025-noskim-data.json
+++ b/data/records/atlas-odeo-FEB2025-noskim-data.json
@@ -154,15 +154,15 @@
         },
         {
           "description": "Resources to understand and use the open data for education and outreach",
-          "url": "https://opendata.atlas.cern/docs/category/13-tev-tutorials-for-education"
+          "url": "https://opendata.atlas.cern/docs/category/13-tev-2025-beta-release"
         },
         {
           "description": "More about this ntuple format",
-          "url": "https://opendata.atlas.cern/docs/data/for_education/13TeV25_details"
+          "url": "https://opendata.atlas.cern/docs/data/for_education/13TeV25_details#variable-list"
         },
         {
-          "description": "Ntuple making framework",
-          "url": "http://gitlab.cern.ch/atlas-outreach-data-tools/physlitetoopendata"
+          "description": "Ntuple making framework (PhysLiteToOpenData)",
+          "url": "https://doi.org/10.5281/zenodo.15791091"
         },
         {
           "description": "Citation policy",

--- a/data/records/atlas-odeo-FEB2025-noskim-data.json
+++ b/data/records/atlas-odeo-FEB2025-noskim-data.json
@@ -1,0 +1,174 @@
+[
+  {
+    "abstract": {
+      "description": "Run 2 2015+2016 proton-proton collision data beta release, no skim from the ATLAS experiment"
+    },
+    "accelerator": "CERN-LHC",
+    "categories": {
+      "source": "ATLAS Collaboration"
+    },
+    "collaboration": {
+      "name": "ATLAS collaboration"
+    },
+    "collections": [
+      "ATLAS-Primary-Datasets"
+    ],
+    "collision_information": {
+      "energy": "13TeV",
+      "type": "pp"
+    },
+    "date_created": [
+      "2015",
+      "2016"
+    ],
+    "date_published": "2025",
+    "date_reprocessed": "2020",
+    "distribution": {
+      "formats": [
+        "root"
+      ],
+      "number_events": 5770706892,
+      "number_files": 16,
+      "size": 1350371377949
+    },
+    "doi": "10.7483/OPENDATA.ATLAS.VV3I.0WJE",
+    "experiment": [
+      "ATLAS"
+    ],
+    "files": [
+      {
+        "checksum": "adler32:b939aa2d",
+        "size": 9449665301,
+        "uri": "root://eospublic.cern.ch//eos/opendata/atlas/rucio/user/egramsta/data15_periodD.noskim.root"
+      },
+      {
+        "checksum": "adler32:7d0ae96d",
+        "size": 44754519250,
+        "uri": "root://eospublic.cern.ch//eos/opendata/atlas/rucio/user/egramsta/data15_periodE.noskim.root"
+      },
+      {
+        "checksum": "adler32:9317ab61",
+        "size": 26842035482,
+        "uri": "root://eospublic.cern.ch//eos/opendata/atlas/rucio/user/egramsta/data15_periodF.noskim.root"
+      },
+      {
+        "checksum": "adler32:5fadbc12",
+        "size": 59986028555,
+        "uri": "root://eospublic.cern.ch//eos/opendata/atlas/rucio/user/egramsta/data15_periodG.noskim.root"
+      },
+      {
+        "checksum": "adler32:3b6565d5",
+        "size": 18671925886,
+        "uri": "root://eospublic.cern.ch//eos/opendata/atlas/rucio/user/egramsta/data15_periodH.noskim.root"
+      },
+      {
+        "checksum": "adler32:ab576177",
+        "size": 100800454231,
+        "uri": "root://eospublic.cern.ch//eos/opendata/atlas/rucio/user/egramsta/data15_periodJ.noskim.root"
+      },
+      {
+        "checksum": "adler32:648aef98",
+        "size": 52580909592,
+        "uri": "root://eospublic.cern.ch//eos/opendata/atlas/rucio/user/egramsta/data16_periodA.noskim.root"
+      },
+      {
+        "checksum": "adler32:82b97059",
+        "size": 75655473930,
+        "uri": "root://eospublic.cern.ch//eos/opendata/atlas/rucio/user/egramsta/data16_periodB.noskim.root"
+      },
+      {
+        "checksum": "adler32:0fc81d54",
+        "size": 100144056957,
+        "uri": "root://eospublic.cern.ch//eos/opendata/atlas/rucio/user/egramsta/data16_periodC.noskim.root"
+      },
+      {
+        "checksum": "adler32:8f8c97b5",
+        "size": 175696779134,
+        "uri": "root://eospublic.cern.ch//eos/opendata/atlas/rucio/user/egramsta/data16_periodD.noskim.root"
+      },
+      {
+        "checksum": "adler32:4eaacee7",
+        "size": 51249266635,
+        "uri": "root://eospublic.cern.ch//eos/opendata/atlas/rucio/user/egramsta/data16_periodE.noskim.root"
+      },
+      {
+        "checksum": "adler32:b8931d67",
+        "size": 101663606025,
+        "uri": "root://eospublic.cern.ch//eos/opendata/atlas/rucio/user/egramsta/data16_periodF.noskim.root"
+      },
+      {
+        "checksum": "adler32:f7cdbcb9",
+        "size": 109126148050,
+        "uri": "root://eospublic.cern.ch//eos/opendata/atlas/rucio/user/egramsta/data16_periodG.noskim.root"
+      },
+      {
+        "checksum": "adler32:a5782c36",
+        "size": 169201818677,
+        "uri": "root://eospublic.cern.ch//eos/opendata/atlas/rucio/user/egramsta/data16_periodI.noskim.root"
+      },
+      {
+        "checksum": "adler32:16137ce7",
+        "size": 66995844193,
+        "uri": "root://eospublic.cern.ch//eos/opendata/atlas/rucio/user/egramsta/data16_periodK.noskim.root"
+      },
+      {
+        "checksum": "adler32:4944bed9",
+        "size": 187552846051,
+        "uri": "root://eospublic.cern.ch//eos/opendata/atlas/rucio/user/egramsta/data16_periodL.noskim.root"
+      }
+    ],
+    "license": {
+      "attribution": "CC0-1.0"
+    },
+    "methodology": {
+      "description": "<p>These data were created during LS2 as part of a major reprocessing campaign of the Run 2 data. All data were reprocessed using Athena Release 22, and new corresponding MC simulation samples were produced. These data and MC simulation datasets were processed into ROOT ntuple files from the DAOD_PHYSLITE format that is released as open data for research. For the files in this record, the following skimming selection was applied: none."
+    },
+    "publisher": "CERN Open Data Portal",
+    "recid": "93933",
+    "relations": [
+      {
+        "description": "For citing all the Open Data for Education and Outreach from this release, and to find other related datasets, please see",
+        "doi": "10.7483/OPENDATA.ATLAS.B5M9.44TN",
+        "recid": "93910",
+        "title": "ROOT ntuple format 2015-2016 proton-proton Open Data for Education and Outreach from the ATLAS experiment",
+        "type": "isChildOf"
+      }
+    ],
+    "run_period": [
+      "2015",
+      "2016"
+    ],
+    "title": "ATLAS ROOT ntuple format Run 2 2015+2016 proton-proton collision data beta release, no skim",
+    "type": {
+      "primary": "Dataset",
+      "secondary": [
+        "Collision"
+      ]
+    },
+    "usage": {
+      "description": "<p> The data and MC simulation provided by the ATLAS experiment in root ntuple format is released under a CC0 license; citation of the data and acknowledgement of the collaboration is requested. This format can be used directly using ROOT or uproot for simple studies and is primarily intended for educational and outreach purposes. <p>Extensive instructions for interacting with the data, as well as documentation of the dataset naming conventions and their contents, are provided on the ATLAS Open Data website linked below. For those interested in implementing a research-quality data analysis, the open data designed for research (also linked below) may be a better starting point. Please be sure to cite the Open Data that you use, in line with the policy below.",
+      "links": [
+        {
+          "description": "ATLAS Open Data Website",
+          "url": "http://opendata.atlas.cern"
+        },
+        {
+          "description": "Resources to understand and use the open data for education and outreach",
+          "url": "https://opendata.atlas.cern/docs/category/13-tev-tutorials-for-education"
+        },
+        {
+          "description": "More about this ntuple format",
+          "url": "https://opendata.atlas.cern/docs/data/for_education/13TeV25_details"
+        },
+        {
+          "description": "Ntuple making framework",
+          "url": "http://gitlab.cern.ch/atlas-outreach-data-tools/physlitetoopendata"
+        },
+        {
+          "description": "Citation policy",
+          "url": "https://opendata.atlas.cern/docs/documentation/ethical_legal/citation_policy"
+        }
+      ]
+    }
+  }
+]

--- a/data/records/atlas-odeo-FEB2025-noskim-mc.json
+++ b/data/records/atlas-odeo-FEB2025-noskim-mc.json
@@ -1939,15 +1939,15 @@
         },
         {
           "description": "Resources to understand and use the open data for education and outreach",
-          "url": "https://opendata.atlas.cern/docs/category/13-tev-tutorials-for-education"
+          "url": "https://opendata.atlas.cern/docs/category/13-tev-2025-beta-release"
         },
         {
           "description": "More about this ntuple format",
-          "url": "https://opendata.atlas.cern/docs/data/for_education/13TeV25_details"
+          "url": "https://opendata.atlas.cern/docs/data/for_education/13TeV25_details#variable-list"
         },
         {
-          "description": "Ntuple making framework",
-          "url": "http://gitlab.cern.ch/atlas-outreach-data-tools/physlitetoopendata"
+          "description": "Ntuple making framework (PhysLiteToOpenData)",
+          "url": "https://doi.org/10.5281/zenodo.15791091"
         },
         {
           "description": "Citation policy",

--- a/data/records/atlas-odeo-FEB2025-noskim-mc.json
+++ b/data/records/atlas-odeo-FEB2025-noskim-mc.json
@@ -1,0 +1,1959 @@
+[
+  {
+    "abstract": {
+      "description": "MC simulation, 2015+2016 proton-proton collisions beta release, no skim from the ATLAS experiment"
+    },
+    "accelerator": "CERN-LHC",
+    "categories": {
+      "source": "ATLAS Collaboration"
+    },
+    "collaboration": {
+      "name": "ATLAS collaboration"
+    },
+    "collections": [
+      "ATLAS-Primary-Datasets"
+    ],
+    "collision_information": {
+      "energy": "13TeV",
+      "type": "pp"
+    },
+    "date_created": [
+      "2015",
+      "2016"
+    ],
+    "date_published": "2025",
+    "date_reprocessed": "2020",
+    "distribution": {
+      "formats": [
+        "root"
+      ],
+      "number_events": 1887007233,
+      "number_files": 373,
+      "size": 683544511780
+    },
+    "doi": "10.7483/OPENDATA.ATLAS.ZPCQ.9VO2",
+    "experiment": [
+      "ATLAS"
+    ],
+    "files": [
+      {
+        "checksum": "adler32:95b3ae42",
+        "size": 7414315,
+        "uri": "root://eospublic.cern.ch//eos/opendata/atlas/rucio/user/egramsta/mc_301204.Pythia8EvtGen_A14MSTW2008LO_Zprime_NoInt_ee_SSM3000.noskim.root"
+      },
+      {
+        "checksum": "adler32:b0226724",
+        "size": 7460791,
+        "uri": "root://eospublic.cern.ch//eos/opendata/atlas/rucio/user/egramsta/mc_301209.Pythia8EvtGen_A14MSTW2008LO_Zprime_NoInt_mumu_SSM3000.noskim.root"
+      },
+      {
+        "checksum": "adler32:784e88ac",
+        "size": 2572571,
+        "uri": "root://eospublic.cern.ch//eos/opendata/atlas/rucio/user/egramsta/mc_301243.Pythia8EvtGen_A14NNPDF23LO_Wprime_enu_SSM3000.noskim.root"
+      },
+      {
+        "checksum": "adler32:bfd416c2",
+        "size": 6470381,
+        "uri": "root://eospublic.cern.ch//eos/opendata/atlas/rucio/user/egramsta/mc_301247.Pythia8EvtGen_A14NNPDF23LO_Wprime_munu_SSM3000.noskim.root"
+      },
+      {
+        "checksum": "adler32:230dafee",
+        "size": 16693784,
+        "uri": "root://eospublic.cern.ch//eos/opendata/atlas/rucio/user/egramsta/mc_301333.Pythia8EvtGen_A14NNPDF23LO_zprime3000_tt.noskim.root"
+      },
+      {
+        "checksum": "adler32:b0d44064",
+        "size": 4969074,
+        "uri": "root://eospublic.cern.ch//eos/opendata/atlas/rucio/user/egramsta/mc_301826.Pythia8EvtGen_A14NNPDF23LO_Wprime_qq_3000.noskim.root"
+      },
+      {
+        "checksum": "adler32:b0571c95",
+        "size": 5104686,
+        "uri": "root://eospublic.cern.ch//eos/opendata/atlas/rucio/user/egramsta/mc_301928.Pythia8EvtGen_A14NNPDF23LO_Zprimebb3000.noskim.root"
+      },
+      {
+        "checksum": "adler32:304b792b",
+        "size": 864777945,
+        "uri": "root://eospublic.cern.ch//eos/opendata/atlas/rucio/user/egramsta/mc_302520.Pythia8EvtGen_A14NNPDF23LO_2DP20_Mass_55_100.noskim.root"
+      },
+      {
+        "checksum": "adler32:83ea31fc",
+        "size": 210593085,
+        "uri": "root://eospublic.cern.ch//eos/opendata/atlas/rucio/user/egramsta/mc_302521.Pythia8EvtGen_A14NNPDF23LO_2DP20_Mass_100_160.noskim.root"
+      },
+      {
+        "checksum": "adler32:89a7239f",
+        "size": 66179213,
+        "uri": "root://eospublic.cern.ch//eos/opendata/atlas/rucio/user/egramsta/mc_302522.Pythia8EvtGen_A14NNPDF23LO_2DP20_Mass_160_250.noskim.root"
+      },
+      {
+        "checksum": "adler32:5854340d",
+        "size": 33665690,
+        "uri": "root://eospublic.cern.ch//eos/opendata/atlas/rucio/user/egramsta/mc_302523.Pythia8EvtGen_A14NNPDF23LO_2DP20_Mass_250_400.noskim.root"
+      },
+      {
+        "checksum": "adler32:8a7add55",
+        "size": 75884024,
+        "uri": "root://eospublic.cern.ch//eos/opendata/atlas/rucio/user/egramsta/mc_302524.Pythia8EvtGen_A14NNPDF23LO_2DP20_Mass_400_650.noskim.root"
+      },
+      {
+        "checksum": "adler32:d496631e",
+        "size": 29771264,
+        "uri": "root://eospublic.cern.ch//eos/opendata/atlas/rucio/user/egramsta/mc_302525.Pythia8EvtGen_A14NNPDF23LO_2DP20_Mass_650_1000.noskim.root"
+      },
+      {
+        "checksum": "adler32:5660b550",
+        "size": 60022621,
+        "uri": "root://eospublic.cern.ch//eos/opendata/atlas/rucio/user/egramsta/mc_302526.Pythia8EvtGen_A14NNPDF23LO_2DP20_Mass_1000_1500.noskim.root"
+      },
+      {
+        "checksum": "adler32:6fcac4a2",
+        "size": 58901996,
+        "uri": "root://eospublic.cern.ch//eos/opendata/atlas/rucio/user/egramsta/mc_302527.Pythia8EvtGen_A14NNPDF23LO_2DP20_Mass_1500_2000.noskim.root"
+      },
+      {
+        "checksum": "adler32:e384c8bf",
+        "size": 80976544,
+        "uri": "root://eospublic.cern.ch//eos/opendata/atlas/rucio/user/egramsta/mc_302528.Pythia8EvtGen_A14NNPDF23LO_2DP20_Mass_2000_2500.noskim.root"
+      },
+      {
+        "checksum": "adler32:375330d6",
+        "size": 52631784,
+        "uri": "root://eospublic.cern.ch//eos/opendata/atlas/rucio/user/egramsta/mc_302529.Pythia8EvtGen_A14NNPDF23LO_2DP20_Mass_2500_3000.noskim.root"
+      },
+      {
+        "checksum": "adler32:98e1fe5b",
+        "size": 84002186,
+        "uri": "root://eospublic.cern.ch//eos/opendata/atlas/rucio/user/egramsta/mc_302530.Pythia8EvtGen_A14NNPDF23LO_2DP20_Mass_3000_3500.noskim.root"
+      },
+      {
+        "checksum": "adler32:99b5c955",
+        "size": 38025424,
+        "uri": "root://eospublic.cern.ch//eos/opendata/atlas/rucio/user/egramsta/mc_302531.Pythia8EvtGen_A14NNPDF23LO_2DP20_Mass_3500_4000.noskim.root"
+      },
+      {
+        "checksum": "adler32:8171df1b",
+        "size": 64722210,
+        "uri": "root://eospublic.cern.ch//eos/opendata/atlas/rucio/user/egramsta/mc_302532.Pythia8EvtGen_A14NNPDF23LO_2DP20_Mass_4000_4500.noskim.root"
+      },
+      {
+        "checksum": "adler32:5839e007",
+        "size": 25622754,
+        "uri": "root://eospublic.cern.ch//eos/opendata/atlas/rucio/user/egramsta/mc_302533.Pythia8EvtGen_A14NNPDF23LO_2DP20_Mass_4500_5000.noskim.root"
+      },
+      {
+        "checksum": "adler32:b05788a2",
+        "size": 61387084,
+        "uri": "root://eospublic.cern.ch//eos/opendata/atlas/rucio/user/egramsta/mc_302534.Pythia8EvtGen_A14NNPDF23LO_2DP20_Mass_5000_inf.noskim.root"
+      },
+      {
+        "checksum": "adler32:65ac66ee",
+        "size": 16253604,
+        "uri": "root://eospublic.cern.ch//eos/opendata/atlas/rucio/user/egramsta/mc_302733.MadGraphPythia8EvtGen_A14NNPDF23LO_WpL_tblep_M3000.noskim.root"
+      },
+      {
+        "checksum": "adler32:5bf78bc1",
+        "size": 20773625,
+        "uri": "root://eospublic.cern.ch//eos/opendata/atlas/rucio/user/egramsta/mc_304014.MadGraphPythia8EvtGen_A14NNPDF23_3top_SM.noskim.root"
+      },
+      {
+        "checksum": "adler32:f75d07a3",
+        "size": 15881715,
+        "uri": "root://eospublic.cern.ch//eos/opendata/atlas/rucio/user/egramsta/mc_306149.MadGraphPythia8EvtGen_A14NNPDF23LO_WpL_tbhad_M3000.noskim.root"
+      },
+      {
+        "checksum": "adler32:e66318c8",
+        "size": 10171005,
+        "uri": "root://eospublic.cern.ch//eos/opendata/atlas/rucio/user/egramsta/mc_311490.PowhegPy8EG_A14N23LO_DMA_500_700_gq0p25.noskim.root"
+      },
+      {
+        "checksum": "adler32:0c1ba7eb",
+        "size": 19377508,
+        "uri": "root://eospublic.cern.ch//eos/opendata/atlas/rucio/user/egramsta/mc_312613.aMcAtNloPy8EG_A14N30NLO_LQd_gstML_0p3_nonallhad_M1000.noskim.root"
+      },
+      {
+        "checksum": "adler32:e75f44b4",
+        "size": 7489823,
+        "uri": "root://eospublic.cern.ch//eos/opendata/atlas/rucio/user/egramsta/mc_341456.PowhegPythia8EvtGen_CT10_AZNLO_ZH125J_MINLO_veveWWlvqq_VpT.noskim.root"
+      },
+      {
+        "checksum": "adler32:dad19fdf",
+        "size": 15013775,
+        "uri": "root://eospublic.cern.ch//eos/opendata/atlas/rucio/user/egramsta/mc_341458.PowhegPythia8EvtGen_CT10_AZNLO_ZH125J_MINLO_vmuvmuWWlvqq_VpT.noskim.root"
+      },
+      {
+        "checksum": "adler32:3f6e0793",
+        "size": 14986897,
+        "uri": "root://eospublic.cern.ch//eos/opendata/atlas/rucio/user/egramsta/mc_341460.PowhegPy8EG_CT10_AZNLO_ZH125J_MINLO_vtauvtauWWlvqq_VpT.noskim.root"
+      },
+      {
+        "checksum": "adler32:7be279e0",
+        "size": 71260095,
+        "uri": "root://eospublic.cern.ch//eos/opendata/atlas/rucio/user/egramsta/mc_343981.PowhegPythia8EvtGen_NNLOPS_nnlo_30_ggH125_gamgam.noskim.root"
+      },
+      {
+        "checksum": "adler32:d6938d53",
+        "size": 44064423,
+        "uri": "root://eospublic.cern.ch//eos/opendata/atlas/rucio/user/egramsta/mc_344158.aMcAtNloPythia8EvtGen_A14NNPDF23LO_ppx0_FxFx_Np012_SM.noskim.root"
+      },
+      {
+        "checksum": "adler32:ade012aa",
+        "size": 40738544,
+        "uri": "root://eospublic.cern.ch//eos/opendata/atlas/rucio/user/egramsta/mc_345056.PowhegPythia8EvtGen_NNPDF3_AZNLO_ZH125J_MINLO_vvbb_VpT.noskim.root"
+      },
+      {
+        "checksum": "adler32:0cd374a6",
+        "size": 36898004,
+        "uri": "root://eospublic.cern.ch//eos/opendata/atlas/rucio/user/egramsta/mc_345058.PowhegPythia8EvtGen_NNPDF3_AZNLO_ggZH125_vvbb.noskim.root"
+      },
+      {
+        "checksum": "adler32:4093ad5b",
+        "size": 677095694,
+        "uri": "root://eospublic.cern.ch//eos/opendata/atlas/rucio/user/egramsta/mc_345060.PowhegPythia8EvtGen_NNLOPS_nnlo_30_ggH125_ZZ4l.noskim.root"
+      },
+      {
+        "checksum": "adler32:3dd370d3",
+        "size": 18428266,
+        "uri": "root://eospublic.cern.ch//eos/opendata/atlas/rucio/user/egramsta/mc_345061.PowhegPythia8EvtGen_NNPDF3_AZNLO_ggZH125_HgamgamZinc.noskim.root"
+      },
+      {
+        "checksum": "adler32:36d6e9bb",
+        "size": 21463904,
+        "uri": "root://eospublic.cern.ch//eos/opendata/atlas/rucio/user/egramsta/mc_345066.PowhegPythia8EvtGen_NNPDF3_AZNLO_ggZH125_ZZ4lepZinc.noskim.root"
+      },
+      {
+        "checksum": "adler32:4b9e75f4",
+        "size": 50441274,
+        "uri": "root://eospublic.cern.ch//eos/opendata/atlas/rucio/user/egramsta/mc_345097.PowhegPythia8EvtGen_NNLOPS_nnlo_30_ggH125_mumu.noskim.root"
+      },
+      {
+        "checksum": "adler32:2092e58b",
+        "size": 17562772,
+        "uri": "root://eospublic.cern.ch//eos/opendata/atlas/rucio/user/egramsta/mc_345098.PowhegPythia8EvtGen_NNPDF3_AZNLO_ggZH125_Hmumu_Zinc.noskim.root"
+      },
+      {
+        "checksum": "adler32:28d6e19c",
+        "size": 20551551,
+        "uri": "root://eospublic.cern.ch//eos/opendata/atlas/rucio/user/egramsta/mc_345103.PowhegPythia8EvtGen_NNPDF30_AZNLO_ZH125J_Hmumu_Zincl_MINLO.noskim.root"
+      },
+      {
+        "checksum": "adler32:b8ca82c4",
+        "size": 20626386,
+        "uri": "root://eospublic.cern.ch//eos/opendata/atlas/rucio/user/egramsta/mc_345104.PowhegPythia8EvtGen_NNPDF30_AZNLO_WpH125J_Hmumu_Wincl_MINLO.noskim.root"
+      },
+      {
+        "checksum": "adler32:aa098ee5",
+        "size": 12459999,
+        "uri": "root://eospublic.cern.ch//eos/opendata/atlas/rucio/user/egramsta/mc_345105.PowhegPythia8EvtGen_NNPDF30_AZNLO_WmH125J_Hmumu_Wincl_MINLO.noskim.root"
+      },
+      {
+        "checksum": "adler32:e7fad76e",
+        "size": 44933538,
+        "uri": "root://eospublic.cern.ch//eos/opendata/atlas/rucio/user/egramsta/mc_345106.PowhegPythia8EvtGen_NNPDF30_AZNLOCTEQ6L1_VBFH125_mumu.noskim.root"
+      },
+      {
+        "checksum": "adler32:34615e65",
+        "size": 40086220,
+        "uri": "root://eospublic.cern.ch//eos/opendata/atlas/rucio/user/egramsta/mc_345112.PowhegPythia8EvtGen_NNPDF3_AZNLO_ZH125J_MINLO_vvcc_VpT.noskim.root"
+      },
+      {
+        "checksum": "adler32:b968c4eb",
+        "size": 34545235,
+        "uri": "root://eospublic.cern.ch//eos/opendata/atlas/rucio/user/egramsta/mc_345114.PowhegPythia8EvtGen_NNPDF3_AZNLO_ggZH125_vvcc.noskim.root"
+      },
+      {
+        "checksum": "adler32:6e98d20c",
+        "size": 63856810,
+        "uri": "root://eospublic.cern.ch//eos/opendata/atlas/rucio/user/egramsta/mc_345120.PowhegPy8EG_NNLOPS_nnlo_30_ggH125_tautaul13l7.noskim.root"
+      },
+      {
+        "checksum": "adler32:9c46ba63",
+        "size": 55011199,
+        "uri": "root://eospublic.cern.ch//eos/opendata/atlas/rucio/user/egramsta/mc_345121.PowhegPy8EG_NNLOPS_nnlo_30_ggH125_tautaulm15hp20.noskim.root"
+      },
+      {
+        "checksum": "adler32:427c8588",
+        "size": 78537686,
+        "uri": "root://eospublic.cern.ch//eos/opendata/atlas/rucio/user/egramsta/mc_345122.PowhegPy8EG_NNLOPS_nnlo_30_ggH125_tautaulp15hm20.noskim.root"
+      },
+      {
+        "checksum": "adler32:114efa83",
+        "size": 101821548,
+        "uri": "root://eospublic.cern.ch//eos/opendata/atlas/rucio/user/egramsta/mc_345123.PowhegPy8EG_NNLOPS_nnlo_30_ggH125_tautauh30h20.noskim.root"
+      },
+      {
+        "checksum": "adler32:d27ce046",
+        "size": 467598224,
+        "uri": "root://eospublic.cern.ch//eos/opendata/atlas/rucio/user/egramsta/mc_345124.PowhegPy8EG_NNLOPS_nnlo_30_ggH125_etau_filt.noskim.root"
+      },
+      {
+        "checksum": "adler32:6a91ad2b",
+        "size": 511333892,
+        "uri": "root://eospublic.cern.ch//eos/opendata/atlas/rucio/user/egramsta/mc_345125.PowhegPy8EG_NNLOPS_nnlo_30_ggH125_mutau_filt.noskim.root"
+      },
+      {
+        "checksum": "adler32:c535eeda",
+        "size": 17182466,
+        "uri": "root://eospublic.cern.ch//eos/opendata/atlas/rucio/user/egramsta/mc_345211.PowhegPy8EG_NNPDF30_AZNLO_WmH125J_Winc_MINLO_tautau.noskim.root"
+      },
+      {
+        "checksum": "adler32:2952ca12",
+        "size": 21375424,
+        "uri": "root://eospublic.cern.ch//eos/opendata/atlas/rucio/user/egramsta/mc_345212.PowhegPy8EG_NNPDF30_AZNLO_WpH125J_Winc_MINLO_tautau.noskim.root"
+      },
+      {
+        "checksum": "adler32:fe06f402",
+        "size": 19463274,
+        "uri": "root://eospublic.cern.ch//eos/opendata/atlas/rucio/user/egramsta/mc_345213.PowhegPy8EG_NNPDF30_AZNLO_WmH125J_Winc_MINLO_etau.noskim.root"
+      },
+      {
+        "checksum": "adler32:647919fe",
+        "size": 34333967,
+        "uri": "root://eospublic.cern.ch//eos/opendata/atlas/rucio/user/egramsta/mc_345214.PowhegPy8EG_NNPDF30_AZNLO_WpH125J_Winc_MINLO_etau.noskim.root"
+      },
+      {
+        "checksum": "adler32:7804f838",
+        "size": 21567630,
+        "uri": "root://eospublic.cern.ch//eos/opendata/atlas/rucio/user/egramsta/mc_345215.PowhegPy8EG_NNPDF30_AZNLO_WmH125J_Winc_MINLO_mutau.noskim.root"
+      },
+      {
+        "checksum": "adler32:3ffcf7ef",
+        "size": 40109977,
+        "uri": "root://eospublic.cern.ch//eos/opendata/atlas/rucio/user/egramsta/mc_345216.PowhegPy8EG_NNPDF30_AZNLO_WpH125J_Winc_MINLO_mutau.noskim.root"
+      },
+      {
+        "checksum": "adler32:33a79cf1",
+        "size": 31443718,
+        "uri": "root://eospublic.cern.ch//eos/opendata/atlas/rucio/user/egramsta/mc_345217.PowhegPy8EG_NNPDF30_AZNLO_ZH125J_Zinc_MINLO_tautau.noskim.root"
+      },
+      {
+        "checksum": "adler32:d6bccf6f",
+        "size": 34241697,
+        "uri": "root://eospublic.cern.ch//eos/opendata/atlas/rucio/user/egramsta/mc_345218.PowhegPy8EG_NNPDF30_AZNLO_ZH125J_Zinc_MINLO_etau.noskim.root"
+      },
+      {
+        "checksum": "adler32:2e1b8b24",
+        "size": 29937012,
+        "uri": "root://eospublic.cern.ch//eos/opendata/atlas/rucio/user/egramsta/mc_345219.PowhegPy8EG_NNPDF30_AZNLO_ZH125J_Zinc_MINLO_mutau.noskim.root"
+      },
+      {
+        "checksum": "adler32:455ca789",
+        "size": 253084554,
+        "uri": "root://eospublic.cern.ch//eos/opendata/atlas/rucio/user/egramsta/mc_345316.PowhegPythia8EvtGen_NNLOPS_nnlo_30_ggH125_Zy_Zll.noskim.root"
+      },
+      {
+        "checksum": "adler32:249a6309",
+        "size": 94024838,
+        "uri": "root://eospublic.cern.ch//eos/opendata/atlas/rucio/user/egramsta/mc_345317.PowhegPythia8EvtGen_NNPDF30_AZNLO_WmH125J_Hyy_Wincl_MINLO.noskim.root"
+      },
+      {
+        "checksum": "adler32:67cde1eb",
+        "size": 51631691,
+        "uri": "root://eospublic.cern.ch//eos/opendata/atlas/rucio/user/egramsta/mc_345318.PowhegPythia8EvtGen_NNPDF30_AZNLO_WpH125J_Hyy_Wincl_MINLO.noskim.root"
+      },
+      {
+        "checksum": "adler32:15c2084e",
+        "size": 33925954,
+        "uri": "root://eospublic.cern.ch//eos/opendata/atlas/rucio/user/egramsta/mc_345319.PowhegPythia8EvtGen_NNPDF30_AZNLO_ZH125J_Hyy_Zincl_MINLO.noskim.root"
+      },
+      {
+        "checksum": "adler32:c4a2d077",
+        "size": 9667366,
+        "uri": "root://eospublic.cern.ch//eos/opendata/atlas/rucio/user/egramsta/mc_345320.PowhegPythia8EvtGen_NNPDF30_AZNLO_WmH125J_HZy_Wincl_MINLO.noskim.root"
+      },
+      {
+        "checksum": "adler32:c4cbf619",
+        "size": 9598852,
+        "uri": "root://eospublic.cern.ch//eos/opendata/atlas/rucio/user/egramsta/mc_345321.PowhegPythia8EvtGen_NNPDF30_AZNLO_WpH125J_HZy_Wincl_MINLO.noskim.root"
+      },
+      {
+        "checksum": "adler32:2949748a",
+        "size": 19225675,
+        "uri": "root://eospublic.cern.ch//eos/opendata/atlas/rucio/user/egramsta/mc_345322.PowhegPythia8EvtGen_NNPDF30_AZNLO_ZH125J_HZy_Zincl_MINLO.noskim.root"
+      },
+      {
+        "checksum": "adler32:6fb410c5",
+        "size": 59434466,
+        "uri": "root://eospublic.cern.ch//eos/opendata/atlas/rucio/user/egramsta/mc_345324.PowhegPythia8EvtGen_NNLOPS_NN30_ggH125_WWlvlv_EF_15_5.noskim.root"
+      },
+      {
+        "checksum": "adler32:e100e113",
+        "size": 41252081,
+        "uri": "root://eospublic.cern.ch//eos/opendata/atlas/rucio/user/egramsta/mc_345325.PowhegPythia8EvtGen_NNPDF3_AZNLO_WpH125J_MINLO_qqWWlvlv.noskim.root"
+      },
+      {
+        "checksum": "adler32:1166bfd0",
+        "size": 49757435,
+        "uri": "root://eospublic.cern.ch//eos/opendata/atlas/rucio/user/egramsta/mc_345433.PowhegPythia8EvtGen_NNPDF3_AZNLO_WmH125J_MINLO_qqWWlvlv.noskim.root"
+      },
+      {
+        "checksum": "adler32:9a8adf09",
+        "size": 18178648,
+        "uri": "root://eospublic.cern.ch//eos/opendata/atlas/rucio/user/egramsta/mc_345445.PowhegPythia8EvtGen_NNPDF3_AZNLO_ZH125J_MINLO_vvWWlvlv.noskim.root"
+      },
+      {
+        "checksum": "adler32:8150759b",
+        "size": 13517849,
+        "uri": "root://eospublic.cern.ch//eos/opendata/atlas/rucio/user/egramsta/mc_345596.PowhegPythia8EvtGen_NNPDF3_AZNLO_ggZH125_Zinc_HZZinv.noskim.root"
+      },
+      {
+        "checksum": "adler32:5371f822",
+        "size": 86713639,
+        "uri": "root://eospublic.cern.ch//eos/opendata/atlas/rucio/user/egramsta/mc_345697.MadGraphPythia8EvtGen_AZNLOCTEQ6L1_ggfhtautaullNp2.noskim.root"
+      },
+      {
+        "checksum": "adler32:aa6cf5f7",
+        "size": 155289562,
+        "uri": "root://eospublic.cern.ch//eos/opendata/atlas/rucio/user/egramsta/mc_345698.MadGraphPythia8EvtGen_AZNLOCTEQ6L1_ggfhtautaulhNp2.noskim.root"
+      },
+      {
+        "checksum": "adler32:36fe76bb",
+        "size": 181588743,
+        "uri": "root://eospublic.cern.ch//eos/opendata/atlas/rucio/user/egramsta/mc_345699.MadGraphPythia8EvtGen_AZNLOCTEQ6L1_ggfhtautauhhNp2.noskim.root"
+      },
+      {
+        "checksum": "adler32:e586a5f3",
+        "size": 136071657,
+        "uri": "root://eospublic.cern.ch//eos/opendata/atlas/rucio/user/egramsta/mc_345833.PowhegPythia8EvtGen_NNPDF30_AZNLOCTEQ6L1_VBFH125_Zllgam.noskim.root"
+      },
+      {
+        "checksum": "adler32:8030cbab",
+        "size": 16816795,
+        "uri": "root://eospublic.cern.ch//eos/opendata/atlas/rucio/user/egramsta/mc_345834.PowhegPythia8EvtGen_NNPDF30_AZNLOCTEQ6L1_VBFH125_gamstargam.noskim.root"
+      },
+      {
+        "checksum": "adler32:7c007641",
+        "size": 20869477,
+        "uri": "root://eospublic.cern.ch//eos/opendata/atlas/rucio/user/egramsta/mc_345876.PowhegPythia8EvtGen_NNPDF30_AZNLO_ZH125J_Hee__Zincl_MINLO.noskim.root"
+      },
+      {
+        "checksum": "adler32:a5ec168e",
+        "size": 12156700,
+        "uri": "root://eospublic.cern.ch//eos/opendata/atlas/rucio/user/egramsta/mc_345877.PowhegPythia8EvtGen_NNPDF30_AZNLO_WpH125J_Hee_Wincl_MINLO.noskim.root"
+      },
+      {
+        "checksum": "adler32:f8a7375d",
+        "size": 12640410,
+        "uri": "root://eospublic.cern.ch//eos/opendata/atlas/rucio/user/egramsta/mc_345878.PowhegPythia8EvtGen_NNPDF30_AZNLO_WmH125J_Hee_Wincl_MINLO.noskim.root"
+      },
+      {
+        "checksum": "adler32:7323737c",
+        "size": 74249154,
+        "uri": "root://eospublic.cern.ch//eos/opendata/atlas/rucio/user/egramsta/mc_345944.aMcAtNloPy8EG_A14NNPDF23LO_ppx0yy_FxFx_Np012_SM.noskim.root"
+      },
+      {
+        "checksum": "adler32:df903de1",
+        "size": 70499131,
+        "uri": "root://eospublic.cern.ch//eos/opendata/atlas/rucio/user/egramsta/mc_345948.PowhegPy8EG_NNPDF30_AZNLOCTEQ6L1_VBFH125_WWlvlv.noskim.root"
+      },
+      {
+        "checksum": "adler32:c2666787",
+        "size": 56775638,
+        "uri": "root://eospublic.cern.ch//eos/opendata/atlas/rucio/user/egramsta/mc_345949.PowhegPythia8EvtGen_NNPDF30_AZNLOCTEQ6L1_VBFH125_bb.noskim.root"
+      },
+      {
+        "checksum": "adler32:4c7f1640",
+        "size": 38452514,
+        "uri": "root://eospublic.cern.ch//eos/opendata/atlas/rucio/user/egramsta/mc_345961.PowhegPythia8EvtGen_NNLOPS_nnlo_30_ggH125_gamstargam.noskim.root"
+      },
+      {
+        "checksum": "adler32:851cde16",
+        "size": 9053513,
+        "uri": "root://eospublic.cern.ch//eos/opendata/atlas/rucio/user/egramsta/mc_345963.PowhegPythia8EvtGen_NNPDF30_AZNLO_WmH125J_Hgamstargam_MINLO.noskim.root"
+      },
+      {
+        "checksum": "adler32:2ac08291",
+        "size": 8978402,
+        "uri": "root://eospublic.cern.ch//eos/opendata/atlas/rucio/user/egramsta/mc_345964.PowhegPythia8EvtGen_NNPDF30_AZNLO_WpH125J_Hgamstargam_MINLO.noskim.root"
+      },
+      {
+        "checksum": "adler32:44ac377d",
+        "size": 17934543,
+        "uri": "root://eospublic.cern.ch//eos/opendata/atlas/rucio/user/egramsta/mc_345965.PowhegPythia8EvtGen_NNPDF30_AZNLO_ZH125J_Hgamstargam_MINLO.noskim.root"
+      },
+      {
+        "checksum": "adler32:cd53a6a3",
+        "size": 21333807,
+        "uri": "root://eospublic.cern.ch//eos/opendata/atlas/rucio/user/egramsta/mc_346188.aMcAtNloPythia8EvtGen_tHjb125_4fl_gamgam.noskim.root"
+      },
+      {
+        "checksum": "adler32:0d475ee3",
+        "size": 34170853,
+        "uri": "root://eospublic.cern.ch//eos/opendata/atlas/rucio/user/egramsta/mc_346189.aMcAtNloPythia8EvtGen_ttH_gamgam.noskim.root"
+      },
+      {
+        "checksum": "adler32:457016b7",
+        "size": 57770212,
+        "uri": "root://eospublic.cern.ch//eos/opendata/atlas/rucio/user/egramsta/mc_346190.PowhegPy8EG_NNPDF30_AZNLOCTEQ6L1_VBFH125_tautaul13l7.noskim.root"
+      },
+      {
+        "checksum": "adler32:6cc2d256",
+        "size": 36749101,
+        "uri": "root://eospublic.cern.ch//eos/opendata/atlas/rucio/user/egramsta/mc_346191.PowhegPy8EG_NNPDF30_AZNLOCTEQ6L1_VBFH125_tautaulm15hp20.noskim.root"
+      },
+      {
+        "checksum": "adler32:36ef3c35",
+        "size": 36366089,
+        "uri": "root://eospublic.cern.ch//eos/opendata/atlas/rucio/user/egramsta/mc_346192.PowhegPy8EG_NNPDF30_AZNLOCTEQ6L1_VBFH125_tautaulp15hm20.noskim.root"
+      },
+      {
+        "checksum": "adler32:d3a18dc5",
+        "size": 47379645,
+        "uri": "root://eospublic.cern.ch//eos/opendata/atlas/rucio/user/egramsta/mc_346193.PowhegPy8EG_NNPDF30_AZNLOCTEQ6L1_VBFH125_tautauh30h20.noskim.root"
+      },
+      {
+        "checksum": "adler32:6d3a9e85",
+        "size": 115710933,
+        "uri": "root://eospublic.cern.ch//eos/opendata/atlas/rucio/user/egramsta/mc_346194.PowhegPy8EG_NNPDF30_AZNLOCTEQ6L1_VBFH125_etau_filt.noskim.root"
+      },
+      {
+        "checksum": "adler32:8b09c71f",
+        "size": 98753054,
+        "uri": "root://eospublic.cern.ch//eos/opendata/atlas/rucio/user/egramsta/mc_346195.PowhegPy8EG_NNPDF30_AZNLOCTEQ6L1_VBFH125_mutau_filt.noskim.root"
+      },
+      {
+        "checksum": "adler32:a2d48f7b",
+        "size": 60209461,
+        "uri": "root://eospublic.cern.ch//eos/opendata/atlas/rucio/user/egramsta/mc_346198.PhPy8EG_A14NNPDF23_NNPDF30ME_ttH125_Zgam.noskim.root"
+      },
+      {
+        "checksum": "adler32:cd5e2e8b",
+        "size": 30892510,
+        "uri": "root://eospublic.cern.ch//eos/opendata/atlas/rucio/user/egramsta/mc_346214.PowhegPy8EG_NNPDF30_AZNLOCTEQ6L1_VBFH125_gamgam.noskim.root"
+      },
+      {
+        "checksum": "adler32:9392f04b",
+        "size": 135991934,
+        "uri": "root://eospublic.cern.ch//eos/opendata/atlas/rucio/user/egramsta/mc_346228.PowhegPy8EG_NNPDF30_AZNLOCTEQ6L1_VBFH125_ZZ4lep_notau.noskim.root"
+      },
+      {
+        "checksum": "adler32:4530934e",
+        "size": 31549045,
+        "uri": "root://eospublic.cern.ch//eos/opendata/atlas/rucio/user/egramsta/mc_346310.PowhegPythia8EvtGen_NNPDF30_AZNLO_ZH125J_Zincl_H_incl_MINLO.noskim.root"
+      },
+      {
+        "checksum": "adler32:0f8d1483",
+        "size": 20261601,
+        "uri": "root://eospublic.cern.ch//eos/opendata/atlas/rucio/user/egramsta/mc_346311.PowhegPythia8EvtGen_NNPDF30_AZNLO_WpH125J_Wincl_H_incl_MINLO.noskim.root"
+      },
+      {
+        "checksum": "adler32:590e7640",
+        "size": 16277972,
+        "uri": "root://eospublic.cern.ch//eos/opendata/atlas/rucio/user/egramsta/mc_346312.PowhegPythia8EvtGen_NNPDF30_AZNLO_WmH125J_Wincl_H_incl_MINLO.noskim.root"
+      },
+      {
+        "checksum": "adler32:b31c902e",
+        "size": 110343903,
+        "uri": "root://eospublic.cern.ch//eos/opendata/atlas/rucio/user/egramsta/mc_346317.PowhegPy8EG_NNPDF30_AZNLOCTEQ6L1_VBFH125_incl.noskim.root"
+      },
+      {
+        "checksum": "adler32:1f4dddcc",
+        "size": 20735045,
+        "uri": "root://eospublic.cern.ch//eos/opendata/atlas/rucio/user/egramsta/mc_346340.PowhegPy8EG_A14NNPDF23_NNPDF30ME_ttH125_ZZ4l_allhad.noskim.root"
+      },
+      {
+        "checksum": "adler32:39dff3f5",
+        "size": 20388080,
+        "uri": "root://eospublic.cern.ch//eos/opendata/atlas/rucio/user/egramsta/mc_346341.PowhegPy8EG_A14NNPDF23_NNPDF30ME_ttH125_ZZ4l_semilep.noskim.root"
+      },
+      {
+        "checksum": "adler32:b72ff78f",
+        "size": 19677803,
+        "uri": "root://eospublic.cern.ch//eos/opendata/atlas/rucio/user/egramsta/mc_346342.PowhegPy8EG_A14NNPDF23_NNPDF30ME_ttH125_ZZ4l_dilep.noskim.root"
+      },
+      {
+        "checksum": "adler32:9ef98c87",
+        "size": 70867847,
+        "uri": "root://eospublic.cern.ch//eos/opendata/atlas/rucio/user/egramsta/mc_346343.PhPy8EG_A14NNPDF23_NNPDF30ME_ttH125_allhad.noskim.root"
+      },
+      {
+        "checksum": "adler32:7ae100e3",
+        "size": 53296074,
+        "uri": "root://eospublic.cern.ch//eos/opendata/atlas/rucio/user/egramsta/mc_346344.PhPy8EG_A14NNPDF23_NNPDF30ME_ttH125_semilep.noskim.root"
+      },
+      {
+        "checksum": "adler32:6d3c6dbc",
+        "size": 104363507,
+        "uri": "root://eospublic.cern.ch//eos/opendata/atlas/rucio/user/egramsta/mc_346345.PhPy8EG_A14NNPDF23_NNPDF30ME_ttH125_dilep.noskim.root"
+      },
+      {
+        "checksum": "adler32:8a8b338b",
+        "size": 27498619,
+        "uri": "root://eospublic.cern.ch//eos/opendata/atlas/rucio/user/egramsta/mc_346398.PowhegHerwig7EvtGen_NNPDF3_AZNLO_ZH125J_MINLO_vvbb_VpT.noskim.root"
+      },
+      {
+        "checksum": "adler32:f1e92da6",
+        "size": 35604743,
+        "uri": "root://eospublic.cern.ch//eos/opendata/atlas/rucio/user/egramsta/mc_346400.PowhegHerwig7EvtGen_NNPDF3_AZNLO_ggZH125J_vvbb.noskim.root"
+      },
+      {
+        "checksum": "adler32:e22c0bd2",
+        "size": 17649364,
+        "uri": "root://eospublic.cern.ch//eos/opendata/atlas/rucio/user/egramsta/mc_346414.aMcAtNloPythia8EvtGen_tHjb125_4fl_ZZ4l.noskim.root"
+      },
+      {
+        "checksum": "adler32:a5235f76",
+        "size": 413260998,
+        "uri": "root://eospublic.cern.ch//eos/opendata/atlas/rucio/user/egramsta/mc_346446.PhH7EG_H7UE_NNLOPS_nnlo_30_ggH125_ZZ4l_noTau.noskim.root"
+      },
+      {
+        "checksum": "adler32:c85dd605",
+        "size": 137861705,
+        "uri": "root://eospublic.cern.ch//eos/opendata/atlas/rucio/user/egramsta/mc_346447.PhH7EG_H7UE_NNPDF30_VBFH125_ZZ4lep_noTau.noskim.root"
+      },
+      {
+        "checksum": "adler32:a541a0db",
+        "size": 49005232,
+        "uri": "root://eospublic.cern.ch//eos/opendata/atlas/rucio/user/egramsta/mc_346448.PhH7EG_H7UE_NNPDF30_ZH125J_Zincl_MINLO.noskim.root"
+      },
+      {
+        "checksum": "adler32:646370ff",
+        "size": 39013203,
+        "uri": "root://eospublic.cern.ch//eos/opendata/atlas/rucio/user/egramsta/mc_346449.PhH7EG_H7UE_NNPDF30_WpH125J_Wincl_MINLO.noskim.root"
+      },
+      {
+        "checksum": "adler32:7460f8f1",
+        "size": 19768079,
+        "uri": "root://eospublic.cern.ch//eos/opendata/atlas/rucio/user/egramsta/mc_346450.PhH7EG_H7UE_NNPDF30_WmH125J_Wincl_MINLO.noskim.root"
+      },
+      {
+        "checksum": "adler32:b487ec68",
+        "size": 21672174,
+        "uri": "root://eospublic.cern.ch//eos/opendata/atlas/rucio/user/egramsta/mc_346451.PhH7EG_H7UE_NNPDF3_ggZH125_ZZ4lepZinc.noskim.root"
+      },
+      {
+        "checksum": "adler32:212014bf",
+        "size": 20881487,
+        "uri": "root://eospublic.cern.ch//eos/opendata/atlas/rucio/user/egramsta/mc_346452.PhH7EG_H7UE_NNPDF30ME_ttH125_ZZ4l_allhad_noTau.noskim.root"
+      },
+      {
+        "checksum": "adler32:4fc8463d",
+        "size": 20473282,
+        "uri": "root://eospublic.cern.ch//eos/opendata/atlas/rucio/user/egramsta/mc_346453.PhH7EG_H7UE_NNPDF30ME_ttH125_ZZ4l_semilep_noTau.noskim.root"
+      },
+      {
+        "checksum": "adler32:313ca62f",
+        "size": 19811331,
+        "uri": "root://eospublic.cern.ch//eos/opendata/atlas/rucio/user/egramsta/mc_346454.PhH7EG_H7UE_NNPDF30ME_ttH125_ZZ4l_dilep_noTau.noskim.root"
+      },
+      {
+        "checksum": "adler32:9ef070bd",
+        "size": 18124742,
+        "uri": "root://eospublic.cern.ch//eos/opendata/atlas/rucio/user/egramsta/mc_346486.aMcAtNloPythia8EvtGen_tWH125_yy.noskim.root"
+      },
+      {
+        "checksum": "adler32:08cbe689",
+        "size": 19815021,
+        "uri": "root://eospublic.cern.ch//eos/opendata/atlas/rucio/user/egramsta/mc_346511.aMcAtNloPythia8EvtGen_tWH125_ZZ4l.noskim.root"
+      },
+      {
+        "checksum": "adler32:7e39197b",
+        "size": 18309551,
+        "uri": "root://eospublic.cern.ch//eos/opendata/atlas/rucio/user/egramsta/mc_346524.PowhegPythia8EvtGen_NNPDF3_AZNLO_ggZH125J_MINLO_ZinclWWlvlv.noskim.root"
+      },
+      {
+        "checksum": "adler32:863f5ccf",
+        "size": 75164433,
+        "uri": "root://eospublic.cern.ch//eos/opendata/atlas/rucio/user/egramsta/mc_346525.PowhegPythia8EvtGen_A14NNPDF23_NNPDF30ME_ttH125_gamgam.noskim.root"
+      },
+      {
+        "checksum": "adler32:9d0995c5",
+        "size": 81464790,
+        "uri": "root://eospublic.cern.ch//eos/opendata/atlas/rucio/user/egramsta/mc_346526.PowhegHerwig7EvtGen_H7UE_NNPDF30ME_ttH125_gamgam.noskim.root"
+      },
+      {
+        "checksum": "adler32:8555ba1d",
+        "size": 52525998,
+        "uri": "root://eospublic.cern.ch//eos/opendata/atlas/rucio/user/egramsta/mc_346588.PowhegPythia8EvtGen_NNLOPS_nnlo_30_ggH125_ZZ4nu_MET75.noskim.root"
+      },
+      {
+        "checksum": "adler32:a26c1fdf",
+        "size": 56520907,
+        "uri": "root://eospublic.cern.ch//eos/opendata/atlas/rucio/user/egramsta/mc_346601.aMcAtNloHerwig7EvtGen_MEN30NLO_ttH125_gamgam.noskim.root"
+      },
+      {
+        "checksum": "adler32:47dbd93e",
+        "size": 20624959,
+        "uri": "root://eospublic.cern.ch//eos/opendata/atlas/rucio/user/egramsta/mc_346602.aMcAtNloHerwig7EvtGen_MEN30NLO_tHjb125_gamgam.noskim.root"
+      },
+      {
+        "checksum": "adler32:26d5d6a5",
+        "size": 32957699,
+        "uri": "root://eospublic.cern.ch//eos/opendata/atlas/rucio/user/egramsta/mc_346605.PowhegPythia8EvtGen_NNPDF30_AZNLO_WpH125J_WinclHinv_MET75.noskim.root"
+      },
+      {
+        "checksum": "adler32:e858b42e",
+        "size": 33332022,
+        "uri": "root://eospublic.cern.ch//eos/opendata/atlas/rucio/user/egramsta/mc_346606.PowhegPythia8EvtGen_NNPDF30_AZNLO_WmH125J_WinclHinv_MET75.noskim.root"
+      },
+      {
+        "checksum": "adler32:5035b433",
+        "size": 46658344,
+        "uri": "root://eospublic.cern.ch//eos/opendata/atlas/rucio/user/egramsta/mc_346607.PowhegPythia8EvtGen_NNPDF30_AZNLO_ZH125J_ZinclHinv_MET75.noskim.root"
+      },
+      {
+        "checksum": "adler32:7ed6a948",
+        "size": 82734690,
+        "uri": "root://eospublic.cern.ch//eos/opendata/atlas/rucio/user/egramsta/mc_346632.PowhegPy8EG_A14NNPDF23_NNPDF30ME_ttH125_ZZ4nu_semilep.noskim.root"
+      },
+      {
+        "checksum": "adler32:3d52f68e",
+        "size": 61118062,
+        "uri": "root://eospublic.cern.ch//eos/opendata/atlas/rucio/user/egramsta/mc_346633.PowhegPy8EG_A14NNPDF23_NNPDF30ME_ttH125_ZZ4nu_allhad.noskim.root"
+      },
+      {
+        "checksum": "adler32:369af08b",
+        "size": 19974602,
+        "uri": "root://eospublic.cern.ch//eos/opendata/atlas/rucio/user/egramsta/mc_346634.PowhegPy8EG_A14NNPDF23_NNPDF30ME_ttH125_ZZ4nu_dilep.noskim.root"
+      },
+      {
+        "checksum": "adler32:f0fa131c",
+        "size": 68184607,
+        "uri": "root://eospublic.cern.ch//eos/opendata/atlas/rucio/user/egramsta/mc_346645.PowhegPythia8EvtGen_NNPDF30_AZNLO_ZH125J_Zincl_MINLO_shw.noskim.root"
+      },
+      {
+        "checksum": "adler32:5c2141cf",
+        "size": 38845866,
+        "uri": "root://eospublic.cern.ch//eos/opendata/atlas/rucio/user/egramsta/mc_346646.PowhegPythia8EvtGen_NNPDF30_AZNLO_WpH125J_Wincl_MINLO_shw.noskim.root"
+      },
+      {
+        "checksum": "adler32:d5fd6707",
+        "size": 19678982,
+        "uri": "root://eospublic.cern.ch//eos/opendata/atlas/rucio/user/egramsta/mc_346647.PowhegPythia8EvtGen_NNPDF30_AZNLO_WmH125J_Wincl_MINLO_shw.noskim.root"
+      },
+      {
+        "checksum": "adler32:c8ea2cee",
+        "size": 60614629,
+        "uri": "root://eospublic.cern.ch//eos/opendata/atlas/rucio/user/egramsta/mc_346726.PowhegHerwig7EvtGen_NNPDF3_AZNLO_ZH125J_MINLO_vvcc_VpT.noskim.root"
+      },
+      {
+        "checksum": "adler32:29e3d38f",
+        "size": 15841402,
+        "uri": "root://eospublic.cern.ch//eos/opendata/atlas/rucio/user/egramsta/mc_346728.PowhegHerwig7EvtGen_NNPDF3_AZNLO_ggZH125J_vvcc.noskim.root"
+      },
+      {
+        "checksum": "adler32:812ba345",
+        "size": 732591534,
+        "uri": "root://eospublic.cern.ch//eos/opendata/atlas/rucio/user/egramsta/mc_346797.PhH7EG_H7UE_NNLOPS_nnlo_30_ggH125_gamgam.noskim.root"
+      },
+      {
+        "checksum": "adler32:6810a860",
+        "size": 379820112,
+        "uri": "root://eospublic.cern.ch//eos/opendata/atlas/rucio/user/egramsta/mc_346802.PhH7EG_NNLOPS_nnlo_30_ggH125_WWlvlv_noTau.noskim.root"
+      },
+      {
+        "checksum": "adler32:f6d75c9f",
+        "size": 58849477,
+        "uri": "root://eospublic.cern.ch//eos/opendata/atlas/rucio/user/egramsta/mc_346877.PhH7EG_NNPDF30_VBFH125_WWlvlv.noskim.root"
+      },
+      {
+        "checksum": "adler32:480298e5",
+        "size": 128191343,
+        "uri": "root://eospublic.cern.ch//eos/opendata/atlas/rucio/user/egramsta/mc_346878.PhH7EG_H7UE_NNPDF30_VBF125_gammagamma.noskim.root"
+      },
+      {
+        "checksum": "adler32:a3c6dfd1",
+        "size": 42329631,
+        "uri": "root://eospublic.cern.ch//eos/opendata/atlas/rucio/user/egramsta/mc_346879.PhH7EG_H7UE_NNPDF30_ZH125J_Zincl_MINLO_gammagamma.noskim.root"
+      },
+      {
+        "checksum": "adler32:58099aa5",
+        "size": 21681017,
+        "uri": "root://eospublic.cern.ch//eos/opendata/atlas/rucio/user/egramsta/mc_346880.PhH7EG_H7UE_NNPDF30_WmH125J_Wincl_MINLO_gammagamma.noskim.root"
+      },
+      {
+        "checksum": "adler32:7f09e5b1",
+        "size": 43119618,
+        "uri": "root://eospublic.cern.ch//eos/opendata/atlas/rucio/user/egramsta/mc_346881.PhH7EG_H7UE_NNPDF30_WpH125J_Wincl_MINLO_gammagamma.noskim.root"
+      },
+      {
+        "checksum": "adler32:7cf72eea",
+        "size": 18509761,
+        "uri": "root://eospublic.cern.ch//eos/opendata/atlas/rucio/user/egramsta/mc_346882.PhH7EG_H7UE_NNPDF30_ggZH125_gammagamma.noskim.root"
+      },
+      {
+        "checksum": "adler32:ef8f2efc",
+        "size": 93164896,
+        "uri": "root://eospublic.cern.ch//eos/opendata/atlas/rucio/user/egramsta/mc_346919.PhPy8EG_A14NNPDF23_NNPDF30ME_ttH125_allhad_tautau_unpol.noskim.root"
+      },
+      {
+        "checksum": "adler32:aceffcc2",
+        "size": 73948864,
+        "uri": "root://eospublic.cern.ch//eos/opendata/atlas/rucio/user/egramsta/mc_346923.PhPy8EG_A14NNPDF23_NNPDF30ME_ttH125_semilep_tautau_unpol.noskim.root"
+      },
+      {
+        "checksum": "adler32:67724e6e",
+        "size": 47879096,
+        "uri": "root://eospublic.cern.ch//eos/opendata/atlas/rucio/user/egramsta/mc_346927.PhPy8EG_A14NNPDF23_NNPDF30ME_ttH125_dilep_tautau_unpol.noskim.root"
+      },
+      {
+        "checksum": "adler32:d94cc28b",
+        "size": 72102449,
+        "uri": "root://eospublic.cern.ch//eos/opendata/atlas/rucio/user/egramsta/mc_364242.Sherpa_222_NNPDF30NNLO_WWW_3l3v_EW6.noskim.root"
+      },
+      {
+        "checksum": "adler32:39a79b06",
+        "size": 24963340,
+        "uri": "root://eospublic.cern.ch//eos/opendata/atlas/rucio/user/egramsta/mc_364243.Sherpa_222_NNPDF30NNLO_WWZ_4l2v_EW6.noskim.root"
+      },
+      {
+        "checksum": "adler32:fabe682b",
+        "size": 20000833,
+        "uri": "root://eospublic.cern.ch//eos/opendata/atlas/rucio/user/egramsta/mc_364244.Sherpa_222_NNPDF30NNLO_WWZ_2l4v_EW6.noskim.root"
+      },
+      {
+        "checksum": "adler32:fc47df11",
+        "size": 21922488,
+        "uri": "root://eospublic.cern.ch//eos/opendata/atlas/rucio/user/egramsta/mc_364245.Sherpa_222_NNPDF30NNLO_WZZ_5l1v_EW6.noskim.root"
+      },
+      {
+        "checksum": "adler32:6c0f7552",
+        "size": 22725137,
+        "uri": "root://eospublic.cern.ch//eos/opendata/atlas/rucio/user/egramsta/mc_364246.Sherpa_222_NNPDF30NNLO_WZZ_3l3v_EW6.noskim.root"
+      },
+      {
+        "checksum": "adler32:1f853ce8",
+        "size": 16733117,
+        "uri": "root://eospublic.cern.ch//eos/opendata/atlas/rucio/user/egramsta/mc_364247.Sherpa_222_NNPDF30NNLO_ZZZ_6l0v_EW6.noskim.root"
+      },
+      {
+        "checksum": "adler32:1a5715b7",
+        "size": 4746641,
+        "uri": "root://eospublic.cern.ch//eos/opendata/atlas/rucio/user/egramsta/mc_364248.Sherpa_222_NNPDF30NNLO_ZZZ_4l2v_EW6.noskim.root"
+      },
+      {
+        "checksum": "adler32:b08d1822",
+        "size": 11166887,
+        "uri": "root://eospublic.cern.ch//eos/opendata/atlas/rucio/user/egramsta/mc_364249.Sherpa_222_NNPDF30NNLO_ZZZ_2l4v_EW6.noskim.root"
+      },
+      {
+        "checksum": "adler32:2d5972ce",
+        "size": 18863442,
+        "uri": "root://eospublic.cern.ch//eos/opendata/atlas/rucio/user/egramsta/mc_364336.Sherpa_222_NNPDF30NNLO_WpWpWn_sslvlvjj_EW6.noskim.root"
+      },
+      {
+        "checksum": "adler32:680f810c",
+        "size": 14268557,
+        "uri": "root://eospublic.cern.ch//eos/opendata/atlas/rucio/user/egramsta/mc_364337.Sherpa_222_NNPDF30NNLO_WnWnWp_sslvlvjj_EW6.noskim.root"
+      },
+      {
+        "checksum": "adler32:3711fc45",
+        "size": 7060254,
+        "uri": "root://eospublic.cern.ch//eos/opendata/atlas/rucio/user/egramsta/mc_364338.Sherpa_222_NNPDF30NNLO_WpWpWn_oslvlvjj_EW6.noskim.root"
+      },
+      {
+        "checksum": "adler32:894ddac6",
+        "size": 2390685,
+        "uri": "root://eospublic.cern.ch//eos/opendata/atlas/rucio/user/egramsta/mc_364339.Sherpa_222_NNPDF30NNLO_WnWnWp_oslvlvjj_EW6.noskim.root"
+      },
+      {
+        "checksum": "adler32:98ba11ff",
+        "size": 351226885,
+        "uri": "root://eospublic.cern.ch//eos/opendata/atlas/rucio/user/egramsta/mc_364350.Sherpa_224_NNPDF30NNLO_Diphoton_myy_0_50.noskim.root"
+      },
+      {
+        "checksum": "adler32:c48ca8a0",
+        "size": 3557693042,
+        "uri": "root://eospublic.cern.ch//eos/opendata/atlas/rucio/user/egramsta/mc_364351.Sherpa_224_NNPDF30NNLO_Diphoton_myy_50_90.noskim.root"
+      },
+      {
+        "checksum": "adler32:d5e90e82",
+        "size": 1384514753,
+        "uri": "root://eospublic.cern.ch//eos/opendata/atlas/rucio/user/egramsta/mc_364352.Sherpa_224_NNPDF30NNLO_Diphoton_myy_90_175.noskim.root"
+      },
+      {
+        "checksum": "adler32:85db6d4a",
+        "size": 339509180,
+        "uri": "root://eospublic.cern.ch//eos/opendata/atlas/rucio/user/egramsta/mc_364353.Sherpa_224_NNPDF30NNLO_Diphoton_myy_175_2000.noskim.root"
+      },
+      {
+        "checksum": "adler32:c3dbc3de",
+        "size": 20538590,
+        "uri": "root://eospublic.cern.ch//eos/opendata/atlas/rucio/user/egramsta/mc_364354.Sherpa_224_NNPDF30NNLO_Diphoton_myy_2000_E_CMS.noskim.root"
+      },
+      {
+        "checksum": "adler32:f50b88f8",
+        "size": 2771577862,
+        "uri": "root://eospublic.cern.ch//eos/opendata/atlas/rucio/user/egramsta/mc_364541.Sherpa_222_NNPDF30NNLO_SinglePhoton_pty_17_35.noskim.root"
+      },
+      {
+        "checksum": "adler32:ec407d19",
+        "size": 3186873556,
+        "uri": "root://eospublic.cern.ch//eos/opendata/atlas/rucio/user/egramsta/mc_364542.Sherpa_222_NNPDF30NNLO_SinglePhoton_pty_35_70.noskim.root"
+      },
+      {
+        "checksum": "adler32:aa7c9681",
+        "size": 3416066755,
+        "uri": "root://eospublic.cern.ch//eos/opendata/atlas/rucio/user/egramsta/mc_364543.Sherpa_222_NNPDF30NNLO_SinglePhoton_pty_70_140.noskim.root"
+      },
+      {
+        "checksum": "adler32:ba379e5a",
+        "size": 3699718035,
+        "uri": "root://eospublic.cern.ch//eos/opendata/atlas/rucio/user/egramsta/mc_364544.Sherpa_222_NNPDF30NNLO_SinglePhoton_pty_140_280.noskim.root"
+      },
+      {
+        "checksum": "adler32:2b250636",
+        "size": 667589248,
+        "uri": "root://eospublic.cern.ch//eos/opendata/atlas/rucio/user/egramsta/mc_364545.Sherpa_222_NNPDF30NNLO_SinglePhoton_pty_280_500.noskim.root"
+      },
+      {
+        "checksum": "adler32:169ee4af",
+        "size": 50357304,
+        "uri": "root://eospublic.cern.ch//eos/opendata/atlas/rucio/user/egramsta/mc_364546.Sherpa_222_NNPDF30NNLO_SinglePhoton_pty_500_1000.noskim.root"
+      },
+      {
+        "checksum": "adler32:ddf37057",
+        "size": 53788313,
+        "uri": "root://eospublic.cern.ch//eos/opendata/atlas/rucio/user/egramsta/mc_364547.Sherpa_222_NNPDF30NNLO_SinglePhoton_pty_1000_E_CMS.noskim.root"
+      },
+      {
+        "checksum": "adler32:f79f5694",
+        "size": 7479001979,
+        "uri": "root://eospublic.cern.ch//eos/opendata/atlas/rucio/user/egramsta/mc_364700.Pythia8EvtGen_A14NNPDF23LO_jetjet_JZ0WithSW.noskim.root"
+      },
+      {
+        "checksum": "adler32:f3a9def5",
+        "size": 9480186617,
+        "uri": "root://eospublic.cern.ch//eos/opendata/atlas/rucio/user/egramsta/mc_364701.Pythia8EvtGen_A14NNPDF23LO_jetjet_JZ1WithSW.noskim.root"
+      },
+      {
+        "checksum": "adler32:95476766",
+        "size": 15537572310,
+        "uri": "root://eospublic.cern.ch//eos/opendata/atlas/rucio/user/egramsta/mc_364702.Pythia8EvtGen_A14NNPDF23LO_jetjet_JZ2WithSW.noskim.root"
+      },
+      {
+        "checksum": "adler32:4ebe916a",
+        "size": 18928183403,
+        "uri": "root://eospublic.cern.ch//eos/opendata/atlas/rucio/user/egramsta/mc_364703.Pythia8EvtGen_A14NNPDF23LO_jetjet_JZ3WithSW.noskim.root"
+      },
+      {
+        "checksum": "adler32:4e3bb1c4",
+        "size": 21694017378,
+        "uri": "root://eospublic.cern.ch//eos/opendata/atlas/rucio/user/egramsta/mc_364704.Pythia8EvtGen_A14NNPDF23LO_jetjet_JZ4WithSW.noskim.root"
+      },
+      {
+        "checksum": "adler32:6bfff480",
+        "size": 2339400025,
+        "uri": "root://eospublic.cern.ch//eos/opendata/atlas/rucio/user/egramsta/mc_364705.Pythia8EvtGen_A14NNPDF23LO_jetjet_JZ5WithSW.noskim.root"
+      },
+      {
+        "checksum": "adler32:5c1ef91d",
+        "size": 95142090,
+        "uri": "root://eospublic.cern.ch//eos/opendata/atlas/rucio/user/egramsta/mc_364706.Pythia8EvtGen_A14NNPDF23LO_jetjet_JZ6WithSW.noskim.root"
+      },
+      {
+        "checksum": "adler32:d88461f6",
+        "size": 50483102,
+        "uri": "root://eospublic.cern.ch//eos/opendata/atlas/rucio/user/egramsta/mc_364707.Pythia8EvtGen_A14NNPDF23LO_jetjet_JZ7WithSW.noskim.root"
+      },
+      {
+        "checksum": "adler32:d7bf71d6",
+        "size": 88122225,
+        "uri": "root://eospublic.cern.ch//eos/opendata/atlas/rucio/user/egramsta/mc_364708.Pythia8EvtGen_A14NNPDF23LO_jetjet_JZ8WithSW.noskim.root"
+      },
+      {
+        "checksum": "adler32:0d65e117",
+        "size": 36329937,
+        "uri": "root://eospublic.cern.ch//eos/opendata/atlas/rucio/user/egramsta/mc_364709.Pythia8EvtGen_A14NNPDF23LO_jetjet_JZ9WithSW.noskim.root"
+      },
+      {
+        "checksum": "adler32:5611bbe0",
+        "size": 110335722,
+        "uri": "root://eospublic.cern.ch//eos/opendata/atlas/rucio/user/egramsta/mc_364710.Pythia8EvtGen_A14NNPDF23LO_jetjet_JZ10WithSW.noskim.root"
+      },
+      {
+        "checksum": "adler32:a4837801",
+        "size": 49425919,
+        "uri": "root://eospublic.cern.ch//eos/opendata/atlas/rucio/user/egramsta/mc_364711.Pythia8EvtGen_A14NNPDF23LO_jetjet_JZ11WithSW.noskim.root"
+      },
+      {
+        "checksum": "adler32:a46a06cf",
+        "size": 61546626,
+        "uri": "root://eospublic.cern.ch//eos/opendata/atlas/rucio/user/egramsta/mc_364712.Pythia8EvtGen_A14NNPDF23LO_jetjet_JZ12WithSW.noskim.root"
+      },
+      {
+        "checksum": "adler32:00e7b157",
+        "size": 7404854,
+        "uri": "root://eospublic.cern.ch//eos/opendata/atlas/rucio/user/egramsta/mc_375884.MGPy8EG_A14N_GG_ttn1_2000_5000_200.noskim.root"
+      },
+      {
+        "checksum": "adler32:a6857f19",
+        "size": 1239060,
+        "uri": "root://eospublic.cern.ch//eos/opendata/atlas/rucio/user/egramsta/mc_376359.MGPy8EG_A14N23LO_SS_onestepCC_1600_900_200.noskim.root"
+      },
+      {
+        "checksum": "adler32:21222dac",
+        "size": 1222250,
+        "uri": "root://eospublic.cern.ch//eos/opendata/atlas/rucio/user/egramsta/mc_376518.MadGraphPythia8EvtGen_A14NNPDF23LO_GG_direct_2400_200.noskim.root"
+      },
+      {
+        "checksum": "adler32:ac29d2f1",
+        "size": 4486989,
+        "uri": "root://eospublic.cern.ch//eos/opendata/atlas/rucio/user/egramsta/mc_392202.MGPy8EG_A14N23LO_C1N2_WZ_500p0_100p0_3L_2L7.noskim.root"
+      },
+      {
+        "checksum": "adler32:cb40fa51",
+        "size": 6506681,
+        "uri": "root://eospublic.cern.ch//eos/opendata/atlas/rucio/user/egramsta/mc_394997.MGPy8EG_A14N23LO_SM_N2C1p_105_100_2L2MET75_MadSpin.noskim.root"
+      },
+      {
+        "checksum": "adler32:02f0a0ba",
+        "size": 18101445,
+        "uri": "root://eospublic.cern.ch//eos/opendata/atlas/rucio/user/egramsta/mc_398384.MGPy8EG_A14N23LO_C1N2N1_GGMHinoZh50_800_noFilter.noskim.root"
+      },
+      {
+        "checksum": "adler32:9981148c",
+        "size": 19256471,
+        "uri": "root://eospublic.cern.ch//eos/opendata/atlas/rucio/user/egramsta/mc_410081.MadGraphPythia8EvtGen_A14NNPDF23_ttbarWW.noskim.root"
+      },
+      {
+        "checksum": "adler32:fac2a5b3",
+        "size": 189096564,
+        "uri": "root://eospublic.cern.ch//eos/opendata/atlas/rucio/user/egramsta/mc_410082.MadGraphPythia8EvtGen_A14NNPDF23LO_ttgamma_noallhad.noskim.root"
+      },
+      {
+        "checksum": "adler32:8af99933",
+        "size": 108907991,
+        "uri": "root://eospublic.cern.ch//eos/opendata/atlas/rucio/user/egramsta/mc_410087.MadGraphPythia8EvtGen_A14NNPDF23LO_ttgamma_allhad.noskim.root"
+      },
+      {
+        "checksum": "adler32:a4e7e4b8",
+        "size": 56743092,
+        "uri": "root://eospublic.cern.ch//eos/opendata/atlas/rucio/user/egramsta/mc_410155.aMcAtNloPythia8EvtGen_MEN30NLO_A14N23LO_ttW.noskim.root"
+      },
+      {
+        "checksum": "adler32:afdc19ec",
+        "size": 58426820,
+        "uri": "root://eospublic.cern.ch//eos/opendata/atlas/rucio/user/egramsta/mc_410156.aMcAtNloPythia8EvtGen_MEN30NLO_A14N23LO_ttZnunu.noskim.root"
+      },
+      {
+        "checksum": "adler32:beec0348",
+        "size": 89567463,
+        "uri": "root://eospublic.cern.ch//eos/opendata/atlas/rucio/user/egramsta/mc_410157.aMcAtNloPythia8EvtGen_MEN30NLO_A14N23LO_ttZqq.noskim.root"
+      },
+      {
+        "checksum": "adler32:a18c4cde",
+        "size": 43552886,
+        "uri": "root://eospublic.cern.ch//eos/opendata/atlas/rucio/user/egramsta/mc_410218.aMcAtNloPythia8EvtGen_MEN30NLO_A14N23LO_ttee.noskim.root"
+      },
+      {
+        "checksum": "adler32:2a29c281",
+        "size": 73997940,
+        "uri": "root://eospublic.cern.ch//eos/opendata/atlas/rucio/user/egramsta/mc_410219.aMcAtNloPythia8EvtGen_MEN30NLO_A14N23LO_ttmumu.noskim.root"
+      },
+      {
+        "checksum": "adler32:69bca4d6",
+        "size": 94399279,
+        "uri": "root://eospublic.cern.ch//eos/opendata/atlas/rucio/user/egramsta/mc_410220.aMcAtNloPythia8EvtGen_MEN30NLO_A14N23LO_tttautau.noskim.root"
+      },
+      {
+        "checksum": "adler32:dea122e4",
+        "size": 265591116,
+        "uri": "root://eospublic.cern.ch//eos/opendata/atlas/rucio/user/egramsta/mc_410389.MadGraphPythia8EvtGen_A14NNPDF23_ttgamma_nonallhadronic.noskim.root"
+      },
+      {
+        "checksum": "adler32:8748d3f9",
+        "size": 244251158,
+        "uri": "root://eospublic.cern.ch//eos/opendata/atlas/rucio/user/egramsta/mc_410395.MGH7EG_H7UE_ttgamma_nonallhadronic.noskim.root"
+      },
+      {
+        "checksum": "adler32:c64e43c3",
+        "size": 159516421,
+        "uri": "root://eospublic.cern.ch//eos/opendata/atlas/rucio/user/egramsta/mc_410396.MGH7EG_H7UE_ttgamma_allhadronic.noskim.root"
+      },
+      {
+        "checksum": "adler32:8f84b49d",
+        "size": 18064402,
+        "uri": "root://eospublic.cern.ch//eos/opendata/atlas/rucio/user/egramsta/mc_410408.aMcAtNloPythia8EvtGen_tWZ_Ztoll_minDR1.noskim.root"
+      },
+      {
+        "checksum": "adler32:f4e27519",
+        "size": 16193476714,
+        "uri": "root://eospublic.cern.ch//eos/opendata/atlas/rucio/user/egramsta/mc_410470.PhPy8EG_A14_ttbar_hdamp258p75_nonallhad.noskim.root"
+      },
+      {
+        "checksum": "adler32:fce5eb11",
+        "size": 8452692014,
+        "uri": "root://eospublic.cern.ch//eos/opendata/atlas/rucio/user/egramsta/mc_410471.PhPy8EG_A14_ttbar_hdamp258p75_allhad.noskim.root"
+      },
+      {
+        "checksum": "adler32:9eb02c6e",
+        "size": 62393978,
+        "uri": "root://eospublic.cern.ch//eos/opendata/atlas/rucio/user/egramsta/mc_410560.MadGraphPythia8EvtGen_A14_tZ_4fl_tchan_noAllHad.noskim.root"
+      },
+      {
+        "checksum": "adler32:fc55386e",
+        "size": 70206576,
+        "uri": "root://eospublic.cern.ch//eos/opendata/atlas/rucio/user/egramsta/mc_410644.PowhegPythia8EvtGen_A14_singletop_schan_lept_top.noskim.root"
+      },
+      {
+        "checksum": "adler32:b880d23e",
+        "size": 46816794,
+        "uri": "root://eospublic.cern.ch//eos/opendata/atlas/rucio/user/egramsta/mc_410645.PowhegPythia8EvtGen_A14_singletop_schan_lept_antitop.noskim.root"
+      },
+      {
+        "checksum": "adler32:883d1654",
+        "size": 1293796328,
+        "uri": "root://eospublic.cern.ch//eos/opendata/atlas/rucio/user/egramsta/mc_410658.PhPy8EG_A14_tchan_BW50_lept_top.noskim.root"
+      },
+      {
+        "checksum": "adler32:4251e5d0",
+        "size": 772721701,
+        "uri": "root://eospublic.cern.ch//eos/opendata/atlas/rucio/user/egramsta/mc_410659.PhPy8EG_A14_tchan_BW50_lept_antitop.noskim.root"
+      },
+      {
+        "checksum": "adler32:02f3868b",
+        "size": 3252778802,
+        "uri": "root://eospublic.cern.ch//eos/opendata/atlas/rucio/user/egramsta/mc_411233.PowhegHerwig7EvtGen_tt_hdamp258p75_713_SingleLep.noskim.root"
+      },
+      {
+        "checksum": "adler32:047a8d60",
+        "size": 1594193400,
+        "uri": "root://eospublic.cern.ch//eos/opendata/atlas/rucio/user/egramsta/mc_411234.PowhegHerwig7EvtGen_tt_hdamp258p75_713_dil.noskim.root"
+      },
+      {
+        "checksum": "adler32:7d8c4144",
+        "size": 11793534047,
+        "uri": "root://eospublic.cern.ch//eos/opendata/atlas/rucio/user/egramsta/mc_411316.PowhegHerwig7EvtGen_tt_hdamp258p75_713_allhad.noskim.root"
+      },
+      {
+        "checksum": "adler32:b152e030",
+        "size": 117722003,
+        "uri": "root://eospublic.cern.ch//eos/opendata/atlas/rucio/user/egramsta/mc_412043.aMcAtNloPythia8EvtGen_A14NNPDF31_SM4topsNLO.noskim.root"
+      },
+      {
+        "checksum": "adler32:d6644327",
+        "size": 114423255,
+        "uri": "root://eospublic.cern.ch//eos/opendata/atlas/rucio/user/egramsta/mc_412044.aMcAtNloHerwig7EvtGen_H7UE_SM4topsNLO.noskim.root"
+      },
+      {
+        "checksum": "adler32:baa0815d",
+        "size": 611381910,
+        "uri": "root://eospublic.cern.ch//eos/opendata/atlas/rucio/user/egramsta/mc_423099.Pythia8EvtGen_A14NNPDF23LO_gammajet_DP8_17.noskim.root"
+      },
+      {
+        "checksum": "adler32:6338548d",
+        "size": 631378407,
+        "uri": "root://eospublic.cern.ch//eos/opendata/atlas/rucio/user/egramsta/mc_423100.Pythia8EvtGen_A14NNPDF23LO_gammajet_DP17_35.noskim.root"
+      },
+      {
+        "checksum": "adler32:a4221b18",
+        "size": 725078115,
+        "uri": "root://eospublic.cern.ch//eos/opendata/atlas/rucio/user/egramsta/mc_423101.Pythia8EvtGen_A14NNPDF23LO_gammajet_DP35_50.noskim.root"
+      },
+      {
+        "checksum": "adler32:7403857d",
+        "size": 1007160136,
+        "uri": "root://eospublic.cern.ch//eos/opendata/atlas/rucio/user/egramsta/mc_423102.Pythia8EvtGen_A14NNPDF23LO_gammajet_DP50_70.noskim.root"
+      },
+      {
+        "checksum": "adler32:273e693a",
+        "size": 704049306,
+        "uri": "root://eospublic.cern.ch//eos/opendata/atlas/rucio/user/egramsta/mc_423103.Pythia8EvtGen_A14NNPDF23LO_gammajet_DP70_140.noskim.root"
+      },
+      {
+        "checksum": "adler32:90f18032",
+        "size": 765556743,
+        "uri": "root://eospublic.cern.ch//eos/opendata/atlas/rucio/user/egramsta/mc_423104.Pythia8EvtGen_A14NNPDF23LO_gammajet_DP140_280.noskim.root"
+      },
+      {
+        "checksum": "adler32:e371db83",
+        "size": 587000735,
+        "uri": "root://eospublic.cern.ch//eos/opendata/atlas/rucio/user/egramsta/mc_423105.Pythia8EvtGen_A14NNPDF23LO_gammajet_DP280_500.noskim.root"
+      },
+      {
+        "checksum": "adler32:19b7923c",
+        "size": 65034780,
+        "uri": "root://eospublic.cern.ch//eos/opendata/atlas/rucio/user/egramsta/mc_423106.Pythia8EvtGen_A14NNPDF23LO_gammajet_DP500_800.noskim.root"
+      },
+      {
+        "checksum": "adler32:c26b2a72",
+        "size": 36016666,
+        "uri": "root://eospublic.cern.ch//eos/opendata/atlas/rucio/user/egramsta/mc_423107.Pythia8EvtGen_A14NNPDF23LO_gammajet_DP800_1000.noskim.root"
+      },
+      {
+        "checksum": "adler32:bf574df0",
+        "size": 45502366,
+        "uri": "root://eospublic.cern.ch//eos/opendata/atlas/rucio/user/egramsta/mc_423108.Pythia8EvtGen_A14NNPDF23LO_gammajet_DP1000_1500.noskim.root"
+      },
+      {
+        "checksum": "adler32:43f49a50",
+        "size": 14654363,
+        "uri": "root://eospublic.cern.ch//eos/opendata/atlas/rucio/user/egramsta/mc_423109.Pythia8EvtGen_A14NNPDF23LO_gammajet_DP1500_2000.noskim.root"
+      },
+      {
+        "checksum": "adler32:a577f442",
+        "size": 10120187,
+        "uri": "root://eospublic.cern.ch//eos/opendata/atlas/rucio/user/egramsta/mc_423110.Pythia8EvtGen_A14NNPDF23LO_gammajet_DP2000_2500.noskim.root"
+      },
+      {
+        "checksum": "adler32:0c863771",
+        "size": 15508843,
+        "uri": "root://eospublic.cern.ch//eos/opendata/atlas/rucio/user/egramsta/mc_423111.Pythia8EvtGen_A14NNPDF23LO_gammajet_DP2500_3000.noskim.root"
+      },
+      {
+        "checksum": "adler32:ed60790f",
+        "size": 10561627,
+        "uri": "root://eospublic.cern.ch//eos/opendata/atlas/rucio/user/egramsta/mc_423112.Pythia8EvtGen_A14NNPDF23LO_gammajet_DP3000_inf.noskim.root"
+      },
+      {
+        "checksum": "adler32:87ef94b5",
+        "size": 7904905,
+        "uri": "root://eospublic.cern.ch//eos/opendata/atlas/rucio/user/egramsta/mc_448624.MGPy8EG_A14N23LO_TT_higgsinoRPV_1075_700.noskim.root"
+      },
+      {
+        "checksum": "adler32:a0e6103d",
+        "size": 6357318,
+        "uri": "root://eospublic.cern.ch//eos/opendata/atlas/rucio/user/egramsta/mc_449595.MGPy8EG_A14N23LO_TT_RPVdirectBL_1400.noskim.root"
+      },
+      {
+        "checksum": "adler32:187e2c98",
+        "size": 21595735,
+        "uri": "root://eospublic.cern.ch//eos/opendata/atlas/rucio/user/egramsta/mc_450576.PowhegPythia8EvtGen_NNLOPS_nnlo_30_VBFH125_ZZllbb.noskim.root"
+      },
+      {
+        "checksum": "adler32:aa015fc5",
+        "size": 58844578,
+        "uri": "root://eospublic.cern.ch//eos/opendata/atlas/rucio/user/egramsta/mc_500335.MGH7EG_VBFHWWlvlv.noskim.root"
+      },
+      {
+        "checksum": "adler32:8c037155",
+        "size": 20896321,
+        "uri": "root://eospublic.cern.ch//eos/opendata/atlas/rucio/user/egramsta/mc_500553.aMCPy8EG_ZH_FxFx_Hyy.noskim.root"
+      },
+      {
+        "checksum": "adler32:e9b9bc1e",
+        "size": 17579700,
+        "uri": "root://eospublic.cern.ch//eos/opendata/atlas/rucio/user/egramsta/mc_500554.aMCPy8EG_WH_FxFx_Hyy.noskim.root"
+      },
+      {
+        "checksum": "adler32:a9d26464",
+        "size": 17971347,
+        "uri": "root://eospublic.cern.ch//eos/opendata/atlas/rucio/user/egramsta/mc_500555.aMCPy8EG_ggZH_Hyy.noskim.root"
+      },
+      {
+        "checksum": "adler32:5839f018",
+        "size": 20263106,
+        "uri": "root://eospublic.cern.ch//eos/opendata/atlas/rucio/user/egramsta/mc_501058.MGPy8EG_StauStauDirect_200p0_1p0_TFilt.noskim.root"
+      },
+      {
+        "checksum": "adler32:2743f898",
+        "size": 34581238,
+        "uri": "root://eospublic.cern.ch//eos/opendata/atlas/rucio/user/egramsta/mc_506098.aMCPy8EG_WpH_FxFx_Htautau.noskim.root"
+      },
+      {
+        "checksum": "adler32:4bac3491",
+        "size": 26060119,
+        "uri": "root://eospublic.cern.ch//eos/opendata/atlas/rucio/user/egramsta/mc_506099.aMCPy8EG_ZH_FxFx_Htautau.noskim.root"
+      },
+      {
+        "checksum": "adler32:6c9d2c69",
+        "size": 79091417,
+        "uri": "root://eospublic.cern.ch//eos/opendata/atlas/rucio/user/egramsta/mc_506101.aMCH7EG_VBF_Htautauh30h20.noskim.root"
+      },
+      {
+        "checksum": "adler32:ce0f25c9",
+        "size": 67964855,
+        "uri": "root://eospublic.cern.ch//eos/opendata/atlas/rucio/user/egramsta/mc_506102.aMCH7EG_VBF_Htautaul13l7.noskim.root"
+      },
+      {
+        "checksum": "adler32:ba919b26",
+        "size": 50799253,
+        "uri": "root://eospublic.cern.ch//eos/opendata/atlas/rucio/user/egramsta/mc_506103.aMCH7EG_VBF_Htautaulp15hm20.noskim.root"
+      },
+      {
+        "checksum": "adler32:7b220713",
+        "size": 84626368,
+        "uri": "root://eospublic.cern.ch//eos/opendata/atlas/rucio/user/egramsta/mc_506104.aMCH7EG_VBF_Htautaulm15hp20.noskim.root"
+      },
+      {
+        "checksum": "adler32:6842eb57",
+        "size": 56812927,
+        "uri": "root://eospublic.cern.ch//eos/opendata/atlas/rucio/user/egramsta/mc_506811.aMCH7EG_VBF_HC_Hyy.noskim.root"
+      },
+      {
+        "checksum": "adler32:1c585e1e",
+        "size": 17428650,
+        "uri": "root://eospublic.cern.ch//eos/opendata/atlas/rucio/user/egramsta/mc_506813.aMCPy8EG_ZH_had_FxFx_Hyy.noskim.root"
+      },
+      {
+        "checksum": "adler32:2f670e53",
+        "size": 18890116,
+        "uri": "root://eospublic.cern.ch//eos/opendata/atlas/rucio/user/egramsta/mc_506814.aMCPy8EG_ggZH_Zhad_Hyy.noskim.root"
+      },
+      {
+        "checksum": "adler32:b0c8a67e",
+        "size": 4528025,
+        "uri": "root://eospublic.cern.ch//eos/opendata/atlas/rucio/user/egramsta/mc_507366.MGPy8EG_A14NNPDF23LO_GGM_N1N2C1_950.noskim.root"
+      },
+      {
+        "checksum": "adler32:0228162a",
+        "size": 14640374,
+        "uri": "root://eospublic.cern.ch//eos/opendata/atlas/rucio/user/egramsta/mc_510097.MGPy8EG_A14N23LO_DM_4topscalar_p1000_c1_nonallhad.noskim.root"
+      },
+      {
+        "checksum": "adler32:ccb30f47",
+        "size": 5499864,
+        "uri": "root://eospublic.cern.ch//eos/opendata/atlas/rucio/user/egramsta/mc_523692.MGPy8EG_A14N23LO_TT_tN1_1200_200_MS.noskim.root"
+      },
+      {
+        "checksum": "adler32:e7ad1290",
+        "size": 622853363,
+        "uri": "root://eospublic.cern.ch//eos/opendata/atlas/rucio/user/egramsta/mc_600017.PhH7EG_H7UE_716_tchan_lept_antitop.noskim.root"
+      },
+      {
+        "checksum": "adler32:cd5b3e22",
+        "size": 1073650029,
+        "uri": "root://eospublic.cern.ch//eos/opendata/atlas/rucio/user/egramsta/mc_600018.PhH7EG_H7UE_716_tchan_lept_top.noskim.root"
+      },
+      {
+        "checksum": "adler32:b73ead98",
+        "size": 55230789,
+        "uri": "root://eospublic.cern.ch//eos/opendata/atlas/rucio/user/egramsta/mc_600019.PhH7EG_H7UE_716_schan_lept_antitop.noskim.root"
+      },
+      {
+        "checksum": "adler32:74a3dcb6",
+        "size": 63075188,
+        "uri": "root://eospublic.cern.ch//eos/opendata/atlas/rucio/user/egramsta/mc_600020.PhH7EG_H7UE_716_schan_lept_top.noskim.root"
+      },
+      {
+        "checksum": "adler32:ad569ad0",
+        "size": 353734705,
+        "uri": "root://eospublic.cern.ch//eos/opendata/atlas/rucio/user/egramsta/mc_600565.PhH7EG_ggH125_tautauh30h20_ShowerSys_fix.noskim.root"
+      },
+      {
+        "checksum": "adler32:2cdf4f01",
+        "size": 263144613,
+        "uri": "root://eospublic.cern.ch//eos/opendata/atlas/rucio/user/egramsta/mc_600566.PhH7EG_ggH125_tautaul13l7_ShowerSys_fix.noskim.root"
+      },
+      {
+        "checksum": "adler32:d84214d3",
+        "size": 141743949,
+        "uri": "root://eospublic.cern.ch//eos/opendata/atlas/rucio/user/egramsta/mc_600567.PhH7EG_ggH125_ttlp15hm20_ShowerSys_fix.noskim.root"
+      },
+      {
+        "checksum": "adler32:cb797d78",
+        "size": 161005527,
+        "uri": "root://eospublic.cern.ch//eos/opendata/atlas/rucio/user/egramsta/mc_600568.PhH7EG_ggH125_ttlm15hp20_ShowerSys_fix.noskim.root"
+      },
+      {
+        "checksum": "adler32:fcb64375",
+        "size": 94915495,
+        "uri": "root://eospublic.cern.ch//eos/opendata/atlas/rucio/user/egramsta/mc_600569.PhH7EG_VBFH125_tautauh30h20_ShowerSys_fix.noskim.root"
+      },
+      {
+        "checksum": "adler32:8da3e55d",
+        "size": 66081719,
+        "uri": "root://eospublic.cern.ch//eos/opendata/atlas/rucio/user/egramsta/mc_600570.PhH7EG_VBFH125_tautaul13l7_ShowerSys_fix.noskim.root"
+      },
+      {
+        "checksum": "adler32:9730ae12",
+        "size": 33819491,
+        "uri": "root://eospublic.cern.ch//eos/opendata/atlas/rucio/user/egramsta/mc_600571.PhH7EG_VBFH125_tautaulp15hm20_ShowerSys_fix.noskim.root"
+      },
+      {
+        "checksum": "adler32:7184a236",
+        "size": 33857769,
+        "uri": "root://eospublic.cern.ch//eos/opendata/atlas/rucio/user/egramsta/mc_600572.PhH7EG_VBFH125_tautaulm15hp20_ShowerSys_fix.noskim.root"
+      },
+      {
+        "checksum": "adler32:3e2fe42c",
+        "size": 21503344,
+        "uri": "root://eospublic.cern.ch//eos/opendata/atlas/rucio/user/egramsta/mc_600573.PhH7EG_WmH125J_Winc_MINLO_tt_ShowerSys_fix.noskim.root"
+      },
+      {
+        "checksum": "adler32:f0a366f0",
+        "size": 34120751,
+        "uri": "root://eospublic.cern.ch//eos/opendata/atlas/rucio/user/egramsta/mc_600574.PhH7EG_WpH125J_Winc_MINLO_tt_ShowerSys_fix.noskim.root"
+      },
+      {
+        "checksum": "adler32:1ac171cd",
+        "size": 38201998,
+        "uri": "root://eospublic.cern.ch//eos/opendata/atlas/rucio/user/egramsta/mc_600575.PhH7EG_ZH125J_Zinc_MINLO_tautau_ShowerSys_fix.noskim.root"
+      },
+      {
+        "checksum": "adler32:866a19ea",
+        "size": 18783110,
+        "uri": "root://eospublic.cern.ch//eos/opendata/atlas/rucio/user/egramsta/mc_600686.PhPy8EG_NNPDF3_AZNLO_ggZH125_Htautau_Zinc.noskim.root"
+      },
+      {
+        "checksum": "adler32:4ccf1245",
+        "size": 1220606675,
+        "uri": "root://eospublic.cern.ch//eos/opendata/atlas/rucio/user/egramsta/mc_601352.PhPy8EG_tW_dyn_DR_incl_antitop.noskim.root"
+      },
+      {
+        "checksum": "adler32:84c66511",
+        "size": 1204268157,
+        "uri": "root://eospublic.cern.ch//eos/opendata/atlas/rucio/user/egramsta/mc_601355.PhPy8EG_tW_dyn_DR_incl_top.noskim.root"
+      },
+      {
+        "checksum": "adler32:0891a94e",
+        "size": 653081747,
+        "uri": "root://eospublic.cern.ch//eos/opendata/atlas/rucio/user/egramsta/mc_601487.PhPy8EG_A14_tchan_pThard1_lep_antitop.noskim.root"
+      },
+      {
+        "checksum": "adler32:0cf296f3",
+        "size": 1064279033,
+        "uri": "root://eospublic.cern.ch//eos/opendata/atlas/rucio/user/egramsta/mc_601489.PhPy8EG_A14_tchan_pThard1_lep_top.noskim.root"
+      },
+      {
+        "checksum": "adler32:cad76ac0",
+        "size": 2718918419,
+        "uri": "root://eospublic.cern.ch//eos/opendata/atlas/rucio/user/egramsta/mc_601491.PhPy8EG_A14_ttbar_pThard1_dil.noskim.root"
+      },
+      {
+        "checksum": "adler32:16422a7d",
+        "size": 87618393,
+        "uri": "root://eospublic.cern.ch//eos/opendata/atlas/rucio/user/egramsta/mc_601495.PhPy8EG_A14_ttbar_pThard1_allhad.noskim.root"
+      },
+      {
+        "checksum": "adler32:0a118764",
+        "size": 11518563652,
+        "uri": "root://eospublic.cern.ch//eos/opendata/atlas/rucio/user/egramsta/mc_601497.PhPy8EG_A14_ttbar_pThard1_singlelep.noskim.root"
+      },
+      {
+        "checksum": "adler32:d6113874",
+        "size": 136709963,
+        "uri": "root://eospublic.cern.ch//eos/opendata/atlas/rucio/user/egramsta/mc_601624.PhPy8EG_tW_DS_dyn_dil_antitop.noskim.root"
+      },
+      {
+        "checksum": "adler32:bcb5cdc5",
+        "size": 1200229138,
+        "uri": "root://eospublic.cern.ch//eos/opendata/atlas/rucio/user/egramsta/mc_601627.PhPy8EG_tW_DS_dyn_incl_antitop.noskim.root"
+      },
+      {
+        "checksum": "adler32:4dd48a10",
+        "size": 171280290,
+        "uri": "root://eospublic.cern.ch//eos/opendata/atlas/rucio/user/egramsta/mc_601628.PhPy8EG_tW_DS_dyn_dil_top.noskim.root"
+      },
+      {
+        "checksum": "adler32:7c7e7c3d",
+        "size": 1157719140,
+        "uri": "root://eospublic.cern.ch//eos/opendata/atlas/rucio/user/egramsta/mc_601631.PhPy8EG_tW_DS_dyn_incl_top.noskim.root"
+      },
+      {
+        "checksum": "adler32:7b30c4ba",
+        "size": 1224412008,
+        "uri": "root://eospublic.cern.ch//eos/opendata/atlas/rucio/user/egramsta/mc_601761.PhPy8EG_tW_dyn_DR_pThard1_incl_top.noskim.root"
+      },
+      {
+        "checksum": "adler32:4532d766",
+        "size": 1206691612,
+        "uri": "root://eospublic.cern.ch//eos/opendata/atlas/rucio/user/egramsta/mc_601762.PhPy8EG_tW_dyn_DR_pThard1_incl_antitop.noskim.root"
+      },
+      {
+        "checksum": "adler32:613b7f6a",
+        "size": 173180233,
+        "uri": "root://eospublic.cern.ch//eos/opendata/atlas/rucio/user/egramsta/mc_601763.PhPy8EG_tW_dyn_DR_pThard1_dil_top.noskim.root"
+      },
+      {
+        "checksum": "adler32:04e7e56a",
+        "size": 173322732,
+        "uri": "root://eospublic.cern.ch//eos/opendata/atlas/rucio/user/egramsta/mc_601764.PhPy8EG_tW_dyn_DR_pThard1_dil_antitop.noskim.root"
+      },
+      {
+        "checksum": "adler32:ef565278",
+        "size": 95085778,
+        "uri": "root://eospublic.cern.ch//eos/opendata/atlas/rucio/user/egramsta/mc_700000.Sh_228_ttW.noskim.root"
+      },
+      {
+        "checksum": "adler32:06ece651",
+        "size": 21203526,
+        "uri": "root://eospublic.cern.ch//eos/opendata/atlas/rucio/user/egramsta/mc_700007.Sh_228_yyy_01NLO.noskim.root"
+      },
+      {
+        "checksum": "adler32:3c1a9a02",
+        "size": 56450782,
+        "uri": "root://eospublic.cern.ch//eos/opendata/atlas/rucio/user/egramsta/mc_700195.Sh_2210_eegammagamma.noskim.root"
+      },
+      {
+        "checksum": "adler32:c148a6d9",
+        "size": 92966644,
+        "uri": "root://eospublic.cern.ch//eos/opendata/atlas/rucio/user/egramsta/mc_700196.Sh_2210_mumugammagamma.noskim.root"
+      },
+      {
+        "checksum": "adler32:22753dcf",
+        "size": 37245720,
+        "uri": "root://eospublic.cern.ch//eos/opendata/atlas/rucio/user/egramsta/mc_700197.Sh_2210_tautaugammagamma.noskim.root"
+      },
+      {
+        "checksum": "adler32:60e76c29",
+        "size": 15457263,
+        "uri": "root://eospublic.cern.ch//eos/opendata/atlas/rucio/user/egramsta/mc_700198.Sh_2210_nunugammagamma.noskim.root"
+      },
+      {
+        "checksum": "adler32:588372cc",
+        "size": 51930646,
+        "uri": "root://eospublic.cern.ch//eos/opendata/atlas/rucio/user/egramsta/mc_700199.Sh_2210_enugammagamma.noskim.root"
+      },
+      {
+        "checksum": "adler32:2fec0ce3",
+        "size": 51036666,
+        "uri": "root://eospublic.cern.ch//eos/opendata/atlas/rucio/user/egramsta/mc_700200.Sh_2210_munugammagamma.noskim.root"
+      },
+      {
+        "checksum": "adler32:96dd8743",
+        "size": 50152970,
+        "uri": "root://eospublic.cern.ch//eos/opendata/atlas/rucio/user/egramsta/mc_700201.Sh_2210_taunugammagamma.noskim.root"
+      },
+      {
+        "checksum": "adler32:71f7a73b",
+        "size": 1946303752,
+        "uri": "root://eospublic.cern.ch//eos/opendata/atlas/rucio/user/egramsta/mc_700320.Sh_2211_Zee_maxHTpTV2_BFilter.noskim.root"
+      },
+      {
+        "checksum": "adler32:51344088",
+        "size": 9213651827,
+        "uri": "root://eospublic.cern.ch//eos/opendata/atlas/rucio/user/egramsta/mc_700321.Sh_2211_Zee_maxHTpTV2_CFilterBVeto.noskim.root"
+      },
+      {
+        "checksum": "adler32:97d04c78",
+        "size": 33029752207,
+        "uri": "root://eospublic.cern.ch//eos/opendata/atlas/rucio/user/egramsta/mc_700322.Sh_2211_Zee_maxHTpTV2_CVetoBVeto.noskim.root"
+      },
+      {
+        "checksum": "adler32:c1380c56",
+        "size": 1834709465,
+        "uri": "root://eospublic.cern.ch//eos/opendata/atlas/rucio/user/egramsta/mc_700323.Sh_2211_Zmumu_maxHTpTV2_BFilter.noskim.root"
+      },
+      {
+        "checksum": "adler32:ef43058b",
+        "size": 9094583471,
+        "uri": "root://eospublic.cern.ch//eos/opendata/atlas/rucio/user/egramsta/mc_700324.Sh_2211_Zmumu_maxHTpTV2_CFilterBVeto.noskim.root"
+      },
+      {
+        "checksum": "adler32:d331ff87",
+        "size": 32732879568,
+        "uri": "root://eospublic.cern.ch//eos/opendata/atlas/rucio/user/egramsta/mc_700325.Sh_2211_Zmumu_maxHTpTV2_CVetoBVeto.noskim.root"
+      },
+      {
+        "checksum": "adler32:d7be0c38",
+        "size": 907783799,
+        "uri": "root://eospublic.cern.ch//eos/opendata/atlas/rucio/user/egramsta/mc_700335.Sh_2211_Znunu_pTV2_BFilter.noskim.root"
+      },
+      {
+        "checksum": "adler32:f259e9ba",
+        "size": 2038829040,
+        "uri": "root://eospublic.cern.ch//eos/opendata/atlas/rucio/user/egramsta/mc_700336.Sh_2211_Znunu_pTV2_CFilterBVeto.noskim.root"
+      },
+      {
+        "checksum": "adler32:888cc886",
+        "size": 6530839256,
+        "uri": "root://eospublic.cern.ch//eos/opendata/atlas/rucio/user/egramsta/mc_700337.Sh_2211_Znunu_pTV2_CVetoBVeto.noskim.root"
+      },
+      {
+        "checksum": "adler32:09eb0f50",
+        "size": 6460373255,
+        "uri": "root://eospublic.cern.ch//eos/opendata/atlas/rucio/user/egramsta/mc_700338.Sh_2211_Wenu_maxHTpTV2_BFilter.noskim.root"
+      },
+      {
+        "checksum": "adler32:221982c1",
+        "size": 50100536277,
+        "uri": "root://eospublic.cern.ch//eos/opendata/atlas/rucio/user/egramsta/mc_700339.Sh_2211_Wenu_maxHTpTV2_CFilterBVeto.noskim.root"
+      },
+      {
+        "checksum": "adler32:bc3e6bd2",
+        "size": 60002625652,
+        "uri": "root://eospublic.cern.ch//eos/opendata/atlas/rucio/user/egramsta/mc_700340.Sh_2211_Wenu_maxHTpTV2_CVetoBVeto.noskim.root"
+      },
+      {
+        "checksum": "adler32:82499132",
+        "size": 6743849459,
+        "uri": "root://eospublic.cern.ch//eos/opendata/atlas/rucio/user/egramsta/mc_700341.Sh_2211_Wmunu_maxHTpTV2_BFilter.noskim.root"
+      },
+      {
+        "checksum": "adler32:34f5641c",
+        "size": 46239260195,
+        "uri": "root://eospublic.cern.ch//eos/opendata/atlas/rucio/user/egramsta/mc_700342.Sh_2211_Wmunu_maxHTpTV2_CFilterBVeto.noskim.root"
+      },
+      {
+        "checksum": "adler32:067f3ed0",
+        "size": 53174843275,
+        "uri": "root://eospublic.cern.ch//eos/opendata/atlas/rucio/user/egramsta/mc_700343.Sh_2211_Wmunu_maxHTpTV2_CVetoBVeto.noskim.root"
+      },
+      {
+        "checksum": "adler32:7832b113",
+        "size": 2233032031,
+        "uri": "root://eospublic.cern.ch//eos/opendata/atlas/rucio/user/egramsta/mc_700344.Sh_2211_Wtaunu_L_maxHTpTV2_BFilter.noskim.root"
+      },
+      {
+        "checksum": "adler32:2751de3d",
+        "size": 9522743204,
+        "uri": "root://eospublic.cern.ch//eos/opendata/atlas/rucio/user/egramsta/mc_700345.Sh_2211_Wtaunu_L_maxHTpTV2_CFilterBVeto.noskim.root"
+      },
+      {
+        "checksum": "adler32:073ed1ca",
+        "size": 19931473752,
+        "uri": "root://eospublic.cern.ch//eos/opendata/atlas/rucio/user/egramsta/mc_700346.Sh_2211_Wtaunu_L_maxHTpTV2_CVetoBVeto.noskim.root"
+      },
+      {
+        "checksum": "adler32:00adaf83",
+        "size": 2936280511,
+        "uri": "root://eospublic.cern.ch//eos/opendata/atlas/rucio/user/egramsta/mc_700347.Sh_2211_Wtaunu_H_maxHTpTV2_BFilter.noskim.root"
+      },
+      {
+        "checksum": "adler32:52c8ae1c",
+        "size": 2817815845,
+        "uri": "root://eospublic.cern.ch//eos/opendata/atlas/rucio/user/egramsta/mc_700348.Sh_2211_Wtaunu_H_maxHTpTV2_CFilterBVeto.noskim.root"
+      },
+      {
+        "checksum": "adler32:73d81602",
+        "size": 18520763121,
+        "uri": "root://eospublic.cern.ch//eos/opendata/atlas/rucio/user/egramsta/mc_700349.Sh_2211_Wtaunu_H_maxHTpTV2_CVetoBVeto.noskim.root"
+      },
+      {
+        "checksum": "adler32:95b48eee",
+        "size": 156434267,
+        "uri": "root://eospublic.cern.ch//eos/opendata/atlas/rucio/user/egramsta/mc_700352.Sh_2211_pTZ100_Zqqgamma.noskim.root"
+      },
+      {
+        "checksum": "adler32:5902e56d",
+        "size": 72441332,
+        "uri": "root://eospublic.cern.ch//eos/opendata/atlas/rucio/user/egramsta/mc_700353.Sh_2211_pTZ100_Zbbgamma.noskim.root"
+      },
+      {
+        "checksum": "adler32:a926bdc6",
+        "size": 71812893,
+        "uri": "root://eospublic.cern.ch//eos/opendata/atlas/rucio/user/egramsta/mc_700358.Sh_2211_Zee2jets_Min_N_TChannel.noskim.root"
+      },
+      {
+        "checksum": "adler32:9cb2401f",
+        "size": 59046042,
+        "uri": "root://eospublic.cern.ch//eos/opendata/atlas/rucio/user/egramsta/mc_700359.Sh_2211_Zmm2jets_Min_N_TChannel.noskim.root"
+      },
+      {
+        "checksum": "adler32:46a0f9fd",
+        "size": 60349058,
+        "uri": "root://eospublic.cern.ch//eos/opendata/atlas/rucio/user/egramsta/mc_700360.Sh_2211_Ztt2jets_Min_N_TChannel.noskim.root"
+      },
+      {
+        "checksum": "adler32:86c238b6",
+        "size": 87638370,
+        "uri": "root://eospublic.cern.ch//eos/opendata/atlas/rucio/user/egramsta/mc_700361.Sh_2211_Znunu2jets_Min_N_TChannel.noskim.root"
+      },
+      {
+        "checksum": "adler32:2ab51d7b",
+        "size": 282559830,
+        "uri": "root://eospublic.cern.ch//eos/opendata/atlas/rucio/user/egramsta/mc_700362.Sh_2211_Wenu2jets_Min_N_TChannel.noskim.root"
+      },
+      {
+        "checksum": "adler32:6974710c",
+        "size": 316258169,
+        "uri": "root://eospublic.cern.ch//eos/opendata/atlas/rucio/user/egramsta/mc_700363.Sh_2211_Wmunu2jets_Min_N_TChannel.noskim.root"
+      },
+      {
+        "checksum": "adler32:dbc3f7b2",
+        "size": 243168481,
+        "uri": "root://eospublic.cern.ch//eos/opendata/atlas/rucio/user/egramsta/mc_700364.Sh_2211_Wtaunu2jets_Min_N_TChannel.noskim.root"
+      },
+      {
+        "checksum": "adler32:6a569191",
+        "size": 2991545093,
+        "uri": "root://eospublic.cern.ch//eos/opendata/atlas/rucio/user/egramsta/mc_700398.Sh_2211_mumugamma.noskim.root"
+      },
+      {
+        "checksum": "adler32:275fbdfa",
+        "size": 3015684786,
+        "uri": "root://eospublic.cern.ch//eos/opendata/atlas/rucio/user/egramsta/mc_700399.Sh_2211_eegamma.noskim.root"
+      },
+      {
+        "checksum": "adler32:27ce980d",
+        "size": 3030855046,
+        "uri": "root://eospublic.cern.ch//eos/opendata/atlas/rucio/user/egramsta/mc_700400.Sh_2211_tautaugamma.noskim.root"
+      },
+      {
+        "checksum": "adler32:0f057796",
+        "size": 1332525398,
+        "uri": "root://eospublic.cern.ch//eos/opendata/atlas/rucio/user/egramsta/mc_700401.Sh_2211_nunugamma.noskim.root"
+      },
+      {
+        "checksum": "adler32:12356c73",
+        "size": 9770978448,
+        "uri": "root://eospublic.cern.ch//eos/opendata/atlas/rucio/user/egramsta/mc_700402.Sh_2211_munugamma.noskim.root"
+      },
+      {
+        "checksum": "adler32:911cc902",
+        "size": 9842886102,
+        "uri": "root://eospublic.cern.ch//eos/opendata/atlas/rucio/user/egramsta/mc_700403.Sh_2211_enugamma.noskim.root"
+      },
+      {
+        "checksum": "adler32:dfb1913c",
+        "size": 9680723661,
+        "uri": "root://eospublic.cern.ch//eos/opendata/atlas/rucio/user/egramsta/mc_700404.Sh_2211_taunugamma.noskim.root"
+      },
+      {
+        "checksum": "adler32:f1598583",
+        "size": 38663520,
+        "uri": "root://eospublic.cern.ch//eos/opendata/atlas/rucio/user/egramsta/mc_700442.Sh_2211_gamma2jets_pTy140_Min_N_TChannel.noskim.root"
+      },
+      {
+        "checksum": "adler32:de742cd4",
+        "size": 266333679,
+        "uri": "root://eospublic.cern.ch//eos/opendata/atlas/rucio/user/egramsta/mc_700467.Sh_2211_Zee_maxHTpTV2_m10_40_pT5_BFilter.noskim.root"
+      },
+      {
+        "checksum": "adler32:60ddd539",
+        "size": 1397053911,
+        "uri": "root://eospublic.cern.ch//eos/opendata/atlas/rucio/user/egramsta/mc_700468.Sh_2211_Zee_maxHTpTV2_m10_40_pT5_CFilterBVeto.noskim.root"
+      },
+      {
+        "checksum": "adler32:76f0626e",
+        "size": 11636951147,
+        "uri": "root://eospublic.cern.ch//eos/opendata/atlas/rucio/user/egramsta/mc_700469.Sh_2211_Zee_maxHTpTV2_m10_40_pT5_CVetoBVeto.noskim.root"
+      },
+      {
+        "checksum": "adler32:43ea8371",
+        "size": 285235672,
+        "uri": "root://eospublic.cern.ch//eos/opendata/atlas/rucio/user/egramsta/mc_700470.Sh_2211_Zmumu_maxHTpTV2_m10_40_pT5_BFilter.noskim.root"
+      },
+      {
+        "checksum": "adler32:687b49f2",
+        "size": 1388333366,
+        "uri": "root://eospublic.cern.ch//eos/opendata/atlas/rucio/user/egramsta/mc_700471.Sh_2211_Zmumu_maxHTpTV2_m10_40_pT5_CFilterBVeto.noskim.root"
+      },
+      {
+        "checksum": "adler32:273b8e19",
+        "size": 11620351105,
+        "uri": "root://eospublic.cern.ch//eos/opendata/atlas/rucio/user/egramsta/mc_700472.Sh_2211_Zmumu_maxHTpTV2_m10_40_pT5_CVetoBVeto.noskim.root"
+      },
+      {
+        "checksum": "adler32:34a4f8a0",
+        "size": 1403846633,
+        "uri": "root://eospublic.cern.ch//eos/opendata/atlas/rucio/user/egramsta/mc_700488.Sh_2211_WlvWqq.noskim.root"
+      },
+      {
+        "checksum": "adler32:b496e577",
+        "size": 276584457,
+        "uri": "root://eospublic.cern.ch//eos/opendata/atlas/rucio/user/egramsta/mc_700489.Sh_2211_WlvZqq.noskim.root"
+      },
+      {
+        "checksum": "adler32:67e36e40",
+        "size": 83582544,
+        "uri": "root://eospublic.cern.ch//eos/opendata/atlas/rucio/user/egramsta/mc_700490.Sh_2211_WlvZbb.noskim.root"
+      },
+      {
+        "checksum": "adler32:acfca6a0",
+        "size": 174083317,
+        "uri": "root://eospublic.cern.ch//eos/opendata/atlas/rucio/user/egramsta/mc_700491.Sh_2211_WqqZvv.noskim.root"
+      },
+      {
+        "checksum": "adler32:5bc72e19",
+        "size": 111213685,
+        "uri": "root://eospublic.cern.ch//eos/opendata/atlas/rucio/user/egramsta/mc_700492.Sh_2211_WqqZll.noskim.root"
+      },
+      {
+        "checksum": "adler32:87c4f5b6",
+        "size": 89885468,
+        "uri": "root://eospublic.cern.ch//eos/opendata/atlas/rucio/user/egramsta/mc_700493.Sh_2211_ZqqZll.noskim.root"
+      },
+      {
+        "checksum": "adler32:01d57bdc",
+        "size": 76947197,
+        "uri": "root://eospublic.cern.ch//eos/opendata/atlas/rucio/user/egramsta/mc_700494.Sh_2211_ZbbZll.noskim.root"
+      },
+      {
+        "checksum": "adler32:ab54c58a",
+        "size": 93777446,
+        "uri": "root://eospublic.cern.ch//eos/opendata/atlas/rucio/user/egramsta/mc_700495.Sh_2211_ZqqZvv.noskim.root"
+      },
+      {
+        "checksum": "adler32:175c83c8",
+        "size": 32243870,
+        "uri": "root://eospublic.cern.ch//eos/opendata/atlas/rucio/user/egramsta/mc_700496.Sh_2211_ZbbZvv.noskim.root"
+      },
+      {
+        "checksum": "adler32:585a8814",
+        "size": 58580037,
+        "uri": "root://eospublic.cern.ch//eos/opendata/atlas/rucio/user/egramsta/mc_700507.Sh_2211_pTW140_Wqqgamma.noskim.root"
+      },
+      {
+        "checksum": "adler32:4e8db9de",
+        "size": 45039509,
+        "uri": "root://eospublic.cern.ch//eos/opendata/atlas/rucio/user/egramsta/mc_700587.Sh_2212_lllljj.noskim.root"
+      },
+      {
+        "checksum": "adler32:edabd3d1",
+        "size": 18513556,
+        "uri": "root://eospublic.cern.ch//eos/opendata/atlas/rucio/user/egramsta/mc_700588.Sh_2212_lllvjj.noskim.root"
+      },
+      {
+        "checksum": "adler32:4ee31bf9",
+        "size": 21174864,
+        "uri": "root://eospublic.cern.ch//eos/opendata/atlas/rucio/user/egramsta/mc_700589.Sh_2212_llvvjj_os.noskim.root"
+      },
+      {
+        "checksum": "adler32:91e0f1c9",
+        "size": 43036895,
+        "uri": "root://eospublic.cern.ch//eos/opendata/atlas/rucio/user/egramsta/mc_700590.Sh_2212_llvvjj_ss.noskim.root"
+      },
+      {
+        "checksum": "adler32:205a2d31",
+        "size": 8060196,
+        "uri": "root://eospublic.cern.ch//eos/opendata/atlas/rucio/user/egramsta/mc_700591.Sh_2212_lllljj_Int.noskim.root"
+      },
+      {
+        "checksum": "adler32:e524b21b",
+        "size": 8848479,
+        "uri": "root://eospublic.cern.ch//eos/opendata/atlas/rucio/user/egramsta/mc_700592.Sh_2212_lllvjj_Int.noskim.root"
+      },
+      {
+        "checksum": "adler32:e9b5a2e3",
+        "size": 9020518,
+        "uri": "root://eospublic.cern.ch//eos/opendata/atlas/rucio/user/egramsta/mc_700593.Sh_2212_llvvjj_os_Int.noskim.root"
+      },
+      {
+        "checksum": "adler32:5ed883c9",
+        "size": 9400793,
+        "uri": "root://eospublic.cern.ch//eos/opendata/atlas/rucio/user/egramsta/mc_700594.Sh_2212_llvvjj_ss_Int.noskim.root"
+      },
+      {
+        "checksum": "adler32:2a786403",
+        "size": 99626743,
+        "uri": "root://eospublic.cern.ch//eos/opendata/atlas/rucio/user/egramsta/mc_700600.Sh_2212_llll.noskim.root"
+      },
+      {
+        "checksum": "adler32:00c8eb46",
+        "size": 180333886,
+        "uri": "root://eospublic.cern.ch//eos/opendata/atlas/rucio/user/egramsta/mc_700601.Sh_2212_lllv.noskim.root"
+      },
+      {
+        "checksum": "adler32:833e046f",
+        "size": 363570202,
+        "uri": "root://eospublic.cern.ch//eos/opendata/atlas/rucio/user/egramsta/mc_700602.Sh_2212_llvv_os.noskim.root"
+      },
+      {
+        "checksum": "adler32:0980d9b3",
+        "size": 56529362,
+        "uri": "root://eospublic.cern.ch//eos/opendata/atlas/rucio/user/egramsta/mc_700603.Sh_2212_llvv_ss.noskim.root"
+      },
+      {
+        "checksum": "adler32:08c8eb11",
+        "size": 110268053,
+        "uri": "root://eospublic.cern.ch//eos/opendata/atlas/rucio/user/egramsta/mc_700604.Sh_2212_lvvv.noskim.root"
+      },
+      {
+        "checksum": "adler32:2554ee56",
+        "size": 38597512,
+        "uri": "root://eospublic.cern.ch//eos/opendata/atlas/rucio/user/egramsta/mc_700605.Sh_2212_vvvv.noskim.root"
+      },
+      {
+        "checksum": "adler32:ad79653b",
+        "size": 61193313,
+        "uri": "root://eospublic.cern.ch//eos/opendata/atlas/rucio/user/egramsta/mc_700709.Sh_2212_lvgammajj.noskim.root"
+      },
+      {
+        "checksum": "adler32:aa719d0a",
+        "size": 103788052,
+        "uri": "root://eospublic.cern.ch//eos/opendata/atlas/rucio/user/egramsta/mc_700710.Sh_2212_llgammajj.noskim.root"
+      },
+      {
+        "checksum": "adler32:c1ef78ca",
+        "size": 1909563593,
+        "uri": "root://eospublic.cern.ch//eos/opendata/atlas/rucio/user/egramsta/mc_700792.Sh_2214_Ztautau_maxHTpTV2_BFilter.noskim.root"
+      },
+      {
+        "checksum": "adler32:c122697f",
+        "size": 9213902099,
+        "uri": "root://eospublic.cern.ch//eos/opendata/atlas/rucio/user/egramsta/mc_700793.Sh_2214_Ztautau_maxHTpTV2_CFilterBVeto.noskim.root"
+      },
+      {
+        "checksum": "adler32:43ef6dc0",
+        "size": 20022466405,
+        "uri": "root://eospublic.cern.ch//eos/opendata/atlas/rucio/user/egramsta/mc_700794.Sh_2214_Ztautau_maxHTpTV2_CVetoBVeto.noskim.root"
+      },
+      {
+        "checksum": "adler32:aa81b56d",
+        "size": 4057129505,
+        "uri": "root://eospublic.cern.ch//eos/opendata/atlas/rucio/user/egramsta/mc_700843.Sh_2214_Wqq_ptW_200_ECMS.noskim.root"
+      },
+      {
+        "checksum": "adler32:b700acb0",
+        "size": 1420886294,
+        "uri": "root://eospublic.cern.ch//eos/opendata/atlas/rucio/user/egramsta/mc_700849.Sh_2214_Zqq_ptZ_200_ECMS.noskim.root"
+      },
+      {
+        "checksum": "adler32:7b498bea",
+        "size": 449514304,
+        "uri": "root://eospublic.cern.ch//eos/opendata/atlas/rucio/user/egramsta/mc_700855.Sh_2214_Zbb_ptZ_200_ECMS.noskim.root"
+      },
+      {
+        "checksum": "adler32:0f2b8d74",
+        "size": 526361738,
+        "uri": "root://eospublic.cern.ch//eos/opendata/atlas/rucio/user/egramsta/mc_700901.Sh_2214_Ztt_maxHTpTV2_Mll10_40_BFilter.noskim.root"
+      },
+      {
+        "checksum": "adler32:8bbc7a3a",
+        "size": 3576332324,
+        "uri": "root://eospublic.cern.ch//eos/opendata/atlas/rucio/user/egramsta/mc_700902.Sh_2214_Ztt_maxHTpTV2_Mll10_40_CFilterBVeto.noskim.root"
+      },
+      {
+        "checksum": "adler32:dbbbce65",
+        "size": 10237436736,
+        "uri": "root://eospublic.cern.ch//eos/opendata/atlas/rucio/user/egramsta/mc_700903.Sh_2214_Ztt_maxHTpTV2_Mll10_40_CVetoBVeto.noskim.root"
+      },
+      {
+        "checksum": "adler32:58e78e51",
+        "size": 18138935,
+        "uri": "root://eospublic.cern.ch//eos/opendata/atlas/rucio/user/egramsta/mc_801976.Py8EG_A14NNPDF23LO_Zprime_NoInt_tautau_SSM3000.noskim.root"
+      },
+      {
+        "checksum": "adler32:4db542be",
+        "size": 7245873,
+        "uri": "root://eospublic.cern.ch//eos/opendata/atlas/rucio/user/egramsta/mc_801978.Py8EG_A14NNPDF23LO_Wprime_taunu_SSM3000.noskim.root"
+      }
+    ],
+    "license": {
+      "attribution": "CC0-1.0"
+    },
+    "methodology": {
+      "description": "<p>These data were created during LS2 as part of a major reprocessing campaign of the Run 2 data. All data were reprocessed using Athena Release 22, and new corresponding MC simulation samples were produced. These data and MC simulation datasets were processed into ROOT ntuple files from the DAOD_PHYSLITE format that is released as open data for research. For the files in this record, the following skimming selection was applied: none."
+    },
+    "publisher": "CERN Open Data Portal",
+    "recid": "93911",
+    "relations": [
+      {
+        "description": "For citing all the Open Data for Education and Outreach from this release, and to find other related datasets, please see",
+        "doi": "10.7483/OPENDATA.ATLAS.B5M9.44TN",
+        "recid": "93910",
+        "title": "ROOT ntuple format 2015-2016 proton-proton Open Data for Education and Outreach from the ATLAS experiment",
+        "type": "isChildOf"
+      }
+    ],
+    "run_period": [
+      "2015",
+      "2016"
+    ],
+    "title": "ATLAS ROOT ntuple format MC simulation, 2015+2016 proton-proton collisions beta release, no skim",
+    "type": {
+      "primary": "Dataset",
+      "secondary": [
+        "Simulated"
+      ]
+    },
+    "usage": {
+      "description": "<p> The data and MC simulation provided by the ATLAS experiment in root ntuple format is released under a CC0 license; citation of the data and acknowledgement of the collaboration is requested. This format can be used directly using ROOT or uproot for simple studies and is primarily intended for educational and outreach purposes. <p>Extensive instructions for interacting with the data, as well as documentation of the dataset naming conventions and their contents, are provided on the ATLAS Open Data website linked below. For those interested in implementing a research-quality data analysis, the open data designed for research (also linked below) may be a better starting point. Please be sure to cite the Open Data that you use, in line with the policy below.",
+      "links": [
+        {
+          "description": "ATLAS Open Data Website",
+          "url": "http://opendata.atlas.cern"
+        },
+        {
+          "description": "Resources to understand and use the open data for education and outreach",
+          "url": "https://opendata.atlas.cern/docs/category/13-tev-tutorials-for-education"
+        },
+        {
+          "description": "More about this ntuple format",
+          "url": "https://opendata.atlas.cern/docs/data/for_education/13TeV25_details"
+        },
+        {
+          "description": "Ntuple making framework",
+          "url": "http://gitlab.cern.ch/atlas-outreach-data-tools/physlitetoopendata"
+        },
+        {
+          "description": "Citation policy",
+          "url": "https://opendata.atlas.cern/docs/documentation/ethical_legal/citation_policy"
+        }
+      ]
+    }
+  }
+]

--- a/data/records/atlas-odeo-FEB2025-summary.json
+++ b/data/records/atlas-odeo-FEB2025-summary.json
@@ -1,0 +1,255 @@
+[
+  {
+    "abstract": {
+      "description": "Run 2 2015+2016 proton-proton collision data and corresponding MC simulation Open Data for Education and Outreach from the ATLAS experiment"
+    },
+    "accelerator": "CERN-LHC",
+    "categories": {
+      "source": "ATLAS Collaboration"
+    },
+    "collaboration": {
+      "name": "ATLAS collaboration"
+    },
+    "collections": [
+      "ATLAS-Simulated-Datasets",
+      "ATLAS-Primary-Datasets"
+    ],
+    "collision_information": {
+      "energy": "13TeV",
+      "type": "pp"
+    },
+    "date_created": [
+      "2015",
+      "2016"
+    ],
+    "date_published": "2025",
+    "date_reprocessed": "2020",
+    "distribution": {
+      "formats": [
+        "root"
+      ],
+      "number_events": 9685448326,
+      "number_files": 4668,
+      "size": 2714467479966
+    },
+    "doi": "10.7483/OPENDATA.ATLAS.B5M9.44TN",
+    "experiment": [
+      "ATLAS"
+    ],
+    "license": {
+      "attribution": "CC0-1.0"
+    },
+    "methodology": {
+      "description": "<p>These data were created during LS2 as part of a major reprocessing campaign of the Run 2 data. All data were reprocessed using Athena Release 22, and new corresponding MC simulation samples were produced. These data and MC simulation datasets were processed into ROOT ntuple files from the DAOD_PHYSLITE format that is released as open data for research. For the files in this record, several event pre-selections are available to accelerate analysis, as well as an inclusive set of all events."
+    },
+    "publisher": "CERN Open Data Portal",
+    "recid": "93910",
+    "relations": [
+      {
+        "description": "Run 2 2015+2016 proton-proton collision data beta release, 2J2LMET30 skim",
+        "doi": "10.7483/OPENDATA.ATLAS.0CJR.N7ZT",
+        "recid": "93934",
+        "title": "Run 2 2015+2016 proton-proton collision data beta release, 2J2LMET30 skim",
+        "type": "isParentOf"
+      },
+      {
+        "description": "Run 2 2015+2016 proton-proton collision data beta release, no skim",
+        "doi": "10.7483/OPENDATA.ATLAS.VV3I.0WJE",
+        "recid": "93933",
+        "title": "Run 2 2015+2016 proton-proton collision data beta release, no skim",
+        "type": "isParentOf"
+      },
+      {
+        "description": "MC simulation, 2015+2016 proton-proton collisions beta release, 4lep skim",
+        "doi": "10.7483/OPENDATA.ATLAS.IPG4.6M6X",
+        "recid": "93932",
+        "title": "MC simulation, 2015+2016 proton-proton collisions beta release, 4lep skim",
+        "type": "isParentOf"
+      },
+      {
+        "description": "MC simulation, 2015+2016 proton-proton collisions beta release, 1LMET30 skim",
+        "doi": "10.7483/OPENDATA.ATLAS.9VTD.OT28",
+        "recid": "93931",
+        "title": "MC simulation, 2015+2016 proton-proton collisions beta release, 1LMET30 skim",
+        "type": "isParentOf"
+      },
+      {
+        "description": "MC simulation, 2015+2016 proton-proton collisions beta release, 2muons skim",
+        "doi": "10.7483/OPENDATA.ATLAS.AR66.6RTA",
+        "recid": "93930",
+        "title": "MC simulation, 2015+2016 proton-proton collisions beta release, 2muons skim",
+        "type": "isParentOf"
+      },
+      {
+        "description": "Run 2 2015+2016 proton-proton collision data beta release, 1LMET30 skim",
+        "doi": "10.7483/OPENDATA.ATLAS.KPYL.P0EE",
+        "recid": "93929",
+        "title": "Run 2 2015+2016 proton-proton collision data beta release, 1LMET30 skim",
+        "type": "isParentOf"
+      },
+      {
+        "description": "MC simulation, 2015+2016 proton-proton collisions beta release, exactly4lep skim",
+        "doi": "10.7483/OPENDATA.ATLAS.XNPI.CX93",
+        "recid": "93928",
+        "title": "MC simulation, 2015+2016 proton-proton collisions beta release, exactly4lep skim",
+        "type": "isParentOf"
+      },
+      {
+        "description": "Run 2 2015+2016 proton-proton collision data beta release, 2bjets skim",
+        "doi": "10.7483/OPENDATA.ATLAS.1P1H.J3QK",
+        "recid": "93927",
+        "title": "Run 2 2015+2016 proton-proton collision data beta release, 2bjets skim",
+        "type": "isParentOf"
+      },
+      {
+        "description": "Run 2 2015+2016 proton-proton collision data beta release, 3J1LMET30 skim",
+        "doi": "10.7483/OPENDATA.ATLAS.CIU5.U5YX",
+        "recid": "93926",
+        "title": "Run 2 2015+2016 proton-proton collision data beta release, 3J1LMET30 skim",
+        "type": "isParentOf"
+      },
+      {
+        "description": "MC simulation, 2015+2016 proton-proton collisions beta release, 3lep skim",
+        "doi": "10.7483/OPENDATA.ATLAS.211Z.76E7",
+        "recid": "93925",
+        "title": "MC simulation, 2015+2016 proton-proton collisions beta release, 3lep skim",
+        "type": "isParentOf"
+      },
+      {
+        "description": "Run 2 2015+2016 proton-proton collision data beta release, exactly4lep skim",
+        "doi": "10.7483/OPENDATA.ATLAS.3ATL.Q9Z2",
+        "recid": "93924",
+        "title": "Run 2 2015+2016 proton-proton collision data beta release, exactly4lep skim",
+        "type": "isParentOf"
+      },
+      {
+        "description": "MC simulation, 2015+2016 proton-proton collisions beta release, 2to4lep skim",
+        "doi": "10.7483/OPENDATA.ATLAS.OMF2.CICK",
+        "recid": "93923",
+        "title": "MC simulation, 2015+2016 proton-proton collisions beta release, 2to4lep skim",
+        "type": "isParentOf"
+      },
+      {
+        "description": "MC simulation, 2015+2016 proton-proton collisions beta release, GamGam skim",
+        "doi": "10.7483/OPENDATA.ATLAS.IMZO.7U52",
+        "recid": "93922",
+        "title": "MC simulation, 2015+2016 proton-proton collisions beta release, GamGam skim",
+        "type": "isParentOf"
+      },
+      {
+        "description": "Run 2 2015+2016 proton-proton collision data beta release, 2muons skim",
+        "doi": "10.7483/OPENDATA.ATLAS.6VGH.HN41",
+        "recid": "93921",
+        "title": "Run 2 2015+2016 proton-proton collision data beta release, 2muons skim",
+        "type": "isParentOf"
+      },
+      {
+        "description": "MC simulation, 2015+2016 proton-proton collisions beta release, 2bjets skim",
+        "doi": "10.7483/OPENDATA.ATLAS.71IP.L3OC",
+        "recid": "93920",
+        "title": "MC simulation, 2015+2016 proton-proton collisions beta release, 2bjets skim",
+        "type": "isParentOf"
+      },
+      {
+        "description": "Run 2 2015+2016 proton-proton collision data beta release, 2to4lep skim",
+        "doi": "10.7483/OPENDATA.ATLAS.ZXYW.FXJO",
+        "recid": "93919",
+        "title": "Run 2 2015+2016 proton-proton collision data beta release, 2to4lep skim",
+        "type": "isParentOf"
+      },
+      {
+        "description": "Run 2 2015+2016 proton-proton collision data beta release, 4lep skim",
+        "doi": "10.7483/OPENDATA.ATLAS.7UW9.C9LL",
+        "recid": "93918",
+        "title": "Run 2 2015+2016 proton-proton collision data beta release, 4lep skim",
+        "type": "isParentOf"
+      },
+      {
+        "description": "Run 2 2015+2016 proton-proton collision data beta release, exactly3lep skim",
+        "doi": "10.7483/OPENDATA.ATLAS.L5QV.U2XC",
+        "recid": "93917",
+        "title": "Run 2 2015+2016 proton-proton collision data beta release, exactly3lep skim",
+        "type": "isParentOf"
+      },
+      {
+        "description": "MC simulation, 2015+2016 proton-proton collisions beta release, 3J1LMET30 skim",
+        "doi": "10.7483/OPENDATA.ATLAS.IBFR.R9L3",
+        "recid": "93916",
+        "title": "MC simulation, 2015+2016 proton-proton collisions beta release, 3J1LMET30 skim",
+        "type": "isParentOf"
+      },
+      {
+        "description": "Run 2 2015+2016 proton-proton collision data beta release, GamGam skim",
+        "doi": "10.7483/OPENDATA.ATLAS.GYRR.GRP3",
+        "recid": "93915",
+        "title": "Run 2 2015+2016 proton-proton collision data beta release, GamGam skim",
+        "type": "isParentOf"
+      },
+      {
+        "description": "MC simulation, 2015+2016 proton-proton collisions beta release, exactly3lep skim",
+        "doi": "10.7483/OPENDATA.ATLAS.SCWS.LYYX",
+        "recid": "93914",
+        "title": "MC simulation, 2015+2016 proton-proton collisions beta release, exactly3lep skim",
+        "type": "isParentOf"
+      },
+      {
+        "description": "MC simulation, 2015+2016 proton-proton collisions beta release, 2J2LMET30 skim",
+        "doi": "10.7483/OPENDATA.ATLAS.NNF8.76IX",
+        "recid": "93913",
+        "title": "MC simulation, 2015+2016 proton-proton collisions beta release, 2J2LMET30 skim",
+        "type": "isParentOf"
+      },
+      {
+        "description": "Run 2 2015+2016 proton-proton collision data beta release, 3lep skim",
+        "doi": "10.7483/OPENDATA.ATLAS.CMHX.9D8M",
+        "recid": "93912",
+        "title": "Run 2 2015+2016 proton-proton collision data beta release, 3lep skim",
+        "type": "isParentOf"
+      },
+      {
+        "description": "MC simulation, 2015+2016 proton-proton collisions beta release, no skim",
+        "doi": "10.7483/OPENDATA.ATLAS.ZPCQ.9VO2",
+        "recid": "93911",
+        "title": "MC simulation, 2015+2016 proton-proton collisions beta release, no skim",
+        "type": "isParentOf"
+      }
+    ],
+    "run_period": [
+      "2015",
+      "2016"
+    ],
+    "title": "ROOT ntuple format 2015-2016 proton-proton Open Data for Education and Outreach beta release from the ATLAS experiment",
+    "type": {
+      "primary": "Dataset",
+      "secondary": [
+        "Simulated",
+        "Collision"
+      ]
+    },
+    "usage": {
+      "description": "<p> The data and MC simulation provided by the ATLAS experiment in root ntuple format is released under a CC0 license; citation of the data and acknowledgement of the collaboration is requested. This format can be used directly using ROOT or uproot for simple studies and is primarily intended for educational and outreach purposes. <p>Extensive instructions for interacting with the data, as well as documentation of the dataset naming conventions and their contents, are provided on the ATLAS Open Data website linked below. For those interested in implementing a research-quality data analysis, the open data designed for research (also linked below) may be a better starting point. Please be sure to cite the Open Data that you use, in line with the policy below.",
+      "links": [
+        {
+          "description": "ATLAS Open Data Website",
+          "url": "http://opendata.atlas.cern"
+        },
+        {
+          "description": "Resources to understand and use the open data for education and outreach",
+          "url": "https://opendata.atlas.cern/docs/category/13-tev-tutorials-for-education"
+        },
+        {
+          "description": "More about this ntuple format",
+          "url": "https://opendata.atlas.cern/docs/data/for_education/13TeV25_details"
+        },
+        {
+          "description": "Ntuple making framework",
+          "url": "http://gitlab.cern.ch/atlas-outreach-data-tools/physlitetoopendata"
+        },
+        {
+          "description": "Citation policy",
+          "url": "https://opendata.atlas.cern/docs/documentation/ethical_legal/citation_policy"
+        }
+      ]
+    }
+  }
+]

--- a/data/records/atlas-odeo-FEB2025-summary.json
+++ b/data/records/atlas-odeo-FEB2025-summary.json
@@ -28,9 +28,9 @@
       "formats": [
         "root"
       ],
-      "number_events": 9685448326,
+      "number_events": 9837961169,
       "number_files": 4668,
-      "size": 2714467479966
+      "size": 2763127198190
     },
     "doi": "10.7483/OPENDATA.ATLAS.B5M9.44TN",
     "experiment": [
@@ -235,15 +235,15 @@
         },
         {
           "description": "Resources to understand and use the open data for education and outreach",
-          "url": "https://opendata.atlas.cern/docs/category/13-tev-tutorials-for-education"
+          "url": "https://opendata.atlas.cern/docs/category/13-tev-2025-beta-release"
         },
         {
           "description": "More about this ntuple format",
-          "url": "https://opendata.atlas.cern/docs/data/for_education/13TeV25_details"
+          "url": "https://opendata.atlas.cern/docs/data/for_education/13TeV25_details#variable-list"
         },
         {
-          "description": "Ntuple making framework",
-          "url": "http://gitlab.cern.ch/atlas-outreach-data-tools/physlitetoopendata"
+          "description": "Ntuple making framework (PhysLiteToOpenData)",
+          "url": "https://doi.org/10.5281/zenodo.15791091"
         },
         {
           "description": "Citation policy",


### PR DESCRIPTION
This is 2025 February ATLAS Education and Outreach Open Data Release. The release contains 25 datasets based on the recent proton-proton Research Open Data release, but with several simplified formats for various educational projects and skims that satisfy a variety of use-cases.