### PR TITLE
feat(records): add individual ATLAS 2020 ROOT files

### DIFF
--- a/data/records/atlas-2020-1largeRjet1lep.json
+++ b/data/records/atlas-2020-1largeRjet1lep.json
@@ -19,8 +19,12 @@
     ],
     "date_published": "2020",
     "distribution": {
-      "number_files": 1,
-      "size": 5886587807
+      "formats": [
+        "root",
+        "zip"
+      ],
+      "number_files": 135,
+      "size": 12502786766
     },
     "doi": "10.7483/OPENDATA.ATLAS.FRWJ.4ZQU",
     "experiment": [
@@ -31,6 +35,676 @@
         "checksum": "adler32:3b35d982",
         "size": 5886587807,
         "uri": "root://eospublic.cern.ch//eos/opendata/atlas/OutreachDatasets/2020-08-19/1largeRjet1lep.zip"
+      },
+      {
+        "checksum": "adler32:8bfdd6fb",
+        "size": 8120689,
+        "uri": "root://eospublic.cern.ch//eos/opendata/atlas/OutreachDatasets/2020-08-19/1largeRjet1lep/Data/data_A.1largeRjet1lep.root"
+      },
+      {
+        "checksum": "adler32:57c90eee",
+        "size": 27449186,
+        "uri": "root://eospublic.cern.ch//eos/opendata/atlas/OutreachDatasets/2020-08-19/1largeRjet1lep/Data/data_B.1largeRjet1lep.root"
+      },
+      {
+        "checksum": "adler32:f0aebd34",
+        "size": 40299501,
+        "uri": "root://eospublic.cern.ch//eos/opendata/atlas/OutreachDatasets/2020-08-19/1largeRjet1lep/Data/data_C.1largeRjet1lep.root"
+      },
+      {
+        "checksum": "adler32:28302474",
+        "size": 64000219,
+        "uri": "root://eospublic.cern.ch//eos/opendata/atlas/OutreachDatasets/2020-08-19/1largeRjet1lep/Data/data_D.1largeRjet1lep.root"
+      },
+      {
+        "checksum": "adler32:11df2f96",
+        "size": 337836,
+        "uri": "root://eospublic.cern.ch//eos/opendata/atlas/OutreachDatasets/2020-08-19/1largeRjet1lep/MC/mc_301322.ZPrime400_tt.1largeRjet1lep.root"
+      },
+      {
+        "checksum": "adler32:00995125",
+        "size": 602403,
+        "uri": "root://eospublic.cern.ch//eos/opendata/atlas/OutreachDatasets/2020-08-19/1largeRjet1lep/MC/mc_301323.ZPrime500_tt.1largeRjet1lep.root"
+      },
+      {
+        "checksum": "adler32:34c2248c",
+        "size": 5753116,
+        "uri": "root://eospublic.cern.ch//eos/opendata/atlas/OutreachDatasets/2020-08-19/1largeRjet1lep/MC/mc_301324.ZPrime750_tt.1largeRjet1lep.root"
+      },
+      {
+        "checksum": "adler32:456e20e8",
+        "size": 11293600,
+        "uri": "root://eospublic.cern.ch//eos/opendata/atlas/OutreachDatasets/2020-08-19/1largeRjet1lep/MC/mc_301325.ZPrime1000_tt.1largeRjet1lep.root"
+      },
+      {
+        "checksum": "adler32:7404b7b1",
+        "size": 13924792,
+        "uri": "root://eospublic.cern.ch//eos/opendata/atlas/OutreachDatasets/2020-08-19/1largeRjet1lep/MC/mc_301326.ZPrime1250_tt.1largeRjet1lep.root"
+      },
+      {
+        "checksum": "adler32:8bade326",
+        "size": 14598416,
+        "uri": "root://eospublic.cern.ch//eos/opendata/atlas/OutreachDatasets/2020-08-19/1largeRjet1lep/MC/mc_301327.ZPrime1500_tt.1largeRjet1lep.root"
+      },
+      {
+        "checksum": "adler32:1a51467d",
+        "size": 14758092,
+        "uri": "root://eospublic.cern.ch//eos/opendata/atlas/OutreachDatasets/2020-08-19/1largeRjet1lep/MC/mc_301328.ZPrime1750_tt.1largeRjet1lep.root"
+      },
+      {
+        "checksum": "adler32:d1a24c94",
+        "size": 14218777,
+        "uri": "root://eospublic.cern.ch//eos/opendata/atlas/OutreachDatasets/2020-08-19/1largeRjet1lep/MC/mc_301329.ZPrime2000_tt.1largeRjet1lep.root"
+      },
+      {
+        "checksum": "adler32:cb45f193",
+        "size": 13653493,
+        "uri": "root://eospublic.cern.ch//eos/opendata/atlas/OutreachDatasets/2020-08-19/1largeRjet1lep/MC/mc_301330.ZPrime2250_tt.1largeRjet1lep.root"
+      },
+      {
+        "checksum": "adler32:32731c4f",
+        "size": 12886171,
+        "uri": "root://eospublic.cern.ch//eos/opendata/atlas/OutreachDatasets/2020-08-19/1largeRjet1lep/MC/mc_301331.ZPrime2500_tt.1largeRjet1lep.root"
+      },
+      {
+        "checksum": "adler32:8634d8ca",
+        "size": 12170233,
+        "uri": "root://eospublic.cern.ch//eos/opendata/atlas/OutreachDatasets/2020-08-19/1largeRjet1lep/MC/mc_301332.ZPrime2750_tt.1largeRjet1lep.root"
+      },
+      {
+        "checksum": "adler32:9cacb349",
+        "size": 11162764,
+        "uri": "root://eospublic.cern.ch//eos/opendata/atlas/OutreachDatasets/2020-08-19/1largeRjet1lep/MC/mc_301333.ZPrime3000_tt.1largeRjet1lep.root"
+      },
+      {
+        "checksum": "adler32:59ead443",
+        "size": 3010865,
+        "uri": "root://eospublic.cern.ch//eos/opendata/atlas/OutreachDatasets/2020-08-19/1largeRjet1lep/MC/mc_361100.Wplusenu.1largeRjet1lep.root"
+      },
+      {
+        "checksum": "adler32:10ab9d83",
+        "size": 2336918,
+        "uri": "root://eospublic.cern.ch//eos/opendata/atlas/OutreachDatasets/2020-08-19/1largeRjet1lep/MC/mc_361101.Wplusmunu.1largeRjet1lep.root"
+      },
+      {
+        "checksum": "adler32:27cecaed",
+        "size": 429824,
+        "uri": "root://eospublic.cern.ch//eos/opendata/atlas/OutreachDatasets/2020-08-19/1largeRjet1lep/MC/mc_361102.Wplustaunu.1largeRjet1lep.root"
+      },
+      {
+        "checksum": "adler32:7b850122",
+        "size": 2295358,
+        "uri": "root://eospublic.cern.ch//eos/opendata/atlas/OutreachDatasets/2020-08-19/1largeRjet1lep/MC/mc_361103.Wminusenu.1largeRjet1lep.root"
+      },
+      {
+        "checksum": "adler32:7db92691",
+        "size": 1699834,
+        "uri": "root://eospublic.cern.ch//eos/opendata/atlas/OutreachDatasets/2020-08-19/1largeRjet1lep/MC/mc_361104.Wminusmunu.1largeRjet1lep.root"
+      },
+      {
+        "checksum": "adler32:9bf88355",
+        "size": 304110,
+        "uri": "root://eospublic.cern.ch//eos/opendata/atlas/OutreachDatasets/2020-08-19/1largeRjet1lep/MC/mc_361105.Wminustaunu.1largeRjet1lep.root"
+      },
+      {
+        "checksum": "adler32:b7881e4f",
+        "size": 19079683,
+        "uri": "root://eospublic.cern.ch//eos/opendata/atlas/OutreachDatasets/2020-08-19/1largeRjet1lep/MC/mc_361106.Zee.1largeRjet1lep.root"
+      },
+      {
+        "checksum": "adler32:32d31879",
+        "size": 7492376,
+        "uri": "root://eospublic.cern.ch//eos/opendata/atlas/OutreachDatasets/2020-08-19/1largeRjet1lep/MC/mc_361107.Zmumu.1largeRjet1lep.root"
+      },
+      {
+        "checksum": "adler32:633e5cc6",
+        "size": 1158043,
+        "uri": "root://eospublic.cern.ch//eos/opendata/atlas/OutreachDatasets/2020-08-19/1largeRjet1lep/MC/mc_361108.Ztautau.1largeRjet1lep.root"
+      },
+      {
+        "checksum": "adler32:919badd5",
+        "size": 17824970,
+        "uri": "root://eospublic.cern.ch//eos/opendata/atlas/OutreachDatasets/2020-08-19/1largeRjet1lep/MC/mc_363356.ZqqZll.1largeRjet1lep.root"
+      },
+      {
+        "checksum": "adler32:ba12746b",
+        "size": 30570041,
+        "uri": "root://eospublic.cern.ch//eos/opendata/atlas/OutreachDatasets/2020-08-19/1largeRjet1lep/MC/mc_363358.WqqZll.1largeRjet1lep.root"
+      },
+      {
+        "checksum": "adler32:8beae0f4",
+        "size": 16182695,
+        "uri": "root://eospublic.cern.ch//eos/opendata/atlas/OutreachDatasets/2020-08-19/1largeRjet1lep/MC/mc_363360.WplvWmqq.1largeRjet1lep.root"
+      },
+      {
+        "checksum": "adler32:060d6eb0",
+        "size": 3622489,
+        "uri": "root://eospublic.cern.ch//eos/opendata/atlas/OutreachDatasets/2020-08-19/1largeRjet1lep/MC/mc_363489.WlvZqq.1largeRjet1lep.root"
+      },
+      {
+        "checksum": "adler32:c1039274",
+        "size": 157991599,
+        "uri": "root://eospublic.cern.ch//eos/opendata/atlas/OutreachDatasets/2020-08-19/1largeRjet1lep/MC/mc_363491.lllv.1largeRjet1lep.root"
+      },
+      {
+        "checksum": "adler32:c5ab21aa",
+        "size": 163673946,
+        "uri": "root://eospublic.cern.ch//eos/opendata/atlas/OutreachDatasets/2020-08-19/1largeRjet1lep/MC/mc_363492.llvv.1largeRjet1lep.root"
+      },
+      {
+        "checksum": "adler32:4833995a",
+        "size": 58845771,
+        "uri": "root://eospublic.cern.ch//eos/opendata/atlas/OutreachDatasets/2020-08-19/1largeRjet1lep/MC/mc_363493.lvvv.1largeRjet1lep.root"
+      },
+      {
+        "checksum": "adler32:a86bdf76",
+        "size": 36050,
+        "uri": "root://eospublic.cern.ch//eos/opendata/atlas/OutreachDatasets/2020-08-19/1largeRjet1lep/MC/mc_364100.Zmumu_PTV0_70_CVetoBVeto.1largeRjet1lep.root"
+      },
+      {
+        "checksum": "adler32:45b18699",
+        "size": 38043,
+        "uri": "root://eospublic.cern.ch//eos/opendata/atlas/OutreachDatasets/2020-08-19/1largeRjet1lep/MC/mc_364101.Zmumu_PTV0_70_CFilterBVeto.1largeRjet1lep.root"
+      },
+      {
+        "checksum": "adler32:68e3d1fd",
+        "size": 57553,
+        "uri": "root://eospublic.cern.ch//eos/opendata/atlas/OutreachDatasets/2020-08-19/1largeRjet1lep/MC/mc_364102.Zmumu_PTV0_70_BFilter.1largeRjet1lep.root"
+      },
+      {
+        "checksum": "adler32:358cbdd5",
+        "size": 49661,
+        "uri": "root://eospublic.cern.ch//eos/opendata/atlas/OutreachDatasets/2020-08-19/1largeRjet1lep/MC/mc_364103.Zmumu_PTV70_140_CVetoBVeto.1largeRjet1lep.root"
+      },
+      {
+        "checksum": "adler32:4a1fbe76",
+        "size": 38059,
+        "uri": "root://eospublic.cern.ch//eos/opendata/atlas/OutreachDatasets/2020-08-19/1largeRjet1lep/MC/mc_364104.Zmumu_PTV70_140_CFilterBVeto.1largeRjet1lep.root"
+      },
+      {
+        "checksum": "adler32:65a6eec9",
+        "size": 66320,
+        "uri": "root://eospublic.cern.ch//eos/opendata/atlas/OutreachDatasets/2020-08-19/1largeRjet1lep/MC/mc_364105.Zmumu_PTV70_140_BFilter.1largeRjet1lep.root"
+      },
+      {
+        "checksum": "adler32:f4451e30",
+        "size": 6413734,
+        "uri": "root://eospublic.cern.ch//eos/opendata/atlas/OutreachDatasets/2020-08-19/1largeRjet1lep/MC/mc_364106.Zmumu_PTV140_280_CVetoBVeto.1largeRjet1lep.root"
+      },
+      {
+        "checksum": "adler32:7fbcabf0",
+        "size": 3123001,
+        "uri": "root://eospublic.cern.ch//eos/opendata/atlas/OutreachDatasets/2020-08-19/1largeRjet1lep/MC/mc_364107.Zmumu_PTV140_280_CFilterBVeto.1largeRjet1lep.root"
+      },
+      {
+        "checksum": "adler32:4f3164b9",
+        "size": 11075019,
+        "uri": "root://eospublic.cern.ch//eos/opendata/atlas/OutreachDatasets/2020-08-19/1largeRjet1lep/MC/mc_364108.Zmumu_PTV140_280_BFilter.1largeRjet1lep.root"
+      },
+      {
+        "checksum": "adler32:6bb7ab17",
+        "size": 68586073,
+        "uri": "root://eospublic.cern.ch//eos/opendata/atlas/OutreachDatasets/2020-08-19/1largeRjet1lep/MC/mc_364109.Zmumu_PTV280_500_CVetoBVeto.1largeRjet1lep.root"
+      },
+      {
+        "checksum": "adler32:a609fcca",
+        "size": 26424547,
+        "uri": "root://eospublic.cern.ch//eos/opendata/atlas/OutreachDatasets/2020-08-19/1largeRjet1lep/MC/mc_364110.Zmumu_PTV280_500_CFilterBVeto.1largeRjet1lep.root"
+      },
+      {
+        "checksum": "adler32:9371284d",
+        "size": 45089220,
+        "uri": "root://eospublic.cern.ch//eos/opendata/atlas/OutreachDatasets/2020-08-19/1largeRjet1lep/MC/mc_364111.Zmumu_PTV280_500_BFilter.1largeRjet1lep.root"
+      },
+      {
+        "checksum": "adler32:a82d7fc3",
+        "size": 236296516,
+        "uri": "root://eospublic.cern.ch//eos/opendata/atlas/OutreachDatasets/2020-08-19/1largeRjet1lep/MC/mc_364113.Zmumu_PTV1000_E_CMS.1largeRjet1lep.root"
+      },
+      {
+        "checksum": "adler32:7ad2dbdf",
+        "size": 121523,
+        "uri": "root://eospublic.cern.ch//eos/opendata/atlas/OutreachDatasets/2020-08-19/1largeRjet1lep/MC/mc_364114.Zee_PTV0_70_CVetoBVeto.1largeRjet1lep.root"
+      },
+      {
+        "checksum": "adler32:48fbc6d6",
+        "size": 96490,
+        "uri": "root://eospublic.cern.ch//eos/opendata/atlas/OutreachDatasets/2020-08-19/1largeRjet1lep/MC/mc_364115.Zee_PTV0_70_CFilterBVeto.1largeRjet1lep.root"
+      },
+      {
+        "checksum": "adler32:8464843f",
+        "size": 143693,
+        "uri": "root://eospublic.cern.ch//eos/opendata/atlas/OutreachDatasets/2020-08-19/1largeRjet1lep/MC/mc_364116.Zee_PTV0_70_BFilter.1largeRjet1lep.root"
+      },
+      {
+        "checksum": "adler32:998bc915",
+        "size": 366255,
+        "uri": "root://eospublic.cern.ch//eos/opendata/atlas/OutreachDatasets/2020-08-19/1largeRjet1lep/MC/mc_364117.Zee_PTV70_140_CVetoBVeto.1largeRjet1lep.root"
+      },
+      {
+        "checksum": "adler32:fa5ce1ad",
+        "size": 133938,
+        "uri": "root://eospublic.cern.ch//eos/opendata/atlas/OutreachDatasets/2020-08-19/1largeRjet1lep/MC/mc_364118.Zee_PTV70_140_CFilterBVeto.1largeRjet1lep.root"
+      },
+      {
+        "checksum": "adler32:b10025f3",
+        "size": 25130,
+        "uri": "root://eospublic.cern.ch//eos/opendata/atlas/OutreachDatasets/2020-08-19/1largeRjet1lep/MC/mc_364119.Zee_PTV70_140_BFilter.1largeRjet1lep.root"
+      },
+      {
+        "checksum": "adler32:27ef7f97",
+        "size": 24377179,
+        "uri": "root://eospublic.cern.ch//eos/opendata/atlas/OutreachDatasets/2020-08-19/1largeRjet1lep/MC/mc_364120.Zee_PTV140_280_CVetoBVeto.1largeRjet1lep.root"
+      },
+      {
+        "checksum": "adler32:2ed31fa3",
+        "size": 12908504,
+        "uri": "root://eospublic.cern.ch//eos/opendata/atlas/OutreachDatasets/2020-08-19/1largeRjet1lep/MC/mc_364121.Zee_PTV140_280_CFilterBVeto.1largeRjet1lep.root"
+      },
+      {
+        "checksum": "adler32:21432653",
+        "size": 18969701,
+        "uri": "root://eospublic.cern.ch//eos/opendata/atlas/OutreachDatasets/2020-08-19/1largeRjet1lep/MC/mc_364122.Zee_PTV140_280_BFilter.1largeRjet1lep.root"
+      },
+      {
+        "checksum": "adler32:471879a5",
+        "size": 137886943,
+        "uri": "root://eospublic.cern.ch//eos/opendata/atlas/OutreachDatasets/2020-08-19/1largeRjet1lep/MC/mc_364123.Zee_PTV280_500_CVetoBVeto.1largeRjet1lep.root"
+      },
+      {
+        "checksum": "adler32:20abc12e",
+        "size": 57604546,
+        "uri": "root://eospublic.cern.ch//eos/opendata/atlas/OutreachDatasets/2020-08-19/1largeRjet1lep/MC/mc_364124.Zee_PTV280_500_CFilterBVeto.1largeRjet1lep.root"
+      },
+      {
+        "checksum": "adler32:c8e3078d",
+        "size": 104987610,
+        "uri": "root://eospublic.cern.ch//eos/opendata/atlas/OutreachDatasets/2020-08-19/1largeRjet1lep/MC/mc_364125.Zee_PTV280_500_BFilter.1largeRjet1lep.root"
+      },
+      {
+        "checksum": "adler32:4b07ad7c",
+        "size": 640611818,
+        "uri": "root://eospublic.cern.ch//eos/opendata/atlas/OutreachDatasets/2020-08-19/1largeRjet1lep/MC/mc_364126.Zee_PTV500_1000.1largeRjet1lep.root"
+      },
+      {
+        "checksum": "adler32:bc889a63",
+        "size": 312060280,
+        "uri": "root://eospublic.cern.ch//eos/opendata/atlas/OutreachDatasets/2020-08-19/1largeRjet1lep/MC/mc_364127.Zee_PTV1000_E_CMS.1largeRjet1lep.root"
+      },
+      {
+        "checksum": "adler32:f5c2cb7a",
+        "size": 31482,
+        "uri": "root://eospublic.cern.ch//eos/opendata/atlas/OutreachDatasets/2020-08-19/1largeRjet1lep/MC/mc_364128.Ztautau_PTV0_70_CVetoBVeto.1largeRjet1lep.root"
+      },
+      {
+        "checksum": "adler32:7c89f934",
+        "size": 26507,
+        "uri": "root://eospublic.cern.ch//eos/opendata/atlas/OutreachDatasets/2020-08-19/1largeRjet1lep/MC/mc_364129.Ztautau_PTV0_70_CFilterBVeto.1largeRjet1lep.root"
+      },
+      {
+        "checksum": "adler32:b25f2fcc",
+        "size": 32371,
+        "uri": "root://eospublic.cern.ch//eos/opendata/atlas/OutreachDatasets/2020-08-19/1largeRjet1lep/MC/mc_364130.Ztautau_PTV0_70_BFilter.1largeRjet1lep.root"
+      },
+      {
+        "checksum": "adler32:e8a18b7c",
+        "size": 52363,
+        "uri": "root://eospublic.cern.ch//eos/opendata/atlas/OutreachDatasets/2020-08-19/1largeRjet1lep/MC/mc_364131.Ztautau_PTV70_140_CVetoBVeto.1largeRjet1lep.root"
+      },
+      {
+        "checksum": "adler32:2ccee63b",
+        "size": 29912,
+        "uri": "root://eospublic.cern.ch//eos/opendata/atlas/OutreachDatasets/2020-08-19/1largeRjet1lep/MC/mc_364132.Ztautau_PTV70_140_CFilterBVeto.1largeRjet1lep.root"
+      },
+      {
+        "checksum": "adler32:a350fe09",
+        "size": 48100,
+        "uri": "root://eospublic.cern.ch//eos/opendata/atlas/OutreachDatasets/2020-08-19/1largeRjet1lep/MC/mc_364133.Ztautau_PTV70_140_BFilter.1largeRjet1lep.root"
+      },
+      {
+        "checksum": "adler32:98e6ab0e",
+        "size": 2450836,
+        "uri": "root://eospublic.cern.ch//eos/opendata/atlas/OutreachDatasets/2020-08-19/1largeRjet1lep/MC/mc_364134.Ztautau_PTV140_280_CVetoBVeto.1largeRjet1lep.root"
+      },
+      {
+        "checksum": "adler32:32de5122",
+        "size": 1200362,
+        "uri": "root://eospublic.cern.ch//eos/opendata/atlas/OutreachDatasets/2020-08-19/1largeRjet1lep/MC/mc_364135.Ztautau_PTV140_280_CFilterBVeto.1largeRjet1lep.root"
+      },
+      {
+        "checksum": "adler32:8f998629",
+        "size": 1622723,
+        "uri": "root://eospublic.cern.ch//eos/opendata/atlas/OutreachDatasets/2020-08-19/1largeRjet1lep/MC/mc_364136.Ztautau_PTV140_280_BFilter.1largeRjet1lep.root"
+      },
+      {
+        "checksum": "adler32:fe8e67c9",
+        "size": 26711804,
+        "uri": "root://eospublic.cern.ch//eos/opendata/atlas/OutreachDatasets/2020-08-19/1largeRjet1lep/MC/mc_364137.Ztautau_PTV280_500_CVetoBVeto.1largeRjet1lep.root"
+      },
+      {
+        "checksum": "adler32:4c277584",
+        "size": 10379791,
+        "uri": "root://eospublic.cern.ch//eos/opendata/atlas/OutreachDatasets/2020-08-19/1largeRjet1lep/MC/mc_364138.Ztautau_PTV280_500_CFilterBVeto.1largeRjet1lep.root"
+      },
+      {
+        "checksum": "adler32:73329547",
+        "size": 18010432,
+        "uri": "root://eospublic.cern.ch//eos/opendata/atlas/OutreachDatasets/2020-08-19/1largeRjet1lep/MC/mc_364139.Ztautau_PTV280_500_BFilter.1largeRjet1lep.root"
+      },
+      {
+        "checksum": "adler32:67027b55",
+        "size": 114536044,
+        "uri": "root://eospublic.cern.ch//eos/opendata/atlas/OutreachDatasets/2020-08-19/1largeRjet1lep/MC/mc_364140.Ztautau_PTV500_1000.1largeRjet1lep.root"
+      },
+      {
+        "checksum": "adler32:e312fdad",
+        "size": 58660737,
+        "uri": "root://eospublic.cern.ch//eos/opendata/atlas/OutreachDatasets/2020-08-19/1largeRjet1lep/MC/mc_364141.Ztautau_PTV1000_E_CMS.1largeRjet1lep.root"
+      },
+      {
+        "checksum": "adler32:40907ef1",
+        "size": 58980,
+        "uri": "root://eospublic.cern.ch//eos/opendata/atlas/OutreachDatasets/2020-08-19/1largeRjet1lep/MC/mc_364156.Wmunu_PTV0_70_CVetoBVeto.1largeRjet1lep.root"
+      },
+      {
+        "checksum": "adler32:a0bd1bda",
+        "size": 42030,
+        "uri": "root://eospublic.cern.ch//eos/opendata/atlas/OutreachDatasets/2020-08-19/1largeRjet1lep/MC/mc_364157.Wmunu_PTV0_70_CFilterBVeto.1largeRjet1lep.root"
+      },
+      {
+        "checksum": "adler32:4c53a9ee",
+        "size": 59686,
+        "uri": "root://eospublic.cern.ch//eos/opendata/atlas/OutreachDatasets/2020-08-19/1largeRjet1lep/MC/mc_364158.Wmunu_PTV0_70_BFilter.1largeRjet1lep.root"
+      },
+      {
+        "checksum": "adler32:cb52a8fa",
+        "size": 74804,
+        "uri": "root://eospublic.cern.ch//eos/opendata/atlas/OutreachDatasets/2020-08-19/1largeRjet1lep/MC/mc_364159.Wmunu_PTV70_140_CVetoBVeto.1largeRjet1lep.root"
+      },
+      {
+        "checksum": "adler32:7f6939e9",
+        "size": 68836,
+        "uri": "root://eospublic.cern.ch//eos/opendata/atlas/OutreachDatasets/2020-08-19/1largeRjet1lep/MC/mc_364160.Wmunu_PTV70_140_CFilterBVeto.1largeRjet1lep.root"
+      },
+      {
+        "checksum": "adler32:0fa54962",
+        "size": 118837,
+        "uri": "root://eospublic.cern.ch//eos/opendata/atlas/OutreachDatasets/2020-08-19/1largeRjet1lep/MC/mc_364161.Wmunu_PTV70_140_BFilter.1largeRjet1lep.root"
+      },
+      {
+        "checksum": "adler32:efe0e7eb",
+        "size": 8854266,
+        "uri": "root://eospublic.cern.ch//eos/opendata/atlas/OutreachDatasets/2020-08-19/1largeRjet1lep/MC/mc_364162.Wmunu_PTV140_280_CVetoBVeto.1largeRjet1lep.root"
+      },
+      {
+        "checksum": "adler32:1debdf93",
+        "size": 5259919,
+        "uri": "root://eospublic.cern.ch//eos/opendata/atlas/OutreachDatasets/2020-08-19/1largeRjet1lep/MC/mc_364163.Wmunu_PTV140_280_CFilterBVeto.1largeRjet1lep.root"
+      },
+      {
+        "checksum": "adler32:4faf4c64",
+        "size": 16400628,
+        "uri": "root://eospublic.cern.ch//eos/opendata/atlas/OutreachDatasets/2020-08-19/1largeRjet1lep/MC/mc_364164.Wmunu_PTV140_280_BFilter.1largeRjet1lep.root"
+      },
+      {
+        "checksum": "adler32:e0761f20",
+        "size": 118583680,
+        "uri": "root://eospublic.cern.ch//eos/opendata/atlas/OutreachDatasets/2020-08-19/1largeRjet1lep/MC/mc_364165.Wmunu_PTV280_500_CVetoBVeto.1largeRjet1lep.root"
+      },
+      {
+        "checksum": "adler32:dce7985e",
+        "size": 53059715,
+        "uri": "root://eospublic.cern.ch//eos/opendata/atlas/OutreachDatasets/2020-08-19/1largeRjet1lep/MC/mc_364166.Wmunu_PTV280_500_CFilterBVeto.1largeRjet1lep.root"
+      },
+      {
+        "checksum": "adler32:4ff930ed",
+        "size": 47457481,
+        "uri": "root://eospublic.cern.ch//eos/opendata/atlas/OutreachDatasets/2020-08-19/1largeRjet1lep/MC/mc_364167.Wmunu_PTV280_500_BFilter.1largeRjet1lep.root"
+      },
+      {
+        "checksum": "adler32:afe5e0c8",
+        "size": 627094766,
+        "uri": "root://eospublic.cern.ch//eos/opendata/atlas/OutreachDatasets/2020-08-19/1largeRjet1lep/MC/mc_364168.Wmunu_PTV500_1000.1largeRjet1lep.root"
+      },
+      {
+        "checksum": "adler32:565bf3fd",
+        "size": 690680461,
+        "uri": "root://eospublic.cern.ch//eos/opendata/atlas/OutreachDatasets/2020-08-19/1largeRjet1lep/MC/mc_364169.Wmunu_PTV1000_E_CMS.1largeRjet1lep.root"
+      },
+      {
+        "checksum": "adler32:46498a92",
+        "size": 86775,
+        "uri": "root://eospublic.cern.ch//eos/opendata/atlas/OutreachDatasets/2020-08-19/1largeRjet1lep/MC/mc_364170.Wenu_PTV0_70_CVetoBVeto.1largeRjet1lep.root"
+      },
+      {
+        "checksum": "adler32:bc4b997b",
+        "size": 57905,
+        "uri": "root://eospublic.cern.ch//eos/opendata/atlas/OutreachDatasets/2020-08-19/1largeRjet1lep/MC/mc_364171.Wenu_PTV0_70_CFilterBVeto.1largeRjet1lep.root"
+      },
+      {
+        "checksum": "adler32:0045ba85",
+        "size": 84399,
+        "uri": "root://eospublic.cern.ch//eos/opendata/atlas/OutreachDatasets/2020-08-19/1largeRjet1lep/MC/mc_364172.Wenu_PTV0_70_BFilter.1largeRjet1lep.root"
+      },
+      {
+        "checksum": "adler32:0e6054ac",
+        "size": 173171,
+        "uri": "root://eospublic.cern.ch//eos/opendata/atlas/OutreachDatasets/2020-08-19/1largeRjet1lep/MC/mc_364173.Wenu_PTV70_140_CVetoBVeto.1largeRjet1lep.root"
+      },
+      {
+        "checksum": "adler32:28b0a56e",
+        "size": 117786,
+        "uri": "root://eospublic.cern.ch//eos/opendata/atlas/OutreachDatasets/2020-08-19/1largeRjet1lep/MC/mc_364174.Wenu_PTV70_140_CFilterBVeto.1largeRjet1lep.root"
+      },
+      {
+        "checksum": "adler32:8de7e64d",
+        "size": 94839,
+        "uri": "root://eospublic.cern.ch//eos/opendata/atlas/OutreachDatasets/2020-08-19/1largeRjet1lep/MC/mc_364175.Wenu_PTV70_140_BFilter.1largeRjet1lep.root"
+      },
+      {
+        "checksum": "adler32:371a6b5f",
+        "size": 13127059,
+        "uri": "root://eospublic.cern.ch//eos/opendata/atlas/OutreachDatasets/2020-08-19/1largeRjet1lep/MC/mc_364176.Wenu_PTV140_280_CVetoBVeto.1largeRjet1lep.root"
+      },
+      {
+        "checksum": "adler32:684539c9",
+        "size": 8477318,
+        "uri": "root://eospublic.cern.ch//eos/opendata/atlas/OutreachDatasets/2020-08-19/1largeRjet1lep/MC/mc_364177.Wenu_PTV140_280_CFilterBVeto.1largeRjet1lep.root"
+      },
+      {
+        "checksum": "adler32:44490a75",
+        "size": 24570530,
+        "uri": "root://eospublic.cern.ch//eos/opendata/atlas/OutreachDatasets/2020-08-19/1largeRjet1lep/MC/mc_364178.Wenu_PTV140_280_BFilter.1largeRjet1lep.root"
+      },
+      {
+        "checksum": "adler32:d4a12c93",
+        "size": 154587813,
+        "uri": "root://eospublic.cern.ch//eos/opendata/atlas/OutreachDatasets/2020-08-19/1largeRjet1lep/MC/mc_364179.Wenu_PTV280_500_CVetoBVeto.1largeRjet1lep.root"
+      },
+      {
+        "checksum": "adler32:9c2d597f",
+        "size": 73860578,
+        "uri": "root://eospublic.cern.ch//eos/opendata/atlas/OutreachDatasets/2020-08-19/1largeRjet1lep/MC/mc_364180.Wenu_PTV280_500_CFilterBVeto.1largeRjet1lep.root"
+      },
+      {
+        "checksum": "adler32:14837011",
+        "size": 66364051,
+        "uri": "root://eospublic.cern.ch//eos/opendata/atlas/OutreachDatasets/2020-08-19/1largeRjet1lep/MC/mc_364181.Wenu_PTV280_500_BFilter.1largeRjet1lep.root"
+      },
+      {
+        "checksum": "adler32:4bf8dfe9",
+        "size": 325721949,
+        "uri": "root://eospublic.cern.ch//eos/opendata/atlas/OutreachDatasets/2020-08-19/1largeRjet1lep/MC/mc_364182.Wenu_PTV500_1000.1largeRjet1lep.root"
+      },
+      {
+        "checksum": "adler32:4967165c",
+        "size": 757032681,
+        "uri": "root://eospublic.cern.ch//eos/opendata/atlas/OutreachDatasets/2020-08-19/1largeRjet1lep/MC/mc_364183.Wenu_PTV1000_E_CMS.1largeRjet1lep.root"
+      },
+      {
+        "checksum": "adler32:07e7cdfa",
+        "size": 23190,
+        "uri": "root://eospublic.cern.ch//eos/opendata/atlas/OutreachDatasets/2020-08-19/1largeRjet1lep/MC/mc_364184.Wtaunu_PTV0_70_CVetoBVeto.1largeRjet1lep.root"
+      },
+      {
+        "checksum": "adler32:1bdeeb86",
+        "size": 22179,
+        "uri": "root://eospublic.cern.ch//eos/opendata/atlas/OutreachDatasets/2020-08-19/1largeRjet1lep/MC/mc_364185.Wtaunu_PTV0_70_CFilterBVeto.1largeRjet1lep.root"
+      },
+      {
+        "checksum": "adler32:12aceefa",
+        "size": 21348,
+        "uri": "root://eospublic.cern.ch//eos/opendata/atlas/OutreachDatasets/2020-08-19/1largeRjet1lep/MC/mc_364186.Wtaunu_PTV0_70_BFilter.1largeRjet1lep.root"
+      },
+      {
+        "checksum": "adler32:6c298d99",
+        "size": 29656,
+        "uri": "root://eospublic.cern.ch//eos/opendata/atlas/OutreachDatasets/2020-08-19/1largeRjet1lep/MC/mc_364187.Wtaunu_PTV70_140_CVetoBVeto.1largeRjet1lep.root"
+      },
+      {
+        "checksum": "adler32:678c7d77",
+        "size": 28017,
+        "uri": "root://eospublic.cern.ch//eos/opendata/atlas/OutreachDatasets/2020-08-19/1largeRjet1lep/MC/mc_364188.Wtaunu_PTV70_140_CFilterBVeto.1largeRjet1lep.root"
+      },
+      {
+        "checksum": "adler32:04e8ad27",
+        "size": 28149,
+        "uri": "root://eospublic.cern.ch//eos/opendata/atlas/OutreachDatasets/2020-08-19/1largeRjet1lep/MC/mc_364189.Wtaunu_PTV70_140_BFilter.1largeRjet1lep.root"
+      },
+      {
+        "checksum": "adler32:e1dede96",
+        "size": 2061988,
+        "uri": "root://eospublic.cern.ch//eos/opendata/atlas/OutreachDatasets/2020-08-19/1largeRjet1lep/MC/mc_364190.Wtaunu_PTV140_280_CVetoBVeto.1largeRjet1lep.root"
+      },
+      {
+        "checksum": "adler32:a7efcb34",
+        "size": 1256987,
+        "uri": "root://eospublic.cern.ch//eos/opendata/atlas/OutreachDatasets/2020-08-19/1largeRjet1lep/MC/mc_364191.Wtaunu_PTV140_280_CFilterBVeto.1largeRjet1lep.root"
+      },
+      {
+        "checksum": "adler32:82c80576",
+        "size": 908476,
+        "uri": "root://eospublic.cern.ch//eos/opendata/atlas/OutreachDatasets/2020-08-19/1largeRjet1lep/MC/mc_364192.Wtaunu_PTV140_280_BFilter.1largeRjet1lep.root"
+      },
+      {
+        "checksum": "adler32:5863009d",
+        "size": 28111877,
+        "uri": "root://eospublic.cern.ch//eos/opendata/atlas/OutreachDatasets/2020-08-19/1largeRjet1lep/MC/mc_364193.Wtaunu_PTV280_500_CVetoBVeto.1largeRjet1lep.root"
+      },
+      {
+        "checksum": "adler32:3313bf70",
+        "size": 13663896,
+        "uri": "root://eospublic.cern.ch//eos/opendata/atlas/OutreachDatasets/2020-08-19/1largeRjet1lep/MC/mc_364194.Wtaunu_PTV280_500_CFilterBVeto.1largeRjet1lep.root"
+      },
+      {
+        "checksum": "adler32:2dc1b110",
+        "size": 11848686,
+        "uri": "root://eospublic.cern.ch//eos/opendata/atlas/OutreachDatasets/2020-08-19/1largeRjet1lep/MC/mc_364195.Wtaunu_PTV280_500_BFilter.1largeRjet1lep.root"
+      },
+      {
+        "checksum": "adler32:e183da49",
+        "size": 112686136,
+        "uri": "root://eospublic.cern.ch//eos/opendata/atlas/OutreachDatasets/2020-08-19/1largeRjet1lep/MC/mc_364196.Wtaunu_PTV500_1000.1largeRjet1lep.root"
+      },
+      {
+        "checksum": "adler32:17d8c25b",
+        "size": 122003016,
+        "uri": "root://eospublic.cern.ch//eos/opendata/atlas/OutreachDatasets/2020-08-19/1largeRjet1lep/MC/mc_364197.Wtaunu_PTV1000_E_CMS.1largeRjet1lep.root"
+      },
+      {
+        "checksum": "adler32:1eb97a30",
+        "size": 19558575,
+        "uri": "root://eospublic.cern.ch//eos/opendata/atlas/OutreachDatasets/2020-08-19/1largeRjet1lep/MC/mc_370114.GG_ttn1_1200_5000_1.1largeRjet1lep.root"
+      },
+      {
+        "checksum": "adler32:743233d5",
+        "size": 13766161,
+        "uri": "root://eospublic.cern.ch//eos/opendata/atlas/OutreachDatasets/2020-08-19/1largeRjet1lep/MC/mc_370118.GG_ttn1_1200_5000_600.1largeRjet1lep.root"
+      },
+      {
+        "checksum": "adler32:e5e52400",
+        "size": 20026384,
+        "uri": "root://eospublic.cern.ch//eos/opendata/atlas/OutreachDatasets/2020-08-19/1largeRjet1lep/MC/mc_370129.GG_ttn1_1400_5000_1.1largeRjet1lep.root"
+      },
+      {
+        "checksum": "adler32:188e3fa6",
+        "size": 19762156,
+        "uri": "root://eospublic.cern.ch//eos/opendata/atlas/OutreachDatasets/2020-08-19/1largeRjet1lep/MC/mc_370144.GG_ttn1_1600_5000_1.1largeRjet1lep.root"
+      },
+      {
+        "checksum": "adler32:b690ae3d",
+        "size": 780855,
+        "uri": "root://eospublic.cern.ch//eos/opendata/atlas/OutreachDatasets/2020-08-19/1largeRjet1lep/MC/mc_387154.TT_directTT_500_1.1largeRjet1lep.root"
+      },
+      {
+        "checksum": "adler32:376988f6",
+        "size": 1377014,
+        "uri": "root://eospublic.cern.ch//eos/opendata/atlas/OutreachDatasets/2020-08-19/1largeRjet1lep/MC/mc_387157.TT_directTT_500_200.1largeRjet1lep.root"
+      },
+      {
+        "checksum": "adler32:2d48140e",
+        "size": 2574429,
+        "uri": "root://eospublic.cern.ch//eos/opendata/atlas/OutreachDatasets/2020-08-19/1largeRjet1lep/MC/mc_387163.TT_directTT_600_1.1largeRjet1lep.root"
+      },
+      {
+        "checksum": "adler32:528a1f2d",
+        "size": 1558769,
+        "uri": "root://eospublic.cern.ch//eos/opendata/atlas/OutreachDatasets/2020-08-19/1largeRjet1lep/MC/mc_388240.TT_directTT_450_1.1largeRjet1lep.root"
+      },
+      {
+        "checksum": "adler32:1c0769c5",
+        "size": 716311,
+        "uri": "root://eospublic.cern.ch//eos/opendata/atlas/OutreachDatasets/2020-08-19/1largeRjet1lep/MC/mc_392217.C1N2_WZ_400p0_0p0_3L_2L7.1largeRjet1lep.root"
+      },
+      {
+        "checksum": "adler32:4361066f",
+        "size": 581840,
+        "uri": "root://eospublic.cern.ch//eos/opendata/atlas/OutreachDatasets/2020-08-19/1largeRjet1lep/MC/mc_392220.C1N2_WZ_350p0_0p0_3L_2L7.1largeRjet1lep.root"
+      },
+      {
+        "checksum": "adler32:0103ce56",
+        "size": 507145,
+        "uri": "root://eospublic.cern.ch//eos/opendata/atlas/OutreachDatasets/2020-08-19/1largeRjet1lep/MC/mc_392223.C1N2_WZ_500p0_0p0_3L_2L7.1largeRjet1lep.root"
+      },
+      {
+        "checksum": "adler32:5f0d6eb3",
+        "size": 139850,
+        "uri": "root://eospublic.cern.ch//eos/opendata/atlas/OutreachDatasets/2020-08-19/1largeRjet1lep/MC/mc_392226.C1N2_WZ_100p0_0p0_3L_2L7.1largeRjet1lep.root"
+      },
+      {
+        "checksum": "adler32:e1b15554",
+        "size": 477450702,
+        "uri": "root://eospublic.cern.ch//eos/opendata/atlas/OutreachDatasets/2020-08-19/1largeRjet1lep/MC/mc_410000.ttbar_lep.1largeRjet1lep.root"
+      },
+      {
+        "checksum": "adler32:f737c530",
+        "size": 11768331,
+        "uri": "root://eospublic.cern.ch//eos/opendata/atlas/OutreachDatasets/2020-08-19/1largeRjet1lep/MC/mc_410011.single_top_tchan.1largeRjet1lep.root"
+      },
+      {
+        "checksum": "adler32:f80ba1ca",
+        "size": 9959220,
+        "uri": "root://eospublic.cern.ch//eos/opendata/atlas/OutreachDatasets/2020-08-19/1largeRjet1lep/MC/mc_410012.single_antitop_tchan.1largeRjet1lep.root"
+      },
+      {
+        "checksum": "adler32:e610fca3",
+        "size": 26569451,
+        "uri": "root://eospublic.cern.ch//eos/opendata/atlas/OutreachDatasets/2020-08-19/1largeRjet1lep/MC/mc_410013.single_top_wtchan.1largeRjet1lep.root"
+      },
+      {
+        "checksum": "adler32:62161305",
+        "size": 26324105,
+        "uri": "root://eospublic.cern.ch//eos/opendata/atlas/OutreachDatasets/2020-08-19/1largeRjet1lep/MC/mc_410014.single_antitop_wtchan.1largeRjet1lep.root"
+      },
+      {
+        "checksum": "adler32:e92fca97",
+        "size": 4036938,
+        "uri": "root://eospublic.cern.ch//eos/opendata/atlas/OutreachDatasets/2020-08-19/1largeRjet1lep/MC/mc_410025.single_top_schan.1largeRjet1lep.root"
+      },
+      {
+        "checksum": "adler32:53fa3cf4",
+        "size": 747499,
+        "uri": "root://eospublic.cern.ch//eos/opendata/atlas/OutreachDatasets/2020-08-19/1largeRjet1lep/MC/mc_410026.single_antitop_schan.1largeRjet1lep.root"
       }
     ],
     "license": {
@@ -53,7 +727,7 @@
       ]
     },
     "usage": {
-      "description": "This dataset is provided by the ATLAS Collaboration <strong>only for educational purposes and is not suited for scientific publications</strong>.\n You can access these data through the ATLAS Virtual Machine and Software.\n More documentation is available at:",
+      "description": "<p>This dataset is provided as a zipped tarball (<code>1largeRjet1lep.zip</code>) and as a list of unzipped individually-accessible ROOT files containing the collision data (such as <code>data_A.1largeRjet1lep.root</code>) and the simulated data (such as <code>mc_301322.ZPrime400_tt.1largeRjet1lep.root</code>). You can use either the tarball or the individual ROOT files.</p> </p>This dataset is provided by the ATLAS Collaboration <strong>only for educational purposes and is not suited for scientific publications</strong>.\n You can access these data through the ATLAS Virtual Machine and Software.\n More documentation is available at:</p>",
       "links": [
         {
           "description": "The ATLAS Open Data documentation for 13 TeV release",

--- a/data/records/atlas-2020-1lep.json
+++ b/data/records/atlas-2020-1lep.json
@@ -19,8 +19,12 @@
     ],
     "date_published": "2020",
     "distribution": {
-      "number_files": 3,
-      "size": 61443906158
+      "formats": [
+        "root",
+        "zip"
+      ],
+      "number_files": 136,
+      "size": 146434332834
     },
     "doi": "10.7483/OPENDATA.ATLAS.NQ31.Y1OO",
     "experiment": [
@@ -41,6 +45,671 @@
         "checksum": "adler32:d7cca164",
         "size": 22363043221,
         "uri": "root://eospublic.cern.ch//eos/opendata/atlas/OutreachDatasets/2020-08-19/MC-2-1lep.zip"
+      },
+      {
+        "checksum": "adler32:b236d777",
+        "size": 1581143872,
+        "uri": "root://eospublic.cern.ch//eos/opendata/atlas/OutreachDatasets/2020-08-19/Data-1lep/Data/data_A.1lep.root"
+      },
+      {
+        "checksum": "adler32:3dc75172",
+        "size": 5628362441,
+        "uri": "root://eospublic.cern.ch//eos/opendata/atlas/OutreachDatasets/2020-08-19/Data-1lep/Data/data_B.1lep.root"
+      },
+      {
+        "checksum": "adler32:08dc5f1a",
+        "size": 8252468104,
+        "uri": "root://eospublic.cern.ch//eos/opendata/atlas/OutreachDatasets/2020-08-19/Data-1lep/Data/data_C.1lep.root"
+      },
+      {
+        "checksum": "adler32:f388882a",
+        "size": 11783935149,
+        "uri": "root://eospublic.cern.ch//eos/opendata/atlas/OutreachDatasets/2020-08-19/Data-1lep/Data/data_D.1lep.root"
+      },
+      {
+        "checksum": "adler32:0708d618",
+        "size": 9150236,
+        "uri": "root://eospublic.cern.ch//eos/opendata/atlas/OutreachDatasets/2020-08-19/MC-1-1lep/tmp1/mc_301322.ZPrime400_tt.1lep.root"
+      },
+      {
+        "checksum": "adler32:f2be227d",
+        "size": 10437780,
+        "uri": "root://eospublic.cern.ch//eos/opendata/atlas/OutreachDatasets/2020-08-19/MC-1-1lep/tmp1/mc_301323.ZPrime500_tt.1lep.root"
+      },
+      {
+        "checksum": "adler32:ce21d7a3",
+        "size": 11998628,
+        "uri": "root://eospublic.cern.ch//eos/opendata/atlas/OutreachDatasets/2020-08-19/MC-1-1lep/tmp1/mc_301324.ZPrime750_tt.1lep.root"
+      },
+      {
+        "checksum": "adler32:53da0fec",
+        "size": 12607457,
+        "uri": "root://eospublic.cern.ch//eos/opendata/atlas/OutreachDatasets/2020-08-19/MC-1-1lep/tmp1/mc_301325.ZPrime1000_tt.1lep.root"
+      },
+      {
+        "checksum": "adler32:0194d1fa",
+        "size": 12829597,
+        "uri": "root://eospublic.cern.ch//eos/opendata/atlas/OutreachDatasets/2020-08-19/MC-1-1lep/tmp1/mc_301326.ZPrime1250_tt.1lep.root"
+      },
+      {
+        "checksum": "adler32:99e30b73",
+        "size": 12476245,
+        "uri": "root://eospublic.cern.ch//eos/opendata/atlas/OutreachDatasets/2020-08-19/MC-1-1lep/tmp1/mc_301327.ZPrime1500_tt.1lep.root"
+      },
+      {
+        "checksum": "adler32:8574f0e3",
+        "size": 12029413,
+        "uri": "root://eospublic.cern.ch//eos/opendata/atlas/OutreachDatasets/2020-08-19/MC-1-1lep/tmp1/mc_301328.ZPrime1750_tt.1lep.root"
+      },
+      {
+        "checksum": "adler32:58aa02c8",
+        "size": 11365987,
+        "uri": "root://eospublic.cern.ch//eos/opendata/atlas/OutreachDatasets/2020-08-19/MC-1-1lep/tmp1/mc_301329.ZPrime2000_tt.1lep.root"
+      },
+      {
+        "checksum": "adler32:917ee527",
+        "size": 10767082,
+        "uri": "root://eospublic.cern.ch//eos/opendata/atlas/OutreachDatasets/2020-08-19/MC-1-1lep/tmp1/mc_301330.ZPrime2250_tt.1lep.root"
+      },
+      {
+        "checksum": "adler32:01d3bf2d",
+        "size": 10164888,
+        "uri": "root://eospublic.cern.ch//eos/opendata/atlas/OutreachDatasets/2020-08-19/MC-1-1lep/tmp1/mc_301331.ZPrime2500_tt.1lep.root"
+      },
+      {
+        "checksum": "adler32:4c30b124",
+        "size": 9570558,
+        "uri": "root://eospublic.cern.ch//eos/opendata/atlas/OutreachDatasets/2020-08-19/MC-1-1lep/tmp1/mc_301332.ZPrime2750_tt.1lep.root"
+      },
+      {
+        "checksum": "adler32:a2ce1709",
+        "size": 8848979,
+        "uri": "root://eospublic.cern.ch//eos/opendata/atlas/OutreachDatasets/2020-08-19/MC-1-1lep/tmp1/mc_301333.ZPrime3000_tt.1lep.root"
+      },
+      {
+        "checksum": "adler32:798cdc71",
+        "size": 2110325769,
+        "uri": "root://eospublic.cern.ch//eos/opendata/atlas/OutreachDatasets/2020-08-19/MC-1-1lep/tmp1/mc_361100.Wplusenu.1lep.root"
+      },
+      {
+        "checksum": "adler32:eb59c19a",
+        "size": 2228801352,
+        "uri": "root://eospublic.cern.ch//eos/opendata/atlas/OutreachDatasets/2020-08-19/MC-1-1lep/tmp1/mc_361101.Wplusmunu.1lep.root"
+      },
+      {
+        "checksum": "adler32:78c47c4d",
+        "size": 97632847,
+        "uri": "root://eospublic.cern.ch//eos/opendata/atlas/OutreachDatasets/2020-08-19/MC-1-1lep/tmp1/mc_361102.Wplustaunu.1lep.root"
+      },
+      {
+        "checksum": "adler32:ab269fc8",
+        "size": 1575996010,
+        "uri": "root://eospublic.cern.ch//eos/opendata/atlas/OutreachDatasets/2020-08-19/MC-1-1lep/tmp1/mc_361103.Wminusenu.1lep.root"
+      },
+      {
+        "checksum": "adler32:7a9fd1c0",
+        "size": 1850176067,
+        "uri": "root://eospublic.cern.ch//eos/opendata/atlas/OutreachDatasets/2020-08-19/MC-1-1lep/tmp1/mc_361104.Wminusmunu.1lep.root"
+      },
+      {
+        "checksum": "adler32:9f103828",
+        "size": 73236961,
+        "uri": "root://eospublic.cern.ch//eos/opendata/atlas/OutreachDatasets/2020-08-19/MC-1-1lep/tmp1/mc_361105.Wminustaunu.1lep.root"
+      },
+      {
+        "checksum": "adler32:2b9ab2c8",
+        "size": 3003083639,
+        "uri": "root://eospublic.cern.ch//eos/opendata/atlas/OutreachDatasets/2020-08-19/MC-1-1lep/tmp1/mc_361106.Zee.1lep.root"
+      },
+      {
+        "checksum": "adler32:45737295",
+        "size": 2241940576,
+        "uri": "root://eospublic.cern.ch//eos/opendata/atlas/OutreachDatasets/2020-08-19/MC-1-1lep/tmp1/mc_361107.Zmumu.1lep.root"
+      },
+      {
+        "checksum": "adler32:702a9148",
+        "size": 196177504,
+        "uri": "root://eospublic.cern.ch//eos/opendata/atlas/OutreachDatasets/2020-08-19/MC-1-1lep/tmp1/mc_361108.Ztautau.1lep.root"
+      },
+      {
+        "checksum": "adler32:5b1293d1",
+        "size": 214883983,
+        "uri": "root://eospublic.cern.ch//eos/opendata/atlas/OutreachDatasets/2020-08-19/MC-1-1lep/tmp1/mc_363356.ZqqZll.1lep.root"
+      },
+      {
+        "checksum": "adler32:465ef569",
+        "size": 208474649,
+        "uri": "root://eospublic.cern.ch//eos/opendata/atlas/OutreachDatasets/2020-08-19/MC-1-1lep/tmp1/mc_363358.WqqZll.1lep.root"
+      },
+      {
+        "checksum": "adler32:805ad1c3",
+        "size": 450855409,
+        "uri": "root://eospublic.cern.ch//eos/opendata/atlas/OutreachDatasets/2020-08-19/MC-1-1lep/tmp1/mc_363359.WpqqWmlv.1lep.root"
+      },
+      {
+        "checksum": "adler32:0cc2b165",
+        "size": 471555842,
+        "uri": "root://eospublic.cern.ch//eos/opendata/atlas/OutreachDatasets/2020-08-19/MC-1-1lep/tmp1/mc_363360.WplvWmqq.1lep.root"
+      },
+      {
+        "checksum": "adler32:447bcf31",
+        "size": 483495222,
+        "uri": "root://eospublic.cern.ch//eos/opendata/atlas/OutreachDatasets/2020-08-19/MC-1-1lep/tmp1/mc_363489.WlvZqq.1lep.root"
+      },
+      {
+        "checksum": "adler32:20b32c4d",
+        "size": 347459793,
+        "uri": "root://eospublic.cern.ch//eos/opendata/atlas/OutreachDatasets/2020-08-19/MC-1-1lep/tmp1/mc_363490.llll.1lep.root"
+      },
+      {
+        "checksum": "adler32:9f77738c",
+        "size": 549170156,
+        "uri": "root://eospublic.cern.ch//eos/opendata/atlas/OutreachDatasets/2020-08-19/MC-1-1lep/tmp1/mc_363491.lllv.1lep.root"
+      },
+      {
+        "checksum": "adler32:1f816c3a",
+        "size": 900646798,
+        "uri": "root://eospublic.cern.ch//eos/opendata/atlas/OutreachDatasets/2020-08-19/MC-1-1lep/tmp1/mc_363492.llvv.1lep.root"
+      },
+      {
+        "checksum": "adler32:d056d151",
+        "size": 427015999,
+        "uri": "root://eospublic.cern.ch//eos/opendata/atlas/OutreachDatasets/2020-08-19/MC-1-1lep/tmp1/mc_363493.lvvv.1lep.root"
+      },
+      {
+        "checksum": "adler32:c25a4b1c",
+        "size": 225069943,
+        "uri": "root://eospublic.cern.ch//eos/opendata/atlas/OutreachDatasets/2020-08-19/MC-1-1lep/tmp1/mc_364100.Zmumu_PTV0_70_CVetoBVeto.1lep.root"
+      },
+      {
+        "checksum": "adler32:98ac8016",
+        "size": 151162042,
+        "uri": "root://eospublic.cern.ch//eos/opendata/atlas/OutreachDatasets/2020-08-19/MC-1-1lep/tmp1/mc_364101.Zmumu_PTV0_70_CFilterBVeto.1lep.root"
+      },
+      {
+        "checksum": "adler32:b91d0573",
+        "size": 234375589,
+        "uri": "root://eospublic.cern.ch//eos/opendata/atlas/OutreachDatasets/2020-08-19/MC-1-1lep/tmp1/mc_364102.Zmumu_PTV0_70_BFilter.1lep.root"
+      },
+      {
+        "checksum": "adler32:ede0980a",
+        "size": 235464249,
+        "uri": "root://eospublic.cern.ch//eos/opendata/atlas/OutreachDatasets/2020-08-19/MC-1-1lep/tmp1/mc_364103.Zmumu_PTV70_140_CVetoBVeto.1lep.root"
+      },
+      {
+        "checksum": "adler32:919bb5cc",
+        "size": 79606591,
+        "uri": "root://eospublic.cern.ch//eos/opendata/atlas/OutreachDatasets/2020-08-19/MC-1-1lep/tmp1/mc_364104.Zmumu_PTV70_140_CFilterBVeto.1lep.root"
+      },
+      {
+        "checksum": "adler32:33b89fb8",
+        "size": 228599240,
+        "uri": "root://eospublic.cern.ch//eos/opendata/atlas/OutreachDatasets/2020-08-19/MC-1-1lep/tmp1/mc_364105.Zmumu_PTV70_140_BFilter.1lep.root"
+      },
+      {
+        "checksum": "adler32:00e8e0a3",
+        "size": 211558814,
+        "uri": "root://eospublic.cern.ch//eos/opendata/atlas/OutreachDatasets/2020-08-19/MC-1-1lep/tmp1/mc_364106.Zmumu_PTV140_280_CVetoBVeto.1lep.root"
+      },
+      {
+        "checksum": "adler32:0f8ddd3a",
+        "size": 132932998,
+        "uri": "root://eospublic.cern.ch//eos/opendata/atlas/OutreachDatasets/2020-08-19/MC-1-1lep/tmp1/mc_364107.Zmumu_PTV140_280_CFilterBVeto.1lep.root"
+      },
+      {
+        "checksum": "adler32:5c49c9c1",
+        "size": 521234116,
+        "uri": "root://eospublic.cern.ch//eos/opendata/atlas/OutreachDatasets/2020-08-19/MC-1-1lep/tmp1/mc_364108.Zmumu_PTV140_280_BFilter.1lep.root"
+      },
+      {
+        "checksum": "adler32:137fdf2e",
+        "size": 99035889,
+        "uri": "root://eospublic.cern.ch//eos/opendata/atlas/OutreachDatasets/2020-08-19/MC-1-1lep/tmp1/mc_364109.Zmumu_PTV280_500_CVetoBVeto.1lep.root"
+      },
+      {
+        "checksum": "adler32:74f24d13",
+        "size": 53198485,
+        "uri": "root://eospublic.cern.ch//eos/opendata/atlas/OutreachDatasets/2020-08-19/MC-1-1lep/tmp1/mc_364110.Zmumu_PTV280_500_CFilterBVeto.1lep.root"
+      },
+      {
+        "checksum": "adler32:a1dc4092",
+        "size": 105199264,
+        "uri": "root://eospublic.cern.ch//eos/opendata/atlas/OutreachDatasets/2020-08-19/MC-1-1lep/tmp1/mc_364111.Zmumu_PTV280_500_BFilter.1lep.root"
+      },
+      {
+        "checksum": "adler32:2a574779",
+        "size": 180171637,
+        "uri": "root://eospublic.cern.ch//eos/opendata/atlas/OutreachDatasets/2020-08-19/MC-1-1lep/tmp1/mc_364112.Zmumu_PTV500_1000.1lep.root"
+      },
+      {
+        "checksum": "adler32:bcaf0804",
+        "size": 68166527,
+        "uri": "root://eospublic.cern.ch//eos/opendata/atlas/OutreachDatasets/2020-08-19/MC-1-1lep/tmp1/mc_364113.Zmumu_PTV1000_E_CMS.1lep.root"
+      },
+      {
+        "checksum": "adler32:6f05fd42",
+        "size": 292182052,
+        "uri": "root://eospublic.cern.ch//eos/opendata/atlas/OutreachDatasets/2020-08-19/MC-1-1lep/tmp1/mc_364114.Zee_PTV0_70_CVetoBVeto.1lep.root"
+      },
+      {
+        "checksum": "adler32:7621fd89",
+        "size": 199024449,
+        "uri": "root://eospublic.cern.ch//eos/opendata/atlas/OutreachDatasets/2020-08-19/MC-1-1lep/tmp1/mc_364115.Zee_PTV0_70_CFilterBVeto.1lep.root"
+      },
+      {
+        "checksum": "adler32:e924f9a5",
+        "size": 319283805,
+        "uri": "root://eospublic.cern.ch//eos/opendata/atlas/OutreachDatasets/2020-08-19/MC-1-1lep/tmp1/mc_364116.Zee_PTV0_70_BFilter.1lep.root"
+      },
+      {
+        "checksum": "adler32:7047be5f",
+        "size": 323352681,
+        "uri": "root://eospublic.cern.ch//eos/opendata/atlas/OutreachDatasets/2020-08-19/MC-1-1lep/tmp1/mc_364117.Zee_PTV70_140_CVetoBVeto.1lep.root"
+      },
+      {
+        "checksum": "adler32:ef23425b",
+        "size": 110721798,
+        "uri": "root://eospublic.cern.ch//eos/opendata/atlas/OutreachDatasets/2020-08-19/MC-1-1lep/tmp1/mc_364118.Zee_PTV70_140_CFilterBVeto.1lep.root"
+      },
+      {
+        "checksum": "adler32:24734787",
+        "size": 321639629,
+        "uri": "root://eospublic.cern.ch//eos/opendata/atlas/OutreachDatasets/2020-08-19/MC-1-1lep/tmp1/mc_364119.Zee_PTV70_140_BFilter.1lep.root"
+      },
+      {
+        "checksum": "adler32:b5180bef",
+        "size": 307816555,
+        "uri": "root://eospublic.cern.ch//eos/opendata/atlas/OutreachDatasets/2020-08-19/MC-1-1lep/tmp1/mc_364120.Zee_PTV140_280_CVetoBVeto.1lep.root"
+      },
+      {
+        "checksum": "adler32:7ceaa1b2",
+        "size": 187229277,
+        "uri": "root://eospublic.cern.ch//eos/opendata/atlas/OutreachDatasets/2020-08-19/MC-1-1lep/tmp1/mc_364121.Zee_PTV140_280_CFilterBVeto.1lep.root"
+      },
+      {
+        "checksum": "adler32:b6f781bc",
+        "size": 754068839,
+        "uri": "root://eospublic.cern.ch//eos/opendata/atlas/OutreachDatasets/2020-08-19/MC-1-1lep/tmp1/mc_364122.Zee_PTV140_280_BFilter.1lep.root"
+      },
+      {
+        "checksum": "adler32:8235e1cc",
+        "size": 137007827,
+        "uri": "root://eospublic.cern.ch//eos/opendata/atlas/OutreachDatasets/2020-08-19/MC-1-1lep/tmp1/mc_364123.Zee_PTV280_500_CVetoBVeto.1lep.root"
+      },
+      {
+        "checksum": "adler32:f046a64e",
+        "size": 73603199,
+        "uri": "root://eospublic.cern.ch//eos/opendata/atlas/OutreachDatasets/2020-08-19/MC-1-1lep/tmp1/mc_364124.Zee_PTV280_500_CFilterBVeto.1lep.root"
+      },
+      {
+        "checksum": "adler32:ee039d62",
+        "size": 145152062,
+        "uri": "root://eospublic.cern.ch//eos/opendata/atlas/OutreachDatasets/2020-08-19/MC-1-1lep/tmp1/mc_364125.Zee_PTV280_500_BFilter.1lep.root"
+      },
+      {
+        "checksum": "adler32:e14db90e",
+        "size": 244506464,
+        "uri": "root://eospublic.cern.ch//eos/opendata/atlas/OutreachDatasets/2020-08-19/MC-1-1lep/tmp1/mc_364126.Zee_PTV500_1000.1lep.root"
+      },
+      {
+        "checksum": "adler32:c8db9264",
+        "size": 91597597,
+        "uri": "root://eospublic.cern.ch//eos/opendata/atlas/OutreachDatasets/2020-08-19/MC-1-1lep/tmp1/mc_364127.Zee_PTV1000_E_CMS.1lep.root"
+      },
+      {
+        "checksum": "adler32:f94cf228",
+        "size": 47865141,
+        "uri": "root://eospublic.cern.ch//eos/opendata/atlas/OutreachDatasets/2020-08-19/MC-1-1lep/tmp1/mc_364128.Ztautau_PTV0_70_CVetoBVeto.1lep.root"
+      },
+      {
+        "checksum": "adler32:f53894fa",
+        "size": 35661225,
+        "uri": "root://eospublic.cern.ch//eos/opendata/atlas/OutreachDatasets/2020-08-19/MC-1-1lep/tmp1/mc_364129.Ztautau_PTV0_70_CFilterBVeto.1lep.root"
+      },
+      {
+        "checksum": "adler32:980508c3",
+        "size": 60459679,
+        "uri": "root://eospublic.cern.ch//eos/opendata/atlas/OutreachDatasets/2020-08-19/MC-1-1lep/tmp1/mc_364130.Ztautau_PTV0_70_BFilter.1lep.root"
+      },
+      {
+        "checksum": "adler32:55dde318",
+        "size": 94061362,
+        "uri": "root://eospublic.cern.ch//eos/opendata/atlas/OutreachDatasets/2020-08-19/MC-1-1lep/tmp1/mc_364131.Ztautau_PTV70_140_CVetoBVeto.1lep.root"
+      },
+      {
+        "checksum": "adler32:a461ad64",
+        "size": 32176413,
+        "uri": "root://eospublic.cern.ch//eos/opendata/atlas/OutreachDatasets/2020-08-19/MC-1-1lep/tmp1/mc_364132.Ztautau_PTV70_140_CFilterBVeto.1lep.root"
+      },
+      {
+        "checksum": "adler32:08e6129b",
+        "size": 97932775,
+        "uri": "root://eospublic.cern.ch//eos/opendata/atlas/OutreachDatasets/2020-08-19/MC-1-1lep/tmp1/mc_364133.Ztautau_PTV70_140_BFilter.1lep.root"
+      },
+      {
+        "checksum": "adler32:b3ee4bbc",
+        "size": 122987640,
+        "uri": "root://eospublic.cern.ch//eos/opendata/atlas/OutreachDatasets/2020-08-19/MC-1-1lep/tmp1/mc_364134.Ztautau_PTV140_280_CVetoBVeto.1lep.root"
+      },
+      {
+        "checksum": "adler32:39e5f65e",
+        "size": 73244549,
+        "uri": "root://eospublic.cern.ch//eos/opendata/atlas/OutreachDatasets/2020-08-19/MC-1-1lep/tmp1/mc_364135.Ztautau_PTV140_280_CFilterBVeto.1lep.root"
+      },
+      {
+        "checksum": "adler32:2b371d75",
+        "size": 120911564,
+        "uri": "root://eospublic.cern.ch//eos/opendata/atlas/OutreachDatasets/2020-08-19/MC-1-1lep/tmp1/mc_364136.Ztautau_PTV140_280_BFilter.1lep.root"
+      },
+      {
+        "checksum": "adler32:0ea4393a",
+        "size": 61002968,
+        "uri": "root://eospublic.cern.ch//eos/opendata/atlas/OutreachDatasets/2020-08-19/MC-1-1lep/tmp1/mc_364137.Ztautau_PTV280_500_CVetoBVeto.1lep.root"
+      },
+      {
+        "checksum": "adler32:d50478bd",
+        "size": 30717163,
+        "uri": "root://eospublic.cern.ch//eos/opendata/atlas/OutreachDatasets/2020-08-19/MC-1-1lep/tmp1/mc_364138.Ztautau_PTV280_500_CFilterBVeto.1lep.root"
+      },
+      {
+        "checksum": "adler32:fc99db9a",
+        "size": 61279360,
+        "uri": "root://eospublic.cern.ch//eos/opendata/atlas/OutreachDatasets/2020-08-19/MC-1-1lep/tmp1/mc_364139.Ztautau_PTV280_500_BFilter.1lep.root"
+      },
+      {
+        "checksum": "adler32:baa46690",
+        "size": 1435326623,
+        "uri": "root://eospublic.cern.ch//eos/opendata/atlas/OutreachDatasets/2020-08-19/MC-1-1lep/tmp1/mc_364156.Wmunu_PTV0_70_CVetoBVeto.1lep.root"
+      },
+      {
+        "checksum": "adler32:4cade42b",
+        "size": 670610691,
+        "uri": "root://eospublic.cern.ch//eos/opendata/atlas/OutreachDatasets/2020-08-19/MC-1-1lep/tmp1/mc_364157.Wmunu_PTV0_70_CFilterBVeto.1lep.root"
+      },
+      {
+        "checksum": "adler32:7ea4c4d6",
+        "size": 1058882099,
+        "uri": "root://eospublic.cern.ch//eos/opendata/atlas/OutreachDatasets/2020-08-19/MC-1-1lep/tmp1/mc_364158.Wmunu_PTV0_70_BFilter.1lep.root"
+      },
+      {
+        "checksum": "adler32:33066a2d",
+        "size": 11040812,
+        "uri": "root://eospublic.cern.ch//eos/opendata/atlas/OutreachDatasets/2020-08-19/MC-1-1lep/tmp1/mc_370114.GG_ttn1_1200_5000_1.1lep.root"
+      },
+      {
+        "checksum": "adler32:1b0be8a2",
+        "size": 10024605,
+        "uri": "root://eospublic.cern.ch//eos/opendata/atlas/OutreachDatasets/2020-08-19/MC-1-1lep/tmp1/mc_370118.GG_ttn1_1200_5000_600.1lep.root"
+      },
+      {
+        "checksum": "adler32:ee6b1e16",
+        "size": 11180281,
+        "uri": "root://eospublic.cern.ch//eos/opendata/atlas/OutreachDatasets/2020-08-19/MC-1-1lep/tmp1/mc_370129.GG_ttn1_1400_5000_1.1lep.root"
+      },
+      {
+        "checksum": "adler32:109b4f92",
+        "size": 10902288,
+        "uri": "root://eospublic.cern.ch//eos/opendata/atlas/OutreachDatasets/2020-08-19/MC-1-1lep/tmp1/mc_370144.GG_ttn1_1600_5000_1.1lep.root"
+      },
+      {
+        "checksum": "adler32:522f645d",
+        "size": 1183884,
+        "uri": "root://eospublic.cern.ch//eos/opendata/atlas/OutreachDatasets/2020-08-19/MC-1-1lep/tmp1/mc_387154.TT_directTT_500_1.1lep.root"
+      },
+      {
+        "checksum": "adler32:be0014f7",
+        "size": 2858451,
+        "uri": "root://eospublic.cern.ch//eos/opendata/atlas/OutreachDatasets/2020-08-19/MC-1-1lep/tmp1/mc_387157.TT_directTT_500_200.1lep.root"
+      },
+      {
+        "checksum": "adler32:6c0b41c9",
+        "size": 3043858,
+        "uri": "root://eospublic.cern.ch//eos/opendata/atlas/OutreachDatasets/2020-08-19/MC-1-1lep/tmp1/mc_387163.TT_directTT_600_1.1lep.root"
+      },
+      {
+        "checksum": "adler32:87ac6bb9",
+        "size": 2895819,
+        "uri": "root://eospublic.cern.ch//eos/opendata/atlas/OutreachDatasets/2020-08-19/MC-1-1lep/tmp1/mc_388240.TT_directTT_450_1.1lep.root"
+      },
+      {
+        "checksum": "adler32:c429ad0d",
+        "size": 335536951,
+        "uri": "root://eospublic.cern.ch//eos/opendata/atlas/OutreachDatasets/2020-08-19/MC-1-1lep/tmp1/mc_410011.single_top_tchan.1lep.root"
+      },
+      {
+        "checksum": "adler32:ec71e356",
+        "size": 352744215,
+        "uri": "root://eospublic.cern.ch//eos/opendata/atlas/OutreachDatasets/2020-08-19/MC-1-1lep/tmp1/mc_410012.single_antitop_tchan.1lep.root"
+      },
+      {
+        "checksum": "adler32:ca2f9154",
+        "size": 237946576,
+        "uri": "root://eospublic.cern.ch//eos/opendata/atlas/OutreachDatasets/2020-08-19/MC-1-1lep/tmp1/mc_410013.single_top_wtchan.1lep.root"
+      },
+      {
+        "checksum": "adler32:a8d33f3f",
+        "size": 241344098,
+        "uri": "root://eospublic.cern.ch//eos/opendata/atlas/OutreachDatasets/2020-08-19/MC-1-1lep/tmp1/mc_410014.single_antitop_wtchan.1lep.root"
+      },
+      {
+        "checksum": "adler32:910f44c7",
+        "size": 64126921,
+        "uri": "root://eospublic.cern.ch//eos/opendata/atlas/OutreachDatasets/2020-08-19/MC-1-1lep/tmp1/mc_410025.single_top_schan.1lep.root"
+      },
+      {
+        "checksum": "adler32:8534f8f2",
+        "size": 66245435,
+        "uri": "root://eospublic.cern.ch//eos/opendata/atlas/OutreachDatasets/2020-08-19/MC-1-1lep/tmp1/mc_410026.single_antitop_schan.1lep.root"
+      },
+      {
+        "checksum": "adler32:eddff083",
+        "size": 97105738,
+        "uri": "root://eospublic.cern.ch//eos/opendata/atlas/OutreachDatasets/2020-08-19/MC-2-1lep/tmp2/mc_364140.Ztautau_PTV500_1000.1lep.root"
+      },
+      {
+        "checksum": "adler32:c75af1bf",
+        "size": 38690339,
+        "uri": "root://eospublic.cern.ch//eos/opendata/atlas/OutreachDatasets/2020-08-19/MC-2-1lep/tmp2/mc_364141.Ztautau_PTV1000_E_CMS.1lep.root"
+      },
+      {
+        "checksum": "adler32:6cf440d8",
+        "size": 1227423695,
+        "uri": "root://eospublic.cern.ch//eos/opendata/atlas/OutreachDatasets/2020-08-19/MC-2-1lep/tmp2/mc_364159.Wmunu_PTV70_140_CVetoBVeto.1lep.root"
+      },
+      {
+        "checksum": "adler32:23b5c3fc",
+        "size": 922835058,
+        "uri": "root://eospublic.cern.ch//eos/opendata/atlas/OutreachDatasets/2020-08-19/MC-2-1lep/tmp2/mc_364160.Wmunu_PTV70_140_CFilterBVeto.1lep.root"
+      },
+      {
+        "checksum": "adler32:86256af3",
+        "size": 1641218403,
+        "uri": "root://eospublic.cern.ch//eos/opendata/atlas/OutreachDatasets/2020-08-19/MC-2-1lep/tmp2/mc_364161.Wmunu_PTV70_140_BFilter.1lep.root"
+      },
+      {
+        "checksum": "adler32:7d30dd54",
+        "size": 963953050,
+        "uri": "root://eospublic.cern.ch//eos/opendata/atlas/OutreachDatasets/2020-08-19/MC-2-1lep/tmp2/mc_364162.Wmunu_PTV140_280_CVetoBVeto.1lep.root"
+      },
+      {
+        "checksum": "adler32:fe0fe8f9",
+        "size": 798428586,
+        "uri": "root://eospublic.cern.ch//eos/opendata/atlas/OutreachDatasets/2020-08-19/MC-2-1lep/tmp2/mc_364163.Wmunu_PTV140_280_CFilterBVeto.1lep.root"
+      },
+      {
+        "checksum": "adler32:f06d4af6",
+        "size": 2404500342,
+        "uri": "root://eospublic.cern.ch//eos/opendata/atlas/OutreachDatasets/2020-08-19/MC-2-1lep/tmp2/mc_364164.Wmunu_PTV140_280_BFilter.1lep.root"
+      },
+      {
+        "checksum": "adler32:334ab377",
+        "size": 551980290,
+        "uri": "root://eospublic.cern.ch//eos/opendata/atlas/OutreachDatasets/2020-08-19/MC-2-1lep/tmp2/mc_364165.Wmunu_PTV280_500_CVetoBVeto.1lep.root"
+      },
+      {
+        "checksum": "adler32:44c130b9",
+        "size": 356853475,
+        "uri": "root://eospublic.cern.ch//eos/opendata/atlas/OutreachDatasets/2020-08-19/MC-2-1lep/tmp2/mc_364166.Wmunu_PTV280_500_CFilterBVeto.1lep.root"
+      },
+      {
+        "checksum": "adler32:6019aa04",
+        "size": 333726236,
+        "uri": "root://eospublic.cern.ch//eos/opendata/atlas/OutreachDatasets/2020-08-19/MC-2-1lep/tmp2/mc_364167.Wmunu_PTV280_500_BFilter.1lep.root"
+      },
+      {
+        "checksum": "adler32:3d32dde9",
+        "size": 748353243,
+        "uri": "root://eospublic.cern.ch//eos/opendata/atlas/OutreachDatasets/2020-08-19/MC-2-1lep/tmp2/mc_364168.Wmunu_PTV500_1000.1lep.root"
+      },
+      {
+        "checksum": "adler32:89a3948d",
+        "size": 543111019,
+        "uri": "root://eospublic.cern.ch//eos/opendata/atlas/OutreachDatasets/2020-08-19/MC-2-1lep/tmp2/mc_364169.Wmunu_PTV1000_E_CMS.1lep.root"
+      },
+      {
+        "checksum": "adler32:689a9356",
+        "size": 1253157934,
+        "uri": "root://eospublic.cern.ch//eos/opendata/atlas/OutreachDatasets/2020-08-19/MC-2-1lep/tmp2/mc_364170.Wenu_PTV0_70_CVetoBVeto.1lep.root"
+      },
+      {
+        "checksum": "adler32:b759838a",
+        "size": 601042989,
+        "uri": "root://eospublic.cern.ch//eos/opendata/atlas/OutreachDatasets/2020-08-19/MC-2-1lep/tmp2/mc_364171.Wenu_PTV0_70_CFilterBVeto.1lep.root"
+      },
+      {
+        "checksum": "adler32:f64c67e9",
+        "size": 937058188,
+        "uri": "root://eospublic.cern.ch//eos/opendata/atlas/OutreachDatasets/2020-08-19/MC-2-1lep/tmp2/mc_364172.Wenu_PTV0_70_BFilter.1lep.root"
+      },
+      {
+        "checksum": "adler32:f2551a4b",
+        "size": 1168230875,
+        "uri": "root://eospublic.cern.ch//eos/opendata/atlas/OutreachDatasets/2020-08-19/MC-2-1lep/tmp2/mc_364173.Wenu_PTV70_140_CVetoBVeto.1lep.root"
+      },
+      {
+        "checksum": "adler32:aded7b2a",
+        "size": 903871214,
+        "uri": "root://eospublic.cern.ch//eos/opendata/atlas/OutreachDatasets/2020-08-19/MC-2-1lep/tmp2/mc_364174.Wenu_PTV70_140_CFilterBVeto.1lep.root"
+      },
+      {
+        "checksum": "adler32:deb250e9",
+        "size": 789464786,
+        "uri": "root://eospublic.cern.ch//eos/opendata/atlas/OutreachDatasets/2020-08-19/MC-2-1lep/tmp2/mc_364175.Wenu_PTV70_140_BFilter.1lep.root"
+      },
+      {
+        "checksum": "adler32:938eed2c",
+        "size": 967931202,
+        "uri": "root://eospublic.cern.ch//eos/opendata/atlas/OutreachDatasets/2020-08-19/MC-2-1lep/tmp2/mc_364176.Wenu_PTV140_280_CVetoBVeto.1lep.root"
+      },
+      {
+        "checksum": "adler32:1b0e3626",
+        "size": 641613996,
+        "uri": "root://eospublic.cern.ch//eos/opendata/atlas/OutreachDatasets/2020-08-19/MC-2-1lep/tmp2/mc_364177.Wenu_PTV140_280_CFilterBVeto.1lep.root"
+      },
+      {
+        "checksum": "adler32:5ae06f97",
+        "size": 2425242491,
+        "uri": "root://eospublic.cern.ch//eos/opendata/atlas/OutreachDatasets/2020-08-19/MC-2-1lep/tmp2/mc_364178.Wenu_PTV140_280_BFilter.1lep.root"
+      },
+      {
+        "checksum": "adler32:641bcad7",
+        "size": 565587233,
+        "uri": "root://eospublic.cern.ch//eos/opendata/atlas/OutreachDatasets/2020-08-19/MC-2-1lep/tmp2/mc_364179.Wenu_PTV280_500_CVetoBVeto.1lep.root"
+      },
+      {
+        "checksum": "adler32:c86b5799",
+        "size": 373145266,
+        "uri": "root://eospublic.cern.ch//eos/opendata/atlas/OutreachDatasets/2020-08-19/MC-2-1lep/tmp2/mc_364180.Wenu_PTV280_500_CFilterBVeto.1lep.root"
+      },
+      {
+        "checksum": "adler32:62ebbf7a",
+        "size": 342342542,
+        "uri": "root://eospublic.cern.ch//eos/opendata/atlas/OutreachDatasets/2020-08-19/MC-2-1lep/tmp2/mc_364181.Wenu_PTV280_500_BFilter.1lep.root"
+      },
+      {
+        "checksum": "adler32:0ef26856",
+        "size": 788244960,
+        "uri": "root://eospublic.cern.ch//eos/opendata/atlas/OutreachDatasets/2020-08-19/MC-2-1lep/tmp2/mc_364182.Wenu_PTV500_1000.1lep.root"
+      },
+      {
+        "checksum": "adler32:f1526d9c",
+        "size": 586544211,
+        "uri": "root://eospublic.cern.ch//eos/opendata/atlas/OutreachDatasets/2020-08-19/MC-2-1lep/tmp2/mc_364183.Wenu_PTV1000_E_CMS.1lep.root"
+      },
+      {
+        "checksum": "adler32:773712ad",
+        "size": 79476758,
+        "uri": "root://eospublic.cern.ch//eos/opendata/atlas/OutreachDatasets/2020-08-19/MC-2-1lep/tmp2/mc_364184.Wtaunu_PTV0_70_CVetoBVeto.1lep.root"
+      },
+      {
+        "checksum": "adler32:81b4ac44",
+        "size": 42946683,
+        "uri": "root://eospublic.cern.ch//eos/opendata/atlas/OutreachDatasets/2020-08-19/MC-2-1lep/tmp2/mc_364185.Wtaunu_PTV0_70_CFilterBVeto.1lep.root"
+      },
+      {
+        "checksum": "adler32:79e4949b",
+        "size": 62934194,
+        "uri": "root://eospublic.cern.ch//eos/opendata/atlas/OutreachDatasets/2020-08-19/MC-2-1lep/tmp2/mc_364186.Wtaunu_PTV0_70_BFilter.1lep.root"
+      },
+      {
+        "checksum": "adler32:1306dd20",
+        "size": 135438456,
+        "uri": "root://eospublic.cern.ch//eos/opendata/atlas/OutreachDatasets/2020-08-19/MC-2-1lep/tmp2/mc_364187.Wtaunu_PTV70_140_CVetoBVeto.1lep.root"
+      },
+      {
+        "checksum": "adler32:fb76e575",
+        "size": 106170228,
+        "uri": "root://eospublic.cern.ch//eos/opendata/atlas/OutreachDatasets/2020-08-19/MC-2-1lep/tmp2/mc_364188.Wtaunu_PTV70_140_CFilterBVeto.1lep.root"
+      },
+      {
+        "checksum": "adler32:cf334fc9",
+        "size": 89175529,
+        "uri": "root://eospublic.cern.ch//eos/opendata/atlas/OutreachDatasets/2020-08-19/MC-2-1lep/tmp2/mc_364189.Wtaunu_PTV70_140_BFilter.1lep.root"
+      },
+      {
+        "checksum": "adler32:427d5140",
+        "size": 140682768,
+        "uri": "root://eospublic.cern.ch//eos/opendata/atlas/OutreachDatasets/2020-08-19/MC-2-1lep/tmp2/mc_364190.Wtaunu_PTV140_280_CVetoBVeto.1lep.root"
+      },
+      {
+        "checksum": "adler32:8f57045b",
+        "size": 115167830,
+        "uri": "root://eospublic.cern.ch//eos/opendata/atlas/OutreachDatasets/2020-08-19/MC-2-1lep/tmp2/mc_364191.Wtaunu_PTV140_280_CFilterBVeto.1lep.root"
+      },
+      {
+        "checksum": "adler32:210fbf6c",
+        "size": 134882271,
+        "uri": "root://eospublic.cern.ch//eos/opendata/atlas/OutreachDatasets/2020-08-19/MC-2-1lep/tmp2/mc_364192.Wtaunu_PTV140_280_BFilter.1lep.root"
+      },
+      {
+        "checksum": "adler32:0fe1f588",
+        "size": 88639862,
+        "uri": "root://eospublic.cern.ch//eos/opendata/atlas/OutreachDatasets/2020-08-19/MC-2-1lep/tmp2/mc_364193.Wtaunu_PTV280_500_CVetoBVeto.1lep.root"
+      },
+      {
+        "checksum": "adler32:aee61024",
+        "size": 56933180,
+        "uri": "root://eospublic.cern.ch//eos/opendata/atlas/OutreachDatasets/2020-08-19/MC-2-1lep/tmp2/mc_364194.Wtaunu_PTV280_500_CFilterBVeto.1lep.root"
+      },
+      {
+        "checksum": "adler32:0fb90c88",
+        "size": 51529004,
+        "uri": "root://eospublic.cern.ch//eos/opendata/atlas/OutreachDatasets/2020-08-19/MC-2-1lep/tmp2/mc_364195.Wtaunu_PTV280_500_BFilter.1lep.root"
+      },
+      {
+        "checksum": "adler32:3da22075",
+        "size": 113754993,
+        "uri": "root://eospublic.cern.ch//eos/opendata/atlas/OutreachDatasets/2020-08-19/MC-2-1lep/tmp2/mc_364196.Wtaunu_PTV500_1000.1lep.root"
+      },
+      {
+        "checksum": "adler32:897faf88",
+        "size": 96056452,
+        "uri": "root://eospublic.cern.ch//eos/opendata/atlas/OutreachDatasets/2020-08-19/MC-2-1lep/tmp2/mc_364197.Wtaunu_PTV1000_E_CMS.1lep.root"
+      },
+      {
+        "checksum": "adler32:197e7b26",
+        "size": 4508741051,
+        "uri": "root://eospublic.cern.ch//eos/opendata/atlas/OutreachDatasets/2020-08-19/MC-2-1lep/tmp2/mc_410000.ttbar_lep.1lep.root"
       }
     ],
     "license": {
@@ -63,7 +732,7 @@
       ]
     },
     "usage": {
-      "description": "This dataset is provided by the ATLAS Collaboration <strong>only for educational purposes and is not suited for scientific publications</strong>.\n You can access these data through the ATLAS Virtual Machine and Software.\n More documentation is available at:",
+      "description": "<p>This dataset is provided as a zipped tarball (<code>MC-2-1lep.zip</code>) and as a list of unzipped individually-accessible ROOT files containing the collision data (such as <code>data_A.1lep.root</code>) and the simulated data (such as <code>mc_301322.ZPrime400_tt.1lep.root</code>). You can use either the tarball or the individual ROOT files.</p> <p>This dataset is provided by the ATLAS Collaboration <strong>only for educational purposes and is not suited for scientific publications</strong>.\n You can access these data through the ATLAS Virtual Machine and Software.\n More documentation is available at:</p>",
       "links": [
         {
           "description": "The ATLAS Open Data documentation for 13 TeV release",

--- a/data/records/atlas-2020-1lep1tau.json
+++ b/data/records/atlas-2020-1lep1tau.json
@@ -19,8 +19,12 @@
     ],
     "date_published": "2020",
     "distribution": {
-      "number_files": 1,
-      "size": 1382398892
+      "formats": [
+        "root",
+        "zip"
+      ],
+      "number_files": 116,
+      "size": 3000421812
     },
     "doi": "10.7483/OPENDATA.ATLAS.W8ZU.YU6N",
     "experiment": [
@@ -31,6 +35,581 @@
         "checksum": "adler32:04f62c93",
         "size": 1382398892,
         "uri": "root://eospublic.cern.ch//eos/opendata/atlas/OutreachDatasets/2020-08-19/1lep1tau.zip"
+      },
+      {
+        "checksum": "adler32:e8fdd3c9",
+        "size": 11878988,
+        "uri": "root://eospublic.cern.ch//eos/opendata/atlas/OutreachDatasets/2020-08-19/1lep1tau/Data/data_A.1lep1tau.root"
+      },
+      {
+        "checksum": "adler32:5784a6fa",
+        "size": 38813217,
+        "uri": "root://eospublic.cern.ch//eos/opendata/atlas/OutreachDatasets/2020-08-19/1lep1tau/Data/data_B.1lep1tau.root"
+      },
+      {
+        "checksum": "adler32:59bc7108",
+        "size": 51580028,
+        "uri": "root://eospublic.cern.ch//eos/opendata/atlas/OutreachDatasets/2020-08-19/1lep1tau/Data/data_C.1lep1tau.root"
+      },
+      {
+        "checksum": "adler32:9d93de79",
+        "size": 85510013,
+        "uri": "root://eospublic.cern.ch//eos/opendata/atlas/OutreachDatasets/2020-08-19/1lep1tau/Data/data_D.1lep1tau.root"
+      },
+      {
+        "checksum": "adler32:c15dab4a",
+        "size": 23173964,
+        "uri": "root://eospublic.cern.ch//eos/opendata/atlas/OutreachDatasets/2020-08-19/1lep1tau/MC/mc_341123.ggH125_tautaulh.1lep1tau.root"
+      },
+      {
+        "checksum": "adler32:0bb60fd8",
+        "size": 37914460,
+        "uri": "root://eospublic.cern.ch//eos/opendata/atlas/OutreachDatasets/2020-08-19/1lep1tau/MC/mc_341156.VBFH125_tautaulh.1lep1tau.root"
+      },
+      {
+        "checksum": "adler32:8f2f8e29",
+        "size": 6290311,
+        "uri": "root://eospublic.cern.ch//eos/opendata/atlas/OutreachDatasets/2020-08-19/1lep1tau/MC/mc_361100.Wplusenu.1lep1tau.root"
+      },
+      {
+        "checksum": "adler32:ba31ab2e",
+        "size": 372979,
+        "uri": "root://eospublic.cern.ch//eos/opendata/atlas/OutreachDatasets/2020-08-19/1lep1tau/MC/mc_361101.Wplusmunu.1lep1tau.root"
+      },
+      {
+        "checksum": "adler32:e438608e",
+        "size": 50791,
+        "uri": "root://eospublic.cern.ch//eos/opendata/atlas/OutreachDatasets/2020-08-19/1lep1tau/MC/mc_361102.Wplustaunu.1lep1tau.root"
+      },
+      {
+        "checksum": "adler32:b71987b2",
+        "size": 5016696,
+        "uri": "root://eospublic.cern.ch//eos/opendata/atlas/OutreachDatasets/2020-08-19/1lep1tau/MC/mc_361103.Wminusenu.1lep1tau.root"
+      },
+      {
+        "checksum": "adler32:80f6eaad",
+        "size": 713443,
+        "uri": "root://eospublic.cern.ch//eos/opendata/atlas/OutreachDatasets/2020-08-19/1lep1tau/MC/mc_361104.Wminusmunu.1lep1tau.root"
+      },
+      {
+        "checksum": "adler32:364d2d71",
+        "size": 67500,
+        "uri": "root://eospublic.cern.ch//eos/opendata/atlas/OutreachDatasets/2020-08-19/1lep1tau/MC/mc_361105.Wminustaunu.1lep1tau.root"
+      },
+      {
+        "checksum": "adler32:99a87f41",
+        "size": 68474130,
+        "uri": "root://eospublic.cern.ch//eos/opendata/atlas/OutreachDatasets/2020-08-19/1lep1tau/MC/mc_361106.Zee.1lep1tau.root"
+      },
+      {
+        "checksum": "adler32:a8eba26d",
+        "size": 679942,
+        "uri": "root://eospublic.cern.ch//eos/opendata/atlas/OutreachDatasets/2020-08-19/1lep1tau/MC/mc_361107.Zmumu.1lep1tau.root"
+      },
+      {
+        "checksum": "adler32:3e40e495",
+        "size": 39771976,
+        "uri": "root://eospublic.cern.ch//eos/opendata/atlas/OutreachDatasets/2020-08-19/1lep1tau/MC/mc_361108.Ztautau.1lep1tau.root"
+      },
+      {
+        "checksum": "adler32:98f5a7da",
+        "size": 18012993,
+        "uri": "root://eospublic.cern.ch//eos/opendata/atlas/OutreachDatasets/2020-08-19/1lep1tau/MC/mc_363356.ZqqZll.1lep1tau.root"
+      },
+      {
+        "checksum": "adler32:105d32f5",
+        "size": 18699193,
+        "uri": "root://eospublic.cern.ch//eos/opendata/atlas/OutreachDatasets/2020-08-19/1lep1tau/MC/mc_363358.WqqZll.1lep1tau.root"
+      },
+      {
+        "checksum": "adler32:527afab7",
+        "size": 8056421,
+        "uri": "root://eospublic.cern.ch//eos/opendata/atlas/OutreachDatasets/2020-08-19/1lep1tau/MC/mc_363359.WpqqWmlv.1lep1tau.root"
+      },
+      {
+        "checksum": "adler32:4742ad99",
+        "size": 8133975,
+        "uri": "root://eospublic.cern.ch//eos/opendata/atlas/OutreachDatasets/2020-08-19/1lep1tau/MC/mc_363360.WplvWmqq.1lep1tau.root"
+      },
+      {
+        "checksum": "adler32:1b2d72c3",
+        "size": 7616339,
+        "uri": "root://eospublic.cern.ch//eos/opendata/atlas/OutreachDatasets/2020-08-19/1lep1tau/MC/mc_363489.WlvZqq.1lep1tau.root"
+      },
+      {
+        "checksum": "adler32:c1dfb0c6",
+        "size": 118332714,
+        "uri": "root://eospublic.cern.ch//eos/opendata/atlas/OutreachDatasets/2020-08-19/1lep1tau/MC/mc_363490.llll.1lep1tau.root"
+      },
+      {
+        "checksum": "adler32:737e9eaf",
+        "size": 143956320,
+        "uri": "root://eospublic.cern.ch//eos/opendata/atlas/OutreachDatasets/2020-08-19/1lep1tau/MC/mc_363491.lllv.1lep1tau.root"
+      },
+      {
+        "checksum": "adler32:36c0dcc1",
+        "size": 131780050,
+        "uri": "root://eospublic.cern.ch//eos/opendata/atlas/OutreachDatasets/2020-08-19/1lep1tau/MC/mc_363492.llvv.1lep1tau.root"
+      },
+      {
+        "checksum": "adler32:9a5f17f9",
+        "size": 3321420,
+        "uri": "root://eospublic.cern.ch//eos/opendata/atlas/OutreachDatasets/2020-08-19/1lep1tau/MC/mc_363493.lvvv.1lep1tau.root"
+      },
+      {
+        "checksum": "adler32:2619997e",
+        "size": 3193867,
+        "uri": "root://eospublic.cern.ch//eos/opendata/atlas/OutreachDatasets/2020-08-19/1lep1tau/MC/mc_364100.Zmumu_PTV0_70_CVetoBVeto.1lep1tau.root"
+      },
+      {
+        "checksum": "adler32:8227547e",
+        "size": 2921728,
+        "uri": "root://eospublic.cern.ch//eos/opendata/atlas/OutreachDatasets/2020-08-19/1lep1tau/MC/mc_364101.Zmumu_PTV0_70_CFilterBVeto.1lep1tau.root"
+      },
+      {
+        "checksum": "adler32:2145868c",
+        "size": 3756332,
+        "uri": "root://eospublic.cern.ch//eos/opendata/atlas/OutreachDatasets/2020-08-19/1lep1tau/MC/mc_364102.Zmumu_PTV0_70_BFilter.1lep1tau.root"
+      },
+      {
+        "checksum": "adler32:afeb1749",
+        "size": 7594171,
+        "uri": "root://eospublic.cern.ch//eos/opendata/atlas/OutreachDatasets/2020-08-19/1lep1tau/MC/mc_364103.Zmumu_PTV70_140_CVetoBVeto.1lep1tau.root"
+      },
+      {
+        "checksum": "adler32:82fed563",
+        "size": 2919037,
+        "uri": "root://eospublic.cern.ch//eos/opendata/atlas/OutreachDatasets/2020-08-19/1lep1tau/MC/mc_364104.Zmumu_PTV70_140_CFilterBVeto.1lep1tau.root"
+      },
+      {
+        "checksum": "adler32:e73534a8",
+        "size": 7245394,
+        "uri": "root://eospublic.cern.ch//eos/opendata/atlas/OutreachDatasets/2020-08-19/1lep1tau/MC/mc_364105.Zmumu_PTV70_140_BFilter.1lep1tau.root"
+      },
+      {
+        "checksum": "adler32:dd097899",
+        "size": 5984735,
+        "uri": "root://eospublic.cern.ch//eos/opendata/atlas/OutreachDatasets/2020-08-19/1lep1tau/MC/mc_364106.Zmumu_PTV140_280_CVetoBVeto.1lep1tau.root"
+      },
+      {
+        "checksum": "adler32:ba13fbf4",
+        "size": 4505934,
+        "uri": "root://eospublic.cern.ch//eos/opendata/atlas/OutreachDatasets/2020-08-19/1lep1tau/MC/mc_364107.Zmumu_PTV140_280_CFilterBVeto.1lep1tau.root"
+      },
+      {
+        "checksum": "adler32:e0d7dda1",
+        "size": 6618515,
+        "uri": "root://eospublic.cern.ch//eos/opendata/atlas/OutreachDatasets/2020-08-19/1lep1tau/MC/mc_364108.Zmumu_PTV140_280_BFilter.1lep1tau.root"
+      },
+      {
+        "checksum": "adler32:8a1df28e",
+        "size": 2435248,
+        "uri": "root://eospublic.cern.ch//eos/opendata/atlas/OutreachDatasets/2020-08-19/1lep1tau/MC/mc_364109.Zmumu_PTV280_500_CVetoBVeto.1lep1tau.root"
+      },
+      {
+        "checksum": "adler32:cd6c5a36",
+        "size": 1609099,
+        "uri": "root://eospublic.cern.ch//eos/opendata/atlas/OutreachDatasets/2020-08-19/1lep1tau/MC/mc_364110.Zmumu_PTV280_500_CFilterBVeto.1lep1tau.root"
+      },
+      {
+        "checksum": "adler32:d0d8f5a8",
+        "size": 2835278,
+        "uri": "root://eospublic.cern.ch//eos/opendata/atlas/OutreachDatasets/2020-08-19/1lep1tau/MC/mc_364111.Zmumu_PTV280_500_BFilter.1lep1tau.root"
+      },
+      {
+        "checksum": "adler32:e33bcae3",
+        "size": 4020679,
+        "uri": "root://eospublic.cern.ch//eos/opendata/atlas/OutreachDatasets/2020-08-19/1lep1tau/MC/mc_364112.Zmumu_PTV500_1000.1lep1tau.root"
+      },
+      {
+        "checksum": "adler32:a344c036",
+        "size": 1298204,
+        "uri": "root://eospublic.cern.ch//eos/opendata/atlas/OutreachDatasets/2020-08-19/1lep1tau/MC/mc_364113.Zmumu_PTV1000_E_CMS.1lep1tau.root"
+      },
+      {
+        "checksum": "adler32:f7e08690",
+        "size": 9900204,
+        "uri": "root://eospublic.cern.ch//eos/opendata/atlas/OutreachDatasets/2020-08-19/1lep1tau/MC/mc_364114.Zee_PTV0_70_CVetoBVeto.1lep1tau.root"
+      },
+      {
+        "checksum": "adler32:ac493a94",
+        "size": 7618112,
+        "uri": "root://eospublic.cern.ch//eos/opendata/atlas/OutreachDatasets/2020-08-19/1lep1tau/MC/mc_364115.Zee_PTV0_70_CFilterBVeto.1lep1tau.root"
+      },
+      {
+        "checksum": "adler32:c1c236cf",
+        "size": 11748213,
+        "uri": "root://eospublic.cern.ch//eos/opendata/atlas/OutreachDatasets/2020-08-19/1lep1tau/MC/mc_364116.Zee_PTV0_70_BFilter.1lep1tau.root"
+      },
+      {
+        "checksum": "adler32:d08962cd",
+        "size": 15393831,
+        "uri": "root://eospublic.cern.ch//eos/opendata/atlas/OutreachDatasets/2020-08-19/1lep1tau/MC/mc_364117.Zee_PTV70_140_CVetoBVeto.1lep1tau.root"
+      },
+      {
+        "checksum": "adler32:294518da",
+        "size": 5664133,
+        "uri": "root://eospublic.cern.ch//eos/opendata/atlas/OutreachDatasets/2020-08-19/1lep1tau/MC/mc_364118.Zee_PTV70_140_CFilterBVeto.1lep1tau.root"
+      },
+      {
+        "checksum": "adler32:6cce3086",
+        "size": 15239867,
+        "uri": "root://eospublic.cern.ch//eos/opendata/atlas/OutreachDatasets/2020-08-19/1lep1tau/MC/mc_364119.Zee_PTV70_140_BFilter.1lep1tau.root"
+      },
+      {
+        "checksum": "adler32:16c193da",
+        "size": 13257472,
+        "uri": "root://eospublic.cern.ch//eos/opendata/atlas/OutreachDatasets/2020-08-19/1lep1tau/MC/mc_364120.Zee_PTV140_280_CVetoBVeto.1lep1tau.root"
+      },
+      {
+        "checksum": "adler32:01be6010",
+        "size": 9180034,
+        "uri": "root://eospublic.cern.ch//eos/opendata/atlas/OutreachDatasets/2020-08-19/1lep1tau/MC/mc_364121.Zee_PTV140_280_CFilterBVeto.1lep1tau.root"
+      },
+      {
+        "checksum": "adler32:4cd18a2a",
+        "size": 14009450,
+        "uri": "root://eospublic.cern.ch//eos/opendata/atlas/OutreachDatasets/2020-08-19/1lep1tau/MC/mc_364122.Zee_PTV140_280_BFilter.1lep1tau.root"
+      },
+      {
+        "checksum": "adler32:0fcfab44",
+        "size": 5301734,
+        "uri": "root://eospublic.cern.ch//eos/opendata/atlas/OutreachDatasets/2020-08-19/1lep1tau/MC/mc_364123.Zee_PTV280_500_CVetoBVeto.1lep1tau.root"
+      },
+      {
+        "checksum": "adler32:7dbd7173",
+        "size": 3271757,
+        "uri": "root://eospublic.cern.ch//eos/opendata/atlas/OutreachDatasets/2020-08-19/1lep1tau/MC/mc_364124.Zee_PTV280_500_CFilterBVeto.1lep1tau.root"
+      },
+      {
+        "checksum": "adler32:1c5215ab",
+        "size": 6370261,
+        "uri": "root://eospublic.cern.ch//eos/opendata/atlas/OutreachDatasets/2020-08-19/1lep1tau/MC/mc_364125.Zee_PTV280_500_BFilter.1lep1tau.root"
+      },
+      {
+        "checksum": "adler32:e49fa326",
+        "size": 8911779,
+        "uri": "root://eospublic.cern.ch//eos/opendata/atlas/OutreachDatasets/2020-08-19/1lep1tau/MC/mc_364126.Zee_PTV500_1000.1lep1tau.root"
+      },
+      {
+        "checksum": "adler32:5b362cdb",
+        "size": 2945621,
+        "uri": "root://eospublic.cern.ch//eos/opendata/atlas/OutreachDatasets/2020-08-19/1lep1tau/MC/mc_364127.Zee_PTV1000_E_CMS.1lep1tau.root"
+      },
+      {
+        "checksum": "adler32:dc3df6e6",
+        "size": 10482603,
+        "uri": "root://eospublic.cern.ch//eos/opendata/atlas/OutreachDatasets/2020-08-19/1lep1tau/MC/mc_364128.Ztautau_PTV0_70_CVetoBVeto.1lep1tau.root"
+      },
+      {
+        "checksum": "adler32:782a80eb",
+        "size": 7427831,
+        "uri": "root://eospublic.cern.ch//eos/opendata/atlas/OutreachDatasets/2020-08-19/1lep1tau/MC/mc_364129.Ztautau_PTV0_70_CFilterBVeto.1lep1tau.root"
+      },
+      {
+        "checksum": "adler32:407131e5",
+        "size": 12842049,
+        "uri": "root://eospublic.cern.ch//eos/opendata/atlas/OutreachDatasets/2020-08-19/1lep1tau/MC/mc_364130.Ztautau_PTV0_70_BFilter.1lep1tau.root"
+      },
+      {
+        "checksum": "adler32:4e4d5bc8",
+        "size": 16327579,
+        "uri": "root://eospublic.cern.ch//eos/opendata/atlas/OutreachDatasets/2020-08-19/1lep1tau/MC/mc_364131.Ztautau_PTV70_140_CVetoBVeto.1lep1tau.root"
+      },
+      {
+        "checksum": "adler32:d0a4dea3",
+        "size": 5585789,
+        "uri": "root://eospublic.cern.ch//eos/opendata/atlas/OutreachDatasets/2020-08-19/1lep1tau/MC/mc_364132.Ztautau_PTV70_140_CFilterBVeto.1lep1tau.root"
+      },
+      {
+        "checksum": "adler32:71c43864",
+        "size": 17486598,
+        "uri": "root://eospublic.cern.ch//eos/opendata/atlas/OutreachDatasets/2020-08-19/1lep1tau/MC/mc_364133.Ztautau_PTV70_140_BFilter.1lep1tau.root"
+      },
+      {
+        "checksum": "adler32:9bf0a0f9",
+        "size": 26918305,
+        "uri": "root://eospublic.cern.ch//eos/opendata/atlas/OutreachDatasets/2020-08-19/1lep1tau/MC/mc_364134.Ztautau_PTV140_280_CVetoBVeto.1lep1tau.root"
+      },
+      {
+        "checksum": "adler32:b824c939",
+        "size": 15487855,
+        "uri": "root://eospublic.cern.ch//eos/opendata/atlas/OutreachDatasets/2020-08-19/1lep1tau/MC/mc_364135.Ztautau_PTV140_280_CFilterBVeto.1lep1tau.root"
+      },
+      {
+        "checksum": "adler32:234c572a",
+        "size": 25846597,
+        "uri": "root://eospublic.cern.ch//eos/opendata/atlas/OutreachDatasets/2020-08-19/1lep1tau/MC/mc_364136.Ztautau_PTV140_280_BFilter.1lep1tau.root"
+      },
+      {
+        "checksum": "adler32:9f1264c9",
+        "size": 16172378,
+        "uri": "root://eospublic.cern.ch//eos/opendata/atlas/OutreachDatasets/2020-08-19/1lep1tau/MC/mc_364137.Ztautau_PTV280_500_CVetoBVeto.1lep1tau.root"
+      },
+      {
+        "checksum": "adler32:e1354df1",
+        "size": 7338493,
+        "uri": "root://eospublic.cern.ch//eos/opendata/atlas/OutreachDatasets/2020-08-19/1lep1tau/MC/mc_364138.Ztautau_PTV280_500_CFilterBVeto.1lep1tau.root"
+      },
+      {
+        "checksum": "adler32:9baed9b9",
+        "size": 14655134,
+        "uri": "root://eospublic.cern.ch//eos/opendata/atlas/OutreachDatasets/2020-08-19/1lep1tau/MC/mc_364139.Ztautau_PTV280_500_BFilter.1lep1tau.root"
+      },
+      {
+        "checksum": "adler32:15bf4143",
+        "size": 23410183,
+        "uri": "root://eospublic.cern.ch//eos/opendata/atlas/OutreachDatasets/2020-08-19/1lep1tau/MC/mc_364140.Ztautau_PTV500_1000.1lep1tau.root"
+      },
+      {
+        "checksum": "adler32:b52b5d71",
+        "size": 8012667,
+        "uri": "root://eospublic.cern.ch//eos/opendata/atlas/OutreachDatasets/2020-08-19/1lep1tau/MC/mc_364141.Ztautau_PTV1000_E_CMS.1lep1tau.root"
+      },
+      {
+        "checksum": "adler32:b2eb34c9",
+        "size": 6261883,
+        "uri": "root://eospublic.cern.ch//eos/opendata/atlas/OutreachDatasets/2020-08-19/1lep1tau/MC/mc_364156.Wmunu_PTV0_70_CVetoBVeto.1lep1tau.root"
+      },
+      {
+        "checksum": "adler32:fde4c497",
+        "size": 4110663,
+        "uri": "root://eospublic.cern.ch//eos/opendata/atlas/OutreachDatasets/2020-08-19/1lep1tau/MC/mc_364157.Wmunu_PTV0_70_CFilterBVeto.1lep1tau.root"
+      },
+      {
+        "checksum": "adler32:6811c85b",
+        "size": 5638898,
+        "uri": "root://eospublic.cern.ch//eos/opendata/atlas/OutreachDatasets/2020-08-19/1lep1tau/MC/mc_364158.Wmunu_PTV0_70_BFilter.1lep1tau.root"
+      },
+      {
+        "checksum": "adler32:aa387494",
+        "size": 12886156,
+        "uri": "root://eospublic.cern.ch//eos/opendata/atlas/OutreachDatasets/2020-08-19/1lep1tau/MC/mc_364159.Wmunu_PTV70_140_CVetoBVeto.1lep1tau.root"
+      },
+      {
+        "checksum": "adler32:97d0294f",
+        "size": 11035465,
+        "uri": "root://eospublic.cern.ch//eos/opendata/atlas/OutreachDatasets/2020-08-19/1lep1tau/MC/mc_364160.Wmunu_PTV70_140_CFilterBVeto.1lep1tau.root"
+      },
+      {
+        "checksum": "adler32:1ca8e6f2",
+        "size": 18396960,
+        "uri": "root://eospublic.cern.ch//eos/opendata/atlas/OutreachDatasets/2020-08-19/1lep1tau/MC/mc_364161.Wmunu_PTV70_140_BFilter.1lep1tau.root"
+      },
+      {
+        "checksum": "adler32:cc24f022",
+        "size": 8342247,
+        "uri": "root://eospublic.cern.ch//eos/opendata/atlas/OutreachDatasets/2020-08-19/1lep1tau/MC/mc_364162.Wmunu_PTV140_280_CVetoBVeto.1lep1tau.root"
+      },
+      {
+        "checksum": "adler32:1161e06d",
+        "size": 8643939,
+        "uri": "root://eospublic.cern.ch//eos/opendata/atlas/OutreachDatasets/2020-08-19/1lep1tau/MC/mc_364163.Wmunu_PTV140_280_CFilterBVeto.1lep1tau.root"
+      },
+      {
+        "checksum": "adler32:d51415e3",
+        "size": 9789832,
+        "uri": "root://eospublic.cern.ch//eos/opendata/atlas/OutreachDatasets/2020-08-19/1lep1tau/MC/mc_364164.Wmunu_PTV140_280_BFilter.1lep1tau.root"
+      },
+      {
+        "checksum": "adler32:4c13801c",
+        "size": 4267419,
+        "uri": "root://eospublic.cern.ch//eos/opendata/atlas/OutreachDatasets/2020-08-19/1lep1tau/MC/mc_364165.Wmunu_PTV280_500_CVetoBVeto.1lep1tau.root"
+      },
+      {
+        "checksum": "adler32:1794f8ed",
+        "size": 3454849,
+        "uri": "root://eospublic.cern.ch//eos/opendata/atlas/OutreachDatasets/2020-08-19/1lep1tau/MC/mc_364166.Wmunu_PTV280_500_CFilterBVeto.1lep1tau.root"
+      },
+      {
+        "checksum": "adler32:ba75789b",
+        "size": 3213372,
+        "uri": "root://eospublic.cern.ch//eos/opendata/atlas/OutreachDatasets/2020-08-19/1lep1tau/MC/mc_364167.Wmunu_PTV280_500_BFilter.1lep1tau.root"
+      },
+      {
+        "checksum": "adler32:f1d12b20",
+        "size": 5503509,
+        "uri": "root://eospublic.cern.ch//eos/opendata/atlas/OutreachDatasets/2020-08-19/1lep1tau/MC/mc_364168.Wmunu_PTV500_1000.1lep1tau.root"
+      },
+      {
+        "checksum": "adler32:9630b9d3",
+        "size": 3501512,
+        "uri": "root://eospublic.cern.ch//eos/opendata/atlas/OutreachDatasets/2020-08-19/1lep1tau/MC/mc_364169.Wmunu_PTV1000_E_CMS.1lep1tau.root"
+      },
+      {
+        "checksum": "adler32:5f952a4a",
+        "size": 5558780,
+        "uri": "root://eospublic.cern.ch//eos/opendata/atlas/OutreachDatasets/2020-08-19/1lep1tau/MC/mc_364170.Wenu_PTV0_70_CVetoBVeto.1lep1tau.root"
+      },
+      {
+        "checksum": "adler32:b2f34040",
+        "size": 3784704,
+        "uri": "root://eospublic.cern.ch//eos/opendata/atlas/OutreachDatasets/2020-08-19/1lep1tau/MC/mc_364171.Wenu_PTV0_70_CFilterBVeto.1lep1tau.root"
+      },
+      {
+        "checksum": "adler32:8b87a0de",
+        "size": 5049144,
+        "uri": "root://eospublic.cern.ch//eos/opendata/atlas/OutreachDatasets/2020-08-19/1lep1tau/MC/mc_364172.Wenu_PTV0_70_BFilter.1lep1tau.root"
+      },
+      {
+        "checksum": "adler32:f689bbf2",
+        "size": 11531632,
+        "uri": "root://eospublic.cern.ch//eos/opendata/atlas/OutreachDatasets/2020-08-19/1lep1tau/MC/mc_364173.Wenu_PTV70_140_CVetoBVeto.1lep1tau.root"
+      },
+      {
+        "checksum": "adler32:15cdf410",
+        "size": 10551053,
+        "uri": "root://eospublic.cern.ch//eos/opendata/atlas/OutreachDatasets/2020-08-19/1lep1tau/MC/mc_364174.Wenu_PTV70_140_CFilterBVeto.1lep1tau.root"
+      },
+      {
+        "checksum": "adler32:1f0df5ca",
+        "size": 8840599,
+        "uri": "root://eospublic.cern.ch//eos/opendata/atlas/OutreachDatasets/2020-08-19/1lep1tau/MC/mc_364175.Wenu_PTV70_140_BFilter.1lep1tau.root"
+      },
+      {
+        "checksum": "adler32:e8cd0f85",
+        "size": 8183355,
+        "uri": "root://eospublic.cern.ch//eos/opendata/atlas/OutreachDatasets/2020-08-19/1lep1tau/MC/mc_364176.Wenu_PTV140_280_CVetoBVeto.1lep1tau.root"
+      },
+      {
+        "checksum": "adler32:c6b8103c",
+        "size": 8668094,
+        "uri": "root://eospublic.cern.ch//eos/opendata/atlas/OutreachDatasets/2020-08-19/1lep1tau/MC/mc_364177.Wenu_PTV140_280_CFilterBVeto.1lep1tau.root"
+      },
+      {
+        "checksum": "adler32:5b18525c",
+        "size": 9963918,
+        "uri": "root://eospublic.cern.ch//eos/opendata/atlas/OutreachDatasets/2020-08-19/1lep1tau/MC/mc_364178.Wenu_PTV140_280_BFilter.1lep1tau.root"
+      },
+      {
+        "checksum": "adler32:7f4b6d7a",
+        "size": 4277108,
+        "uri": "root://eospublic.cern.ch//eos/opendata/atlas/OutreachDatasets/2020-08-19/1lep1tau/MC/mc_364179.Wenu_PTV280_500_CVetoBVeto.1lep1tau.root"
+      },
+      {
+        "checksum": "adler32:ff58d295",
+        "size": 3543185,
+        "uri": "root://eospublic.cern.ch//eos/opendata/atlas/OutreachDatasets/2020-08-19/1lep1tau/MC/mc_364180.Wenu_PTV280_500_CFilterBVeto.1lep1tau.root"
+      },
+      {
+        "checksum": "adler32:34985f71",
+        "size": 3318469,
+        "uri": "root://eospublic.cern.ch//eos/opendata/atlas/OutreachDatasets/2020-08-19/1lep1tau/MC/mc_364181.Wenu_PTV280_500_BFilter.1lep1tau.root"
+      },
+      {
+        "checksum": "adler32:cc072a22",
+        "size": 5929039,
+        "uri": "root://eospublic.cern.ch//eos/opendata/atlas/OutreachDatasets/2020-08-19/1lep1tau/MC/mc_364182.Wenu_PTV500_1000.1lep1tau.root"
+      },
+      {
+        "checksum": "adler32:e866fe7a",
+        "size": 3785475,
+        "uri": "root://eospublic.cern.ch//eos/opendata/atlas/OutreachDatasets/2020-08-19/1lep1tau/MC/mc_364183.Wenu_PTV1000_E_CMS.1lep1tau.root"
+      },
+      {
+        "checksum": "adler32:170ca999",
+        "size": 439769,
+        "uri": "root://eospublic.cern.ch//eos/opendata/atlas/OutreachDatasets/2020-08-19/1lep1tau/MC/mc_364184.Wtaunu_PTV0_70_CVetoBVeto.1lep1tau.root"
+      },
+      {
+        "checksum": "adler32:b93a2113",
+        "size": 333405,
+        "uri": "root://eospublic.cern.ch//eos/opendata/atlas/OutreachDatasets/2020-08-19/1lep1tau/MC/mc_364185.Wtaunu_PTV0_70_CFilterBVeto.1lep1tau.root"
+      },
+      {
+        "checksum": "adler32:5eed4dd6",
+        "size": 425966,
+        "uri": "root://eospublic.cern.ch//eos/opendata/atlas/OutreachDatasets/2020-08-19/1lep1tau/MC/mc_364186.Wtaunu_PTV0_70_BFilter.1lep1tau.root"
+      },
+      {
+        "checksum": "adler32:8a15e67d",
+        "size": 1312815,
+        "uri": "root://eospublic.cern.ch//eos/opendata/atlas/OutreachDatasets/2020-08-19/1lep1tau/MC/mc_364187.Wtaunu_PTV70_140_CVetoBVeto.1lep1tau.root"
+      },
+      {
+        "checksum": "adler32:2a22ae90",
+        "size": 1186508,
+        "uri": "root://eospublic.cern.ch//eos/opendata/atlas/OutreachDatasets/2020-08-19/1lep1tau/MC/mc_364188.Wtaunu_PTV70_140_CFilterBVeto.1lep1tau.root"
+      },
+      {
+        "checksum": "adler32:9f5bf9c7",
+        "size": 952329,
+        "uri": "root://eospublic.cern.ch//eos/opendata/atlas/OutreachDatasets/2020-08-19/1lep1tau/MC/mc_364189.Wtaunu_PTV70_140_BFilter.1lep1tau.root"
+      },
+      {
+        "checksum": "adler32:d66a05f6",
+        "size": 1159674,
+        "uri": "root://eospublic.cern.ch//eos/opendata/atlas/OutreachDatasets/2020-08-19/1lep1tau/MC/mc_364190.Wtaunu_PTV140_280_CVetoBVeto.1lep1tau.root"
+      },
+      {
+        "checksum": "adler32:8c2711c9",
+        "size": 1115802,
+        "uri": "root://eospublic.cern.ch//eos/opendata/atlas/OutreachDatasets/2020-08-19/1lep1tau/MC/mc_364191.Wtaunu_PTV140_280_CFilterBVeto.1lep1tau.root"
+      },
+      {
+        "checksum": "adler32:610f74da",
+        "size": 1316198,
+        "uri": "root://eospublic.cern.ch//eos/opendata/atlas/OutreachDatasets/2020-08-19/1lep1tau/MC/mc_364192.Wtaunu_PTV140_280_BFilter.1lep1tau.root"
+      },
+      {
+        "checksum": "adler32:c1de6f7d",
+        "size": 709723,
+        "uri": "root://eospublic.cern.ch//eos/opendata/atlas/OutreachDatasets/2020-08-19/1lep1tau/MC/mc_364193.Wtaunu_PTV280_500_CVetoBVeto.1lep1tau.root"
+      },
+      {
+        "checksum": "adler32:b03b358c",
+        "size": 571980,
+        "uri": "root://eospublic.cern.ch//eos/opendata/atlas/OutreachDatasets/2020-08-19/1lep1tau/MC/mc_364194.Wtaunu_PTV280_500_CFilterBVeto.1lep1tau.root"
+      },
+      {
+        "checksum": "adler32:e2595123",
+        "size": 525960,
+        "uri": "root://eospublic.cern.ch//eos/opendata/atlas/OutreachDatasets/2020-08-19/1lep1tau/MC/mc_364195.Wtaunu_PTV280_500_BFilter.1lep1tau.root"
+      },
+      {
+        "checksum": "adler32:41380f8a",
+        "size": 1019585,
+        "uri": "root://eospublic.cern.ch//eos/opendata/atlas/OutreachDatasets/2020-08-19/1lep1tau/MC/mc_364196.Wtaunu_PTV500_1000.1lep1tau.root"
+      },
+      {
+        "checksum": "adler32:82980a67",
+        "size": 856128,
+        "uri": "root://eospublic.cern.ch//eos/opendata/atlas/OutreachDatasets/2020-08-19/1lep1tau/MC/mc_364197.Wtaunu_PTV1000_E_CMS.1lep1tau.root"
+      },
+      {
+        "checksum": "adler32:e8c494a9",
+        "size": 173951010,
+        "uri": "root://eospublic.cern.ch//eos/opendata/atlas/OutreachDatasets/2020-08-19/1lep1tau/MC/mc_410000.ttbar_lep.1lep1tau.root"
+      },
+      {
+        "checksum": "adler32:00638152",
+        "size": 1255126,
+        "uri": "root://eospublic.cern.ch//eos/opendata/atlas/OutreachDatasets/2020-08-19/1lep1tau/MC/mc_410011.single_top_tchan.1lep1tau.root"
+      },
+      {
+        "checksum": "adler32:c4ebb766",
+        "size": 1465588,
+        "uri": "root://eospublic.cern.ch//eos/opendata/atlas/OutreachDatasets/2020-08-19/1lep1tau/MC/mc_410012.single_antitop_tchan.1lep1tau.root"
+      },
+      {
+        "checksum": "adler32:0fe8790b",
+        "size": 4165544,
+        "uri": "root://eospublic.cern.ch//eos/opendata/atlas/OutreachDatasets/2020-08-19/1lep1tau/MC/mc_410013.single_top_wtchan.1lep1tau.root"
+      },
+      {
+        "checksum": "adler32:2e3cf35e",
+        "size": 4108818,
+        "uri": "root://eospublic.cern.ch//eos/opendata/atlas/OutreachDatasets/2020-08-19/1lep1tau/MC/mc_410014.single_antitop_wtchan.1lep1tau.root"
+      },
+      {
+        "checksum": "adler32:73dfcf34",
+        "size": 564361,
+        "uri": "root://eospublic.cern.ch//eos/opendata/atlas/OutreachDatasets/2020-08-19/1lep1tau/MC/mc_410025.single_top_schan.1lep1tau.root"
+      },
+      {
+        "checksum": "adler32:83a5de0d",
+        "size": 592759,
+        "uri": "root://eospublic.cern.ch//eos/opendata/atlas/OutreachDatasets/2020-08-19/1lep1tau/MC/mc_410026.single_antitop_schan.1lep1tau.root"
       }
     ],
     "license": {
@@ -53,7 +632,7 @@
       ]
     },
     "usage": {
-      "description": "This dataset is provided by the ATLAS Collaboration <strong>only for educational purposes and is not suited for scientific publications</strong>.\n You can access these data through the ATLAS Virtual Machine and Software.\n More documentation is available at:",
+      "description": "<p>This dataset is provided as a zipped tarball (<code>1lep1tau.zip</code>) and as a list of unzipped individually-accessible ROOT files containing the collision data (such as <code>data_A.1lep1tau.root</code>) and the simulated data (such as <code>mc_341123.ggH125_tautaulh.1lep1tau.root</code>). You can use either the tarball or the individual ROOT files.</p> <p>This dataset is provided by the ATLAS Collaboration <strong>only for educational purposes and is not suited for scientific publications</strong>.\n You can access these data through the ATLAS Virtual Machine and Software.\n More documentation is available at:</p>",
       "links": [
         {
           "description": "The ATLAS Open Data documentation for 13 TeV release",

--- a/data/records/atlas-2020-2lep.json
+++ b/data/records/atlas-2020-2lep.json
@@ -19,8 +19,12 @@
     ],
     "date_published": "2020",
     "distribution": {
-      "number_files": 1,
-      "size": 25896593653
+      "formats": [
+        "root",
+        "zip"
+      ],
+      "number_files": 227,
+      "size": 58407450332
     },
     "doi": "10.7483/OPENDATA.ATLAS.GQ1W.I9VI",
     "experiment": [
@@ -31,6 +35,1136 @@
         "checksum": "adler32:8477e1c1",
         "size": 25896593653,
         "uri": "root://eospublic.cern.ch//eos/opendata/atlas/OutreachDatasets/2020-08-19/2lep.zip"
+      },
+      {
+        "checksum": "adler32:e20f6177",
+        "size": 130088359,
+        "uri": "root://eospublic.cern.ch//eos/opendata/atlas/OutreachDatasets/2020-08-19/2lep/Data/data_A.2lep.root"
+      },
+      {
+        "checksum": "adler32:4b7cd731",
+        "size": 480643049,
+        "uri": "root://eospublic.cern.ch//eos/opendata/atlas/OutreachDatasets/2020-08-19/2lep/Data/data_B.2lep.root"
+      },
+      {
+        "checksum": "adler32:083ffeab",
+        "size": 700705538,
+        "uri": "root://eospublic.cern.ch//eos/opendata/atlas/OutreachDatasets/2020-08-19/2lep/Data/data_C.2lep.root"
+      },
+      {
+        "checksum": "adler32:379ba7e0",
+        "size": 1077664850,
+        "uri": "root://eospublic.cern.ch//eos/opendata/atlas/OutreachDatasets/2020-08-19/2lep/Data/data_D.2lep.root"
+      },
+      {
+        "checksum": "adler32:8d1e8693",
+        "size": 437,
+        "uri": "root://eospublic.cern.ch//eos/opendata/atlas/OutreachDatasets/2020-08-19/2lep/MC/FilesToProcess.txt~"
+      },
+      {
+        "checksum": "adler32:b45a663a",
+        "size": 3700023,
+        "uri": "root://eospublic.cern.ch//eos/opendata/atlas/OutreachDatasets/2020-08-19/2lep/MC/mc_301215.ZPrime2000_ee.2lep.root"
+      },
+      {
+        "checksum": "adler32:873035ab",
+        "size": 3730183,
+        "uri": "root://eospublic.cern.ch//eos/opendata/atlas/OutreachDatasets/2020-08-19/2lep/MC/mc_301216.ZPrime3000_ee.2lep.root"
+      },
+      {
+        "checksum": "adler32:ea71ab2e",
+        "size": 3718604,
+        "uri": "root://eospublic.cern.ch//eos/opendata/atlas/OutreachDatasets/2020-08-19/2lep/MC/mc_301217.ZPrime4000_ee.2lep.root"
+      },
+      {
+        "checksum": "adler32:b06af58d",
+        "size": 3112323,
+        "uri": "root://eospublic.cern.ch//eos/opendata/atlas/OutreachDatasets/2020-08-19/2lep/MC/mc_301218.ZPrime5000_ee.2lep.root"
+      },
+      {
+        "checksum": "adler32:a1d3d0a3",
+        "size": 121945175,
+        "uri": "root://eospublic.cern.ch//eos/opendata/atlas/OutreachDatasets/2020-08-19/2lep/MC/mc_301220.ZPrime2000_mumu.2lep.root"
+      },
+      {
+        "checksum": "adler32:15a851f6",
+        "size": 120328562,
+        "uri": "root://eospublic.cern.ch//eos/opendata/atlas/OutreachDatasets/2020-08-19/2lep/MC/mc_301221.ZPrime3000_mumu.2lep.root"
+      },
+      {
+        "checksum": "adler32:32b8ebe6",
+        "size": 116511769,
+        "uri": "root://eospublic.cern.ch//eos/opendata/atlas/OutreachDatasets/2020-08-19/2lep/MC/mc_301222.ZPrime4000_mumu.2lep.root"
+      },
+      {
+        "checksum": "adler32:dab095b3",
+        "size": 113595963,
+        "uri": "root://eospublic.cern.ch//eos/opendata/atlas/OutreachDatasets/2020-08-19/2lep/MC/mc_301223.ZPrime5000_mumu.2lep.root"
+      },
+      {
+        "checksum": "adler32:b6f9ebf3",
+        "size": 1789433,
+        "uri": "root://eospublic.cern.ch//eos/opendata/atlas/OutreachDatasets/2020-08-19/2lep/MC/mc_301322.ZPrime400_tt.2lep.root"
+      },
+      {
+        "checksum": "adler32:792ba393",
+        "size": 1956516,
+        "uri": "root://eospublic.cern.ch//eos/opendata/atlas/OutreachDatasets/2020-08-19/2lep/MC/mc_301323.ZPrime500_tt.2lep.root"
+      },
+      {
+        "checksum": "adler32:657aebd3",
+        "size": 2105468,
+        "uri": "root://eospublic.cern.ch//eos/opendata/atlas/OutreachDatasets/2020-08-19/2lep/MC/mc_301324.ZPrime750_tt.2lep.root"
+      },
+      {
+        "checksum": "adler32:9facd16d",
+        "size": 2108563,
+        "uri": "root://eospublic.cern.ch//eos/opendata/atlas/OutreachDatasets/2020-08-19/2lep/MC/mc_301325.ZPrime1000_tt.2lep.root"
+      },
+      {
+        "checksum": "adler32:d34ad73d",
+        "size": 1958469,
+        "uri": "root://eospublic.cern.ch//eos/opendata/atlas/OutreachDatasets/2020-08-19/2lep/MC/mc_301326.ZPrime1250_tt.2lep.root"
+      },
+      {
+        "checksum": "adler32:7dce8be2",
+        "size": 1782900,
+        "uri": "root://eospublic.cern.ch//eos/opendata/atlas/OutreachDatasets/2020-08-19/2lep/MC/mc_301327.ZPrime1500_tt.2lep.root"
+      },
+      {
+        "checksum": "adler32:0644ba24",
+        "size": 1625908,
+        "uri": "root://eospublic.cern.ch//eos/opendata/atlas/OutreachDatasets/2020-08-19/2lep/MC/mc_301328.ZPrime1750_tt.2lep.root"
+      },
+      {
+        "checksum": "adler32:efad7e4b",
+        "size": 1468615,
+        "uri": "root://eospublic.cern.ch//eos/opendata/atlas/OutreachDatasets/2020-08-19/2lep/MC/mc_301329.ZPrime2000_tt.2lep.root"
+      },
+      {
+        "checksum": "adler32:d1180b12",
+        "size": 1289004,
+        "uri": "root://eospublic.cern.ch//eos/opendata/atlas/OutreachDatasets/2020-08-19/2lep/MC/mc_301330.ZPrime2250_tt.2lep.root"
+      },
+      {
+        "checksum": "adler32:1c9ed279",
+        "size": 1151673,
+        "uri": "root://eospublic.cern.ch//eos/opendata/atlas/OutreachDatasets/2020-08-19/2lep/MC/mc_301331.ZPrime2500_tt.2lep.root"
+      },
+      {
+        "checksum": "adler32:d68a41f4",
+        "size": 1079636,
+        "uri": "root://eospublic.cern.ch//eos/opendata/atlas/OutreachDatasets/2020-08-19/2lep/MC/mc_301332.ZPrime2750_tt.2lep.root"
+      },
+      {
+        "checksum": "adler32:79a7d097",
+        "size": 939425,
+        "uri": "root://eospublic.cern.ch//eos/opendata/atlas/OutreachDatasets/2020-08-19/2lep/MC/mc_301333.ZPrime3000_tt.2lep.root"
+      },
+      {
+        "checksum": "adler32:9ee755de",
+        "size": 785318,
+        "uri": "root://eospublic.cern.ch//eos/opendata/atlas/OutreachDatasets/2020-08-19/2lep/MC/mc_303329.RS_G_ZZ_llll_c10_m1000.2lep.root"
+      },
+      {
+        "checksum": "adler32:4dcef098",
+        "size": 1018762,
+        "uri": "root://eospublic.cern.ch//eos/opendata/atlas/OutreachDatasets/2020-08-19/2lep/MC/mc_303334.RS_G_ZZ_llll_c10_m2000.2lep.root"
+      },
+      {
+        "checksum": "adler32:d08dc321",
+        "size": 807493,
+        "uri": "root://eospublic.cern.ch//eos/opendata/atlas/OutreachDatasets/2020-08-19/2lep/MC/mc_303511.dmV_Zll_MET40_DM1_MM10.2lep.root"
+      },
+      {
+        "checksum": "adler32:fb2612b9",
+        "size": 982236,
+        "uri": "root://eospublic.cern.ch//eos/opendata/atlas/OutreachDatasets/2020-08-19/2lep/MC/mc_303512.dmV_Zll_MET40_DM1_MM100.2lep.root"
+      },
+      {
+        "checksum": "adler32:b915343e",
+        "size": 1172799,
+        "uri": "root://eospublic.cern.ch//eos/opendata/atlas/OutreachDatasets/2020-08-19/2lep/MC/mc_303513.dmV_Zll_MET40_DM1_MM300.2lep.root"
+      },
+      {
+        "checksum": "adler32:f8baf182",
+        "size": 1390201,
+        "uri": "root://eospublic.cern.ch//eos/opendata/atlas/OutreachDatasets/2020-08-19/2lep/MC/mc_303514.dmV_Zll_MET40_DM1_MM2000.2lep.root"
+      },
+      {
+        "checksum": "adler32:05a4e6f6",
+        "size": 7218990,
+        "uri": "root://eospublic.cern.ch//eos/opendata/atlas/OutreachDatasets/2020-08-19/2lep/MC/mc_305550.Gee_01_750.2lep.root"
+      },
+      {
+        "checksum": "adler32:94b55dbb",
+        "size": 6898126,
+        "uri": "root://eospublic.cern.ch//eos/opendata/atlas/OutreachDatasets/2020-08-19/2lep/MC/mc_305553.Gee_01_1000.2lep.root"
+      },
+      {
+        "checksum": "adler32:d6e1bab3",
+        "size": 6676235,
+        "uri": "root://eospublic.cern.ch//eos/opendata/atlas/OutreachDatasets/2020-08-19/2lep/MC/mc_305556.Gee_01_2000.2lep.root"
+      },
+      {
+        "checksum": "adler32:caa76cf1",
+        "size": 6588152,
+        "uri": "root://eospublic.cern.ch//eos/opendata/atlas/OutreachDatasets/2020-08-19/2lep/MC/mc_305559.Gee_01_3000.2lep.root"
+      },
+      {
+        "checksum": "adler32:43acf47d",
+        "size": 6403795,
+        "uri": "root://eospublic.cern.ch//eos/opendata/atlas/OutreachDatasets/2020-08-19/2lep/MC/mc_305562.Gee_01_4000.2lep.root"
+      },
+      {
+        "checksum": "adler32:8801be71",
+        "size": 7368142,
+        "uri": "root://eospublic.cern.ch//eos/opendata/atlas/OutreachDatasets/2020-08-19/2lep/MC/mc_305568.Gmumu_01_750.2lep.root"
+      },
+      {
+        "checksum": "adler32:a184c94c",
+        "size": 7313109,
+        "uri": "root://eospublic.cern.ch//eos/opendata/atlas/OutreachDatasets/2020-08-19/2lep/MC/mc_305571.Gmumu_01_1000.2lep.root"
+      },
+      {
+        "checksum": "adler32:93c487c4",
+        "size": 6963974,
+        "uri": "root://eospublic.cern.ch//eos/opendata/atlas/OutreachDatasets/2020-08-19/2lep/MC/mc_305574.Gmumu_01_2000.2lep.root"
+      },
+      {
+        "checksum": "adler32:8ab3b59b",
+        "size": 6709449,
+        "uri": "root://eospublic.cern.ch//eos/opendata/atlas/OutreachDatasets/2020-08-19/2lep/MC/mc_305577.Gmumu_01_3000.2lep.root"
+      },
+      {
+        "checksum": "adler32:b5eff16c",
+        "size": 6230795,
+        "uri": "root://eospublic.cern.ch//eos/opendata/atlas/OutreachDatasets/2020-08-19/2lep/MC/mc_305580.Gmumu_01_4000.2lep.root"
+      },
+      {
+        "checksum": "adler32:a20615a4",
+        "size": 1228870,
+        "uri": "root://eospublic.cern.ch//eos/opendata/atlas/OutreachDatasets/2020-08-19/2lep/MC/mc_305710.dmV_Zll_MET40_DM1_MM500.2lep.root"
+      },
+      {
+        "checksum": "adler32:363bdf28",
+        "size": 1307009,
+        "uri": "root://eospublic.cern.ch//eos/opendata/atlas/OutreachDatasets/2020-08-19/2lep/MC/mc_305711.dmV_Zll_MET40_DM1_MM700.2lep.root"
+      },
+      {
+        "checksum": "adler32:5e2f13d6",
+        "size": 1093358,
+        "uri": "root://eospublic.cern.ch//eos/opendata/atlas/OutreachDatasets/2020-08-19/2lep/MC/mc_306085.dmV_Zll_MET40_DM1_MM200.2lep.root"
+      },
+      {
+        "checksum": "adler32:f4f34928",
+        "size": 1198284,
+        "uri": "root://eospublic.cern.ch//eos/opendata/atlas/OutreachDatasets/2020-08-19/2lep/MC/mc_306093.dmV_Zll_MET40_DM1_MM400.2lep.root"
+      },
+      {
+        "checksum": "adler32:07e07734",
+        "size": 1283127,
+        "uri": "root://eospublic.cern.ch//eos/opendata/atlas/OutreachDatasets/2020-08-19/2lep/MC/mc_306103.dmV_Zll_MET40_DM1_MM600.2lep.root"
+      },
+      {
+        "checksum": "adler32:93e11059",
+        "size": 1301104,
+        "uri": "root://eospublic.cern.ch//eos/opendata/atlas/OutreachDatasets/2020-08-19/2lep/MC/mc_306109.dmV_Zll_MET40_DM1_MM800.2lep.root"
+      },
+      {
+        "checksum": "adler32:5534fe91",
+        "size": 5110833,
+        "uri": "root://eospublic.cern.ch//eos/opendata/atlas/OutreachDatasets/2020-08-19/2lep/MC/mc_307431.RS_G_ZZ_llll_c10_m0200.2lep.root"
+      },
+      {
+        "checksum": "adler32:8a3d41ed",
+        "size": 6732099,
+        "uri": "root://eospublic.cern.ch//eos/opendata/atlas/OutreachDatasets/2020-08-19/2lep/MC/mc_307434.RS_G_ZZ_llll_c10_m0500.2lep.root"
+      },
+      {
+        "checksum": "adler32:ac31999d",
+        "size": 7606530,
+        "uri": "root://eospublic.cern.ch//eos/opendata/atlas/OutreachDatasets/2020-08-19/2lep/MC/mc_307439.RS_G_ZZ_llll_c10_m1500.2lep.root"
+      },
+      {
+        "checksum": "adler32:e7539e82",
+        "size": 25976040,
+        "uri": "root://eospublic.cern.ch//eos/opendata/atlas/OutreachDatasets/2020-08-19/2lep/MC/mc_341122.ggH125_tautaull.2lep.root"
+      },
+      {
+        "checksum": "adler32:55040b2b",
+        "size": 98032116,
+        "uri": "root://eospublic.cern.ch//eos/opendata/atlas/OutreachDatasets/2020-08-19/2lep/MC/mc_341155.VBFH125_tautaull.2lep.root"
+      },
+      {
+        "checksum": "adler32:86e4b6f9",
+        "size": 20033842,
+        "uri": "root://eospublic.cern.ch//eos/opendata/atlas/OutreachDatasets/2020-08-19/2lep/MC/mc_341947.ZH125_ZZ4lep.2lep.root"
+      },
+      {
+        "checksum": "adler32:fcc1791a",
+        "size": 20510560,
+        "uri": "root://eospublic.cern.ch//eos/opendata/atlas/OutreachDatasets/2020-08-19/2lep/MC/mc_341964.WH125_ZZ4lep.2lep.root"
+      },
+      {
+        "checksum": "adler32:8019e3c7",
+        "size": 179759228,
+        "uri": "root://eospublic.cern.ch//eos/opendata/atlas/OutreachDatasets/2020-08-19/2lep/MC/mc_344235.VBFH125_ZZ4lep.2lep.root"
+      },
+      {
+        "checksum": "adler32:fd8890e7",
+        "size": 156779845,
+        "uri": "root://eospublic.cern.ch//eos/opendata/atlas/OutreachDatasets/2020-08-19/2lep/MC/mc_345060.ggH125_ZZ4lep.2lep.root"
+      },
+      {
+        "checksum": "adler32:705e41a9",
+        "size": 102998796,
+        "uri": "root://eospublic.cern.ch//eos/opendata/atlas/OutreachDatasets/2020-08-19/2lep/MC/mc_345323.VBFH125_WW2lep.2lep.root"
+      },
+      {
+        "checksum": "adler32:5cc6217a",
+        "size": 146407864,
+        "uri": "root://eospublic.cern.ch//eos/opendata/atlas/OutreachDatasets/2020-08-19/2lep/MC/mc_345324.ggH125_WW2lep.2lep.root"
+      },
+      {
+        "checksum": "adler32:cf58bd25",
+        "size": 15968174,
+        "uri": "root://eospublic.cern.ch//eos/opendata/atlas/OutreachDatasets/2020-08-19/2lep/MC/mc_345325.WpH125J_qqWW2lep.2lep.root"
+      },
+      {
+        "checksum": "adler32:c4c3f18c",
+        "size": 12065144,
+        "uri": "root://eospublic.cern.ch//eos/opendata/atlas/OutreachDatasets/2020-08-19/2lep/MC/mc_345327.WpH125J_lvWW2lep.2lep.root"
+      },
+      {
+        "checksum": "adler32:b662bbe4",
+        "size": 14474866,
+        "uri": "root://eospublic.cern.ch//eos/opendata/atlas/OutreachDatasets/2020-08-19/2lep/MC/mc_345336.ZH125J_qqWW2lep.2lep.root"
+      },
+      {
+        "checksum": "adler32:a7bbb98b",
+        "size": 50858024,
+        "uri": "root://eospublic.cern.ch//eos/opendata/atlas/OutreachDatasets/2020-08-19/2lep/MC/mc_345337.ZH125J_llWW2lep.2lep.root"
+      },
+      {
+        "checksum": "adler32:22dce3e6",
+        "size": 10127210,
+        "uri": "root://eospublic.cern.ch//eos/opendata/atlas/OutreachDatasets/2020-08-19/2lep/MC/mc_345445.ZH125J_vvWW2lep.2lep.root"
+      },
+      {
+        "checksum": "adler32:b9dc51e3",
+        "size": 9739200,
+        "uri": "root://eospublic.cern.ch//eos/opendata/atlas/OutreachDatasets/2020-08-19/2lep/MC/mc_361100.Wplusenu.2lep.root"
+      },
+      {
+        "checksum": "adler32:b8fe1201",
+        "size": 8190006,
+        "uri": "root://eospublic.cern.ch//eos/opendata/atlas/OutreachDatasets/2020-08-19/2lep/MC/mc_361101.Wplusmunu.2lep.root"
+      },
+      {
+        "checksum": "adler32:ae2de908",
+        "size": 448400,
+        "uri": "root://eospublic.cern.ch//eos/opendata/atlas/OutreachDatasets/2020-08-19/2lep/MC/mc_361102.Wplustaunu.2lep.root"
+      },
+      {
+        "checksum": "adler32:7a4f5b94",
+        "size": 7495709,
+        "uri": "root://eospublic.cern.ch//eos/opendata/atlas/OutreachDatasets/2020-08-19/2lep/MC/mc_361103.Wminusenu.2lep.root"
+      },
+      {
+        "checksum": "adler32:9e5e4ff8",
+        "size": 7083578,
+        "uri": "root://eospublic.cern.ch//eos/opendata/atlas/OutreachDatasets/2020-08-19/2lep/MC/mc_361104.Wminusmunu.2lep.root"
+      },
+      {
+        "checksum": "adler32:fa7a4de5",
+        "size": 364356,
+        "uri": "root://eospublic.cern.ch//eos/opendata/atlas/OutreachDatasets/2020-08-19/2lep/MC/mc_361105.Wminustaunu.2lep.root"
+      },
+      {
+        "checksum": "adler32:5c4c6d5f",
+        "size": 4629684290,
+        "uri": "root://eospublic.cern.ch//eos/opendata/atlas/OutreachDatasets/2020-08-19/2lep/MC/mc_361106.Zee.2lep.root"
+      },
+      {
+        "checksum": "adler32:a2573825",
+        "size": 4641811205,
+        "uri": "root://eospublic.cern.ch//eos/opendata/atlas/OutreachDatasets/2020-08-19/2lep/MC/mc_361107.Zmumu.2lep.root"
+      },
+      {
+        "checksum": "adler32:d07a9859",
+        "size": 40361722,
+        "uri": "root://eospublic.cern.ch//eos/opendata/atlas/OutreachDatasets/2020-08-19/2lep/MC/mc_361108.Ztautau.2lep.root"
+      },
+      {
+        "checksum": "adler32:fa69b9a3",
+        "size": 380418685,
+        "uri": "root://eospublic.cern.ch//eos/opendata/atlas/OutreachDatasets/2020-08-19/2lep/MC/mc_363356.ZqqZll.2lep.root"
+      },
+      {
+        "checksum": "adler32:612c6d62",
+        "size": 356208741,
+        "uri": "root://eospublic.cern.ch//eos/opendata/atlas/OutreachDatasets/2020-08-19/2lep/MC/mc_363358.WqqZll.2lep.root"
+      },
+      {
+        "checksum": "adler32:03b3f0fc",
+        "size": 3833185,
+        "uri": "root://eospublic.cern.ch//eos/opendata/atlas/OutreachDatasets/2020-08-19/2lep/MC/mc_363359.WpqqWmlv.2lep.root"
+      },
+      {
+        "checksum": "adler32:9270f216",
+        "size": 4084391,
+        "uri": "root://eospublic.cern.ch//eos/opendata/atlas/OutreachDatasets/2020-08-19/2lep/MC/mc_363360.WplvWmqq.2lep.root"
+      },
+      {
+        "checksum": "adler32:ea46e933",
+        "size": 8108937,
+        "uri": "root://eospublic.cern.ch//eos/opendata/atlas/OutreachDatasets/2020-08-19/2lep/MC/mc_363489.WlvZqq.2lep.root"
+      },
+      {
+        "checksum": "adler32:6ab2f1d2",
+        "size": 1252359206,
+        "uri": "root://eospublic.cern.ch//eos/opendata/atlas/OutreachDatasets/2020-08-19/2lep/MC/mc_363490.llll.2lep.root"
+      },
+      {
+        "checksum": "adler32:7f7791d2",
+        "size": 1117114350,
+        "uri": "root://eospublic.cern.ch//eos/opendata/atlas/OutreachDatasets/2020-08-19/2lep/MC/mc_363491.lllv.2lep.root"
+      },
+      {
+        "checksum": "adler32:e255b284",
+        "size": 864447113,
+        "uri": "root://eospublic.cern.ch//eos/opendata/atlas/OutreachDatasets/2020-08-19/2lep/MC/mc_363492.llvv.2lep.root"
+      },
+      {
+        "checksum": "adler32:c53528c4",
+        "size": 3388431,
+        "uri": "root://eospublic.cern.ch//eos/opendata/atlas/OutreachDatasets/2020-08-19/2lep/MC/mc_363493.lvvv.2lep.root"
+      },
+      {
+        "checksum": "adler32:d4102af9",
+        "size": 448244100,
+        "uri": "root://eospublic.cern.ch//eos/opendata/atlas/OutreachDatasets/2020-08-19/2lep/MC/mc_364100.Zmumu_PTV0_70_CVetoBVeto.2lep.root"
+      },
+      {
+        "checksum": "adler32:1ba71d95",
+        "size": 318543105,
+        "uri": "root://eospublic.cern.ch//eos/opendata/atlas/OutreachDatasets/2020-08-19/2lep/MC/mc_364101.Zmumu_PTV0_70_CFilterBVeto.2lep.root"
+      },
+      {
+        "checksum": "adler32:b0c7d7fb",
+        "size": 567795928,
+        "uri": "root://eospublic.cern.ch//eos/opendata/atlas/OutreachDatasets/2020-08-19/2lep/MC/mc_364102.Zmumu_PTV0_70_BFilter.2lep.root"
+      },
+      {
+        "checksum": "adler32:15bcf9c5",
+        "size": 465035117,
+        "uri": "root://eospublic.cern.ch//eos/opendata/atlas/OutreachDatasets/2020-08-19/2lep/MC/mc_364103.Zmumu_PTV70_140_CVetoBVeto.2lep.root"
+      },
+      {
+        "checksum": "adler32:f3f0b03f",
+        "size": 164903122,
+        "uri": "root://eospublic.cern.ch//eos/opendata/atlas/OutreachDatasets/2020-08-19/2lep/MC/mc_364104.Zmumu_PTV70_140_CFilterBVeto.2lep.root"
+      },
+      {
+        "checksum": "adler32:e116ae11",
+        "size": 526996158,
+        "uri": "root://eospublic.cern.ch//eos/opendata/atlas/OutreachDatasets/2020-08-19/2lep/MC/mc_364105.Zmumu_PTV70_140_BFilter.2lep.root"
+      },
+      {
+        "checksum": "adler32:f5d162b1",
+        "size": 453771496,
+        "uri": "root://eospublic.cern.ch//eos/opendata/atlas/OutreachDatasets/2020-08-19/2lep/MC/mc_364106.Zmumu_PTV140_280_CVetoBVeto.2lep.root"
+      },
+      {
+        "checksum": "adler32:abb418a8",
+        "size": 281344489,
+        "uri": "root://eospublic.cern.ch//eos/opendata/atlas/OutreachDatasets/2020-08-19/2lep/MC/mc_364107.Zmumu_PTV140_280_CFilterBVeto.2lep.root"
+      },
+      {
+        "checksum": "adler32:7ad6521f",
+        "size": 1186153504,
+        "uri": "root://eospublic.cern.ch//eos/opendata/atlas/OutreachDatasets/2020-08-19/2lep/MC/mc_364108.Zmumu_PTV140_280_BFilter.2lep.root"
+      },
+      {
+        "checksum": "adler32:4ef2801e",
+        "size": 204135398,
+        "uri": "root://eospublic.cern.ch//eos/opendata/atlas/OutreachDatasets/2020-08-19/2lep/MC/mc_364109.Zmumu_PTV280_500_CVetoBVeto.2lep.root"
+      },
+      {
+        "checksum": "adler32:a8e1866e",
+        "size": 104019295,
+        "uri": "root://eospublic.cern.ch//eos/opendata/atlas/OutreachDatasets/2020-08-19/2lep/MC/mc_364110.Zmumu_PTV280_500_CFilterBVeto.2lep.root"
+      },
+      {
+        "checksum": "adler32:e36ceb66",
+        "size": 214896032,
+        "uri": "root://eospublic.cern.ch//eos/opendata/atlas/OutreachDatasets/2020-08-19/2lep/MC/mc_364111.Zmumu_PTV280_500_BFilter.2lep.root"
+      },
+      {
+        "checksum": "adler32:4fa39eb7",
+        "size": 333731469,
+        "uri": "root://eospublic.cern.ch//eos/opendata/atlas/OutreachDatasets/2020-08-19/2lep/MC/mc_364112.Zmumu_PTV500_1000.2lep.root"
+      },
+      {
+        "checksum": "adler32:50a8b52b",
+        "size": 117636044,
+        "uri": "root://eospublic.cern.ch//eos/opendata/atlas/OutreachDatasets/2020-08-19/2lep/MC/mc_364113.Zmumu_PTV1000_E_CMS.2lep.root"
+      },
+      {
+        "checksum": "adler32:7cfa2512",
+        "size": 434680180,
+        "uri": "root://eospublic.cern.ch//eos/opendata/atlas/OutreachDatasets/2020-08-19/2lep/MC/mc_364114.Zee_PTV0_70_CVetoBVeto.2lep.root"
+      },
+      {
+        "checksum": "adler32:c56686cd",
+        "size": 326783926,
+        "uri": "root://eospublic.cern.ch//eos/opendata/atlas/OutreachDatasets/2020-08-19/2lep/MC/mc_364115.Zee_PTV0_70_CFilterBVeto.2lep.root"
+      },
+      {
+        "checksum": "adler32:f886def6",
+        "size": 587988572,
+        "uri": "root://eospublic.cern.ch//eos/opendata/atlas/OutreachDatasets/2020-08-19/2lep/MC/mc_364116.Zee_PTV0_70_BFilter.2lep.root"
+      },
+      {
+        "checksum": "adler32:571fc274",
+        "size": 541309163,
+        "uri": "root://eospublic.cern.ch//eos/opendata/atlas/OutreachDatasets/2020-08-19/2lep/MC/mc_364117.Zee_PTV70_140_CVetoBVeto.2lep.root"
+      },
+      {
+        "checksum": "adler32:35aed1e2",
+        "size": 197721002,
+        "uri": "root://eospublic.cern.ch//eos/opendata/atlas/OutreachDatasets/2020-08-19/2lep/MC/mc_364118.Zee_PTV70_140_CFilterBVeto.2lep.root"
+      },
+      {
+        "checksum": "adler32:3987b327",
+        "size": 636085569,
+        "uri": "root://eospublic.cern.ch//eos/opendata/atlas/OutreachDatasets/2020-08-19/2lep/MC/mc_364119.Zee_PTV70_140_BFilter.2lep.root"
+      },
+      {
+        "checksum": "adler32:bd811de4",
+        "size": 551294797,
+        "uri": "root://eospublic.cern.ch//eos/opendata/atlas/OutreachDatasets/2020-08-19/2lep/MC/mc_364120.Zee_PTV140_280_CVetoBVeto.2lep.root"
+      },
+      {
+        "checksum": "adler32:8ae36ffa",
+        "size": 344476781,
+        "uri": "root://eospublic.cern.ch//eos/opendata/atlas/OutreachDatasets/2020-08-19/2lep/MC/mc_364121.Zee_PTV140_280_CFilterBVeto.2lep.root"
+      },
+      {
+        "checksum": "adler32:c72ba849",
+        "size": 1506319726,
+        "uri": "root://eospublic.cern.ch//eos/opendata/atlas/OutreachDatasets/2020-08-19/2lep/MC/mc_364122.Zee_PTV140_280_BFilter.2lep.root"
+      },
+      {
+        "checksum": "adler32:88232f0c",
+        "size": 244111519,
+        "uri": "root://eospublic.cern.ch//eos/opendata/atlas/OutreachDatasets/2020-08-19/2lep/MC/mc_364123.Zee_PTV280_500_CVetoBVeto.2lep.root"
+      },
+      {
+        "checksum": "adler32:fdded5c0",
+        "size": 129975595,
+        "uri": "root://eospublic.cern.ch//eos/opendata/atlas/OutreachDatasets/2020-08-19/2lep/MC/mc_364124.Zee_PTV280_500_CFilterBVeto.2lep.root"
+      },
+      {
+        "checksum": "adler32:d7a172cc",
+        "size": 274786333,
+        "uri": "root://eospublic.cern.ch//eos/opendata/atlas/OutreachDatasets/2020-08-19/2lep/MC/mc_364125.Zee_PTV280_500_BFilter.2lep.root"
+      },
+      {
+        "checksum": "adler32:4ded7e54",
+        "size": 420728865,
+        "uri": "root://eospublic.cern.ch//eos/opendata/atlas/OutreachDatasets/2020-08-19/2lep/MC/mc_364126.Zee_PTV500_1000.2lep.root"
+      },
+      {
+        "checksum": "adler32:4ed8e1af",
+        "size": 150005750,
+        "uri": "root://eospublic.cern.ch//eos/opendata/atlas/OutreachDatasets/2020-08-19/2lep/MC/mc_364127.Zee_PTV1000_E_CMS.2lep.root"
+      },
+      {
+        "checksum": "adler32:2f435ffd",
+        "size": 10519304,
+        "uri": "root://eospublic.cern.ch//eos/opendata/atlas/OutreachDatasets/2020-08-19/2lep/MC/mc_364128.Ztautau_PTV0_70_CVetoBVeto.2lep.root"
+      },
+      {
+        "checksum": "adler32:849341da",
+        "size": 7852864,
+        "uri": "root://eospublic.cern.ch//eos/opendata/atlas/OutreachDatasets/2020-08-19/2lep/MC/mc_364129.Ztautau_PTV0_70_CFilterBVeto.2lep.root"
+      },
+      {
+        "checksum": "adler32:eb4f0294",
+        "size": 15052746,
+        "uri": "root://eospublic.cern.ch//eos/opendata/atlas/OutreachDatasets/2020-08-19/2lep/MC/mc_364130.Ztautau_PTV0_70_BFilter.2lep.root"
+      },
+      {
+        "checksum": "adler32:cc4cf91c",
+        "size": 17355769,
+        "uri": "root://eospublic.cern.ch//eos/opendata/atlas/OutreachDatasets/2020-08-19/2lep/MC/mc_364131.Ztautau_PTV70_140_CVetoBVeto.2lep.root"
+      },
+      {
+        "checksum": "adler32:5720ecf8",
+        "size": 6170579,
+        "uri": "root://eospublic.cern.ch//eos/opendata/atlas/OutreachDatasets/2020-08-19/2lep/MC/mc_364132.Ztautau_PTV70_140_CFilterBVeto.2lep.root"
+      },
+      {
+        "checksum": "adler32:f2351b7d",
+        "size": 21429280,
+        "uri": "root://eospublic.cern.ch//eos/opendata/atlas/OutreachDatasets/2020-08-19/2lep/MC/mc_364133.Ztautau_PTV70_140_BFilter.2lep.root"
+      },
+      {
+        "checksum": "adler32:7dbac2f6",
+        "size": 23796826,
+        "uri": "root://eospublic.cern.ch//eos/opendata/atlas/OutreachDatasets/2020-08-19/2lep/MC/mc_364134.Ztautau_PTV140_280_CVetoBVeto.2lep.root"
+      },
+      {
+        "checksum": "adler32:6fb917e6",
+        "size": 14376410,
+        "uri": "root://eospublic.cern.ch//eos/opendata/atlas/OutreachDatasets/2020-08-19/2lep/MC/mc_364135.Ztautau_PTV140_280_CFilterBVeto.2lep.root"
+      },
+      {
+        "checksum": "adler32:0fb79474",
+        "size": 26216313,
+        "uri": "root://eospublic.cern.ch//eos/opendata/atlas/OutreachDatasets/2020-08-19/2lep/MC/mc_364136.Ztautau_PTV140_280_BFilter.2lep.root"
+      },
+      {
+        "checksum": "adler32:af62ed33",
+        "size": 12460700,
+        "uri": "root://eospublic.cern.ch//eos/opendata/atlas/OutreachDatasets/2020-08-19/2lep/MC/mc_364137.Ztautau_PTV280_500_CVetoBVeto.2lep.root"
+      },
+      {
+        "checksum": "adler32:744918f3",
+        "size": 6212512,
+        "uri": "root://eospublic.cern.ch//eos/opendata/atlas/OutreachDatasets/2020-08-19/2lep/MC/mc_364138.Ztautau_PTV280_500_CFilterBVeto.2lep.root"
+      },
+      {
+        "checksum": "adler32:26d05fb0",
+        "size": 13323139,
+        "uri": "root://eospublic.cern.ch//eos/opendata/atlas/OutreachDatasets/2020-08-19/2lep/MC/mc_364139.Ztautau_PTV280_500_BFilter.2lep.root"
+      },
+      {
+        "checksum": "adler32:400938a9",
+        "size": 19956000,
+        "uri": "root://eospublic.cern.ch//eos/opendata/atlas/OutreachDatasets/2020-08-19/2lep/MC/mc_364140.Ztautau_PTV500_1000.2lep.root"
+      },
+      {
+        "checksum": "adler32:a5d4084c",
+        "size": 7741667,
+        "uri": "root://eospublic.cern.ch//eos/opendata/atlas/OutreachDatasets/2020-08-19/2lep/MC/mc_364141.Ztautau_PTV1000_E_CMS.2lep.root"
+      },
+      {
+        "checksum": "adler32:f50d538c",
+        "size": 7239264,
+        "uri": "root://eospublic.cern.ch//eos/opendata/atlas/OutreachDatasets/2020-08-19/2lep/MC/mc_364156.Wmunu_PTV0_70_CVetoBVeto.2lep.root"
+      },
+      {
+        "checksum": "adler32:4232bba6",
+        "size": 4718044,
+        "uri": "root://eospublic.cern.ch//eos/opendata/atlas/OutreachDatasets/2020-08-19/2lep/MC/mc_364157.Wmunu_PTV0_70_CFilterBVeto.2lep.root"
+      },
+      {
+        "checksum": "adler32:b372a54d",
+        "size": 13000141,
+        "uri": "root://eospublic.cern.ch//eos/opendata/atlas/OutreachDatasets/2020-08-19/2lep/MC/mc_364158.Wmunu_PTV0_70_BFilter.2lep.root"
+      },
+      {
+        "checksum": "adler32:7b6f2230",
+        "size": 6550468,
+        "uri": "root://eospublic.cern.ch//eos/opendata/atlas/OutreachDatasets/2020-08-19/2lep/MC/mc_364159.Wmunu_PTV70_140_CVetoBVeto.2lep.root"
+      },
+      {
+        "checksum": "adler32:3156617a",
+        "size": 6926384,
+        "uri": "root://eospublic.cern.ch//eos/opendata/atlas/OutreachDatasets/2020-08-19/2lep/MC/mc_364160.Wmunu_PTV70_140_CFilterBVeto.2lep.root"
+      },
+      {
+        "checksum": "adler32:de341b06",
+        "size": 29123581,
+        "uri": "root://eospublic.cern.ch//eos/opendata/atlas/OutreachDatasets/2020-08-19/2lep/MC/mc_364161.Wmunu_PTV70_140_BFilter.2lep.root"
+      },
+      {
+        "checksum": "adler32:12ebfd30",
+        "size": 5151553,
+        "uri": "root://eospublic.cern.ch//eos/opendata/atlas/OutreachDatasets/2020-08-19/2lep/MC/mc_364162.Wmunu_PTV140_280_CVetoBVeto.2lep.root"
+      },
+      {
+        "checksum": "adler32:ac8872d8",
+        "size": 5718045,
+        "uri": "root://eospublic.cern.ch//eos/opendata/atlas/OutreachDatasets/2020-08-19/2lep/MC/mc_364163.Wmunu_PTV140_280_CFilterBVeto.2lep.root"
+      },
+      {
+        "checksum": "adler32:c2197593",
+        "size": 40671802,
+        "uri": "root://eospublic.cern.ch//eos/opendata/atlas/OutreachDatasets/2020-08-19/2lep/MC/mc_364164.Wmunu_PTV140_280_BFilter.2lep.root"
+      },
+      {
+        "checksum": "adler32:37d04c62",
+        "size": 3077256,
+        "uri": "root://eospublic.cern.ch//eos/opendata/atlas/OutreachDatasets/2020-08-19/2lep/MC/mc_364165.Wmunu_PTV280_500_CVetoBVeto.2lep.root"
+      },
+      {
+        "checksum": "adler32:c6e10d1c",
+        "size": 2535091,
+        "uri": "root://eospublic.cern.ch//eos/opendata/atlas/OutreachDatasets/2020-08-19/2lep/MC/mc_364166.Wmunu_PTV280_500_CFilterBVeto.2lep.root"
+      },
+      {
+        "checksum": "adler32:dd20b7b1",
+        "size": 6832254,
+        "uri": "root://eospublic.cern.ch//eos/opendata/atlas/OutreachDatasets/2020-08-19/2lep/MC/mc_364167.Wmunu_PTV280_500_BFilter.2lep.root"
+      },
+      {
+        "checksum": "adler32:b5552b01",
+        "size": 6370963,
+        "uri": "root://eospublic.cern.ch//eos/opendata/atlas/OutreachDatasets/2020-08-19/2lep/MC/mc_364168.Wmunu_PTV500_1000.2lep.root"
+      },
+      {
+        "checksum": "adler32:8bb9a45f",
+        "size": 5403844,
+        "uri": "root://eospublic.cern.ch//eos/opendata/atlas/OutreachDatasets/2020-08-19/2lep/MC/mc_364169.Wmunu_PTV1000_E_CMS.2lep.root"
+      },
+      {
+        "checksum": "adler32:933d8fad",
+        "size": 7524626,
+        "uri": "root://eospublic.cern.ch//eos/opendata/atlas/OutreachDatasets/2020-08-19/2lep/MC/mc_364170.Wenu_PTV0_70_CVetoBVeto.2lep.root"
+      },
+      {
+        "checksum": "adler32:7770560c",
+        "size": 5405847,
+        "uri": "root://eospublic.cern.ch//eos/opendata/atlas/OutreachDatasets/2020-08-19/2lep/MC/mc_364171.Wenu_PTV0_70_CFilterBVeto.2lep.root"
+      },
+      {
+        "checksum": "adler32:1f5acb25",
+        "size": 15538164,
+        "uri": "root://eospublic.cern.ch//eos/opendata/atlas/OutreachDatasets/2020-08-19/2lep/MC/mc_364172.Wenu_PTV0_70_BFilter.2lep.root"
+      },
+      {
+        "checksum": "adler32:bb7996fc",
+        "size": 7545454,
+        "uri": "root://eospublic.cern.ch//eos/opendata/atlas/OutreachDatasets/2020-08-19/2lep/MC/mc_364173.Wenu_PTV70_140_CVetoBVeto.2lep.root"
+      },
+      {
+        "checksum": "adler32:8c40ae20",
+        "size": 9035594,
+        "uri": "root://eospublic.cern.ch//eos/opendata/atlas/OutreachDatasets/2020-08-19/2lep/MC/mc_364174.Wenu_PTV70_140_CFilterBVeto.2lep.root"
+      },
+      {
+        "checksum": "adler32:d9eeada3",
+        "size": 20645180,
+        "uri": "root://eospublic.cern.ch//eos/opendata/atlas/OutreachDatasets/2020-08-19/2lep/MC/mc_364175.Wenu_PTV70_140_BFilter.2lep.root"
+      },
+      {
+        "checksum": "adler32:2013e105",
+        "size": 6086988,
+        "uri": "root://eospublic.cern.ch//eos/opendata/atlas/OutreachDatasets/2020-08-19/2lep/MC/mc_364176.Wenu_PTV140_280_CVetoBVeto.2lep.root"
+      },
+      {
+        "checksum": "adler32:362d83b6",
+        "size": 7656428,
+        "uri": "root://eospublic.cern.ch//eos/opendata/atlas/OutreachDatasets/2020-08-19/2lep/MC/mc_364177.Wenu_PTV140_280_CFilterBVeto.2lep.root"
+      },
+      {
+        "checksum": "adler32:3f004bf7",
+        "size": 62949297,
+        "uri": "root://eospublic.cern.ch//eos/opendata/atlas/OutreachDatasets/2020-08-19/2lep/MC/mc_364178.Wenu_PTV140_280_BFilter.2lep.root"
+      },
+      {
+        "checksum": "adler32:faa0f95d",
+        "size": 3677287,
+        "uri": "root://eospublic.cern.ch//eos/opendata/atlas/OutreachDatasets/2020-08-19/2lep/MC/mc_364179.Wenu_PTV280_500_CVetoBVeto.2lep.root"
+      },
+      {
+        "checksum": "adler32:d6eca17b",
+        "size": 3373406,
+        "uri": "root://eospublic.cern.ch//eos/opendata/atlas/OutreachDatasets/2020-08-19/2lep/MC/mc_364180.Wenu_PTV280_500_CFilterBVeto.2lep.root"
+      },
+      {
+        "checksum": "adler32:baeacd83",
+        "size": 9473259,
+        "uri": "root://eospublic.cern.ch//eos/opendata/atlas/OutreachDatasets/2020-08-19/2lep/MC/mc_364181.Wenu_PTV280_500_BFilter.2lep.root"
+      },
+      {
+        "checksum": "adler32:e0418777",
+        "size": 8317784,
+        "uri": "root://eospublic.cern.ch//eos/opendata/atlas/OutreachDatasets/2020-08-19/2lep/MC/mc_364182.Wenu_PTV500_1000.2lep.root"
+      },
+      {
+        "checksum": "adler32:28bc2294",
+        "size": 6609691,
+        "uri": "root://eospublic.cern.ch//eos/opendata/atlas/OutreachDatasets/2020-08-19/2lep/MC/mc_364183.Wenu_PTV1000_E_CMS.2lep.root"
+      },
+      {
+        "checksum": "adler32:7f10c5eb",
+        "size": 434212,
+        "uri": "root://eospublic.cern.ch//eos/opendata/atlas/OutreachDatasets/2020-08-19/2lep/MC/mc_364184.Wtaunu_PTV0_70_CVetoBVeto.2lep.root"
+      },
+      {
+        "checksum": "adler32:7aa74146",
+        "size": 373451,
+        "uri": "root://eospublic.cern.ch//eos/opendata/atlas/OutreachDatasets/2020-08-19/2lep/MC/mc_364185.Wtaunu_PTV0_70_CFilterBVeto.2lep.root"
+      },
+      {
+        "checksum": "adler32:28698b41",
+        "size": 930690,
+        "uri": "root://eospublic.cern.ch//eos/opendata/atlas/OutreachDatasets/2020-08-19/2lep/MC/mc_364186.Wtaunu_PTV0_70_BFilter.2lep.root"
+      },
+      {
+        "checksum": "adler32:d33de11e",
+        "size": 776009,
+        "uri": "root://eospublic.cern.ch//eos/opendata/atlas/OutreachDatasets/2020-08-19/2lep/MC/mc_364187.Wtaunu_PTV70_140_CVetoBVeto.2lep.root"
+      },
+      {
+        "checksum": "adler32:c4db175f",
+        "size": 908040,
+        "uri": "root://eospublic.cern.ch//eos/opendata/atlas/OutreachDatasets/2020-08-19/2lep/MC/mc_364188.Wtaunu_PTV70_140_CFilterBVeto.2lep.root"
+      },
+      {
+        "checksum": "adler32:bfce7454",
+        "size": 1926721,
+        "uri": "root://eospublic.cern.ch//eos/opendata/atlas/OutreachDatasets/2020-08-19/2lep/MC/mc_364189.Wtaunu_PTV70_140_BFilter.2lep.root"
+      },
+      {
+        "checksum": "adler32:1cadae0e",
+        "size": 806233,
+        "uri": "root://eospublic.cern.ch//eos/opendata/atlas/OutreachDatasets/2020-08-19/2lep/MC/mc_364190.Wtaunu_PTV140_280_CVetoBVeto.2lep.root"
+      },
+      {
+        "checksum": "adler32:44edb7b6",
+        "size": 961038,
+        "uri": "root://eospublic.cern.ch//eos/opendata/atlas/OutreachDatasets/2020-08-19/2lep/MC/mc_364191.Wtaunu_PTV140_280_CFilterBVeto.2lep.root"
+      },
+      {
+        "checksum": "adler32:be8a4773",
+        "size": 3045775,
+        "uri": "root://eospublic.cern.ch//eos/opendata/atlas/OutreachDatasets/2020-08-19/2lep/MC/mc_364192.Wtaunu_PTV140_280_BFilter.2lep.root"
+      },
+      {
+        "checksum": "adler32:a6344a67",
+        "size": 553669,
+        "uri": "root://eospublic.cern.ch//eos/opendata/atlas/OutreachDatasets/2020-08-19/2lep/MC/mc_364193.Wtaunu_PTV280_500_CVetoBVeto.2lep.root"
+      },
+      {
+        "checksum": "adler32:84f7111a",
+        "size": 479381,
+        "uri": "root://eospublic.cern.ch//eos/opendata/atlas/OutreachDatasets/2020-08-19/2lep/MC/mc_364194.Wtaunu_PTV280_500_CFilterBVeto.2lep.root"
+      },
+      {
+        "checksum": "adler32:05a7cc82",
+        "size": 1248182,
+        "uri": "root://eospublic.cern.ch//eos/opendata/atlas/OutreachDatasets/2020-08-19/2lep/MC/mc_364195.Wtaunu_PTV280_500_BFilter.2lep.root"
+      },
+      {
+        "checksum": "adler32:c609e332",
+        "size": 1083190,
+        "uri": "root://eospublic.cern.ch//eos/opendata/atlas/OutreachDatasets/2020-08-19/2lep/MC/mc_364196.Wtaunu_PTV500_1000.2lep.root"
+      },
+      {
+        "checksum": "adler32:71898ff3",
+        "size": 1097267,
+        "uri": "root://eospublic.cern.ch//eos/opendata/atlas/OutreachDatasets/2020-08-19/2lep/MC/mc_364197.Wtaunu_PTV1000_E_CMS.2lep.root"
+      },
+      {
+        "checksum": "adler32:fb412723",
+        "size": 1229970353,
+        "uri": "root://eospublic.cern.ch//eos/opendata/atlas/OutreachDatasets/2020-08-19/2lep/MC/mc_364250.llll_filter.2lep.root"
+      },
+      {
+        "checksum": "adler32:53a60d0d",
+        "size": 5642076,
+        "uri": "root://eospublic.cern.ch//eos/opendata/atlas/OutreachDatasets/2020-08-19/2lep/MC/mc_370114.GG_ttn1_1200_5000_1.2lep.root"
+      },
+      {
+        "checksum": "adler32:884fcc7f",
+        "size": 5810926,
+        "uri": "root://eospublic.cern.ch//eos/opendata/atlas/OutreachDatasets/2020-08-19/2lep/MC/mc_370118.GG_ttn1_1200_5000_600.2lep.root"
+      },
+      {
+        "checksum": "adler32:6a064933",
+        "size": 5357879,
+        "uri": "root://eospublic.cern.ch//eos/opendata/atlas/OutreachDatasets/2020-08-19/2lep/MC/mc_370129.GG_ttn1_1400_5000_1.2lep.root"
+      },
+      {
+        "checksum": "adler32:e62ffda1",
+        "size": 5140577,
+        "uri": "root://eospublic.cern.ch//eos/opendata/atlas/OutreachDatasets/2020-08-19/2lep/MC/mc_370144.GG_ttn1_1600_5000_1.2lep.root"
+      },
+      {
+        "checksum": "adler32:1f21d38a",
+        "size": 237135,
+        "uri": "root://eospublic.cern.ch//eos/opendata/atlas/OutreachDatasets/2020-08-19/2lep/MC/mc_387154.TT_directTT_500_1.2lep.root"
+      },
+      {
+        "checksum": "adler32:2d7f4b48",
+        "size": 577517,
+        "uri": "root://eospublic.cern.ch//eos/opendata/atlas/OutreachDatasets/2020-08-19/2lep/MC/mc_387157.TT_directTT_500_200.2lep.root"
+      },
+      {
+        "checksum": "adler32:5ee38b29",
+        "size": 570540,
+        "uri": "root://eospublic.cern.ch//eos/opendata/atlas/OutreachDatasets/2020-08-19/2lep/MC/mc_387163.TT_directTT_600_1.2lep.root"
+      },
+      {
+        "checksum": "adler32:2210ff32",
+        "size": 548585,
+        "uri": "root://eospublic.cern.ch//eos/opendata/atlas/OutreachDatasets/2020-08-19/2lep/MC/mc_388240.TT_directTT_450_1.2lep.root"
+      },
+      {
+        "checksum": "adler32:39818bde",
+        "size": 2081866,
+        "uri": "root://eospublic.cern.ch//eos/opendata/atlas/OutreachDatasets/2020-08-19/2lep/MC/mc_392217.C1N2_WZ_400p0_0p0_3L_2L7.2lep.root"
+      },
+      {
+        "checksum": "adler32:977e92af",
+        "size": 2044727,
+        "uri": "root://eospublic.cern.ch//eos/opendata/atlas/OutreachDatasets/2020-08-19/2lep/MC/mc_392220.C1N2_WZ_350p0_0p0_3L_2L7.2lep.root"
+      },
+      {
+        "checksum": "adler32:061a1555",
+        "size": 1089109,
+        "uri": "root://eospublic.cern.ch//eos/opendata/atlas/OutreachDatasets/2020-08-19/2lep/MC/mc_392223.C1N2_WZ_500p0_0p0_3L_2L7.2lep.root"
+      },
+      {
+        "checksum": "adler32:a1e361bb",
+        "size": 3274636,
+        "uri": "root://eospublic.cern.ch//eos/opendata/atlas/OutreachDatasets/2020-08-19/2lep/MC/mc_392226.C1N2_WZ_100p0_0p0_3L_2L7.2lep.root"
+      },
+      {
+        "checksum": "adler32:b000eb84",
+        "size": 883744,
+        "uri": "root://eospublic.cern.ch//eos/opendata/atlas/OutreachDatasets/2020-08-19/2lep/MC/mc_392302.C1N2_WZ_500p0_100p0_2L2J_2L7.2lep.root"
+      },
+      {
+        "checksum": "adler32:26cbb4ec",
+        "size": 1613289,
+        "uri": "root://eospublic.cern.ch//eos/opendata/atlas/OutreachDatasets/2020-08-19/2lep/MC/mc_392304.C1N2_WZ_300p0_100p0_2L2J_2L7.2lep.root"
+      },
+      {
+        "checksum": "adler32:fa3a09bb",
+        "size": 1463914,
+        "uri": "root://eospublic.cern.ch//eos/opendata/atlas/OutreachDatasets/2020-08-19/2lep/MC/mc_392308.C1N2_WZ_300p0_200p0_2L2J_2L7.2lep.root"
+      },
+      {
+        "checksum": "adler32:08be331c",
+        "size": 1703255,
+        "uri": "root://eospublic.cern.ch//eos/opendata/atlas/OutreachDatasets/2020-08-19/2lep/MC/mc_392317.C1N2_WZ_400p0_0p0_2L2J_2L7.2lep.root"
+      },
+      {
+        "checksum": "adler32:c1074c02",
+        "size": 881178,
+        "uri": "root://eospublic.cern.ch//eos/opendata/atlas/OutreachDatasets/2020-08-19/2lep/MC/mc_392323.C1N2_WZ_500p0_0p0_2L2J_2L7.2lep.root"
+      },
+      {
+        "checksum": "adler32:ce7a346c",
+        "size": 1516218,
+        "uri": "root://eospublic.cern.ch//eos/opendata/atlas/OutreachDatasets/2020-08-19/2lep/MC/mc_392324.C1N2_WZ_400p0_300p0_2L2J_2L7.2lep.root"
+      },
+      {
+        "checksum": "adler32:588f2a13",
+        "size": 2776369,
+        "uri": "root://eospublic.cern.ch//eos/opendata/atlas/OutreachDatasets/2020-08-19/2lep/MC/mc_392326.C1N2_WZ_100p0_0p0_2L2J_2L7.2lep.root"
+      },
+      {
+        "checksum": "adler32:ab8a08a2",
+        "size": 2879577,
+        "uri": "root://eospublic.cern.ch//eos/opendata/atlas/OutreachDatasets/2020-08-19/2lep/MC/mc_392330.C1N2_WZ_200p0_100p0_2L2J_2L7.2lep.root"
+      },
+      {
+        "checksum": "adler32:cbebfbe7",
+        "size": 849841,
+        "uri": "root://eospublic.cern.ch//eos/opendata/atlas/OutreachDatasets/2020-08-19/2lep/MC/mc_392332.C1N2_WZ_500p0_300p0_2L2J_2L7.2lep.root"
+      },
+      {
+        "checksum": "adler32:9d8192f3",
+        "size": 910833,
+        "uri": "root://eospublic.cern.ch//eos/opendata/atlas/OutreachDatasets/2020-08-19/2lep/MC/mc_392354.C1N2_WZ_600_100_2L2J_2L7.2lep.root"
+      },
+      {
+        "checksum": "adler32:cd4f9ed0",
+        "size": 918151,
+        "uri": "root://eospublic.cern.ch//eos/opendata/atlas/OutreachDatasets/2020-08-19/2lep/MC/mc_392356.C1N2_WZ_600_0_2L2J_2L7.2lep.root"
+      },
+      {
+        "checksum": "adler32:e4a256a2",
+        "size": 738301,
+        "uri": "root://eospublic.cern.ch//eos/opendata/atlas/OutreachDatasets/2020-08-19/2lep/MC/mc_392361.C1N2_WZ_700_400_2L2J_2L7.2lep.root"
+      },
+      {
+        "checksum": "adler32:3525bfe6",
+        "size": 905008,
+        "uri": "root://eospublic.cern.ch//eos/opendata/atlas/OutreachDatasets/2020-08-19/2lep/MC/mc_392364.C1N2_WZ_700_100_2L2J_2L7.2lep.root"
+      },
+      {
+        "checksum": "adler32:3521488e",
+        "size": 928853,
+        "uri": "root://eospublic.cern.ch//eos/opendata/atlas/OutreachDatasets/2020-08-19/2lep/MC/mc_392365.C1N2_WZ_700_0_2L2J_2L7.2lep.root"
+      },
+      {
+        "checksum": "adler32:5d414f26",
+        "size": 3311288,
+        "uri": "root://eospublic.cern.ch//eos/opendata/atlas/OutreachDatasets/2020-08-19/2lep/MC/mc_392501.C1C1_SlepSnu_x0p50_200p0_100p0_2L8.2lep.root"
+      },
+      {
+        "checksum": "adler32:ea347f44",
+        "size": 1131853,
+        "uri": "root://eospublic.cern.ch//eos/opendata/atlas/OutreachDatasets/2020-08-19/2lep/MC/mc_392502.C1C1_SlepSnu_x0p50_200p0_150p0_2L8.2lep.root"
+      },
+      {
+        "checksum": "adler32:12070a45",
+        "size": 3822242,
+        "uri": "root://eospublic.cern.ch//eos/opendata/atlas/OutreachDatasets/2020-08-19/2lep/MC/mc_392504.C1C1_SlepSnu_x0p50_300p0_100p0_2L8.2lep.root"
+      },
+      {
+        "checksum": "adler32:eecf5af0",
+        "size": 1148799,
+        "uri": "root://eospublic.cern.ch//eos/opendata/atlas/OutreachDatasets/2020-08-19/2lep/MC/mc_392506.C1C1_SlepSnu_x0p50_300p0_250p0_2L8.2lep.root"
+      },
+      {
+        "checksum": "adler32:8db31ad4",
+        "size": 4170212,
+        "uri": "root://eospublic.cern.ch//eos/opendata/atlas/OutreachDatasets/2020-08-19/2lep/MC/mc_392507.C1C1_SlepSnu_x0p50_400p0_100p0_2L8.2lep.root"
+      },
+      {
+        "checksum": "adler32:6ee4f177",
+        "size": 3512099,
+        "uri": "root://eospublic.cern.ch//eos/opendata/atlas/OutreachDatasets/2020-08-19/2lep/MC/mc_392509.C1C1_SlepSnu_x0p50_400p0_300p0_2L8.2lep.root"
+      },
+      {
+        "checksum": "adler32:09537348",
+        "size": 4148811,
+        "uri": "root://eospublic.cern.ch//eos/opendata/atlas/OutreachDatasets/2020-08-19/2lep/MC/mc_392513.C1C1_SlepSnu_x0p50_500p0_300p0_2L8.2lep.root"
+      },
+      {
+        "checksum": "adler32:6c4176e9",
+        "size": 4343330,
+        "uri": "root://eospublic.cern.ch//eos/opendata/atlas/OutreachDatasets/2020-08-19/2lep/MC/mc_392517.C1C1_SlepSnu_x0p50_600p0_300p0_2L8.2lep.root"
+      },
+      {
+        "checksum": "adler32:605c8203",
+        "size": 4412055,
+        "uri": "root://eospublic.cern.ch//eos/opendata/atlas/OutreachDatasets/2020-08-19/2lep/MC/mc_392518.C1C1_SlepSnu_x0p50_700p0_1p0_2L8.2lep.root"
+      },
+      {
+        "checksum": "adler32:4a78ec88",
+        "size": 4417986,
+        "uri": "root://eospublic.cern.ch//eos/opendata/atlas/OutreachDatasets/2020-08-19/2lep/MC/mc_392521.C1C1_SlepSnu_x0p50_700p0_300p0_2L8.2lep.root"
+      },
+      {
+        "checksum": "adler32:fb975b9d",
+        "size": 1357078,
+        "uri": "root://eospublic.cern.ch//eos/opendata/atlas/OutreachDatasets/2020-08-19/2lep/MC/mc_392916.SlepSlep_direct_100p5_1p0_2L8.2lep.root"
+      },
+      {
+        "checksum": "adler32:bbf484ca",
+        "size": 1244303,
+        "uri": "root://eospublic.cern.ch//eos/opendata/atlas/OutreachDatasets/2020-08-19/2lep/MC/mc_392918.SlepSlep_direct_200p5_1p0_2L8.2lep.root"
+      },
+      {
+        "checksum": "adler32:cfd80eec",
+        "size": 1643009,
+        "uri": "root://eospublic.cern.ch//eos/opendata/atlas/OutreachDatasets/2020-08-19/2lep/MC/mc_392920.SlepSlep_direct_300p5_1p0_2L8.2lep.root"
+      },
+      {
+        "checksum": "adler32:093c0e7a",
+        "size": 1514414,
+        "uri": "root://eospublic.cern.ch//eos/opendata/atlas/OutreachDatasets/2020-08-19/2lep/MC/mc_392924.SlepSlep_direct_500p5_1p0_2L8.2lep.root"
+      },
+      {
+        "checksum": "adler32:fb7b3aec",
+        "size": 1231125,
+        "uri": "root://eospublic.cern.ch//eos/opendata/atlas/OutreachDatasets/2020-08-19/2lep/MC/mc_392925.SlepSlep_direct_100p0_50p0_2L8.2lep.root"
+      },
+      {
+        "checksum": "adler32:044fe4f4",
+        "size": 1531095,
+        "uri": "root://eospublic.cern.ch//eos/opendata/atlas/OutreachDatasets/2020-08-19/2lep/MC/mc_392936.SlepSlep_direct_200p0_100p0_2L8.2lep.root"
+      },
+      {
+        "checksum": "adler32:a109bb73",
+        "size": 1667472,
+        "uri": "root://eospublic.cern.ch//eos/opendata/atlas/OutreachDatasets/2020-08-19/2lep/MC/mc_392942.SlepSlep_direct_500p0_100p0_2L8.2lep.root"
+      },
+      {
+        "checksum": "adler32:3aaa4d7d",
+        "size": 1567370,
+        "uri": "root://eospublic.cern.ch//eos/opendata/atlas/OutreachDatasets/2020-08-19/2lep/MC/mc_392951.SlepSlep_direct_300p0_200p0_2L8.2lep.root"
+      },
+      {
+        "checksum": "adler32:52dda175",
+        "size": 1607686,
+        "uri": "root://eospublic.cern.ch//eos/opendata/atlas/OutreachDatasets/2020-08-19/2lep/MC/mc_392962.SlepSlep_direct_400p0_300p0_2L8.2lep.root"
+      },
+      {
+        "checksum": "adler32:a7a1942d",
+        "size": 1710323,
+        "uri": "root://eospublic.cern.ch//eos/opendata/atlas/OutreachDatasets/2020-08-19/2lep/MC/mc_392964.SlepSlep_direct_500p0_300p0_2L8.2lep.root"
+      },
+      {
+        "checksum": "adler32:89c0574a",
+        "size": 1693584,
+        "uri": "root://eospublic.cern.ch//eos/opendata/atlas/OutreachDatasets/2020-08-19/2lep/MC/mc_392982.SlepSlep_direct_600p0_1p0_2L8.2lep.root"
+      },
+      {
+        "checksum": "adler32:e501bfda",
+        "size": 1693987,
+        "uri": "root://eospublic.cern.ch//eos/opendata/atlas/OutreachDatasets/2020-08-19/2lep/MC/mc_392985.SlepSlep_direct_600p0_300p0_2L8.2lep.root"
+      },
+      {
+        "checksum": "adler32:d3489e99",
+        "size": 1699678,
+        "uri": "root://eospublic.cern.ch//eos/opendata/atlas/OutreachDatasets/2020-08-19/2lep/MC/mc_392996.SlepSlep_direct_700p0_1p0_2L8.2lep.root"
+      },
+      {
+        "checksum": "adler32:ccee1cc8",
+        "size": 1728318,
+        "uri": "root://eospublic.cern.ch//eos/opendata/atlas/OutreachDatasets/2020-08-19/2lep/MC/mc_392999.SlepSlep_direct_700p0_300p0_2L8.2lep.root"
+      },
+      {
+        "checksum": "adler32:0331aea5",
+        "size": 872707533,
+        "uri": "root://eospublic.cern.ch//eos/opendata/atlas/OutreachDatasets/2020-08-19/2lep/MC/mc_410000.ttbar_lep.2lep.root"
+      },
+      {
+        "checksum": "adler32:ed56ddaf",
+        "size": 10232260,
+        "uri": "root://eospublic.cern.ch//eos/opendata/atlas/OutreachDatasets/2020-08-19/2lep/MC/mc_410011.single_top_tchan.2lep.root"
+      },
+      {
+        "checksum": "adler32:c40f2a61",
+        "size": 10819401,
+        "uri": "root://eospublic.cern.ch//eos/opendata/atlas/OutreachDatasets/2020-08-19/2lep/MC/mc_410012.single_antitop_tchan.2lep.root"
+      },
+      {
+        "checksum": "adler32:680dc64b",
+        "size": 45740480,
+        "uri": "root://eospublic.cern.ch//eos/opendata/atlas/OutreachDatasets/2020-08-19/2lep/MC/mc_410013.single_top_wtchan.2lep.root"
+      },
+      {
+        "checksum": "adler32:fa3652ef",
+        "size": 46383711,
+        "uri": "root://eospublic.cern.ch//eos/opendata/atlas/OutreachDatasets/2020-08-19/2lep/MC/mc_410014.single_antitop_wtchan.2lep.root"
+      },
+      {
+        "checksum": "adler32:8d8355a0",
+        "size": 2011931,
+        "uri": "root://eospublic.cern.ch//eos/opendata/atlas/OutreachDatasets/2020-08-19/2lep/MC/mc_410025.single_top_schan.2lep.root"
+      },
+      {
+        "checksum": "adler32:1ed8e5d3",
+        "size": 2139887,
+        "uri": "root://eospublic.cern.ch//eos/opendata/atlas/OutreachDatasets/2020-08-19/2lep/MC/mc_410026.single_antitop_schan.2lep.root"
+      },
+      {
+        "checksum": "adler32:cf843700",
+        "size": 191613177,
+        "uri": "root://eospublic.cern.ch//eos/opendata/atlas/OutreachDatasets/2020-08-19/2lep/MC/mc_410155.ttW.2lep.root"
+      },
+      {
+        "checksum": "adler32:35b1bb0b",
+        "size": 311011578,
+        "uri": "root://eospublic.cern.ch//eos/opendata/atlas/OutreachDatasets/2020-08-19/2lep/MC/mc_410218.ttee.2lep.root"
+      },
+      {
+        "checksum": "adler32:200f2080",
+        "size": 227333001,
+        "uri": "root://eospublic.cern.ch//eos/opendata/atlas/OutreachDatasets/2020-08-19/2lep/MC/mc_410219.ttmumu.2lep.root"
       }
     ],
     "license": {
@@ -53,7 +1187,7 @@
       ]
     },
     "usage": {
-      "description": "This dataset is provided by the ATLAS Collaboration <strong>only for educational purposes and is not suited for scientific publications</strong>.\n You can access these data through the ATLAS Virtual Machine and Software.\n More documentation is available at:",
+      "description": "<p>This dataset is provided as a zipped tarball (<code>2lep.zip</code>) and as a list of unzipped individually-accessible ROOT files containing the collision data (such as <code>data_A.2lep.root</code>) and the simulated data (such as <code>mc_301215.ZPrime2000_ee.2lep.root</code>). You can use either the tarball or the individual ROOT files.</p> <p>This dataset is provided by the ATLAS Collaboration <strong>only for educational purposes and is not suited for scientific publications</strong>.\n You can access these data through the ATLAS Virtual Machine and Software.\n More documentation is available at:</p>",
       "links": [
         {
           "description": "The ATLAS Open Data documentation for 13 TeV release",

--- a/data/records/atlas-2020-3lep.json
+++ b/data/records/atlas-2020-3lep.json
@@ -19,8 +19,12 @@
     ],
     "date_published": "2020",
     "distribution": {
-      "number_files": 1,
-      "size": 1081143830
+      "formats": [
+        "root",
+        "zip"
+      ],
+      "number_files": 215,
+      "size": 2381258569
     },
     "doi": "10.7483/OPENDATA.ATLAS.DN95.JW6T",
     "experiment": [
@@ -31,6 +35,1076 @@
         "checksum": "adler32:c4f2ef5e",
         "size": 1081143830,
         "uri": "root://eospublic.cern.ch//eos/opendata/atlas/OutreachDatasets/2020-08-19/3lep.zip"
+      },
+      {
+        "checksum": "adler32:d2578db7",
+        "size": 882658,
+        "uri": "root://eospublic.cern.ch//eos/opendata/atlas/OutreachDatasets/2020-08-19/3lep/Data/data_A.3lep.root"
+      },
+      {
+        "checksum": "adler32:a0897e0e",
+        "size": 3423001,
+        "uri": "root://eospublic.cern.ch//eos/opendata/atlas/OutreachDatasets/2020-08-19/3lep/Data/data_B.3lep.root"
+      },
+      {
+        "checksum": "adler32:a6789ec9",
+        "size": 5118329,
+        "uri": "root://eospublic.cern.ch//eos/opendata/atlas/OutreachDatasets/2020-08-19/3lep/Data/data_C.3lep.root"
+      },
+      {
+        "checksum": "adler32:945fcfa9",
+        "size": 8523758,
+        "uri": "root://eospublic.cern.ch//eos/opendata/atlas/OutreachDatasets/2020-08-19/3lep/Data/data_D.3lep.root"
+      },
+      {
+        "checksum": "adler32:3dc77c98",
+        "size": 58249,
+        "uri": "root://eospublic.cern.ch//eos/opendata/atlas/OutreachDatasets/2020-08-19/3lep/MC/mc_301215.ZPrime2000_ee.3lep.root"
+      },
+      {
+        "checksum": "adler32:60f5a569",
+        "size": 58749,
+        "uri": "root://eospublic.cern.ch//eos/opendata/atlas/OutreachDatasets/2020-08-19/3lep/MC/mc_301216.ZPrime3000_ee.3lep.root"
+      },
+      {
+        "checksum": "adler32:7c0a3372",
+        "size": 58793,
+        "uri": "root://eospublic.cern.ch//eos/opendata/atlas/OutreachDatasets/2020-08-19/3lep/MC/mc_301217.ZPrime4000_ee.3lep.root"
+      },
+      {
+        "checksum": "adler32:e61dc2b2",
+        "size": 51040,
+        "uri": "root://eospublic.cern.ch//eos/opendata/atlas/OutreachDatasets/2020-08-19/3lep/MC/mc_301218.ZPrime5000_ee.3lep.root"
+      },
+      {
+        "checksum": "adler32:6f4edbff",
+        "size": 1375222,
+        "uri": "root://eospublic.cern.ch//eos/opendata/atlas/OutreachDatasets/2020-08-19/3lep/MC/mc_301220.ZPrime2000_mumu.3lep.root"
+      },
+      {
+        "checksum": "adler32:3d24d562",
+        "size": 1485684,
+        "uri": "root://eospublic.cern.ch//eos/opendata/atlas/OutreachDatasets/2020-08-19/3lep/MC/mc_301221.ZPrime3000_mumu.3lep.root"
+      },
+      {
+        "checksum": "adler32:1bcdc16b",
+        "size": 1429161,
+        "uri": "root://eospublic.cern.ch//eos/opendata/atlas/OutreachDatasets/2020-08-19/3lep/MC/mc_301222.ZPrime4000_mumu.3lep.root"
+      },
+      {
+        "checksum": "adler32:7eacb023",
+        "size": 1304238,
+        "uri": "root://eospublic.cern.ch//eos/opendata/atlas/OutreachDatasets/2020-08-19/3lep/MC/mc_301223.ZPrime5000_mumu.3lep.root"
+      },
+      {
+        "checksum": "adler32:d5d972a1",
+        "size": 80712,
+        "uri": "root://eospublic.cern.ch//eos/opendata/atlas/OutreachDatasets/2020-08-19/3lep/MC/mc_301322.ZPrime400_tt.3lep.root"
+      },
+      {
+        "checksum": "adler32:08f087e6",
+        "size": 69739,
+        "uri": "root://eospublic.cern.ch//eos/opendata/atlas/OutreachDatasets/2020-08-19/3lep/MC/mc_301323.ZPrime500_tt.3lep.root"
+      },
+      {
+        "checksum": "adler32:3e938808",
+        "size": 65961,
+        "uri": "root://eospublic.cern.ch//eos/opendata/atlas/OutreachDatasets/2020-08-19/3lep/MC/mc_301324.ZPrime750_tt.3lep.root"
+      },
+      {
+        "checksum": "adler32:7a6e9cc0",
+        "size": 62249,
+        "uri": "root://eospublic.cern.ch//eos/opendata/atlas/OutreachDatasets/2020-08-19/3lep/MC/mc_301325.ZPrime1000_tt.3lep.root"
+      },
+      {
+        "checksum": "adler32:18274c58",
+        "size": 53845,
+        "uri": "root://eospublic.cern.ch//eos/opendata/atlas/OutreachDatasets/2020-08-19/3lep/MC/mc_301326.ZPrime1250_tt.3lep.root"
+      },
+      {
+        "checksum": "adler32:80cc9359",
+        "size": 50679,
+        "uri": "root://eospublic.cern.ch//eos/opendata/atlas/OutreachDatasets/2020-08-19/3lep/MC/mc_301327.ZPrime1500_tt.3lep.root"
+      },
+      {
+        "checksum": "adler32:375a8cd3",
+        "size": 47771,
+        "uri": "root://eospublic.cern.ch//eos/opendata/atlas/OutreachDatasets/2020-08-19/3lep/MC/mc_301328.ZPrime1750_tt.3lep.root"
+      },
+      {
+        "checksum": "adler32:561f6161",
+        "size": 50329,
+        "uri": "root://eospublic.cern.ch//eos/opendata/atlas/OutreachDatasets/2020-08-19/3lep/MC/mc_301329.ZPrime2000_tt.3lep.root"
+      },
+      {
+        "checksum": "adler32:fd012212",
+        "size": 50144,
+        "uri": "root://eospublic.cern.ch//eos/opendata/atlas/OutreachDatasets/2020-08-19/3lep/MC/mc_301330.ZPrime2250_tt.3lep.root"
+      },
+      {
+        "checksum": "adler32:31784e3c",
+        "size": 42329,
+        "uri": "root://eospublic.cern.ch//eos/opendata/atlas/OutreachDatasets/2020-08-19/3lep/MC/mc_301331.ZPrime2500_tt.3lep.root"
+      },
+      {
+        "checksum": "adler32:20abb043",
+        "size": 38549,
+        "uri": "root://eospublic.cern.ch//eos/opendata/atlas/OutreachDatasets/2020-08-19/3lep/MC/mc_301332.ZPrime2750_tt.3lep.root"
+      },
+      {
+        "checksum": "adler32:b13e62d1",
+        "size": 37320,
+        "uri": "root://eospublic.cern.ch//eos/opendata/atlas/OutreachDatasets/2020-08-19/3lep/MC/mc_301333.ZPrime3000_tt.3lep.root"
+      },
+      {
+        "checksum": "adler32:f2d7121e",
+        "size": 26210,
+        "uri": "root://eospublic.cern.ch//eos/opendata/atlas/OutreachDatasets/2020-08-19/3lep/MC/mc_303511.dmV_Zll_MET40_DM1_MM10.3lep.root"
+      },
+      {
+        "checksum": "adler32:ddb51443",
+        "size": 26869,
+        "uri": "root://eospublic.cern.ch//eos/opendata/atlas/OutreachDatasets/2020-08-19/3lep/MC/mc_303512.dmV_Zll_MET40_DM1_MM100.3lep.root"
+      },
+      {
+        "checksum": "adler32:730a3252",
+        "size": 30452,
+        "uri": "root://eospublic.cern.ch//eos/opendata/atlas/OutreachDatasets/2020-08-19/3lep/MC/mc_303513.dmV_Zll_MET40_DM1_MM300.3lep.root"
+      },
+      {
+        "checksum": "adler32:6c859394",
+        "size": 33551,
+        "uri": "root://eospublic.cern.ch//eos/opendata/atlas/OutreachDatasets/2020-08-19/3lep/MC/mc_303514.dmV_Zll_MET40_DM1_MM2000.3lep.root"
+      },
+      {
+        "checksum": "adler32:432f8a7d",
+        "size": 83326,
+        "uri": "root://eospublic.cern.ch//eos/opendata/atlas/OutreachDatasets/2020-08-19/3lep/MC/mc_305550.Gee_01_750.3lep.root"
+      },
+      {
+        "checksum": "adler32:44ddf54a",
+        "size": 90325,
+        "uri": "root://eospublic.cern.ch//eos/opendata/atlas/OutreachDatasets/2020-08-19/3lep/MC/mc_305553.Gee_01_1000.3lep.root"
+      },
+      {
+        "checksum": "adler32:c5f7be77",
+        "size": 95704,
+        "uri": "root://eospublic.cern.ch//eos/opendata/atlas/OutreachDatasets/2020-08-19/3lep/MC/mc_305556.Gee_01_2000.3lep.root"
+      },
+      {
+        "checksum": "adler32:9b61ecb3",
+        "size": 103640,
+        "uri": "root://eospublic.cern.ch//eos/opendata/atlas/OutreachDatasets/2020-08-19/3lep/MC/mc_305559.Gee_01_3000.3lep.root"
+      },
+      {
+        "checksum": "adler32:7119289f",
+        "size": 111252,
+        "uri": "root://eospublic.cern.ch//eos/opendata/atlas/OutreachDatasets/2020-08-19/3lep/MC/mc_305562.Gee_01_4000.3lep.root"
+      },
+      {
+        "checksum": "adler32:d845a6cf",
+        "size": 87764,
+        "uri": "root://eospublic.cern.ch//eos/opendata/atlas/OutreachDatasets/2020-08-19/3lep/MC/mc_305568.Gmumu_01_750.3lep.root"
+      },
+      {
+        "checksum": "adler32:59508703",
+        "size": 96925,
+        "uri": "root://eospublic.cern.ch//eos/opendata/atlas/OutreachDatasets/2020-08-19/3lep/MC/mc_305571.Gmumu_01_1000.3lep.root"
+      },
+      {
+        "checksum": "adler32:68fd8131",
+        "size": 93381,
+        "uri": "root://eospublic.cern.ch//eos/opendata/atlas/OutreachDatasets/2020-08-19/3lep/MC/mc_305574.Gmumu_01_2000.3lep.root"
+      },
+      {
+        "checksum": "adler32:dba6542a",
+        "size": 115709,
+        "uri": "root://eospublic.cern.ch//eos/opendata/atlas/OutreachDatasets/2020-08-19/3lep/MC/mc_305577.Gmumu_01_3000.3lep.root"
+      },
+      {
+        "checksum": "adler32:bf0946dc",
+        "size": 105779,
+        "uri": "root://eospublic.cern.ch//eos/opendata/atlas/OutreachDatasets/2020-08-19/3lep/MC/mc_305580.Gmumu_01_4000.3lep.root"
+      },
+      {
+        "checksum": "adler32:eb64679b",
+        "size": 28462,
+        "uri": "root://eospublic.cern.ch//eos/opendata/atlas/OutreachDatasets/2020-08-19/3lep/MC/mc_305710.dmV_Zll_MET40_DM1_MM500.3lep.root"
+      },
+      {
+        "checksum": "adler32:49c56464",
+        "size": 29163,
+        "uri": "root://eospublic.cern.ch//eos/opendata/atlas/OutreachDatasets/2020-08-19/3lep/MC/mc_305711.dmV_Zll_MET40_DM1_MM700.3lep.root"
+      },
+      {
+        "checksum": "adler32:ae5e8616",
+        "size": 32611,
+        "uri": "root://eospublic.cern.ch//eos/opendata/atlas/OutreachDatasets/2020-08-19/3lep/MC/mc_306085.dmV_Zll_MET40_DM1_MM200.3lep.root"
+      },
+      {
+        "checksum": "adler32:09d0e07d",
+        "size": 29440,
+        "uri": "root://eospublic.cern.ch//eos/opendata/atlas/OutreachDatasets/2020-08-19/3lep/MC/mc_306093.dmV_Zll_MET40_DM1_MM400.3lep.root"
+      },
+      {
+        "checksum": "adler32:38c276ac",
+        "size": 32586,
+        "uri": "root://eospublic.cern.ch//eos/opendata/atlas/OutreachDatasets/2020-08-19/3lep/MC/mc_306103.dmV_Zll_MET40_DM1_MM600.3lep.root"
+      },
+      {
+        "checksum": "adler32:d7c8fa5b",
+        "size": 28047,
+        "uri": "root://eospublic.cern.ch//eos/opendata/atlas/OutreachDatasets/2020-08-19/3lep/MC/mc_306109.dmV_Zll_MET40_DM1_MM800.3lep.root"
+      },
+      {
+        "checksum": "adler32:94ab8ea4",
+        "size": 201636,
+        "uri": "root://eospublic.cern.ch//eos/opendata/atlas/OutreachDatasets/2020-08-19/3lep/MC/mc_341122.ggH125_tautaull.3lep.root"
+      },
+      {
+        "checksum": "adler32:c24ab7ce",
+        "size": 739676,
+        "uri": "root://eospublic.cern.ch//eos/opendata/atlas/OutreachDatasets/2020-08-19/3lep/MC/mc_341155.VBFH125_tautaull.3lep.root"
+      },
+      {
+        "checksum": "adler32:0ad05433",
+        "size": 768177,
+        "uri": "root://eospublic.cern.ch//eos/opendata/atlas/OutreachDatasets/2020-08-19/3lep/MC/mc_345323.VBFH125_WW2lep.3lep.root"
+      },
+      {
+        "checksum": "adler32:e02195c3",
+        "size": 986866,
+        "uri": "root://eospublic.cern.ch//eos/opendata/atlas/OutreachDatasets/2020-08-19/3lep/MC/mc_345324.ggH125_WW2lep.3lep.root"
+      },
+      {
+        "checksum": "adler32:35271d8c",
+        "size": 2814565,
+        "uri": "root://eospublic.cern.ch//eos/opendata/atlas/OutreachDatasets/2020-08-19/3lep/MC/mc_345325.WpH125J_qqWW2lep.3lep.root"
+      },
+      {
+        "checksum": "adler32:d98a8e8f",
+        "size": 4328056,
+        "uri": "root://eospublic.cern.ch//eos/opendata/atlas/OutreachDatasets/2020-08-19/3lep/MC/mc_345327.WpH125J_lvWW2lep.3lep.root"
+      },
+      {
+        "checksum": "adler32:fd995ca2",
+        "size": 1561793,
+        "uri": "root://eospublic.cern.ch//eos/opendata/atlas/OutreachDatasets/2020-08-19/3lep/MC/mc_345336.ZH125J_qqWW2lep.3lep.root"
+      },
+      {
+        "checksum": "adler32:d53ed2da",
+        "size": 89545,
+        "uri": "root://eospublic.cern.ch//eos/opendata/atlas/OutreachDatasets/2020-08-19/3lep/MC/mc_345445.ZH125J_vvWW2lep.3lep.root"
+      },
+      {
+        "checksum": "adler32:1c3dbb51",
+        "size": 89416,
+        "uri": "root://eospublic.cern.ch//eos/opendata/atlas/OutreachDatasets/2020-08-19/3lep/MC/mc_361100.Wplusenu.3lep.root"
+      },
+      {
+        "checksum": "adler32:788c3518",
+        "size": 67686,
+        "uri": "root://eospublic.cern.ch//eos/opendata/atlas/OutreachDatasets/2020-08-19/3lep/MC/mc_361101.Wplusmunu.3lep.root"
+      },
+      {
+        "checksum": "adler32:f76359c9",
+        "size": 21822,
+        "uri": "root://eospublic.cern.ch//eos/opendata/atlas/OutreachDatasets/2020-08-19/3lep/MC/mc_361102.Wplustaunu.3lep.root"
+      },
+      {
+        "checksum": "adler32:3ba70bbe",
+        "size": 77378,
+        "uri": "root://eospublic.cern.ch//eos/opendata/atlas/OutreachDatasets/2020-08-19/3lep/MC/mc_361103.Wminusenu.3lep.root"
+      },
+      {
+        "checksum": "adler32:e7b68fbd",
+        "size": 63297,
+        "uri": "root://eospublic.cern.ch//eos/opendata/atlas/OutreachDatasets/2020-08-19/3lep/MC/mc_361104.Wminusmunu.3lep.root"
+      },
+      {
+        "checksum": "adler32:fe8b8980",
+        "size": 23076,
+        "uri": "root://eospublic.cern.ch//eos/opendata/atlas/OutreachDatasets/2020-08-19/3lep/MC/mc_361105.Wminustaunu.3lep.root"
+      },
+      {
+        "checksum": "adler32:02424f8a",
+        "size": 33906728,
+        "uri": "root://eospublic.cern.ch//eos/opendata/atlas/OutreachDatasets/2020-08-19/3lep/MC/mc_361106.Zee.3lep.root"
+      },
+      {
+        "checksum": "adler32:045ff762",
+        "size": 28150748,
+        "uri": "root://eospublic.cern.ch//eos/opendata/atlas/OutreachDatasets/2020-08-19/3lep/MC/mc_361107.Zmumu.3lep.root"
+      },
+      {
+        "checksum": "adler32:706530d2",
+        "size": 300006,
+        "uri": "root://eospublic.cern.ch//eos/opendata/atlas/OutreachDatasets/2020-08-19/3lep/MC/mc_361108.Ztautau.3lep.root"
+      },
+      {
+        "checksum": "adler32:7acf743b",
+        "size": 6392936,
+        "uri": "root://eospublic.cern.ch//eos/opendata/atlas/OutreachDatasets/2020-08-19/3lep/MC/mc_363356.ZqqZll.3lep.root"
+      },
+      {
+        "checksum": "adler32:23b374c2",
+        "size": 3126534,
+        "uri": "root://eospublic.cern.ch//eos/opendata/atlas/OutreachDatasets/2020-08-19/3lep/MC/mc_363358.WqqZll.3lep.root"
+      },
+      {
+        "checksum": "adler32:72b37a17",
+        "size": 46979,
+        "uri": "root://eospublic.cern.ch//eos/opendata/atlas/OutreachDatasets/2020-08-19/3lep/MC/mc_363359.WpqqWmlv.3lep.root"
+      },
+      {
+        "checksum": "adler32:5bc720ce",
+        "size": 50828,
+        "uri": "root://eospublic.cern.ch//eos/opendata/atlas/OutreachDatasets/2020-08-19/3lep/MC/mc_363360.WplvWmqq.3lep.root"
+      },
+      {
+        "checksum": "adler32:24009a87",
+        "size": 122277,
+        "uri": "root://eospublic.cern.ch//eos/opendata/atlas/OutreachDatasets/2020-08-19/3lep/MC/mc_363489.WlvZqq.3lep.root"
+      },
+      {
+        "checksum": "adler32:0ee27290",
+        "size": 380523675,
+        "uri": "root://eospublic.cern.ch//eos/opendata/atlas/OutreachDatasets/2020-08-19/3lep/MC/mc_363490.llll.3lep.root"
+      },
+      {
+        "checksum": "adler32:7b18d193",
+        "size": 420023127,
+        "uri": "root://eospublic.cern.ch//eos/opendata/atlas/OutreachDatasets/2020-08-19/3lep/MC/mc_363491.lllv.3lep.root"
+      },
+      {
+        "checksum": "adler32:0d8e0a95",
+        "size": 5996547,
+        "uri": "root://eospublic.cern.ch//eos/opendata/atlas/OutreachDatasets/2020-08-19/3lep/MC/mc_363492.llvv.3lep.root"
+      },
+      {
+        "checksum": "adler32:5dbdeb58",
+        "size": 42794,
+        "uri": "root://eospublic.cern.ch//eos/opendata/atlas/OutreachDatasets/2020-08-19/3lep/MC/mc_363493.lvvv.3lep.root"
+      },
+      {
+        "checksum": "adler32:219ca940",
+        "size": 2241015,
+        "uri": "root://eospublic.cern.ch//eos/opendata/atlas/OutreachDatasets/2020-08-19/3lep/MC/mc_364100.Zmumu_PTV0_70_CVetoBVeto.3lep.root"
+      },
+      {
+        "checksum": "adler32:27cd9fc4",
+        "size": 2231617,
+        "uri": "root://eospublic.cern.ch//eos/opendata/atlas/OutreachDatasets/2020-08-19/3lep/MC/mc_364101.Zmumu_PTV0_70_CFilterBVeto.3lep.root"
+      },
+      {
+        "checksum": "adler32:9d77cc0f",
+        "size": 10574770,
+        "uri": "root://eospublic.cern.ch//eos/opendata/atlas/OutreachDatasets/2020-08-19/3lep/MC/mc_364102.Zmumu_PTV0_70_BFilter.3lep.root"
+      },
+      {
+        "checksum": "adler32:2de132fb",
+        "size": 2502679,
+        "uri": "root://eospublic.cern.ch//eos/opendata/atlas/OutreachDatasets/2020-08-19/3lep/MC/mc_364103.Zmumu_PTV70_140_CVetoBVeto.3lep.root"
+      },
+      {
+        "checksum": "adler32:bf3e94d3",
+        "size": 1283104,
+        "uri": "root://eospublic.cern.ch//eos/opendata/atlas/OutreachDatasets/2020-08-19/3lep/MC/mc_364104.Zmumu_PTV70_140_CFilterBVeto.3lep.root"
+      },
+      {
+        "checksum": "adler32:a82ff529",
+        "size": 11873084,
+        "uri": "root://eospublic.cern.ch//eos/opendata/atlas/OutreachDatasets/2020-08-19/3lep/MC/mc_364105.Zmumu_PTV70_140_BFilter.3lep.root"
+      },
+      {
+        "checksum": "adler32:2fc90f7c",
+        "size": 2476742,
+        "uri": "root://eospublic.cern.ch//eos/opendata/atlas/OutreachDatasets/2020-08-19/3lep/MC/mc_364106.Zmumu_PTV140_280_CVetoBVeto.3lep.root"
+      },
+      {
+        "checksum": "adler32:2c4e2678",
+        "size": 2101228,
+        "uri": "root://eospublic.cern.ch//eos/opendata/atlas/OutreachDatasets/2020-08-19/3lep/MC/mc_364107.Zmumu_PTV140_280_CFilterBVeto.3lep.root"
+      },
+      {
+        "checksum": "adler32:13389ae1",
+        "size": 23101694,
+        "uri": "root://eospublic.cern.ch//eos/opendata/atlas/OutreachDatasets/2020-08-19/3lep/MC/mc_364108.Zmumu_PTV140_280_BFilter.3lep.root"
+      },
+      {
+        "checksum": "adler32:4ed7faec",
+        "size": 1189591,
+        "uri": "root://eospublic.cern.ch//eos/opendata/atlas/OutreachDatasets/2020-08-19/3lep/MC/mc_364109.Zmumu_PTV280_500_CVetoBVeto.3lep.root"
+      },
+      {
+        "checksum": "adler32:df616321",
+        "size": 785491,
+        "uri": "root://eospublic.cern.ch//eos/opendata/atlas/OutreachDatasets/2020-08-19/3lep/MC/mc_364110.Zmumu_PTV280_500_CFilterBVeto.3lep.root"
+      },
+      {
+        "checksum": "adler32:5b1bdeb7",
+        "size": 3987268,
+        "uri": "root://eospublic.cern.ch//eos/opendata/atlas/OutreachDatasets/2020-08-19/3lep/MC/mc_364111.Zmumu_PTV280_500_BFilter.3lep.root"
+      },
+      {
+        "checksum": "adler32:eb1e5497",
+        "size": 2922780,
+        "uri": "root://eospublic.cern.ch//eos/opendata/atlas/OutreachDatasets/2020-08-19/3lep/MC/mc_364112.Zmumu_PTV500_1000.3lep.root"
+      },
+      {
+        "checksum": "adler32:300bacaf",
+        "size": 1158237,
+        "uri": "root://eospublic.cern.ch//eos/opendata/atlas/OutreachDatasets/2020-08-19/3lep/MC/mc_364113.Zmumu_PTV1000_E_CMS.3lep.root"
+      },
+      {
+        "checksum": "adler32:fb6b76ff",
+        "size": 2476617,
+        "uri": "root://eospublic.cern.ch//eos/opendata/atlas/OutreachDatasets/2020-08-19/3lep/MC/mc_364114.Zee_PTV0_70_CVetoBVeto.3lep.root"
+      },
+      {
+        "checksum": "adler32:f22c52ad",
+        "size": 2721253,
+        "uri": "root://eospublic.cern.ch//eos/opendata/atlas/OutreachDatasets/2020-08-19/3lep/MC/mc_364115.Zee_PTV0_70_CFilterBVeto.3lep.root"
+      },
+      {
+        "checksum": "adler32:71154c9e",
+        "size": 14439792,
+        "uri": "root://eospublic.cern.ch//eos/opendata/atlas/OutreachDatasets/2020-08-19/3lep/MC/mc_364116.Zee_PTV0_70_BFilter.3lep.root"
+      },
+      {
+        "checksum": "adler32:06dbfa23",
+        "size": 3258005,
+        "uri": "root://eospublic.cern.ch//eos/opendata/atlas/OutreachDatasets/2020-08-19/3lep/MC/mc_364117.Zee_PTV70_140_CVetoBVeto.3lep.root"
+      },
+      {
+        "checksum": "adler32:d98661c0",
+        "size": 1878677,
+        "uri": "root://eospublic.cern.ch//eos/opendata/atlas/OutreachDatasets/2020-08-19/3lep/MC/mc_364118.Zee_PTV70_140_CFilterBVeto.3lep.root"
+      },
+      {
+        "checksum": "adler32:4c9467c1",
+        "size": 17743129,
+        "uri": "root://eospublic.cern.ch//eos/opendata/atlas/OutreachDatasets/2020-08-19/3lep/MC/mc_364119.Zee_PTV70_140_BFilter.3lep.root"
+      },
+      {
+        "checksum": "adler32:d0eeb4db",
+        "size": 3274947,
+        "uri": "root://eospublic.cern.ch//eos/opendata/atlas/OutreachDatasets/2020-08-19/3lep/MC/mc_364120.Zee_PTV140_280_CVetoBVeto.3lep.root"
+      },
+      {
+        "checksum": "adler32:c7588e11",
+        "size": 3018541,
+        "uri": "root://eospublic.cern.ch//eos/opendata/atlas/OutreachDatasets/2020-08-19/3lep/MC/mc_364121.Zee_PTV140_280_CFilterBVeto.3lep.root"
+      },
+      {
+        "checksum": "adler32:b51b1584",
+        "size": 36619615,
+        "uri": "root://eospublic.cern.ch//eos/opendata/atlas/OutreachDatasets/2020-08-19/3lep/MC/mc_364122.Zee_PTV140_280_BFilter.3lep.root"
+      },
+      {
+        "checksum": "adler32:394d3eb3",
+        "size": 1490364,
+        "uri": "root://eospublic.cern.ch//eos/opendata/atlas/OutreachDatasets/2020-08-19/3lep/MC/mc_364123.Zee_PTV280_500_CVetoBVeto.3lep.root"
+      },
+      {
+        "checksum": "adler32:c4d9ed85",
+        "size": 1104638,
+        "uri": "root://eospublic.cern.ch//eos/opendata/atlas/OutreachDatasets/2020-08-19/3lep/MC/mc_364124.Zee_PTV280_500_CFilterBVeto.3lep.root"
+      },
+      {
+        "checksum": "adler32:87f093a6",
+        "size": 6445746,
+        "uri": "root://eospublic.cern.ch//eos/opendata/atlas/OutreachDatasets/2020-08-19/3lep/MC/mc_364125.Zee_PTV280_500_BFilter.3lep.root"
+      },
+      {
+        "checksum": "adler32:b04dd390",
+        "size": 4166100,
+        "uri": "root://eospublic.cern.ch//eos/opendata/atlas/OutreachDatasets/2020-08-19/3lep/MC/mc_364126.Zee_PTV500_1000.3lep.root"
+      },
+      {
+        "checksum": "adler32:3b5f5543",
+        "size": 1659040,
+        "uri": "root://eospublic.cern.ch//eos/opendata/atlas/OutreachDatasets/2020-08-19/3lep/MC/mc_364127.Zee_PTV1000_E_CMS.3lep.root"
+      },
+      {
+        "checksum": "adler32:918180b3",
+        "size": 77168,
+        "uri": "root://eospublic.cern.ch//eos/opendata/atlas/OutreachDatasets/2020-08-19/3lep/MC/mc_364128.Ztautau_PTV0_70_CVetoBVeto.3lep.root"
+      },
+      {
+        "checksum": "adler32:133df3cc",
+        "size": 80452,
+        "uri": "root://eospublic.cern.ch//eos/opendata/atlas/OutreachDatasets/2020-08-19/3lep/MC/mc_364129.Ztautau_PTV0_70_CFilterBVeto.3lep.root"
+      },
+      {
+        "checksum": "adler32:c596c78c",
+        "size": 331385,
+        "uri": "root://eospublic.cern.ch//eos/opendata/atlas/OutreachDatasets/2020-08-19/3lep/MC/mc_364130.Ztautau_PTV0_70_BFilter.3lep.root"
+      },
+      {
+        "checksum": "adler32:e07e123b",
+        "size": 106804,
+        "uri": "root://eospublic.cern.ch//eos/opendata/atlas/OutreachDatasets/2020-08-19/3lep/MC/mc_364131.Ztautau_PTV70_140_CVetoBVeto.3lep.root"
+      },
+      {
+        "checksum": "adler32:4f540ff2",
+        "size": 69460,
+        "uri": "root://eospublic.cern.ch//eos/opendata/atlas/OutreachDatasets/2020-08-19/3lep/MC/mc_364132.Ztautau_PTV70_140_CFilterBVeto.3lep.root"
+      },
+      {
+        "checksum": "adler32:e34c6d4e",
+        "size": 488411,
+        "uri": "root://eospublic.cern.ch//eos/opendata/atlas/OutreachDatasets/2020-08-19/3lep/MC/mc_364133.Ztautau_PTV70_140_BFilter.3lep.root"
+      },
+      {
+        "checksum": "adler32:ed311346",
+        "size": 147299,
+        "uri": "root://eospublic.cern.ch//eos/opendata/atlas/OutreachDatasets/2020-08-19/3lep/MC/mc_364134.Ztautau_PTV140_280_CVetoBVeto.3lep.root"
+      },
+      {
+        "checksum": "adler32:000f761e",
+        "size": 124628,
+        "uri": "root://eospublic.cern.ch//eos/opendata/atlas/OutreachDatasets/2020-08-19/3lep/MC/mc_364135.Ztautau_PTV140_280_CFilterBVeto.3lep.root"
+      },
+      {
+        "checksum": "adler32:5e0764f9",
+        "size": 548667,
+        "uri": "root://eospublic.cern.ch//eos/opendata/atlas/OutreachDatasets/2020-08-19/3lep/MC/mc_364136.Ztautau_PTV140_280_BFilter.3lep.root"
+      },
+      {
+        "checksum": "adler32:7c4207b4",
+        "size": 91645,
+        "uri": "root://eospublic.cern.ch//eos/opendata/atlas/OutreachDatasets/2020-08-19/3lep/MC/mc_364137.Ztautau_PTV280_500_CVetoBVeto.3lep.root"
+      },
+      {
+        "checksum": "adler32:99f1a5c2",
+        "size": 73796,
+        "uri": "root://eospublic.cern.ch//eos/opendata/atlas/OutreachDatasets/2020-08-19/3lep/MC/mc_364138.Ztautau_PTV280_500_CFilterBVeto.3lep.root"
+      },
+      {
+        "checksum": "adler32:c471306f",
+        "size": 270973,
+        "uri": "root://eospublic.cern.ch//eos/opendata/atlas/OutreachDatasets/2020-08-19/3lep/MC/mc_364139.Ztautau_PTV280_500_BFilter.3lep.root"
+      },
+      {
+        "checksum": "adler32:6addae7b",
+        "size": 202832,
+        "uri": "root://eospublic.cern.ch//eos/opendata/atlas/OutreachDatasets/2020-08-19/3lep/MC/mc_364140.Ztautau_PTV500_1000.3lep.root"
+      },
+      {
+        "checksum": "adler32:d163e4b2",
+        "size": 99097,
+        "uri": "root://eospublic.cern.ch//eos/opendata/atlas/OutreachDatasets/2020-08-19/3lep/MC/mc_364141.Ztautau_PTV1000_E_CMS.3lep.root"
+      },
+      {
+        "checksum": "adler32:1dc76619",
+        "size": 69915,
+        "uri": "root://eospublic.cern.ch//eos/opendata/atlas/OutreachDatasets/2020-08-19/3lep/MC/mc_364156.Wmunu_PTV0_70_CVetoBVeto.3lep.root"
+      },
+      {
+        "checksum": "adler32:2527a8d7",
+        "size": 49774,
+        "uri": "root://eospublic.cern.ch//eos/opendata/atlas/OutreachDatasets/2020-08-19/3lep/MC/mc_364157.Wmunu_PTV0_70_CFilterBVeto.3lep.root"
+      },
+      {
+        "checksum": "adler32:1e6f3d3a",
+        "size": 123645,
+        "uri": "root://eospublic.cern.ch//eos/opendata/atlas/OutreachDatasets/2020-08-19/3lep/MC/mc_364158.Wmunu_PTV0_70_BFilter.3lep.root"
+      },
+      {
+        "checksum": "adler32:6e2e4c60",
+        "size": 52936,
+        "uri": "root://eospublic.cern.ch//eos/opendata/atlas/OutreachDatasets/2020-08-19/3lep/MC/mc_364159.Wmunu_PTV70_140_CVetoBVeto.3lep.root"
+      },
+      {
+        "checksum": "adler32:9f0f34ae",
+        "size": 62018,
+        "uri": "root://eospublic.cern.ch//eos/opendata/atlas/OutreachDatasets/2020-08-19/3lep/MC/mc_364160.Wmunu_PTV70_140_CFilterBVeto.3lep.root"
+      },
+      {
+        "checksum": "adler32:a7bf36a1",
+        "size": 334426,
+        "uri": "root://eospublic.cern.ch//eos/opendata/atlas/OutreachDatasets/2020-08-19/3lep/MC/mc_364161.Wmunu_PTV70_140_BFilter.3lep.root"
+      },
+      {
+        "checksum": "adler32:0893f633",
+        "size": 48513,
+        "uri": "root://eospublic.cern.ch//eos/opendata/atlas/OutreachDatasets/2020-08-19/3lep/MC/mc_364162.Wmunu_PTV140_280_CVetoBVeto.3lep.root"
+      },
+      {
+        "checksum": "adler32:fed44d0d",
+        "size": 51781,
+        "uri": "root://eospublic.cern.ch//eos/opendata/atlas/OutreachDatasets/2020-08-19/3lep/MC/mc_364163.Wmunu_PTV140_280_CFilterBVeto.3lep.root"
+      },
+      {
+        "checksum": "adler32:b3aa4172",
+        "size": 476680,
+        "uri": "root://eospublic.cern.ch//eos/opendata/atlas/OutreachDatasets/2020-08-19/3lep/MC/mc_364164.Wmunu_PTV140_280_BFilter.3lep.root"
+      },
+      {
+        "checksum": "adler32:c8497330",
+        "size": 35961,
+        "uri": "root://eospublic.cern.ch//eos/opendata/atlas/OutreachDatasets/2020-08-19/3lep/MC/mc_364165.Wmunu_PTV280_500_CVetoBVeto.3lep.root"
+      },
+      {
+        "checksum": "adler32:ce34dcf8",
+        "size": 38682,
+        "uri": "root://eospublic.cern.ch//eos/opendata/atlas/OutreachDatasets/2020-08-19/3lep/MC/mc_364166.Wmunu_PTV280_500_CFilterBVeto.3lep.root"
+      },
+      {
+        "checksum": "adler32:a3b1b9f8",
+        "size": 98025,
+        "uri": "root://eospublic.cern.ch//eos/opendata/atlas/OutreachDatasets/2020-08-19/3lep/MC/mc_364167.Wmunu_PTV280_500_BFilter.3lep.root"
+      },
+      {
+        "checksum": "adler32:4de211b0",
+        "size": 70325,
+        "uri": "root://eospublic.cern.ch//eos/opendata/atlas/OutreachDatasets/2020-08-19/3lep/MC/mc_364168.Wmunu_PTV500_1000.3lep.root"
+      },
+      {
+        "checksum": "adler32:fa7bc4bb",
+        "size": 67591,
+        "uri": "root://eospublic.cern.ch//eos/opendata/atlas/OutreachDatasets/2020-08-19/3lep/MC/mc_364169.Wmunu_PTV1000_E_CMS.3lep.root"
+      },
+      {
+        "checksum": "adler32:dfc5bfb4",
+        "size": 75540,
+        "uri": "root://eospublic.cern.ch//eos/opendata/atlas/OutreachDatasets/2020-08-19/3lep/MC/mc_364170.Wenu_PTV0_70_CVetoBVeto.3lep.root"
+      },
+      {
+        "checksum": "adler32:eea88498",
+        "size": 61078,
+        "uri": "root://eospublic.cern.ch//eos/opendata/atlas/OutreachDatasets/2020-08-19/3lep/MC/mc_364171.Wenu_PTV0_70_CFilterBVeto.3lep.root"
+      },
+      {
+        "checksum": "adler32:c43d1145",
+        "size": 160198,
+        "uri": "root://eospublic.cern.ch//eos/opendata/atlas/OutreachDatasets/2020-08-19/3lep/MC/mc_364172.Wenu_PTV0_70_BFilter.3lep.root"
+      },
+      {
+        "checksum": "adler32:472ef7cc",
+        "size": 72369,
+        "uri": "root://eospublic.cern.ch//eos/opendata/atlas/OutreachDatasets/2020-08-19/3lep/MC/mc_364173.Wenu_PTV70_140_CVetoBVeto.3lep.root"
+      },
+      {
+        "checksum": "adler32:37a34f08",
+        "size": 81771,
+        "uri": "root://eospublic.cern.ch//eos/opendata/atlas/OutreachDatasets/2020-08-19/3lep/MC/mc_364174.Wenu_PTV70_140_CFilterBVeto.3lep.root"
+      },
+      {
+        "checksum": "adler32:58ff8435",
+        "size": 278917,
+        "uri": "root://eospublic.cern.ch//eos/opendata/atlas/OutreachDatasets/2020-08-19/3lep/MC/mc_364175.Wenu_PTV70_140_BFilter.3lep.root"
+      },
+      {
+        "checksum": "adler32:8336e7cf",
+        "size": 64696,
+        "uri": "root://eospublic.cern.ch//eos/opendata/atlas/OutreachDatasets/2020-08-19/3lep/MC/mc_364176.Wenu_PTV140_280_CVetoBVeto.3lep.root"
+      },
+      {
+        "checksum": "adler32:fba10174",
+        "size": 73210,
+        "uri": "root://eospublic.cern.ch//eos/opendata/atlas/OutreachDatasets/2020-08-19/3lep/MC/mc_364177.Wenu_PTV140_280_CFilterBVeto.3lep.root"
+      },
+      {
+        "checksum": "adler32:6f5775f3",
+        "size": 899377,
+        "uri": "root://eospublic.cern.ch//eos/opendata/atlas/OutreachDatasets/2020-08-19/3lep/MC/mc_364178.Wenu_PTV140_280_BFilter.3lep.root"
+      },
+      {
+        "checksum": "adler32:62fd8375",
+        "size": 45811,
+        "uri": "root://eospublic.cern.ch//eos/opendata/atlas/OutreachDatasets/2020-08-19/3lep/MC/mc_364179.Wenu_PTV280_500_CVetoBVeto.3lep.root"
+      },
+      {
+        "checksum": "adler32:8199b1d3",
+        "size": 49251,
+        "uri": "root://eospublic.cern.ch//eos/opendata/atlas/OutreachDatasets/2020-08-19/3lep/MC/mc_364180.Wenu_PTV280_500_CFilterBVeto.3lep.root"
+      },
+      {
+        "checksum": "adler32:bb8c84c9",
+        "size": 146973,
+        "uri": "root://eospublic.cern.ch//eos/opendata/atlas/OutreachDatasets/2020-08-19/3lep/MC/mc_364181.Wenu_PTV280_500_BFilter.3lep.root"
+      },
+      {
+        "checksum": "adler32:247a46ff",
+        "size": 94070,
+        "uri": "root://eospublic.cern.ch//eos/opendata/atlas/OutreachDatasets/2020-08-19/3lep/MC/mc_364182.Wenu_PTV500_1000.3lep.root"
+      },
+      {
+        "checksum": "adler32:a0611f95",
+        "size": 88094,
+        "uri": "root://eospublic.cern.ch//eos/opendata/atlas/OutreachDatasets/2020-08-19/3lep/MC/mc_364183.Wenu_PTV1000_E_CMS.3lep.root"
+      },
+      {
+        "checksum": "adler32:02997da2",
+        "size": 22579,
+        "uri": "root://eospublic.cern.ch//eos/opendata/atlas/OutreachDatasets/2020-08-19/3lep/MC/mc_364184.Wtaunu_PTV0_70_CVetoBVeto.3lep.root"
+      },
+      {
+        "checksum": "adler32:d8f53279",
+        "size": 23587,
+        "uri": "root://eospublic.cern.ch//eos/opendata/atlas/OutreachDatasets/2020-08-19/3lep/MC/mc_364185.Wtaunu_PTV0_70_CFilterBVeto.3lep.root"
+      },
+      {
+        "checksum": "adler32:8db84de6",
+        "size": 31977,
+        "uri": "root://eospublic.cern.ch//eos/opendata/atlas/OutreachDatasets/2020-08-19/3lep/MC/mc_364186.Wtaunu_PTV0_70_BFilter.3lep.root"
+      },
+      {
+        "checksum": "adler32:071d3df1",
+        "size": 24251,
+        "uri": "root://eospublic.cern.ch//eos/opendata/atlas/OutreachDatasets/2020-08-19/3lep/MC/mc_364187.Wtaunu_PTV70_140_CVetoBVeto.3lep.root"
+      },
+      {
+        "checksum": "adler32:b098695e",
+        "size": 26334,
+        "uri": "root://eospublic.cern.ch//eos/opendata/atlas/OutreachDatasets/2020-08-19/3lep/MC/mc_364188.Wtaunu_PTV70_140_CFilterBVeto.3lep.root"
+      },
+      {
+        "checksum": "adler32:7b7094ac",
+        "size": 45561,
+        "uri": "root://eospublic.cern.ch//eos/opendata/atlas/OutreachDatasets/2020-08-19/3lep/MC/mc_364189.Wtaunu_PTV70_140_BFilter.3lep.root"
+      },
+      {
+        "checksum": "adler32:e9aa7f92",
+        "size": 28172,
+        "uri": "root://eospublic.cern.ch//eos/opendata/atlas/OutreachDatasets/2020-08-19/3lep/MC/mc_364190.Wtaunu_PTV140_280_CVetoBVeto.3lep.root"
+      },
+      {
+        "checksum": "adler32:347f0b63",
+        "size": 30012,
+        "uri": "root://eospublic.cern.ch//eos/opendata/atlas/OutreachDatasets/2020-08-19/3lep/MC/mc_364191.Wtaunu_PTV140_280_CFilterBVeto.3lep.root"
+      },
+      {
+        "checksum": "adler32:598e7753",
+        "size": 61275,
+        "uri": "root://eospublic.cern.ch//eos/opendata/atlas/OutreachDatasets/2020-08-19/3lep/MC/mc_364192.Wtaunu_PTV140_280_BFilter.3lep.root"
+      },
+      {
+        "checksum": "adler32:8163ed47",
+        "size": 23262,
+        "uri": "root://eospublic.cern.ch//eos/opendata/atlas/OutreachDatasets/2020-08-19/3lep/MC/mc_364193.Wtaunu_PTV280_500_CVetoBVeto.3lep.root"
+      },
+      {
+        "checksum": "adler32:1b3fc94a",
+        "size": 23056,
+        "uri": "root://eospublic.cern.ch//eos/opendata/atlas/OutreachDatasets/2020-08-19/3lep/MC/mc_364194.Wtaunu_PTV280_500_CFilterBVeto.3lep.root"
+      },
+      {
+        "checksum": "adler32:328016db",
+        "size": 36631,
+        "uri": "root://eospublic.cern.ch//eos/opendata/atlas/OutreachDatasets/2020-08-19/3lep/MC/mc_364195.Wtaunu_PTV280_500_BFilter.3lep.root"
+      },
+      {
+        "checksum": "adler32:4959fcd0",
+        "size": 26584,
+        "uri": "root://eospublic.cern.ch//eos/opendata/atlas/OutreachDatasets/2020-08-19/3lep/MC/mc_364196.Wtaunu_PTV500_1000.3lep.root"
+      },
+      {
+        "checksum": "adler32:864c2963",
+        "size": 31400,
+        "uri": "root://eospublic.cern.ch//eos/opendata/atlas/OutreachDatasets/2020-08-19/3lep/MC/mc_364197.Wtaunu_PTV1000_E_CMS.3lep.root"
+      },
+      {
+        "checksum": "adler32:59a91d6e",
+        "size": 850908,
+        "uri": "root://eospublic.cern.ch//eos/opendata/atlas/OutreachDatasets/2020-08-19/3lep/MC/mc_370114.GG_ttn1_1200_5000_1.3lep.root"
+      },
+      {
+        "checksum": "adler32:38750a49",
+        "size": 971834,
+        "uri": "root://eospublic.cern.ch//eos/opendata/atlas/OutreachDatasets/2020-08-19/3lep/MC/mc_370118.GG_ttn1_1200_5000_600.3lep.root"
+      },
+      {
+        "checksum": "adler32:d57210f7",
+        "size": 758741,
+        "uri": "root://eospublic.cern.ch//eos/opendata/atlas/OutreachDatasets/2020-08-19/3lep/MC/mc_370129.GG_ttn1_1400_5000_1.3lep.root"
+      },
+      {
+        "checksum": "adler32:b9c94ba1",
+        "size": 714181,
+        "uri": "root://eospublic.cern.ch//eos/opendata/atlas/OutreachDatasets/2020-08-19/3lep/MC/mc_370144.GG_ttn1_1600_5000_1.3lep.root"
+      },
+      {
+        "checksum": "adler32:19613456",
+        "size": 24595,
+        "uri": "root://eospublic.cern.ch//eos/opendata/atlas/OutreachDatasets/2020-08-19/3lep/MC/mc_387154.TT_directTT_500_1.3lep.root"
+      },
+      {
+        "checksum": "adler32:7c8d2a6f",
+        "size": 38018,
+        "uri": "root://eospublic.cern.ch//eos/opendata/atlas/OutreachDatasets/2020-08-19/3lep/MC/mc_387157.TT_directTT_500_200.3lep.root"
+      },
+      {
+        "checksum": "adler32:a70c3d35",
+        "size": 35570,
+        "uri": "root://eospublic.cern.ch//eos/opendata/atlas/OutreachDatasets/2020-08-19/3lep/MC/mc_387163.TT_directTT_600_1.3lep.root"
+      },
+      {
+        "checksum": "adler32:5d672a59",
+        "size": 36683,
+        "uri": "root://eospublic.cern.ch//eos/opendata/atlas/OutreachDatasets/2020-08-19/3lep/MC/mc_388240.TT_directTT_450_1.3lep.root"
+      },
+      {
+        "checksum": "adler32:3f29f4f0",
+        "size": 1018094,
+        "uri": "root://eospublic.cern.ch//eos/opendata/atlas/OutreachDatasets/2020-08-19/3lep/MC/mc_392217.C1N2_WZ_400p0_0p0_3L_2L7.3lep.root"
+      },
+      {
+        "checksum": "adler32:6923e9cc",
+        "size": 982507,
+        "uri": "root://eospublic.cern.ch//eos/opendata/atlas/OutreachDatasets/2020-08-19/3lep/MC/mc_392220.C1N2_WZ_350p0_0p0_3L_2L7.3lep.root"
+      },
+      {
+        "checksum": "adler32:b8dda289",
+        "size": 535621,
+        "uri": "root://eospublic.cern.ch//eos/opendata/atlas/OutreachDatasets/2020-08-19/3lep/MC/mc_392223.C1N2_WZ_500p0_0p0_3L_2L7.3lep.root"
+      },
+      {
+        "checksum": "adler32:c9d03f04",
+        "size": 1400953,
+        "uri": "root://eospublic.cern.ch//eos/opendata/atlas/OutreachDatasets/2020-08-19/3lep/MC/mc_392226.C1N2_WZ_100p0_0p0_3L_2L7.3lep.root"
+      },
+      {
+        "checksum": "adler32:bcf75abc",
+        "size": 25304,
+        "uri": "root://eospublic.cern.ch//eos/opendata/atlas/OutreachDatasets/2020-08-19/3lep/MC/mc_392302.C1N2_WZ_500p0_100p0_2L2J_2L7.3lep.root"
+      },
+      {
+        "checksum": "adler32:a2628e4b",
+        "size": 33897,
+        "uri": "root://eospublic.cern.ch//eos/opendata/atlas/OutreachDatasets/2020-08-19/3lep/MC/mc_392304.C1N2_WZ_300p0_100p0_2L2J_2L7.3lep.root"
+      },
+      {
+        "checksum": "adler32:a06b15c0",
+        "size": 33818,
+        "uri": "root://eospublic.cern.ch//eos/opendata/atlas/OutreachDatasets/2020-08-19/3lep/MC/mc_392308.C1N2_WZ_300p0_200p0_2L2J_2L7.3lep.root"
+      },
+      {
+        "checksum": "adler32:bfceda4d",
+        "size": 32860,
+        "uri": "root://eospublic.cern.ch//eos/opendata/atlas/OutreachDatasets/2020-08-19/3lep/MC/mc_392317.C1N2_WZ_400p0_0p0_2L2J_2L7.3lep.root"
+      },
+      {
+        "checksum": "adler32:a4ec05c4",
+        "size": 28534,
+        "uri": "root://eospublic.cern.ch//eos/opendata/atlas/OutreachDatasets/2020-08-19/3lep/MC/mc_392323.C1N2_WZ_500p0_0p0_2L2J_2L7.3lep.root"
+      },
+      {
+        "checksum": "adler32:95d39a0a",
+        "size": 35298,
+        "uri": "root://eospublic.cern.ch//eos/opendata/atlas/OutreachDatasets/2020-08-19/3lep/MC/mc_392324.C1N2_WZ_400p0_300p0_2L2J_2L7.3lep.root"
+      },
+      {
+        "checksum": "adler32:64b15a2a",
+        "size": 47431,
+        "uri": "root://eospublic.cern.ch//eos/opendata/atlas/OutreachDatasets/2020-08-19/3lep/MC/mc_392326.C1N2_WZ_100p0_0p0_2L2J_2L7.3lep.root"
+      },
+      {
+        "checksum": "adler32:65f59064",
+        "size": 42673,
+        "uri": "root://eospublic.cern.ch//eos/opendata/atlas/OutreachDatasets/2020-08-19/3lep/MC/mc_392330.C1N2_WZ_200p0_100p0_2L2J_2L7.3lep.root"
+      },
+      {
+        "checksum": "adler32:50c9a65c",
+        "size": 27341,
+        "uri": "root://eospublic.cern.ch//eos/opendata/atlas/OutreachDatasets/2020-08-19/3lep/MC/mc_392332.C1N2_WZ_500p0_300p0_2L2J_2L7.3lep.root"
+      },
+      {
+        "checksum": "adler32:b3448263",
+        "size": 28493,
+        "uri": "root://eospublic.cern.ch//eos/opendata/atlas/OutreachDatasets/2020-08-19/3lep/MC/mc_392354.C1N2_WZ_600_100_2L2J_2L7.3lep.root"
+      },
+      {
+        "checksum": "adler32:1ca52c60",
+        "size": 27818,
+        "uri": "root://eospublic.cern.ch//eos/opendata/atlas/OutreachDatasets/2020-08-19/3lep/MC/mc_392356.C1N2_WZ_600_0_2L2J_2L7.3lep.root"
+      },
+      {
+        "checksum": "adler32:b913097a",
+        "size": 27749,
+        "uri": "root://eospublic.cern.ch//eos/opendata/atlas/OutreachDatasets/2020-08-19/3lep/MC/mc_392361.C1N2_WZ_700_400_2L2J_2L7.3lep.root"
+      },
+      {
+        "checksum": "adler32:f450c294",
+        "size": 26508,
+        "uri": "root://eospublic.cern.ch//eos/opendata/atlas/OutreachDatasets/2020-08-19/3lep/MC/mc_392364.C1N2_WZ_700_100_2L2J_2L7.3lep.root"
+      },
+      {
+        "checksum": "adler32:0db0c005",
+        "size": 29725,
+        "uri": "root://eospublic.cern.ch//eos/opendata/atlas/OutreachDatasets/2020-08-19/3lep/MC/mc_392365.C1N2_WZ_700_0_2L2J_2L7.3lep.root"
+      },
+      {
+        "checksum": "adler32:06ec5e20",
+        "size": 45080,
+        "uri": "root://eospublic.cern.ch//eos/opendata/atlas/OutreachDatasets/2020-08-19/3lep/MC/mc_392501.C1C1_SlepSnu_x0p50_200p0_100p0_2L8.3lep.root"
+      },
+      {
+        "checksum": "adler32:d820e132",
+        "size": 26652,
+        "uri": "root://eospublic.cern.ch//eos/opendata/atlas/OutreachDatasets/2020-08-19/3lep/MC/mc_392502.C1C1_SlepSnu_x0p50_200p0_150p0_2L8.3lep.root"
+      },
+      {
+        "checksum": "adler32:a7a637a7",
+        "size": 51829,
+        "uri": "root://eospublic.cern.ch//eos/opendata/atlas/OutreachDatasets/2020-08-19/3lep/MC/mc_392504.C1C1_SlepSnu_x0p50_300p0_100p0_2L8.3lep.root"
+      },
+      {
+        "checksum": "adler32:9b83481f",
+        "size": 29570,
+        "uri": "root://eospublic.cern.ch//eos/opendata/atlas/OutreachDatasets/2020-08-19/3lep/MC/mc_392506.C1C1_SlepSnu_x0p50_300p0_250p0_2L8.3lep.root"
+      },
+      {
+        "checksum": "adler32:5ac8232d",
+        "size": 54583,
+        "uri": "root://eospublic.cern.ch//eos/opendata/atlas/OutreachDatasets/2020-08-19/3lep/MC/mc_392507.C1C1_SlepSnu_x0p50_400p0_100p0_2L8.3lep.root"
+      },
+      {
+        "checksum": "adler32:33bf3a36",
+        "size": 48021,
+        "uri": "root://eospublic.cern.ch//eos/opendata/atlas/OutreachDatasets/2020-08-19/3lep/MC/mc_392509.C1C1_SlepSnu_x0p50_400p0_300p0_2L8.3lep.root"
+      },
+      {
+        "checksum": "adler32:09f0fb36",
+        "size": 54579,
+        "uri": "root://eospublic.cern.ch//eos/opendata/atlas/OutreachDatasets/2020-08-19/3lep/MC/mc_392513.C1C1_SlepSnu_x0p50_500p0_300p0_2L8.3lep.root"
+      },
+      {
+        "checksum": "adler32:17833b57",
+        "size": 61864,
+        "uri": "root://eospublic.cern.ch//eos/opendata/atlas/OutreachDatasets/2020-08-19/3lep/MC/mc_392517.C1C1_SlepSnu_x0p50_600p0_300p0_2L8.3lep.root"
+      },
+      {
+        "checksum": "adler32:f10d185b",
+        "size": 60394,
+        "uri": "root://eospublic.cern.ch//eos/opendata/atlas/OutreachDatasets/2020-08-19/3lep/MC/mc_392518.C1C1_SlepSnu_x0p50_700p0_1p0_2L8.3lep.root"
+      },
+      {
+        "checksum": "adler32:b31a009e",
+        "size": 60903,
+        "uri": "root://eospublic.cern.ch//eos/opendata/atlas/OutreachDatasets/2020-08-19/3lep/MC/mc_392521.C1C1_SlepSnu_x0p50_700p0_300p0_2L8.3lep.root"
+      },
+      {
+        "checksum": "adler32:096805ec",
+        "size": 29392,
+        "uri": "root://eospublic.cern.ch//eos/opendata/atlas/OutreachDatasets/2020-08-19/3lep/MC/mc_392916.SlepSlep_direct_100p5_1p0_2L8.3lep.root"
+      },
+      {
+        "checksum": "adler32:0da7b8b0",
+        "size": 30640,
+        "uri": "root://eospublic.cern.ch//eos/opendata/atlas/OutreachDatasets/2020-08-19/3lep/MC/mc_392918.SlepSlep_direct_200p5_1p0_2L8.3lep.root"
+      },
+      {
+        "checksum": "adler32:f58ded61",
+        "size": 35529,
+        "uri": "root://eospublic.cern.ch//eos/opendata/atlas/OutreachDatasets/2020-08-19/3lep/MC/mc_392920.SlepSlep_direct_300p5_1p0_2L8.3lep.root"
+      },
+      {
+        "checksum": "adler32:8051319e",
+        "size": 36302,
+        "uri": "root://eospublic.cern.ch//eos/opendata/atlas/OutreachDatasets/2020-08-19/3lep/MC/mc_392924.SlepSlep_direct_500p5_1p0_2L8.3lep.root"
+      },
+      {
+        "checksum": "adler32:4f18f8d2",
+        "size": 26615,
+        "uri": "root://eospublic.cern.ch//eos/opendata/atlas/OutreachDatasets/2020-08-19/3lep/MC/mc_392925.SlepSlep_direct_100p0_50p0_2L8.3lep.root"
+      },
+      {
+        "checksum": "adler32:6818c6c9",
+        "size": 34059,
+        "uri": "root://eospublic.cern.ch//eos/opendata/atlas/OutreachDatasets/2020-08-19/3lep/MC/mc_392936.SlepSlep_direct_200p0_100p0_2L8.3lep.root"
+      },
+      {
+        "checksum": "adler32:5957e039",
+        "size": 33735,
+        "uri": "root://eospublic.cern.ch//eos/opendata/atlas/OutreachDatasets/2020-08-19/3lep/MC/mc_392942.SlepSlep_direct_500p0_100p0_2L8.3lep.root"
+      },
+      {
+        "checksum": "adler32:2b64fa08",
+        "size": 32279,
+        "uri": "root://eospublic.cern.ch//eos/opendata/atlas/OutreachDatasets/2020-08-19/3lep/MC/mc_392951.SlepSlep_direct_300p0_200p0_2L8.3lep.root"
+      },
+      {
+        "checksum": "adler32:ab50f691",
+        "size": 33207,
+        "uri": "root://eospublic.cern.ch//eos/opendata/atlas/OutreachDatasets/2020-08-19/3lep/MC/mc_392962.SlepSlep_direct_400p0_300p0_2L8.3lep.root"
+      },
+      {
+        "checksum": "adler32:ae8525e4",
+        "size": 42457,
+        "uri": "root://eospublic.cern.ch//eos/opendata/atlas/OutreachDatasets/2020-08-19/3lep/MC/mc_392964.SlepSlep_direct_500p0_300p0_2L8.3lep.root"
+      },
+      {
+        "checksum": "adler32:8ddc30c6",
+        "size": 35649,
+        "uri": "root://eospublic.cern.ch//eos/opendata/atlas/OutreachDatasets/2020-08-19/3lep/MC/mc_392982.SlepSlep_direct_600p0_1p0_2L8.3lep.root"
+      },
+      {
+        "checksum": "adler32:3cf7ede8",
+        "size": 31948,
+        "uri": "root://eospublic.cern.ch//eos/opendata/atlas/OutreachDatasets/2020-08-19/3lep/MC/mc_392985.SlepSlep_direct_600p0_300p0_2L8.3lep.root"
+      },
+      {
+        "checksum": "adler32:c0aca356",
+        "size": 35883,
+        "uri": "root://eospublic.cern.ch//eos/opendata/atlas/OutreachDatasets/2020-08-19/3lep/MC/mc_392996.SlepSlep_direct_700p0_1p0_2L8.3lep.root"
+      },
+      {
+        "checksum": "adler32:1fbe510c",
+        "size": 37731,
+        "uri": "root://eospublic.cern.ch//eos/opendata/atlas/OutreachDatasets/2020-08-19/3lep/MC/mc_392999.SlepSlep_direct_700p0_300p0_2L8.3lep.root"
+      },
+      {
+        "checksum": "adler32:d2d6f28e",
+        "size": 24197644,
+        "uri": "root://eospublic.cern.ch//eos/opendata/atlas/OutreachDatasets/2020-08-19/3lep/MC/mc_410000.ttbar_lep.3lep.root"
+      },
+      {
+        "checksum": "adler32:2b6f450d",
+        "size": 157489,
+        "uri": "root://eospublic.cern.ch//eos/opendata/atlas/OutreachDatasets/2020-08-19/3lep/MC/mc_410011.single_top_tchan.3lep.root"
+      },
+      {
+        "checksum": "adler32:d10e83f3",
+        "size": 160597,
+        "uri": "root://eospublic.cern.ch//eos/opendata/atlas/OutreachDatasets/2020-08-19/3lep/MC/mc_410012.single_antitop_tchan.3lep.root"
+      },
+      {
+        "checksum": "adler32:cf7fccb0",
+        "size": 1142235,
+        "uri": "root://eospublic.cern.ch//eos/opendata/atlas/OutreachDatasets/2020-08-19/3lep/MC/mc_410013.single_top_wtchan.3lep.root"
+      },
+      {
+        "checksum": "adler32:24da823b",
+        "size": 1173920,
+        "uri": "root://eospublic.cern.ch//eos/opendata/atlas/OutreachDatasets/2020-08-19/3lep/MC/mc_410014.single_antitop_wtchan.3lep.root"
+      },
+      {
+        "checksum": "adler32:e97c9f34",
+        "size": 49059,
+        "uri": "root://eospublic.cern.ch//eos/opendata/atlas/OutreachDatasets/2020-08-19/3lep/MC/mc_410025.single_top_schan.3lep.root"
+      },
+      {
+        "checksum": "adler32:dc628334",
+        "size": 51431,
+        "uri": "root://eospublic.cern.ch//eos/opendata/atlas/OutreachDatasets/2020-08-19/3lep/MC/mc_410026.single_antitop_schan.3lep.root"
+      },
+      {
+        "checksum": "adler32:60b04f13",
+        "size": 18480186,
+        "uri": "root://eospublic.cern.ch//eos/opendata/atlas/OutreachDatasets/2020-08-19/3lep/MC/mc_410155.ttW.3lep.root"
+      },
+      {
+        "checksum": "adler32:af64d480",
+        "size": 87374192,
+        "uri": "root://eospublic.cern.ch//eos/opendata/atlas/OutreachDatasets/2020-08-19/3lep/MC/mc_410218.ttee.3lep.root"
+      },
+      {
+        "checksum": "adler32:9f98bb25",
+        "size": 66683369,
+        "uri": "root://eospublic.cern.ch//eos/opendata/atlas/OutreachDatasets/2020-08-19/3lep/MC/mc_410219.ttmumu.3lep.root"
       }
     ],
     "license": {
@@ -53,7 +1127,7 @@
       ]
     },
     "usage": {
-      "description": "This dataset is provided by the ATLAS Collaboration <strong>only for educational purposes and is not suited for scientific publications</strong>.\n You can access these data through the ATLAS Virtual Machine and Software.\n More documentation is available at:",
+      "description": "<p>This dataset is provided as a zipped tarball (<code>3lep.zip</code>) and as a list of unzipped individually-accessible ROOT files containing the collision data (such as <code>data_A.3lep.root</code>) and the simulated data (such as <code>mc_301215.ZPrime2000_ee.3lep.root</code>). You can use either the tarball or the individual ROOT files.</p> <p>This dataset is provided by the ATLAS Collaboration <strong>only for educational purposes and is not suited for scientific publications</strong>.\n You can access these data through the ATLAS Virtual Machine and Software.\n More documentation is available at:</p>",
       "links": [
         {
           "description": "The ATLAS Open Data documentation for 13 TeV release",

--- a/data/records/atlas-2020-4lep.json
+++ b/data/records/atlas-2020-4lep.json
@@ -19,8 +19,12 @@
     ],
     "date_published": "2020",
     "distribution": {
-      "number_files": 1,
-      "size": 446971392
+      "formats": [
+        "root",
+        "zip"
+      ],
+      "number_files": 111,
+      "size": 975705245
     },
     "doi": "10.7483/OPENDATA.ATLAS.2Y1T.TLGL",
     "experiment": [
@@ -31,6 +35,556 @@
         "checksum": "adler32:b934c380",
         "size": 446971392,
         "uri": "root://eospublic.cern.ch//eos/opendata/atlas/OutreachDatasets/2020-08-19/4lep.zip"
+      },
+      {
+        "checksum": "adler32:b6a8df64",
+        "size": 33765,
+        "uri": "root://eospublic.cern.ch//eos/opendata/atlas/OutreachDatasets/2020-08-19/4lep/Data/data_A.4lep.root"
+      },
+      {
+        "checksum": "adler32:f870fe84",
+        "size": 68738,
+        "uri": "root://eospublic.cern.ch//eos/opendata/atlas/OutreachDatasets/2020-08-19/4lep/Data/data_B.4lep.root"
+      },
+      {
+        "checksum": "adler32:c7681404",
+        "size": 92295,
+        "uri": "root://eospublic.cern.ch//eos/opendata/atlas/OutreachDatasets/2020-08-19/4lep/Data/data_C.4lep.root"
+      },
+      {
+        "checksum": "adler32:266a7775",
+        "size": 139606,
+        "uri": "root://eospublic.cern.ch//eos/opendata/atlas/OutreachDatasets/2020-08-19/4lep/Data/data_D.4lep.root"
+      },
+      {
+        "checksum": "adler32:142a907b",
+        "size": 21508,
+        "uri": "root://eospublic.cern.ch//eos/opendata/atlas/OutreachDatasets/2020-08-19/4lep/MC/mc_301215.ZPrime2000_ee.4lep.root"
+      },
+      {
+        "checksum": "adler32:e81dd0eb",
+        "size": 20687,
+        "uri": "root://eospublic.cern.ch//eos/opendata/atlas/OutreachDatasets/2020-08-19/4lep/MC/mc_301216.ZPrime3000_ee.4lep.root"
+      },
+      {
+        "checksum": "adler32:2336bc75",
+        "size": 46283,
+        "uri": "root://eospublic.cern.ch//eos/opendata/atlas/OutreachDatasets/2020-08-19/4lep/MC/mc_301220.ZPrime2000_mumu.4lep.root"
+      },
+      {
+        "checksum": "adler32:415ee761",
+        "size": 41798,
+        "uri": "root://eospublic.cern.ch//eos/opendata/atlas/OutreachDatasets/2020-08-19/4lep/MC/mc_301221.ZPrime3000_mumu.4lep.root"
+      },
+      {
+        "checksum": "adler32:9d100851",
+        "size": 21279,
+        "uri": "root://eospublic.cern.ch//eos/opendata/atlas/OutreachDatasets/2020-08-19/4lep/MC/mc_301322.ZPrime400_tt.4lep.root"
+      },
+      {
+        "checksum": "adler32:a18b0956",
+        "size": 19823,
+        "uri": "root://eospublic.cern.ch//eos/opendata/atlas/OutreachDatasets/2020-08-19/4lep/MC/mc_301323.ZPrime500_tt.4lep.root"
+      },
+      {
+        "checksum": "adler32:c8557fd3",
+        "size": 292662,
+        "uri": "root://eospublic.cern.ch//eos/opendata/atlas/OutreachDatasets/2020-08-19/4lep/MC/mc_303329.RS_G_ZZ_llll_c10_m1000.4lep.root"
+      },
+      {
+        "checksum": "adler32:72a1c728",
+        "size": 283757,
+        "uri": "root://eospublic.cern.ch//eos/opendata/atlas/OutreachDatasets/2020-08-19/4lep/MC/mc_303334.RS_G_ZZ_llll_c10_m2000.4lep.root"
+      },
+      {
+        "checksum": "adler32:1f06035a",
+        "size": 21306,
+        "uri": "root://eospublic.cern.ch//eos/opendata/atlas/OutreachDatasets/2020-08-19/4lep/MC/mc_305553.Gee_01_1000.4lep.root"
+      },
+      {
+        "checksum": "adler32:3abaab7d",
+        "size": 20631,
+        "uri": "root://eospublic.cern.ch//eos/opendata/atlas/OutreachDatasets/2020-08-19/4lep/MC/mc_305556.Gee_01_2000.4lep.root"
+      },
+      {
+        "checksum": "adler32:afa35ca4",
+        "size": 21206,
+        "uri": "root://eospublic.cern.ch//eos/opendata/atlas/OutreachDatasets/2020-08-19/4lep/MC/mc_305559.Gee_01_3000.4lep.root"
+      },
+      {
+        "checksum": "adler32:280ee091",
+        "size": 21180,
+        "uri": "root://eospublic.cern.ch//eos/opendata/atlas/OutreachDatasets/2020-08-19/4lep/MC/mc_305562.Gee_01_4000.4lep.root"
+      },
+      {
+        "checksum": "adler32:9fa4a006",
+        "size": 21341,
+        "uri": "root://eospublic.cern.ch//eos/opendata/atlas/OutreachDatasets/2020-08-19/4lep/MC/mc_305571.Gmumu_01_1000.4lep.root"
+      },
+      {
+        "checksum": "adler32:0361d676",
+        "size": 21371,
+        "uri": "root://eospublic.cern.ch//eos/opendata/atlas/OutreachDatasets/2020-08-19/4lep/MC/mc_305574.Gmumu_01_2000.4lep.root"
+      },
+      {
+        "checksum": "adler32:99205beb",
+        "size": 19906,
+        "uri": "root://eospublic.cern.ch//eos/opendata/atlas/OutreachDatasets/2020-08-19/4lep/MC/mc_305577.Gmumu_01_3000.4lep.root"
+      },
+      {
+        "checksum": "adler32:692a8c3a",
+        "size": 19895,
+        "uri": "root://eospublic.cern.ch//eos/opendata/atlas/OutreachDatasets/2020-08-19/4lep/MC/mc_305580.Gmumu_01_4000.4lep.root"
+      },
+      {
+        "checksum": "adler32:6859a25f",
+        "size": 1451404,
+        "uri": "root://eospublic.cern.ch//eos/opendata/atlas/OutreachDatasets/2020-08-19/4lep/MC/mc_307431.RS_G_ZZ_llll_c10_m0200.4lep.root"
+      },
+      {
+        "checksum": "adler32:70633804",
+        "size": 2213278,
+        "uri": "root://eospublic.cern.ch//eos/opendata/atlas/OutreachDatasets/2020-08-19/4lep/MC/mc_307434.RS_G_ZZ_llll_c10_m0500.4lep.root"
+      },
+      {
+        "checksum": "adler32:2a130322",
+        "size": 2754772,
+        "uri": "root://eospublic.cern.ch//eos/opendata/atlas/OutreachDatasets/2020-08-19/4lep/MC/mc_307439.RS_G_ZZ_llll_c10_m1500.4lep.root"
+      },
+      {
+        "checksum": "adler32:43b610d8",
+        "size": 22749,
+        "uri": "root://eospublic.cern.ch//eos/opendata/atlas/OutreachDatasets/2020-08-19/4lep/MC/mc_341122.ggH125_tautaull.4lep.root"
+      },
+      {
+        "checksum": "adler32:2c629095",
+        "size": 28894,
+        "uri": "root://eospublic.cern.ch//eos/opendata/atlas/OutreachDatasets/2020-08-19/4lep/MC/mc_341155.VBFH125_tautaull.4lep.root"
+      },
+      {
+        "checksum": "adler32:18c94313",
+        "size": 5293850,
+        "uri": "root://eospublic.cern.ch//eos/opendata/atlas/OutreachDatasets/2020-08-19/4lep/MC/mc_341947.ZH125_ZZ4lep.4lep.root"
+      },
+      {
+        "checksum": "adler32:a923e2e8",
+        "size": 5528294,
+        "uri": "root://eospublic.cern.ch//eos/opendata/atlas/OutreachDatasets/2020-08-19/4lep/MC/mc_341964.WH125_ZZ4lep.4lep.root"
+      },
+      {
+        "checksum": "adler32:e551abab",
+        "size": 60503237,
+        "uri": "root://eospublic.cern.ch//eos/opendata/atlas/OutreachDatasets/2020-08-19/4lep/MC/mc_344235.VBFH125_ZZ4lep.4lep.root"
+      },
+      {
+        "checksum": "adler32:1ea0e560",
+        "size": 50518236,
+        "uri": "root://eospublic.cern.ch//eos/opendata/atlas/OutreachDatasets/2020-08-19/4lep/MC/mc_345060.ggH125_ZZ4lep.4lep.root"
+      },
+      {
+        "checksum": "adler32:33edbc1e",
+        "size": 26850,
+        "uri": "root://eospublic.cern.ch//eos/opendata/atlas/OutreachDatasets/2020-08-19/4lep/MC/mc_345323.VBFH125_WW2lep.4lep.root"
+      },
+      {
+        "checksum": "adler32:9699d850",
+        "size": 29899,
+        "uri": "root://eospublic.cern.ch//eos/opendata/atlas/OutreachDatasets/2020-08-19/4lep/MC/mc_345324.ggH125_WW2lep.4lep.root"
+      },
+      {
+        "checksum": "adler32:be5c8a49",
+        "size": 46457,
+        "uri": "root://eospublic.cern.ch//eos/opendata/atlas/OutreachDatasets/2020-08-19/4lep/MC/mc_345325.WpH125J_qqWW2lep.4lep.root"
+      },
+      {
+        "checksum": "adler32:877fa565",
+        "size": 51697,
+        "uri": "root://eospublic.cern.ch//eos/opendata/atlas/OutreachDatasets/2020-08-19/4lep/MC/mc_345327.WpH125J_lvWW2lep.4lep.root"
+      },
+      {
+        "checksum": "adler32:ca016954",
+        "size": 787504,
+        "uri": "root://eospublic.cern.ch//eos/opendata/atlas/OutreachDatasets/2020-08-19/4lep/MC/mc_345336.ZH125J_qqWW2lep.4lep.root"
+      },
+      {
+        "checksum": "adler32:549dfdd1",
+        "size": 11167200,
+        "uri": "root://eospublic.cern.ch//eos/opendata/atlas/OutreachDatasets/2020-08-19/4lep/MC/mc_345337.ZH125J_llWW2lep.4lep.root"
+      },
+      {
+        "checksum": "adler32:1bc41e1e",
+        "size": 22679,
+        "uri": "root://eospublic.cern.ch//eos/opendata/atlas/OutreachDatasets/2020-08-19/4lep/MC/mc_345445.ZH125J_vvWW2lep.4lep.root"
+      },
+      {
+        "checksum": "adler32:f38878a3",
+        "size": 9645,
+        "uri": "root://eospublic.cern.ch//eos/opendata/atlas/OutreachDatasets/2020-08-19/4lep/MC/mc_361100.Wplusenu.4lep.root"
+      },
+      {
+        "checksum": "adler32:4f3e3203",
+        "size": 9659,
+        "uri": "root://eospublic.cern.ch//eos/opendata/atlas/OutreachDatasets/2020-08-19/4lep/MC/mc_361101.Wplusmunu.4lep.root"
+      },
+      {
+        "checksum": "adler32:9e455a8b",
+        "size": 9650,
+        "uri": "root://eospublic.cern.ch//eos/opendata/atlas/OutreachDatasets/2020-08-19/4lep/MC/mc_361102.Wplustaunu.4lep.root"
+      },
+      {
+        "checksum": "adler32:03837a6e",
+        "size": 9612,
+        "uri": "root://eospublic.cern.ch//eos/opendata/atlas/OutreachDatasets/2020-08-19/4lep/MC/mc_361103.Wminusenu.4lep.root"
+      },
+      {
+        "checksum": "adler32:602f56ae",
+        "size": 9667,
+        "uri": "root://eospublic.cern.ch//eos/opendata/atlas/OutreachDatasets/2020-08-19/4lep/MC/mc_361104.Wminusmunu.4lep.root"
+      },
+      {
+        "checksum": "adler32:9a8a66c3",
+        "size": 9653,
+        "uri": "root://eospublic.cern.ch//eos/opendata/atlas/OutreachDatasets/2020-08-19/4lep/MC/mc_361105.Wminustaunu.4lep.root"
+      },
+      {
+        "checksum": "adler32:d58a256c",
+        "size": 299577,
+        "uri": "root://eospublic.cern.ch//eos/opendata/atlas/OutreachDatasets/2020-08-19/4lep/MC/mc_361106.Zee.4lep.root"
+      },
+      {
+        "checksum": "adler32:8f471536",
+        "size": 233914,
+        "uri": "root://eospublic.cern.ch//eos/opendata/atlas/OutreachDatasets/2020-08-19/4lep/MC/mc_361107.Zmumu.4lep.root"
+      },
+      {
+        "checksum": "adler32:633cc8b3",
+        "size": 23858,
+        "uri": "root://eospublic.cern.ch//eos/opendata/atlas/OutreachDatasets/2020-08-19/4lep/MC/mc_361108.Ztautau.4lep.root"
+      },
+      {
+        "checksum": "adler32:823275b1",
+        "size": 111159,
+        "uri": "root://eospublic.cern.ch//eos/opendata/atlas/OutreachDatasets/2020-08-19/4lep/MC/mc_363356.ZqqZll.4lep.root"
+      },
+      {
+        "checksum": "adler32:2d439fbe",
+        "size": 45233,
+        "uri": "root://eospublic.cern.ch//eos/opendata/atlas/OutreachDatasets/2020-08-19/4lep/MC/mc_363358.WqqZll.4lep.root"
+      },
+      {
+        "checksum": "adler32:2e875c51",
+        "size": 9590,
+        "uri": "root://eospublic.cern.ch//eos/opendata/atlas/OutreachDatasets/2020-08-19/4lep/MC/mc_363359.WpqqWmlv.4lep.root"
+      },
+      {
+        "checksum": "adler32:97d08aea",
+        "size": 9696,
+        "uri": "root://eospublic.cern.ch//eos/opendata/atlas/OutreachDatasets/2020-08-19/4lep/MC/mc_363360.WplvWmqq.4lep.root"
+      },
+      {
+        "checksum": "adler32:f7d042bb",
+        "size": 9616,
+        "uri": "root://eospublic.cern.ch//eos/opendata/atlas/OutreachDatasets/2020-08-19/4lep/MC/mc_363489.WlvZqq.4lep.root"
+      },
+      {
+        "checksum": "adler32:6298e6cb",
+        "size": 179082866,
+        "uri": "root://eospublic.cern.ch//eos/opendata/atlas/OutreachDatasets/2020-08-19/4lep/MC/mc_363490.llll.4lep.root"
+      },
+      {
+        "checksum": "adler32:a7c04986",
+        "size": 3304821,
+        "uri": "root://eospublic.cern.ch//eos/opendata/atlas/OutreachDatasets/2020-08-19/4lep/MC/mc_363491.lllv.4lep.root"
+      },
+      {
+        "checksum": "adler32:fd1cedd3",
+        "size": 74111,
+        "uri": "root://eospublic.cern.ch//eos/opendata/atlas/OutreachDatasets/2020-08-19/4lep/MC/mc_363492.llvv.4lep.root"
+      },
+      {
+        "checksum": "adler32:2b0c5969",
+        "size": 9574,
+        "uri": "root://eospublic.cern.ch//eos/opendata/atlas/OutreachDatasets/2020-08-19/4lep/MC/mc_363493.lvvv.4lep.root"
+      },
+      {
+        "checksum": "adler32:4cc3c06a",
+        "size": 34477,
+        "uri": "root://eospublic.cern.ch//eos/opendata/atlas/OutreachDatasets/2020-08-19/4lep/MC/mc_364100.Zmumu_PTV0_70_CVetoBVeto.4lep.root"
+      },
+      {
+        "checksum": "adler32:5065689d",
+        "size": 39536,
+        "uri": "root://eospublic.cern.ch//eos/opendata/atlas/OutreachDatasets/2020-08-19/4lep/MC/mc_364101.Zmumu_PTV0_70_CFilterBVeto.4lep.root"
+      },
+      {
+        "checksum": "adler32:3e5fbc9c",
+        "size": 122860,
+        "uri": "root://eospublic.cern.ch//eos/opendata/atlas/OutreachDatasets/2020-08-19/4lep/MC/mc_364102.Zmumu_PTV0_70_BFilter.4lep.root"
+      },
+      {
+        "checksum": "adler32:bbec4064",
+        "size": 36930,
+        "uri": "root://eospublic.cern.ch//eos/opendata/atlas/OutreachDatasets/2020-08-19/4lep/MC/mc_364103.Zmumu_PTV70_140_CVetoBVeto.4lep.root"
+      },
+      {
+        "checksum": "adler32:c3e5d6ff",
+        "size": 29885,
+        "uri": "root://eospublic.cern.ch//eos/opendata/atlas/OutreachDatasets/2020-08-19/4lep/MC/mc_364104.Zmumu_PTV70_140_CFilterBVeto.4lep.root"
+      },
+      {
+        "checksum": "adler32:42cbd056",
+        "size": 155054,
+        "uri": "root://eospublic.cern.ch//eos/opendata/atlas/OutreachDatasets/2020-08-19/4lep/MC/mc_364105.Zmumu_PTV70_140_BFilter.4lep.root"
+      },
+      {
+        "checksum": "adler32:c935c4f4",
+        "size": 40174,
+        "uri": "root://eospublic.cern.ch//eos/opendata/atlas/OutreachDatasets/2020-08-19/4lep/MC/mc_364106.Zmumu_PTV140_280_CVetoBVeto.4lep.root"
+      },
+      {
+        "checksum": "adler32:7848ba1e",
+        "size": 30809,
+        "uri": "root://eospublic.cern.ch//eos/opendata/atlas/OutreachDatasets/2020-08-19/4lep/MC/mc_364107.Zmumu_PTV140_280_CFilterBVeto.4lep.root"
+      },
+      {
+        "checksum": "adler32:38ab72da",
+        "size": 292029,
+        "uri": "root://eospublic.cern.ch//eos/opendata/atlas/OutreachDatasets/2020-08-19/4lep/MC/mc_364108.Zmumu_PTV140_280_BFilter.4lep.root"
+      },
+      {
+        "checksum": "adler32:6e684e2f",
+        "size": 27688,
+        "uri": "root://eospublic.cern.ch//eos/opendata/atlas/OutreachDatasets/2020-08-19/4lep/MC/mc_364109.Zmumu_PTV280_500_CVetoBVeto.4lep.root"
+      },
+      {
+        "checksum": "adler32:a53346d8",
+        "size": 27023,
+        "uri": "root://eospublic.cern.ch//eos/opendata/atlas/OutreachDatasets/2020-08-19/4lep/MC/mc_364110.Zmumu_PTV280_500_CFilterBVeto.4lep.root"
+      },
+      {
+        "checksum": "adler32:d6b837f0",
+        "size": 67867,
+        "uri": "root://eospublic.cern.ch//eos/opendata/atlas/OutreachDatasets/2020-08-19/4lep/MC/mc_364111.Zmumu_PTV280_500_BFilter.4lep.root"
+      },
+      {
+        "checksum": "adler32:f6aaa1d9",
+        "size": 50368,
+        "uri": "root://eospublic.cern.ch//eos/opendata/atlas/OutreachDatasets/2020-08-19/4lep/MC/mc_364112.Zmumu_PTV500_1000.4lep.root"
+      },
+      {
+        "checksum": "adler32:46a92fcc",
+        "size": 31030,
+        "uri": "root://eospublic.cern.ch//eos/opendata/atlas/OutreachDatasets/2020-08-19/4lep/MC/mc_364113.Zmumu_PTV1000_E_CMS.4lep.root"
+      },
+      {
+        "checksum": "adler32:2cc7d122",
+        "size": 43132,
+        "uri": "root://eospublic.cern.ch//eos/opendata/atlas/OutreachDatasets/2020-08-19/4lep/MC/mc_364114.Zee_PTV0_70_CVetoBVeto.4lep.root"
+      },
+      {
+        "checksum": "adler32:687864e0",
+        "size": 47524,
+        "uri": "root://eospublic.cern.ch//eos/opendata/atlas/OutreachDatasets/2020-08-19/4lep/MC/mc_364115.Zee_PTV0_70_CFilterBVeto.4lep.root"
+      },
+      {
+        "checksum": "adler32:90f3ddd4",
+        "size": 185041,
+        "uri": "root://eospublic.cern.ch//eos/opendata/atlas/OutreachDatasets/2020-08-19/4lep/MC/mc_364116.Zee_PTV0_70_BFilter.4lep.root"
+      },
+      {
+        "checksum": "adler32:80ceeb8b",
+        "size": 43563,
+        "uri": "root://eospublic.cern.ch//eos/opendata/atlas/OutreachDatasets/2020-08-19/4lep/MC/mc_364117.Zee_PTV70_140_CVetoBVeto.4lep.root"
+      },
+      {
+        "checksum": "adler32:69400337",
+        "size": 38119,
+        "uri": "root://eospublic.cern.ch//eos/opendata/atlas/OutreachDatasets/2020-08-19/4lep/MC/mc_364118.Zee_PTV70_140_CFilterBVeto.4lep.root"
+      },
+      {
+        "checksum": "adler32:2add7f08",
+        "size": 288878,
+        "uri": "root://eospublic.cern.ch//eos/opendata/atlas/OutreachDatasets/2020-08-19/4lep/MC/mc_364119.Zee_PTV70_140_BFilter.4lep.root"
+      },
+      {
+        "checksum": "adler32:1bf5b184",
+        "size": 47543,
+        "uri": "root://eospublic.cern.ch//eos/opendata/atlas/OutreachDatasets/2020-08-19/4lep/MC/mc_364120.Zee_PTV140_280_CVetoBVeto.4lep.root"
+      },
+      {
+        "checksum": "adler32:ee4c9f95",
+        "size": 42961,
+        "uri": "root://eospublic.cern.ch//eos/opendata/atlas/OutreachDatasets/2020-08-19/4lep/MC/mc_364121.Zee_PTV140_280_CFilterBVeto.4lep.root"
+      },
+      {
+        "checksum": "adler32:1934abe3",
+        "size": 543329,
+        "uri": "root://eospublic.cern.ch//eos/opendata/atlas/OutreachDatasets/2020-08-19/4lep/MC/mc_364122.Zee_PTV140_280_BFilter.4lep.root"
+      },
+      {
+        "checksum": "adler32:453c601a",
+        "size": 34910,
+        "uri": "root://eospublic.cern.ch//eos/opendata/atlas/OutreachDatasets/2020-08-19/4lep/MC/mc_364123.Zee_PTV280_500_CVetoBVeto.4lep.root"
+      },
+      {
+        "checksum": "adler32:c5b1618e",
+        "size": 29578,
+        "uri": "root://eospublic.cern.ch//eos/opendata/atlas/OutreachDatasets/2020-08-19/4lep/MC/mc_364124.Zee_PTV280_500_CFilterBVeto.4lep.root"
+      },
+      {
+        "checksum": "adler32:ce6eb7f3",
+        "size": 116792,
+        "uri": "root://eospublic.cern.ch//eos/opendata/atlas/OutreachDatasets/2020-08-19/4lep/MC/mc_364125.Zee_PTV280_500_BFilter.4lep.root"
+      },
+      {
+        "checksum": "adler32:16b253a3",
+        "size": 67232,
+        "uri": "root://eospublic.cern.ch//eos/opendata/atlas/OutreachDatasets/2020-08-19/4lep/MC/mc_364126.Zee_PTV500_1000.4lep.root"
+      },
+      {
+        "checksum": "adler32:41424f2b",
+        "size": 37801,
+        "uri": "root://eospublic.cern.ch//eos/opendata/atlas/OutreachDatasets/2020-08-19/4lep/MC/mc_364127.Zee_PTV1000_E_CMS.4lep.root"
+      },
+      {
+        "checksum": "adler32:fbd22bd3",
+        "size": 19902,
+        "uri": "root://eospublic.cern.ch//eos/opendata/atlas/OutreachDatasets/2020-08-19/4lep/MC/mc_364128.Ztautau_PTV0_70_CVetoBVeto.4lep.root"
+      },
+      {
+        "checksum": "adler32:fd19637f",
+        "size": 20598,
+        "uri": "root://eospublic.cern.ch//eos/opendata/atlas/OutreachDatasets/2020-08-19/4lep/MC/mc_364129.Ztautau_PTV0_70_CFilterBVeto.4lep.root"
+      },
+      {
+        "checksum": "adler32:823afc42",
+        "size": 23411,
+        "uri": "root://eospublic.cern.ch//eos/opendata/atlas/OutreachDatasets/2020-08-19/4lep/MC/mc_364130.Ztautau_PTV0_70_BFilter.4lep.root"
+      },
+      {
+        "checksum": "adler32:5775feb7",
+        "size": 19864,
+        "uri": "root://eospublic.cern.ch//eos/opendata/atlas/OutreachDatasets/2020-08-19/4lep/MC/mc_364131.Ztautau_PTV70_140_CVetoBVeto.4lep.root"
+      },
+      {
+        "checksum": "adler32:dad11e61",
+        "size": 19841,
+        "uri": "root://eospublic.cern.ch//eos/opendata/atlas/OutreachDatasets/2020-08-19/4lep/MC/mc_364132.Ztautau_PTV70_140_CFilterBVeto.4lep.root"
+      },
+      {
+        "checksum": "adler32:ea8393d9",
+        "size": 28358,
+        "uri": "root://eospublic.cern.ch//eos/opendata/atlas/OutreachDatasets/2020-08-19/4lep/MC/mc_364133.Ztautau_PTV70_140_BFilter.4lep.root"
+      },
+      {
+        "checksum": "adler32:541fbfd3",
+        "size": 21508,
+        "uri": "root://eospublic.cern.ch//eos/opendata/atlas/OutreachDatasets/2020-08-19/4lep/MC/mc_364134.Ztautau_PTV140_280_CVetoBVeto.4lep.root"
+      },
+      {
+        "checksum": "adler32:0e809699",
+        "size": 20706,
+        "uri": "root://eospublic.cern.ch//eos/opendata/atlas/OutreachDatasets/2020-08-19/4lep/MC/mc_364135.Ztautau_PTV140_280_CFilterBVeto.4lep.root"
+      },
+      {
+        "checksum": "adler32:105bc556",
+        "size": 25595,
+        "uri": "root://eospublic.cern.ch//eos/opendata/atlas/OutreachDatasets/2020-08-19/4lep/MC/mc_364136.Ztautau_PTV140_280_BFilter.4lep.root"
+      },
+      {
+        "checksum": "adler32:d7c545fe",
+        "size": 19916,
+        "uri": "root://eospublic.cern.ch//eos/opendata/atlas/OutreachDatasets/2020-08-19/4lep/MC/mc_364137.Ztautau_PTV280_500_CVetoBVeto.4lep.root"
+      },
+      {
+        "checksum": "adler32:bc9db663",
+        "size": 20042,
+        "uri": "root://eospublic.cern.ch//eos/opendata/atlas/OutreachDatasets/2020-08-19/4lep/MC/mc_364138.Ztautau_PTV280_500_CFilterBVeto.4lep.root"
+      },
+      {
+        "checksum": "adler32:09e8041b",
+        "size": 25153,
+        "uri": "root://eospublic.cern.ch//eos/opendata/atlas/OutreachDatasets/2020-08-19/4lep/MC/mc_364139.Ztautau_PTV280_500_BFilter.4lep.root"
+      },
+      {
+        "checksum": "adler32:f01833d2",
+        "size": 21648,
+        "uri": "root://eospublic.cern.ch//eos/opendata/atlas/OutreachDatasets/2020-08-19/4lep/MC/mc_364140.Ztautau_PTV500_1000.4lep.root"
+      },
+      {
+        "checksum": "adler32:bc3190b9",
+        "size": 176035691,
+        "uri": "root://eospublic.cern.ch//eos/opendata/atlas/OutreachDatasets/2020-08-19/4lep/MC/mc_364250.llll_filter.4lep.root"
+      },
+      {
+        "checksum": "adler32:c2baeb65",
+        "size": 93126,
+        "uri": "root://eospublic.cern.ch//eos/opendata/atlas/OutreachDatasets/2020-08-19/4lep/MC/mc_370114.GG_ttn1_1200_5000_1.4lep.root"
+      },
+      {
+        "checksum": "adler32:dbaf9e88",
+        "size": 111850,
+        "uri": "root://eospublic.cern.ch//eos/opendata/atlas/OutreachDatasets/2020-08-19/4lep/MC/mc_370118.GG_ttn1_1200_5000_600.4lep.root"
+      },
+      {
+        "checksum": "adler32:1e37dfb8",
+        "size": 78806,
+        "uri": "root://eospublic.cern.ch//eos/opendata/atlas/OutreachDatasets/2020-08-19/4lep/MC/mc_370129.GG_ttn1_1400_5000_1.4lep.root"
+      },
+      {
+        "checksum": "adler32:1e45db00",
+        "size": 71760,
+        "uri": "root://eospublic.cern.ch//eos/opendata/atlas/OutreachDatasets/2020-08-19/4lep/MC/mc_370144.GG_ttn1_1600_5000_1.4lep.root"
+      },
+      {
+        "checksum": "adler32:8d8b3a96",
+        "size": 391352,
+        "uri": "root://eospublic.cern.ch//eos/opendata/atlas/OutreachDatasets/2020-08-19/4lep/MC/mc_410000.ttbar_lep.4lep.root"
+      },
+      {
+        "checksum": "adler32:3f5ada65",
+        "size": 20698,
+        "uri": "root://eospublic.cern.ch//eos/opendata/atlas/OutreachDatasets/2020-08-19/4lep/MC/mc_410011.single_top_tchan.4lep.root"
+      },
+      {
+        "checksum": "adler32:03b4eb71",
+        "size": 20802,
+        "uri": "root://eospublic.cern.ch//eos/opendata/atlas/OutreachDatasets/2020-08-19/4lep/MC/mc_410012.single_antitop_tchan.4lep.root"
+      },
+      {
+        "checksum": "adler32:7685e876",
+        "size": 43677,
+        "uri": "root://eospublic.cern.ch//eos/opendata/atlas/OutreachDatasets/2020-08-19/4lep/MC/mc_410013.single_top_wtchan.4lep.root"
+      },
+      {
+        "checksum": "adler32:ff89bae5",
+        "size": 39845,
+        "uri": "root://eospublic.cern.ch//eos/opendata/atlas/OutreachDatasets/2020-08-19/4lep/MC/mc_410014.single_antitop_wtchan.4lep.root"
+      },
+      {
+        "checksum": "adler32:a613e43d",
+        "size": 20778,
+        "uri": "root://eospublic.cern.ch//eos/opendata/atlas/OutreachDatasets/2020-08-19/4lep/MC/mc_410025.single_top_schan.4lep.root"
+      },
+      {
+        "checksum": "adler32:f4fd8146",
+        "size": 20609,
+        "uri": "root://eospublic.cern.ch//eos/opendata/atlas/OutreachDatasets/2020-08-19/4lep/MC/mc_410026.single_antitop_schan.4lep.root"
+      },
+      {
+        "checksum": "adler32:3145248c",
+        "size": 545480,
+        "uri": "root://eospublic.cern.ch//eos/opendata/atlas/OutreachDatasets/2020-08-19/4lep/MC/mc_410155.ttW.4lep.root"
+      },
+      {
+        "checksum": "adler32:83a7903b",
+        "size": 12812484,
+        "uri": "root://eospublic.cern.ch//eos/opendata/atlas/OutreachDatasets/2020-08-19/4lep/MC/mc_410218.ttee.4lep.root"
+      },
+      {
+        "checksum": "adler32:0b8ff7d0",
+        "size": 10620282,
+        "uri": "root://eospublic.cern.ch//eos/opendata/atlas/OutreachDatasets/2020-08-19/4lep/MC/mc_410219.ttmumu.4lep.root"
       }
     ],
     "license": {
@@ -53,7 +607,7 @@
       ]
     },
     "usage": {
-      "description": "This dataset is provided by the ATLAS Collaboration <strong>only for educational purposes and is not suited for scientific publications</strong>.\n You can access these data through the ATLAS Virtual Machine and Software.\n More documentation is available at:",
+      "description": "<p>This dataset is provided as a zipped tarball (<code>4lep.zip</code>) and as a list of unzipped individually-accessible ROOT files containing the collision data (such as <code>data_A.4lep.root</code>) and the simulated data (such as <code>mc_301215.ZPrime2000_ee.4lep.root</code>). You can use either the tarball or the individual ROOT files.</p> <p>This dataset is provided by the ATLAS Collaboration <strong>only for educational purposes and is not suited for scientific publications</strong>.\n You can access these data through the ATLAS Virtual Machine and Software.\n More documentation is available at:</p>",
       "links": [
         {
           "description": "The ATLAS Open Data documentation for 13 TeV release",

--- a/data/records/atlas-2020-GamGam.json
+++ b/data/records/atlas-2020-GamGam.json
@@ -19,8 +19,12 @@
     ],
     "date_published": "2020",
     "distribution": {
-      "number_files": 1,
-      "size": 1593950859
+      "formats": [
+        "root",
+        "zip"
+      ],
+      "number_files": 10,
+      "size": 3709990685
     },
     "doi": "10.7483/OPENDATA.ATLAS.B5BJ.3SGS",
     "experiment": [
@@ -31,6 +35,51 @@
         "checksum": "adler32:d880482c",
         "size": 1593950859,
         "uri": "root://eospublic.cern.ch//eos/opendata/atlas/OutreachDatasets/2020-08-19/GamGam.zip"
+      },
+      {
+        "checksum": "adler32:29634ba7",
+        "size": 81250713,
+        "uri": "root://eospublic.cern.ch//eos/opendata/atlas/OutreachDatasets/2020-08-19/GamGam/Data/data_A.GamGam.root"
+      },
+      {
+        "checksum": "adler32:afaa0bed",
+        "size": 289902606,
+        "uri": "root://eospublic.cern.ch//eos/opendata/atlas/OutreachDatasets/2020-08-19/GamGam/Data/data_B.GamGam.root"
+      },
+      {
+        "checksum": "adler32:46c10b74",
+        "size": 424774751,
+        "uri": "root://eospublic.cern.ch//eos/opendata/atlas/OutreachDatasets/2020-08-19/GamGam/Data/data_C.GamGam.root"
+      },
+      {
+        "checksum": "adler32:3c5ca072",
+        "size": 686798449,
+        "uri": "root://eospublic.cern.ch//eos/opendata/atlas/OutreachDatasets/2020-08-19/GamGam/Data/data_D.GamGam.root"
+      },
+      {
+        "checksum": "adler32:f76530f0",
+        "size": 217819076,
+        "uri": "root://eospublic.cern.ch//eos/opendata/atlas/OutreachDatasets/2020-08-19/GamGam/MC/mc_341081.ttH125_gamgam.GamGam.root"
+      },
+      {
+        "checksum": "adler32:5b858188",
+        "size": 218418347,
+        "uri": "root://eospublic.cern.ch//eos/opendata/atlas/OutreachDatasets/2020-08-19/GamGam/MC/mc_343981.ggH125_gamgam.GamGam.root"
+      },
+      {
+        "checksum": "adler32:8cff2e38",
+        "size": 108616148,
+        "uri": "root://eospublic.cern.ch//eos/opendata/atlas/OutreachDatasets/2020-08-19/GamGam/MC/mc_345041.VBFH125_gamgam.GamGam.root"
+      },
+      {
+        "checksum": "adler32:5ac6bca3",
+        "size": 29757932,
+        "uri": "root://eospublic.cern.ch//eos/opendata/atlas/OutreachDatasets/2020-08-19/GamGam/MC/mc_345318.WpH125J_Wincl_gamgam.GamGam.root"
+      },
+      {
+        "checksum": "adler32:6b506f04",
+        "size": 58701804,
+        "uri": "root://eospublic.cern.ch//eos/opendata/atlas/OutreachDatasets/2020-08-19/GamGam/MC/mc_345319.ZH125J_Zincl_gamgam.GamGam.root"
       }
     ],
     "license": {
@@ -53,7 +102,7 @@
       ]
     },
     "usage": {
-      "description": "This dataset is provided by the ATLAS Collaboration <strong>only for educational purposes and is not suited for scientific publications</strong>.\n You can access these data through the ATLAS Virtual Machine and Software.\n More documentation is available at:",
+      "description": "<p>This dataset is provided as a zipped tarball (<code>GamGam.zip</code>) and as a list of unzipped individually-accessible ROOT files containing the collision data (such as <code>data_A.GamGam.root</code>) and the simulated data (such as <code>mc_341081.ttH125_gamgam.GamGam.root</code>). You can use either the tarball or the individual ROOT files.</p> <p>This dataset is provided by the ATLAS Collaboration <strong>only for educational purposes and is not suited for scientific publications</strong>.\n You can access these data through the ATLAS Virtual Machine and Software.\n More documentation is available at:</p>",
       "links": [
         {
           "description": "The ATLAS Open Data documentation for 13 TeV release",

--- a/data/records/atlas-2020-exactly2lep.json
+++ b/data/records/atlas-2020-exactly2lep.json
@@ -19,8 +19,12 @@
     ],
     "date_published": "2020",
     "distribution": {
-      "number_files": 1,
-      "size": 22407459332
+      "formats": [
+        "root",
+        "zip"
+      ],
+      "number_files": 210,
+      "size": 51231798849
     },
     "doi": "10.7483/OPENDATA.ATLAS.OHZ7.RFNH",
     "experiment": [
@@ -31,6 +35,1051 @@
         "checksum": "adler32:fe5d6c07",
         "size": 22407459332,
         "uri": "root://eospublic.cern.ch//eos/opendata/atlas/OutreachDatasets/2020-08-19/exactly2lep.zip"
+      },
+      {
+        "checksum": "adler32:05a9f0af",
+        "size": 128065605,
+        "uri": "root://eospublic.cern.ch//eos/opendata/atlas/OutreachDatasets/2020-08-19/exactly2lep/Data/data_A.exactly2lep.root"
+      },
+      {
+        "checksum": "adler32:36830051",
+        "size": 472747051,
+        "uri": "root://eospublic.cern.ch//eos/opendata/atlas/OutreachDatasets/2020-08-19/exactly2lep/Data/data_B.exactly2lep.root"
+      },
+      {
+        "checksum": "adler32:4ad53d8b",
+        "size": 688964556,
+        "uri": "root://eospublic.cern.ch//eos/opendata/atlas/OutreachDatasets/2020-08-19/exactly2lep/Data/data_C.exactly2lep.root"
+      },
+      {
+        "checksum": "adler32:93d0cf3c",
+        "size": 1058407534,
+        "uri": "root://eospublic.cern.ch//eos/opendata/atlas/OutreachDatasets/2020-08-19/exactly2lep/Data/data_D.exactly2lep.root"
+      },
+      {
+        "checksum": "adler32:a867ac03",
+        "size": 3624784,
+        "uri": "root://eospublic.cern.ch//eos/opendata/atlas/OutreachDatasets/2020-08-19/exactly2lep/MC/mc_301215.ZPrime2000_ee.exactly2lep.root"
+      },
+      {
+        "checksum": "adler32:4b5511c7",
+        "size": 3655506,
+        "uri": "root://eospublic.cern.ch//eos/opendata/atlas/OutreachDatasets/2020-08-19/exactly2lep/MC/mc_301216.ZPrime3000_ee.exactly2lep.root"
+      },
+      {
+        "checksum": "adler32:10e2bd09",
+        "size": 3643767,
+        "uri": "root://eospublic.cern.ch//eos/opendata/atlas/OutreachDatasets/2020-08-19/exactly2lep/MC/mc_301217.ZPrime4000_ee.exactly2lep.root"
+      },
+      {
+        "checksum": "adler32:59388a4c",
+        "size": 3055306,
+        "uri": "root://eospublic.cern.ch//eos/opendata/atlas/OutreachDatasets/2020-08-19/exactly2lep/MC/mc_301218.ZPrime5000_ee.exactly2lep.root"
+      },
+      {
+        "checksum": "adler32:7d0e9f8d",
+        "size": 119085223,
+        "uri": "root://eospublic.cern.ch//eos/opendata/atlas/OutreachDatasets/2020-08-19/exactly2lep/MC/mc_301220.ZPrime2000_mumu.exactly2lep.root"
+      },
+      {
+        "checksum": "adler32:af5820c4",
+        "size": 117285561,
+        "uri": "root://eospublic.cern.ch//eos/opendata/atlas/OutreachDatasets/2020-08-19/exactly2lep/MC/mc_301221.ZPrime3000_mumu.exactly2lep.root"
+      },
+      {
+        "checksum": "adler32:ec11831a",
+        "size": 113590806,
+        "uri": "root://eospublic.cern.ch//eos/opendata/atlas/OutreachDatasets/2020-08-19/exactly2lep/MC/mc_301222.ZPrime4000_mumu.exactly2lep.root"
+      },
+      {
+        "checksum": "adler32:b2b4ad19",
+        "size": 110909347,
+        "uri": "root://eospublic.cern.ch//eos/opendata/atlas/OutreachDatasets/2020-08-19/exactly2lep/MC/mc_301223.ZPrime5000_mumu.exactly2lep.root"
+      },
+      {
+        "checksum": "adler32:569fe2b1",
+        "size": 1690560,
+        "uri": "root://eospublic.cern.ch//eos/opendata/atlas/OutreachDatasets/2020-08-19/exactly2lep/MC/mc_301322.ZPrime400_tt.exactly2lep.root"
+      },
+      {
+        "checksum": "adler32:ed1985b9",
+        "size": 1876489,
+        "uri": "root://eospublic.cern.ch//eos/opendata/atlas/OutreachDatasets/2020-08-19/exactly2lep/MC/mc_301323.ZPrime500_tt.exactly2lep.root"
+      },
+      {
+        "checksum": "adler32:92a01c95",
+        "size": 2033418,
+        "uri": "root://eospublic.cern.ch//eos/opendata/atlas/OutreachDatasets/2020-08-19/exactly2lep/MC/mc_301324.ZPrime750_tt.exactly2lep.root"
+      },
+      {
+        "checksum": "adler32:4090ae9f",
+        "size": 2037493,
+        "uri": "root://eospublic.cern.ch//eos/opendata/atlas/OutreachDatasets/2020-08-19/exactly2lep/MC/mc_301325.ZPrime1000_tt.exactly2lep.root"
+      },
+      {
+        "checksum": "adler32:79071dcf",
+        "size": 1902532,
+        "uri": "root://eospublic.cern.ch//eos/opendata/atlas/OutreachDatasets/2020-08-19/exactly2lep/MC/mc_301326.ZPrime1250_tt.exactly2lep.root"
+      },
+      {
+        "checksum": "adler32:46650930",
+        "size": 1731958,
+        "uri": "root://eospublic.cern.ch//eos/opendata/atlas/OutreachDatasets/2020-08-19/exactly2lep/MC/mc_301327.ZPrime1500_tt.exactly2lep.root"
+      },
+      {
+        "checksum": "adler32:ef67b35e",
+        "size": 1582279,
+        "uri": "root://eospublic.cern.ch//eos/opendata/atlas/OutreachDatasets/2020-08-19/exactly2lep/MC/mc_301328.ZPrime1750_tt.exactly2lep.root"
+      },
+      {
+        "checksum": "adler32:57e0e3e1",
+        "size": 1424195,
+        "uri": "root://eospublic.cern.ch//eos/opendata/atlas/OutreachDatasets/2020-08-19/exactly2lep/MC/mc_301329.ZPrime2000_tt.exactly2lep.root"
+      },
+      {
+        "checksum": "adler32:09f422bf",
+        "size": 1242212,
+        "uri": "root://eospublic.cern.ch//eos/opendata/atlas/OutreachDatasets/2020-08-19/exactly2lep/MC/mc_301330.ZPrime2250_tt.exactly2lep.root"
+      },
+      {
+        "checksum": "adler32:bda537f0",
+        "size": 1118948,
+        "uri": "root://eospublic.cern.ch//eos/opendata/atlas/OutreachDatasets/2020-08-19/exactly2lep/MC/mc_301331.ZPrime2500_tt.exactly2lep.root"
+      },
+      {
+        "checksum": "adler32:04e26191",
+        "size": 1052989,
+        "uri": "root://eospublic.cern.ch//eos/opendata/atlas/OutreachDatasets/2020-08-19/exactly2lep/MC/mc_301332.ZPrime2750_tt.exactly2lep.root"
+      },
+      {
+        "checksum": "adler32:eef55c59",
+        "size": 914876,
+        "uri": "root://eospublic.cern.ch//eos/opendata/atlas/OutreachDatasets/2020-08-19/exactly2lep/MC/mc_301333.ZPrime3000_tt.exactly2lep.root"
+      },
+      {
+        "checksum": "adler32:75c396c0",
+        "size": 796610,
+        "uri": "root://eospublic.cern.ch//eos/opendata/atlas/OutreachDatasets/2020-08-19/exactly2lep/MC/mc_303511.dmV_Zll_MET40_DM1_MM10.exactly2lep.root"
+      },
+      {
+        "checksum": "adler32:cf34cccd",
+        "size": 969604,
+        "uri": "root://eospublic.cern.ch//eos/opendata/atlas/OutreachDatasets/2020-08-19/exactly2lep/MC/mc_303512.dmV_Zll_MET40_DM1_MM100.exactly2lep.root"
+      },
+      {
+        "checksum": "adler32:f03a0d7c",
+        "size": 1154730,
+        "uri": "root://eospublic.cern.ch//eos/opendata/atlas/OutreachDatasets/2020-08-19/exactly2lep/MC/mc_303513.dmV_Zll_MET40_DM1_MM300.exactly2lep.root"
+      },
+      {
+        "checksum": "adler32:4a788c5a",
+        "size": 1368176,
+        "uri": "root://eospublic.cern.ch//eos/opendata/atlas/OutreachDatasets/2020-08-19/exactly2lep/MC/mc_303514.dmV_Zll_MET40_DM1_MM2000.exactly2lep.root"
+      },
+      {
+        "checksum": "adler32:8a9d6279",
+        "size": 7091664,
+        "uri": "root://eospublic.cern.ch//eos/opendata/atlas/OutreachDatasets/2020-08-19/exactly2lep/MC/mc_305550.Gee_01_750.exactly2lep.root"
+      },
+      {
+        "checksum": "adler32:62dfdc24",
+        "size": 6757559,
+        "uri": "root://eospublic.cern.ch//eos/opendata/atlas/OutreachDatasets/2020-08-19/exactly2lep/MC/mc_305553.Gee_01_1000.exactly2lep.root"
+      },
+      {
+        "checksum": "adler32:aab37e67",
+        "size": 6531977,
+        "uri": "root://eospublic.cern.ch//eos/opendata/atlas/OutreachDatasets/2020-08-19/exactly2lep/MC/mc_305556.Gee_01_2000.exactly2lep.root"
+      },
+      {
+        "checksum": "adler32:b71fcab7",
+        "size": 6424429,
+        "uri": "root://eospublic.cern.ch//eos/opendata/atlas/OutreachDatasets/2020-08-19/exactly2lep/MC/mc_305559.Gee_01_3000.exactly2lep.root"
+      },
+      {
+        "checksum": "adler32:a0de9c10",
+        "size": 6228732,
+        "uri": "root://eospublic.cern.ch//eos/opendata/atlas/OutreachDatasets/2020-08-19/exactly2lep/MC/mc_305562.Gee_01_4000.exactly2lep.root"
+      },
+      {
+        "checksum": "adler32:aa6cd3e6",
+        "size": 7233937,
+        "uri": "root://eospublic.cern.ch//eos/opendata/atlas/OutreachDatasets/2020-08-19/exactly2lep/MC/mc_305568.Gmumu_01_750.exactly2lep.root"
+      },
+      {
+        "checksum": "adler32:b39b5c99",
+        "size": 7162239,
+        "uri": "root://eospublic.cern.ch//eos/opendata/atlas/OutreachDatasets/2020-08-19/exactly2lep/MC/mc_305571.Gmumu_01_1000.exactly2lep.root"
+      },
+      {
+        "checksum": "adler32:4b6eeb57",
+        "size": 6819186,
+        "uri": "root://eospublic.cern.ch//eos/opendata/atlas/OutreachDatasets/2020-08-19/exactly2lep/MC/mc_305574.Gmumu_01_2000.exactly2lep.root"
+      },
+      {
+        "checksum": "adler32:8ab126c2",
+        "size": 6526231,
+        "uri": "root://eospublic.cern.ch//eos/opendata/atlas/OutreachDatasets/2020-08-19/exactly2lep/MC/mc_305577.Gmumu_01_3000.exactly2lep.root"
+      },
+      {
+        "checksum": "adler32:b6fbe68a",
+        "size": 6068225,
+        "uri": "root://eospublic.cern.ch//eos/opendata/atlas/OutreachDatasets/2020-08-19/exactly2lep/MC/mc_305580.Gmumu_01_4000.exactly2lep.root"
+      },
+      {
+        "checksum": "adler32:106488b9",
+        "size": 1213815,
+        "uri": "root://eospublic.cern.ch//eos/opendata/atlas/OutreachDatasets/2020-08-19/exactly2lep/MC/mc_305710.dmV_Zll_MET40_DM1_MM500.exactly2lep.root"
+      },
+      {
+        "checksum": "adler32:1ae8cbba",
+        "size": 1290136,
+        "uri": "root://eospublic.cern.ch//eos/opendata/atlas/OutreachDatasets/2020-08-19/exactly2lep/MC/mc_305711.dmV_Zll_MET40_DM1_MM700.exactly2lep.root"
+      },
+      {
+        "checksum": "adler32:86e14239",
+        "size": 1072063,
+        "uri": "root://eospublic.cern.ch//eos/opendata/atlas/OutreachDatasets/2020-08-19/exactly2lep/MC/mc_306085.dmV_Zll_MET40_DM1_MM200.exactly2lep.root"
+      },
+      {
+        "checksum": "adler32:6aeafa83",
+        "size": 1181982,
+        "uri": "root://eospublic.cern.ch//eos/opendata/atlas/OutreachDatasets/2020-08-19/exactly2lep/MC/mc_306093.dmV_Zll_MET40_DM1_MM400.exactly2lep.root"
+      },
+      {
+        "checksum": "adler32:b45ab537",
+        "size": 1261306,
+        "uri": "root://eospublic.cern.ch//eos/opendata/atlas/OutreachDatasets/2020-08-19/exactly2lep/MC/mc_306103.dmV_Zll_MET40_DM1_MM600.exactly2lep.root"
+      },
+      {
+        "checksum": "adler32:d1acd85d",
+        "size": 1287205,
+        "uri": "root://eospublic.cern.ch//eos/opendata/atlas/OutreachDatasets/2020-08-19/exactly2lep/MC/mc_306109.dmV_Zll_MET40_DM1_MM800.exactly2lep.root"
+      },
+      {
+        "checksum": "adler32:c10983cc",
+        "size": 25572368,
+        "uri": "root://eospublic.cern.ch//eos/opendata/atlas/OutreachDatasets/2020-08-19/exactly2lep/MC/mc_341122.ggH125_tautaull.exactly2lep.root"
+      },
+      {
+        "checksum": "adler32:ebcca9db",
+        "size": 96463881,
+        "uri": "root://eospublic.cern.ch//eos/opendata/atlas/OutreachDatasets/2020-08-19/exactly2lep/MC/mc_341155.VBFH125_tautaull.exactly2lep.root"
+      },
+      {
+        "checksum": "adler32:6fb4cb22",
+        "size": 101359621,
+        "uri": "root://eospublic.cern.ch//eos/opendata/atlas/OutreachDatasets/2020-08-19/exactly2lep/MC/mc_345323.VBFH125_WW2lep.exactly2lep.root"
+      },
+      {
+        "checksum": "adler32:ea6fa112",
+        "size": 144195912,
+        "uri": "root://eospublic.cern.ch//eos/opendata/atlas/OutreachDatasets/2020-08-19/exactly2lep/MC/mc_345324.ggH125_WW2lep.exactly2lep.root"
+      },
+      {
+        "checksum": "adler32:6b3529f7",
+        "size": 12441908,
+        "uri": "root://eospublic.cern.ch//eos/opendata/atlas/OutreachDatasets/2020-08-19/exactly2lep/MC/mc_345325.WpH125J_qqWW2lep.exactly2lep.root"
+      },
+      {
+        "checksum": "adler32:bcdfdce3",
+        "size": 11503924,
+        "uri": "root://eospublic.cern.ch//eos/opendata/atlas/OutreachDatasets/2020-08-19/exactly2lep/MC/mc_345336.ZH125J_qqWW2lep.exactly2lep.root"
+      },
+      {
+        "checksum": "adler32:c21ab4be",
+        "size": 9975731,
+        "uri": "root://eospublic.cern.ch//eos/opendata/atlas/OutreachDatasets/2020-08-19/exactly2lep/MC/mc_345445.ZH125J_vvWW2lep.exactly2lep.root"
+      },
+      {
+        "checksum": "adler32:1822bb7a",
+        "size": 9586852,
+        "uri": "root://eospublic.cern.ch//eos/opendata/atlas/OutreachDatasets/2020-08-19/exactly2lep/MC/mc_361100.Wplusenu.exactly2lep.root"
+      },
+      {
+        "checksum": "adler32:0ff7ba62",
+        "size": 8083614,
+        "uri": "root://eospublic.cern.ch//eos/opendata/atlas/OutreachDatasets/2020-08-19/exactly2lep/MC/mc_361101.Wplusmunu.exactly2lep.root"
+      },
+      {
+        "checksum": "adler32:f20b8204",
+        "size": 441877,
+        "uri": "root://eospublic.cern.ch//eos/opendata/atlas/OutreachDatasets/2020-08-19/exactly2lep/MC/mc_361102.Wplustaunu.exactly2lep.root"
+      },
+      {
+        "checksum": "adler32:7a21da31",
+        "size": 7372178,
+        "uri": "root://eospublic.cern.ch//eos/opendata/atlas/OutreachDatasets/2020-08-19/exactly2lep/MC/mc_361103.Wminusenu.exactly2lep.root"
+      },
+      {
+        "checksum": "adler32:aeea18f1",
+        "size": 6987682,
+        "uri": "root://eospublic.cern.ch//eos/opendata/atlas/OutreachDatasets/2020-08-19/exactly2lep/MC/mc_361104.Wminusmunu.exactly2lep.root"
+      },
+      {
+        "checksum": "adler32:a1c0d297",
+        "size": 359219,
+        "uri": "root://eospublic.cern.ch//eos/opendata/atlas/OutreachDatasets/2020-08-19/exactly2lep/MC/mc_361105.Wminustaunu.exactly2lep.root"
+      },
+      {
+        "checksum": "adler32:e4f23583",
+        "size": 4548214140,
+        "uri": "root://eospublic.cern.ch//eos/opendata/atlas/OutreachDatasets/2020-08-19/exactly2lep/MC/mc_361106.Zee.exactly2lep.root"
+      },
+      {
+        "checksum": "adler32:cbdb1ae1",
+        "size": 4571370389,
+        "uri": "root://eospublic.cern.ch//eos/opendata/atlas/OutreachDatasets/2020-08-19/exactly2lep/MC/mc_361107.Zmumu.exactly2lep.root"
+      },
+      {
+        "checksum": "adler32:2a81a9f7",
+        "size": 39711265,
+        "uri": "root://eospublic.cern.ch//eos/opendata/atlas/OutreachDatasets/2020-08-19/exactly2lep/MC/mc_361108.Ztautau.exactly2lep.root"
+      },
+      {
+        "checksum": "adler32:dd161c05",
+        "size": 368209489,
+        "uri": "root://eospublic.cern.ch//eos/opendata/atlas/OutreachDatasets/2020-08-19/exactly2lep/MC/mc_363356.ZqqZll.exactly2lep.root"
+      },
+      {
+        "checksum": "adler32:62b6c33a",
+        "size": 349838784,
+        "uri": "root://eospublic.cern.ch//eos/opendata/atlas/OutreachDatasets/2020-08-19/exactly2lep/MC/mc_363358.WqqZll.exactly2lep.root"
+      },
+      {
+        "checksum": "adler32:18659c9f",
+        "size": 3784205,
+        "uri": "root://eospublic.cern.ch//eos/opendata/atlas/OutreachDatasets/2020-08-19/exactly2lep/MC/mc_363359.WpqqWmlv.exactly2lep.root"
+      },
+      {
+        "checksum": "adler32:4899e2a1",
+        "size": 4023321,
+        "uri": "root://eospublic.cern.ch//eos/opendata/atlas/OutreachDatasets/2020-08-19/exactly2lep/MC/mc_363360.WplvWmqq.exactly2lep.root"
+      },
+      {
+        "checksum": "adler32:05aebf33",
+        "size": 7919467,
+        "uri": "root://eospublic.cern.ch//eos/opendata/atlas/OutreachDatasets/2020-08-19/exactly2lep/MC/mc_363489.WlvZqq.exactly2lep.root"
+      },
+      {
+        "checksum": "adler32:08b6c66b",
+        "size": 614968576,
+        "uri": "root://eospublic.cern.ch//eos/opendata/atlas/OutreachDatasets/2020-08-19/exactly2lep/MC/mc_363490.llll.exactly2lep.root"
+      },
+      {
+        "checksum": "adler32:533f407c",
+        "size": 636304344,
+        "uri": "root://eospublic.cern.ch//eos/opendata/atlas/OutreachDatasets/2020-08-19/exactly2lep/MC/mc_363491.lllv.exactly2lep.root"
+      },
+      {
+        "checksum": "adler32:e1d4622b",
+        "size": 851328260,
+        "uri": "root://eospublic.cern.ch//eos/opendata/atlas/OutreachDatasets/2020-08-19/exactly2lep/MC/mc_363492.llvv.exactly2lep.root"
+      },
+      {
+        "checksum": "adler32:86aeca92",
+        "size": 3348479,
+        "uri": "root://eospublic.cern.ch//eos/opendata/atlas/OutreachDatasets/2020-08-19/exactly2lep/MC/mc_363493.lvvv.exactly2lep.root"
+      },
+      {
+        "checksum": "adler32:a3848350",
+        "size": 442447677,
+        "uri": "root://eospublic.cern.ch//eos/opendata/atlas/OutreachDatasets/2020-08-19/exactly2lep/MC/mc_364100.Zmumu_PTV0_70_CVetoBVeto.exactly2lep.root"
+      },
+      {
+        "checksum": "adler32:3b365629",
+        "size": 313328617,
+        "uri": "root://eospublic.cern.ch//eos/opendata/atlas/OutreachDatasets/2020-08-19/exactly2lep/MC/mc_364101.Zmumu_PTV0_70_CFilterBVeto.exactly2lep.root"
+      },
+      {
+        "checksum": "adler32:0c032454",
+        "size": 546324445,
+        "uri": "root://eospublic.cern.ch//eos/opendata/atlas/OutreachDatasets/2020-08-19/exactly2lep/MC/mc_364102.Zmumu_PTV0_70_BFilter.exactly2lep.root"
+      },
+      {
+        "checksum": "adler32:0311f137",
+        "size": 459285654,
+        "uri": "root://eospublic.cern.ch//eos/opendata/atlas/OutreachDatasets/2020-08-19/exactly2lep/MC/mc_364103.Zmumu_PTV70_140_CVetoBVeto.exactly2lep.root"
+      },
+      {
+        "checksum": "adler32:257d5eb4",
+        "size": 162162395,
+        "uri": "root://eospublic.cern.ch//eos/opendata/atlas/OutreachDatasets/2020-08-19/exactly2lep/MC/mc_364104.Zmumu_PTV70_140_CFilterBVeto.exactly2lep.root"
+      },
+      {
+        "checksum": "adler32:fed5468c",
+        "size": 504635076,
+        "uri": "root://eospublic.cern.ch//eos/opendata/atlas/OutreachDatasets/2020-08-19/exactly2lep/MC/mc_364105.Zmumu_PTV70_140_BFilter.exactly2lep.root"
+      },
+      {
+        "checksum": "adler32:f7f63aba",
+        "size": 448165172,
+        "uri": "root://eospublic.cern.ch//eos/opendata/atlas/OutreachDatasets/2020-08-19/exactly2lep/MC/mc_364106.Zmumu_PTV140_280_CVetoBVeto.exactly2lep.root"
+      },
+      {
+        "checksum": "adler32:604f2507",
+        "size": 277005727,
+        "uri": "root://eospublic.cern.ch//eos/opendata/atlas/OutreachDatasets/2020-08-19/exactly2lep/MC/mc_364107.Zmumu_PTV140_280_CFilterBVeto.exactly2lep.root"
+      },
+      {
+        "checksum": "adler32:292ce53a",
+        "size": 1143271222,
+        "uri": "root://eospublic.cern.ch//eos/opendata/atlas/OutreachDatasets/2020-08-19/exactly2lep/MC/mc_364108.Zmumu_PTV140_280_BFilter.exactly2lep.root"
+      },
+      {
+        "checksum": "adler32:498790e8",
+        "size": 201650253,
+        "uri": "root://eospublic.cern.ch//eos/opendata/atlas/OutreachDatasets/2020-08-19/exactly2lep/MC/mc_364109.Zmumu_PTV280_500_CVetoBVeto.exactly2lep.root"
+      },
+      {
+        "checksum": "adler32:29148634",
+        "size": 102532518,
+        "uri": "root://eospublic.cern.ch//eos/opendata/atlas/OutreachDatasets/2020-08-19/exactly2lep/MC/mc_364110.Zmumu_PTV280_500_CFilterBVeto.exactly2lep.root"
+      },
+      {
+        "checksum": "adler32:2274cd25",
+        "size": 207884514,
+        "uri": "root://eospublic.cern.ch//eos/opendata/atlas/OutreachDatasets/2020-08-19/exactly2lep/MC/mc_364111.Zmumu_PTV280_500_BFilter.exactly2lep.root"
+      },
+      {
+        "checksum": "adler32:882c594d",
+        "size": 328232948,
+        "uri": "root://eospublic.cern.ch//eos/opendata/atlas/OutreachDatasets/2020-08-19/exactly2lep/MC/mc_364112.Zmumu_PTV500_1000.exactly2lep.root"
+      },
+      {
+        "checksum": "adler32:70bbece3",
+        "size": 115575139,
+        "uri": "root://eospublic.cern.ch//eos/opendata/atlas/OutreachDatasets/2020-08-19/exactly2lep/MC/mc_364113.Zmumu_PTV1000_E_CMS.exactly2lep.root"
+      },
+      {
+        "checksum": "adler32:9f927910",
+        "size": 428470646,
+        "uri": "root://eospublic.cern.ch//eos/opendata/atlas/OutreachDatasets/2020-08-19/exactly2lep/MC/mc_364114.Zee_PTV0_70_CVetoBVeto.exactly2lep.root"
+      },
+      {
+        "checksum": "adler32:3c85533a",
+        "size": 320620070,
+        "uri": "root://eospublic.cern.ch//eos/opendata/atlas/OutreachDatasets/2020-08-19/exactly2lep/MC/mc_364115.Zee_PTV0_70_CFilterBVeto.exactly2lep.root"
+      },
+      {
+        "checksum": "adler32:fd015f28",
+        "size": 559401835,
+        "uri": "root://eospublic.cern.ch//eos/opendata/atlas/OutreachDatasets/2020-08-19/exactly2lep/MC/mc_364116.Zee_PTV0_70_BFilter.exactly2lep.root"
+      },
+      {
+        "checksum": "adler32:8b473ee1",
+        "size": 533892972,
+        "uri": "root://eospublic.cern.ch//eos/opendata/atlas/OutreachDatasets/2020-08-19/exactly2lep/MC/mc_364117.Zee_PTV70_140_CVetoBVeto.exactly2lep.root"
+      },
+      {
+        "checksum": "adler32:605278f2",
+        "size": 193846975,
+        "uri": "root://eospublic.cern.ch//eos/opendata/atlas/OutreachDatasets/2020-08-19/exactly2lep/MC/mc_364118.Zee_PTV70_140_CFilterBVeto.exactly2lep.root"
+      },
+      {
+        "checksum": "adler32:3f2387db",
+        "size": 603090565,
+        "uri": "root://eospublic.cern.ch//eos/opendata/atlas/OutreachDatasets/2020-08-19/exactly2lep/MC/mc_364119.Zee_PTV70_140_BFilter.exactly2lep.root"
+      },
+      {
+        "checksum": "adler32:2db22cfd",
+        "size": 543998211,
+        "uri": "root://eospublic.cern.ch//eos/opendata/atlas/OutreachDatasets/2020-08-19/exactly2lep/MC/mc_364120.Zee_PTV140_280_CVetoBVeto.exactly2lep.root"
+      },
+      {
+        "checksum": "adler32:7aefa01d",
+        "size": 338376640,
+        "uri": "root://eospublic.cern.ch//eos/opendata/atlas/OutreachDatasets/2020-08-19/exactly2lep/MC/mc_364121.Zee_PTV140_280_CFilterBVeto.exactly2lep.root"
+      },
+      {
+        "checksum": "adler32:50a3ba9d",
+        "size": 1439230964,
+        "uri": "root://eospublic.cern.ch//eos/opendata/atlas/OutreachDatasets/2020-08-19/exactly2lep/MC/mc_364122.Zee_PTV140_280_BFilter.exactly2lep.root"
+      },
+      {
+        "checksum": "adler32:c12005e0",
+        "size": 241026565,
+        "uri": "root://eospublic.cern.ch//eos/opendata/atlas/OutreachDatasets/2020-08-19/exactly2lep/MC/mc_364123.Zee_PTV280_500_CVetoBVeto.exactly2lep.root"
+      },
+      {
+        "checksum": "adler32:f83c743f",
+        "size": 127872713,
+        "uri": "root://eospublic.cern.ch//eos/opendata/atlas/OutreachDatasets/2020-08-19/exactly2lep/MC/mc_364124.Zee_PTV280_500_CFilterBVeto.exactly2lep.root"
+      },
+      {
+        "checksum": "adler32:3cffdfc4",
+        "size": 263663611,
+        "uri": "root://eospublic.cern.ch//eos/opendata/atlas/OutreachDatasets/2020-08-19/exactly2lep/MC/mc_364125.Zee_PTV280_500_BFilter.exactly2lep.root"
+      },
+      {
+        "checksum": "adler32:bc6dfea9",
+        "size": 412959314,
+        "uri": "root://eospublic.cern.ch//eos/opendata/atlas/OutreachDatasets/2020-08-19/exactly2lep/MC/mc_364126.Zee_PTV500_1000.exactly2lep.root"
+      },
+      {
+        "checksum": "adler32:327c9137",
+        "size": 147100028,
+        "uri": "root://eospublic.cern.ch//eos/opendata/atlas/OutreachDatasets/2020-08-19/exactly2lep/MC/mc_364127.Zee_PTV1000_E_CMS.exactly2lep.root"
+      },
+      {
+        "checksum": "adler32:5cace483",
+        "size": 10387787,
+        "uri": "root://eospublic.cern.ch//eos/opendata/atlas/OutreachDatasets/2020-08-19/exactly2lep/MC/mc_364128.Ztautau_PTV0_70_CVetoBVeto.exactly2lep.root"
+      },
+      {
+        "checksum": "adler32:d824eaa4",
+        "size": 7724414,
+        "uri": "root://eospublic.cern.ch//eos/opendata/atlas/OutreachDatasets/2020-08-19/exactly2lep/MC/mc_364129.Ztautau_PTV0_70_CFilterBVeto.exactly2lep.root"
+      },
+      {
+        "checksum": "adler32:83e5dbe9",
+        "size": 14447738,
+        "uri": "root://eospublic.cern.ch//eos/opendata/atlas/OutreachDatasets/2020-08-19/exactly2lep/MC/mc_364130.Ztautau_PTV0_70_BFilter.exactly2lep.root"
+      },
+      {
+        "checksum": "adler32:feba7ba8",
+        "size": 17160169,
+        "uri": "root://eospublic.cern.ch//eos/opendata/atlas/OutreachDatasets/2020-08-19/exactly2lep/MC/mc_364131.Ztautau_PTV70_140_CVetoBVeto.exactly2lep.root"
+      },
+      {
+        "checksum": "adler32:dcc508cf",
+        "size": 6073929,
+        "uri": "root://eospublic.cern.ch//eos/opendata/atlas/OutreachDatasets/2020-08-19/exactly2lep/MC/mc_364132.Ztautau_PTV70_140_CFilterBVeto.exactly2lep.root"
+      },
+      {
+        "checksum": "adler32:a1622a11",
+        "size": 20555727,
+        "uri": "root://eospublic.cern.ch//eos/opendata/atlas/OutreachDatasets/2020-08-19/exactly2lep/MC/mc_364133.Ztautau_PTV70_140_BFilter.exactly2lep.root"
+      },
+      {
+        "checksum": "adler32:39475c0e",
+        "size": 23513805,
+        "uri": "root://eospublic.cern.ch//eos/opendata/atlas/OutreachDatasets/2020-08-19/exactly2lep/MC/mc_364134.Ztautau_PTV140_280_CVetoBVeto.exactly2lep.root"
+      },
+      {
+        "checksum": "adler32:db0a2983",
+        "size": 14161623,
+        "uri": "root://eospublic.cern.ch//eos/opendata/atlas/OutreachDatasets/2020-08-19/exactly2lep/MC/mc_364135.Ztautau_PTV140_280_CFilterBVeto.exactly2lep.root"
+      },
+      {
+        "checksum": "adler32:555f2857",
+        "size": 25255243,
+        "uri": "root://eospublic.cern.ch//eos/opendata/atlas/OutreachDatasets/2020-08-19/exactly2lep/MC/mc_364136.Ztautau_PTV140_280_BFilter.exactly2lep.root"
+      },
+      {
+        "checksum": "adler32:99b35859",
+        "size": 12314522,
+        "uri": "root://eospublic.cern.ch//eos/opendata/atlas/OutreachDatasets/2020-08-19/exactly2lep/MC/mc_364137.Ztautau_PTV280_500_CVetoBVeto.exactly2lep.root"
+      },
+      {
+        "checksum": "adler32:07d7c1aa",
+        "size": 6114733,
+        "uri": "root://eospublic.cern.ch//eos/opendata/atlas/OutreachDatasets/2020-08-19/exactly2lep/MC/mc_364138.Ztautau_PTV280_500_CFilterBVeto.exactly2lep.root"
+      },
+      {
+        "checksum": "adler32:f11ba4bb",
+        "size": 12876599,
+        "uri": "root://eospublic.cern.ch//eos/opendata/atlas/OutreachDatasets/2020-08-19/exactly2lep/MC/mc_364139.Ztautau_PTV280_500_BFilter.exactly2lep.root"
+      },
+      {
+        "checksum": "adler32:ff11c27b",
+        "size": 19614910,
+        "uri": "root://eospublic.cern.ch//eos/opendata/atlas/OutreachDatasets/2020-08-19/exactly2lep/MC/mc_364140.Ztautau_PTV500_1000.exactly2lep.root"
+      },
+      {
+        "checksum": "adler32:45dc994a",
+        "size": 7599950,
+        "uri": "root://eospublic.cern.ch//eos/opendata/atlas/OutreachDatasets/2020-08-19/exactly2lep/MC/mc_364141.Ztautau_PTV1000_E_CMS.exactly2lep.root"
+      },
+      {
+        "checksum": "adler32:79eb34a1",
+        "size": 7131412,
+        "uri": "root://eospublic.cern.ch//eos/opendata/atlas/OutreachDatasets/2020-08-19/exactly2lep/MC/mc_364156.Wmunu_PTV0_70_CVetoBVeto.exactly2lep.root"
+      },
+      {
+        "checksum": "adler32:1c4215ac",
+        "size": 4657433,
+        "uri": "root://eospublic.cern.ch//eos/opendata/atlas/OutreachDatasets/2020-08-19/exactly2lep/MC/mc_364157.Wmunu_PTV0_70_CFilterBVeto.exactly2lep.root"
+      },
+      {
+        "checksum": "adler32:e14a352b",
+        "size": 12778328,
+        "uri": "root://eospublic.cern.ch//eos/opendata/atlas/OutreachDatasets/2020-08-19/exactly2lep/MC/mc_364158.Wmunu_PTV0_70_BFilter.exactly2lep.root"
+      },
+      {
+        "checksum": "adler32:1c0cf80c",
+        "size": 6481764,
+        "uri": "root://eospublic.cern.ch//eos/opendata/atlas/OutreachDatasets/2020-08-19/exactly2lep/MC/mc_364159.Wmunu_PTV70_140_CVetoBVeto.exactly2lep.root"
+      },
+      {
+        "checksum": "adler32:4708ac02",
+        "size": 6841552,
+        "uri": "root://eospublic.cern.ch//eos/opendata/atlas/OutreachDatasets/2020-08-19/exactly2lep/MC/mc_364160.Wmunu_PTV70_140_CFilterBVeto.exactly2lep.root"
+      },
+      {
+        "checksum": "adler32:592f8ef0",
+        "size": 28515517,
+        "uri": "root://eospublic.cern.ch//eos/opendata/atlas/OutreachDatasets/2020-08-19/exactly2lep/MC/mc_364161.Wmunu_PTV70_140_BFilter.exactly2lep.root"
+      },
+      {
+        "checksum": "adler32:4cd9ee2f",
+        "size": 5095684,
+        "uri": "root://eospublic.cern.ch//eos/opendata/atlas/OutreachDatasets/2020-08-19/exactly2lep/MC/mc_364162.Wmunu_PTV140_280_CVetoBVeto.exactly2lep.root"
+      },
+      {
+        "checksum": "adler32:38e76b43",
+        "size": 5656982,
+        "uri": "root://eospublic.cern.ch//eos/opendata/atlas/OutreachDatasets/2020-08-19/exactly2lep/MC/mc_364163.Wmunu_PTV140_280_CFilterBVeto.exactly2lep.root"
+      },
+      {
+        "checksum": "adler32:b32ac299",
+        "size": 39801766,
+        "uri": "root://eospublic.cern.ch//eos/opendata/atlas/OutreachDatasets/2020-08-19/exactly2lep/MC/mc_364164.Wmunu_PTV140_280_BFilter.exactly2lep.root"
+      },
+      {
+        "checksum": "adler32:63a5a9af",
+        "size": 3048359,
+        "uri": "root://eospublic.cern.ch//eos/opendata/atlas/OutreachDatasets/2020-08-19/exactly2lep/MC/mc_364165.Wmunu_PTV280_500_CVetoBVeto.exactly2lep.root"
+      },
+      {
+        "checksum": "adler32:7a0aa24e",
+        "size": 2502699,
+        "uri": "root://eospublic.cern.ch//eos/opendata/atlas/OutreachDatasets/2020-08-19/exactly2lep/MC/mc_364166.Wmunu_PTV280_500_CFilterBVeto.exactly2lep.root"
+      },
+      {
+        "checksum": "adler32:e6811491",
+        "size": 6697089,
+        "uri": "root://eospublic.cern.ch//eos/opendata/atlas/OutreachDatasets/2020-08-19/exactly2lep/MC/mc_364167.Wmunu_PTV280_500_BFilter.exactly2lep.root"
+      },
+      {
+        "checksum": "adler32:0ce98ef4",
+        "size": 6281409,
+        "uri": "root://eospublic.cern.ch//eos/opendata/atlas/OutreachDatasets/2020-08-19/exactly2lep/MC/mc_364168.Wmunu_PTV500_1000.exactly2lep.root"
+      },
+      {
+        "checksum": "adler32:d18d4b19",
+        "size": 5323067,
+        "uri": "root://eospublic.cern.ch//eos/opendata/atlas/OutreachDatasets/2020-08-19/exactly2lep/MC/mc_364169.Wmunu_PTV1000_E_CMS.exactly2lep.root"
+      },
+      {
+        "checksum": "adler32:38b6e6c6",
+        "size": 7404564,
+        "uri": "root://eospublic.cern.ch//eos/opendata/atlas/OutreachDatasets/2020-08-19/exactly2lep/MC/mc_364170.Wenu_PTV0_70_CVetoBVeto.exactly2lep.root"
+      },
+      {
+        "checksum": "adler32:54235d54",
+        "size": 5318951,
+        "uri": "root://eospublic.cern.ch//eos/opendata/atlas/OutreachDatasets/2020-08-19/exactly2lep/MC/mc_364171.Wenu_PTV0_70_CFilterBVeto.exactly2lep.root"
+      },
+      {
+        "checksum": "adler32:a97d4ddf",
+        "size": 15241067,
+        "uri": "root://eospublic.cern.ch//eos/opendata/atlas/OutreachDatasets/2020-08-19/exactly2lep/MC/mc_364172.Wenu_PTV0_70_BFilter.exactly2lep.root"
+      },
+      {
+        "checksum": "adler32:384485f7",
+        "size": 7439190,
+        "uri": "root://eospublic.cern.ch//eos/opendata/atlas/OutreachDatasets/2020-08-19/exactly2lep/MC/mc_364173.Wenu_PTV70_140_CVetoBVeto.exactly2lep.root"
+      },
+      {
+        "checksum": "adler32:b0934d9e",
+        "size": 8907557,
+        "uri": "root://eospublic.cern.ch//eos/opendata/atlas/OutreachDatasets/2020-08-19/exactly2lep/MC/mc_364174.Wenu_PTV70_140_CFilterBVeto.exactly2lep.root"
+      },
+      {
+        "checksum": "adler32:f96e67b6",
+        "size": 20138699,
+        "uri": "root://eospublic.cern.ch//eos/opendata/atlas/OutreachDatasets/2020-08-19/exactly2lep/MC/mc_364175.Wenu_PTV70_140_BFilter.exactly2lep.root"
+      },
+      {
+        "checksum": "adler32:d6c29b47",
+        "size": 6000679,
+        "uri": "root://eospublic.cern.ch//eos/opendata/atlas/OutreachDatasets/2020-08-19/exactly2lep/MC/mc_364176.Wenu_PTV140_280_CVetoBVeto.exactly2lep.root"
+      },
+      {
+        "checksum": "adler32:b1d01adc",
+        "size": 7554581,
+        "uri": "root://eospublic.cern.ch//eos/opendata/atlas/OutreachDatasets/2020-08-19/exactly2lep/MC/mc_364177.Wenu_PTV140_280_CFilterBVeto.exactly2lep.root"
+      },
+      {
+        "checksum": "adler32:aeb0aa7d",
+        "size": 61319537,
+        "uri": "root://eospublic.cern.ch//eos/opendata/atlas/OutreachDatasets/2020-08-19/exactly2lep/MC/mc_364178.Wenu_PTV140_280_BFilter.exactly2lep.root"
+      },
+      {
+        "checksum": "adler32:c579956d",
+        "size": 3632537,
+        "uri": "root://eospublic.cern.ch//eos/opendata/atlas/OutreachDatasets/2020-08-19/exactly2lep/MC/mc_364179.Wenu_PTV280_500_CVetoBVeto.exactly2lep.root"
+      },
+      {
+        "checksum": "adler32:431bb06f",
+        "size": 3324569,
+        "uri": "root://eospublic.cern.ch//eos/opendata/atlas/OutreachDatasets/2020-08-19/exactly2lep/MC/mc_364180.Wenu_PTV280_500_CFilterBVeto.exactly2lep.root"
+      },
+      {
+        "checksum": "adler32:8d672cda",
+        "size": 9247483,
+        "uri": "root://eospublic.cern.ch//eos/opendata/atlas/OutreachDatasets/2020-08-19/exactly2lep/MC/mc_364181.Wenu_PTV280_500_BFilter.exactly2lep.root"
+      },
+      {
+        "checksum": "adler32:e987660c",
+        "size": 8183498,
+        "uri": "root://eospublic.cern.ch//eos/opendata/atlas/OutreachDatasets/2020-08-19/exactly2lep/MC/mc_364182.Wenu_PTV500_1000.exactly2lep.root"
+      },
+      {
+        "checksum": "adler32:42dd21b7",
+        "size": 6494275,
+        "uri": "root://eospublic.cern.ch//eos/opendata/atlas/OutreachDatasets/2020-08-19/exactly2lep/MC/mc_364183.Wenu_PTV1000_E_CMS.exactly2lep.root"
+      },
+      {
+        "checksum": "adler32:73c060ce",
+        "size": 429607,
+        "uri": "root://eospublic.cern.ch//eos/opendata/atlas/OutreachDatasets/2020-08-19/exactly2lep/MC/mc_364184.Wtaunu_PTV0_70_CVetoBVeto.exactly2lep.root"
+      },
+      {
+        "checksum": "adler32:35b4a778",
+        "size": 367906,
+        "uri": "root://eospublic.cern.ch//eos/opendata/atlas/OutreachDatasets/2020-08-19/exactly2lep/MC/mc_364185.Wtaunu_PTV0_70_CFilterBVeto.exactly2lep.root"
+      },
+      {
+        "checksum": "adler32:1903fb29",
+        "size": 910977,
+        "uri": "root://eospublic.cern.ch//eos/opendata/atlas/OutreachDatasets/2020-08-19/exactly2lep/MC/mc_364186.Wtaunu_PTV0_70_BFilter.exactly2lep.root"
+      },
+      {
+        "checksum": "adler32:e0f59dc0",
+        "size": 769133,
+        "uri": "root://eospublic.cern.ch//eos/opendata/atlas/OutreachDatasets/2020-08-19/exactly2lep/MC/mc_364187.Wtaunu_PTV70_140_CVetoBVeto.exactly2lep.root"
+      },
+      {
+        "checksum": "adler32:230121b5",
+        "size": 896636,
+        "uri": "root://eospublic.cern.ch//eos/opendata/atlas/OutreachDatasets/2020-08-19/exactly2lep/MC/mc_364188.Wtaunu_PTV70_140_CFilterBVeto.exactly2lep.root"
+      },
+      {
+        "checksum": "adler32:259fb265",
+        "size": 1884334,
+        "uri": "root://eospublic.cern.ch//eos/opendata/atlas/OutreachDatasets/2020-08-19/exactly2lep/MC/mc_364189.Wtaunu_PTV70_140_BFilter.exactly2lep.root"
+      },
+      {
+        "checksum": "adler32:25701f57",
+        "size": 793461,
+        "uri": "root://eospublic.cern.ch//eos/opendata/atlas/OutreachDatasets/2020-08-19/exactly2lep/MC/mc_364190.Wtaunu_PTV140_280_CVetoBVeto.exactly2lep.root"
+      },
+      {
+        "checksum": "adler32:76206553",
+        "size": 945794,
+        "uri": "root://eospublic.cern.ch//eos/opendata/atlas/OutreachDatasets/2020-08-19/exactly2lep/MC/mc_364191.Wtaunu_PTV140_280_CFilterBVeto.exactly2lep.root"
+      },
+      {
+        "checksum": "adler32:7e311256",
+        "size": 2975021,
+        "uri": "root://eospublic.cern.ch//eos/opendata/atlas/OutreachDatasets/2020-08-19/exactly2lep/MC/mc_364192.Wtaunu_PTV140_280_BFilter.exactly2lep.root"
+      },
+      {
+        "checksum": "adler32:044dbc72",
+        "size": 547565,
+        "uri": "root://eospublic.cern.ch//eos/opendata/atlas/OutreachDatasets/2020-08-19/exactly2lep/MC/mc_364193.Wtaunu_PTV280_500_CVetoBVeto.exactly2lep.root"
+      },
+      {
+        "checksum": "adler32:bfa9b033",
+        "size": 474712,
+        "uri": "root://eospublic.cern.ch//eos/opendata/atlas/OutreachDatasets/2020-08-19/exactly2lep/MC/mc_364194.Wtaunu_PTV280_500_CFilterBVeto.exactly2lep.root"
+      },
+      {
+        "checksum": "adler32:70f1f680",
+        "size": 1222278,
+        "uri": "root://eospublic.cern.ch//eos/opendata/atlas/OutreachDatasets/2020-08-19/exactly2lep/MC/mc_364195.Wtaunu_PTV280_500_BFilter.exactly2lep.root"
+      },
+      {
+        "checksum": "adler32:011799e7",
+        "size": 1072926,
+        "uri": "root://eospublic.cern.ch//eos/opendata/atlas/OutreachDatasets/2020-08-19/exactly2lep/MC/mc_364196.Wtaunu_PTV500_1000.exactly2lep.root"
+      },
+      {
+        "checksum": "adler32:099ced97",
+        "size": 1081007,
+        "uri": "root://eospublic.cern.ch//eos/opendata/atlas/OutreachDatasets/2020-08-19/exactly2lep/MC/mc_364197.Wtaunu_PTV1000_E_CMS.exactly2lep.root"
+      },
+      {
+        "checksum": "adler32:3afd8264",
+        "size": 4595055,
+        "uri": "root://eospublic.cern.ch//eos/opendata/atlas/OutreachDatasets/2020-08-19/exactly2lep/MC/mc_370114.GG_ttn1_1200_5000_1.exactly2lep.root"
+      },
+      {
+        "checksum": "adler32:f96fb982",
+        "size": 4603971,
+        "uri": "root://eospublic.cern.ch//eos/opendata/atlas/OutreachDatasets/2020-08-19/exactly2lep/MC/mc_370118.GG_ttn1_1200_5000_600.exactly2lep.root"
+      },
+      {
+        "checksum": "adler32:ac104de3",
+        "size": 4424177,
+        "uri": "root://eospublic.cern.ch//eos/opendata/atlas/OutreachDatasets/2020-08-19/exactly2lep/MC/mc_370129.GG_ttn1_1400_5000_1.exactly2lep.root"
+      },
+      {
+        "checksum": "adler32:e5449271",
+        "size": 4258986,
+        "uri": "root://eospublic.cern.ch//eos/opendata/atlas/OutreachDatasets/2020-08-19/exactly2lep/MC/mc_370144.GG_ttn1_1600_5000_1.exactly2lep.root"
+      },
+      {
+        "checksum": "adler32:87ab9d45",
+        "size": 230967,
+        "uri": "root://eospublic.cern.ch//eos/opendata/atlas/OutreachDatasets/2020-08-19/exactly2lep/MC/mc_387154.TT_directTT_500_1.exactly2lep.root"
+      },
+      {
+        "checksum": "adler32:d05b138e",
+        "size": 552202,
+        "uri": "root://eospublic.cern.ch//eos/opendata/atlas/OutreachDatasets/2020-08-19/exactly2lep/MC/mc_387157.TT_directTT_500_200.exactly2lep.root"
+      },
+      {
+        "checksum": "adler32:f849fcab",
+        "size": 548913,
+        "uri": "root://eospublic.cern.ch//eos/opendata/atlas/OutreachDatasets/2020-08-19/exactly2lep/MC/mc_387163.TT_directTT_600_1.exactly2lep.root"
+      },
+      {
+        "checksum": "adler32:286f9683",
+        "size": 523995,
+        "uri": "root://eospublic.cern.ch//eos/opendata/atlas/OutreachDatasets/2020-08-19/exactly2lep/MC/mc_388240.TT_directTT_450_1.exactly2lep.root"
+      },
+      {
+        "checksum": "adler32:c37a216c",
+        "size": 875154,
+        "uri": "root://eospublic.cern.ch//eos/opendata/atlas/OutreachDatasets/2020-08-19/exactly2lep/MC/mc_392302.C1N2_WZ_500p0_100p0_2L2J_2L7.exactly2lep.root"
+      },
+      {
+        "checksum": "adler32:2eb2905c",
+        "size": 1591093,
+        "uri": "root://eospublic.cern.ch//eos/opendata/atlas/OutreachDatasets/2020-08-19/exactly2lep/MC/mc_392304.C1N2_WZ_300p0_100p0_2L2J_2L7.exactly2lep.root"
+      },
+      {
+        "checksum": "adler32:9b75caa4",
+        "size": 1441006,
+        "uri": "root://eospublic.cern.ch//eos/opendata/atlas/OutreachDatasets/2020-08-19/exactly2lep/MC/mc_392308.C1N2_WZ_300p0_200p0_2L2J_2L7.exactly2lep.root"
+      },
+      {
+        "checksum": "adler32:513e496d",
+        "size": 1681899,
+        "uri": "root://eospublic.cern.ch//eos/opendata/atlas/OutreachDatasets/2020-08-19/exactly2lep/MC/mc_392317.C1N2_WZ_400p0_0p0_2L2J_2L7.exactly2lep.root"
+      },
+      {
+        "checksum": "adler32:7fbfda74",
+        "size": 868695,
+        "uri": "root://eospublic.cern.ch//eos/opendata/atlas/OutreachDatasets/2020-08-19/exactly2lep/MC/mc_392323.C1N2_WZ_500p0_0p0_2L2J_2L7.exactly2lep.root"
+      },
+      {
+        "checksum": "adler32:60850616",
+        "size": 1490248,
+        "uri": "root://eospublic.cern.ch//eos/opendata/atlas/OutreachDatasets/2020-08-19/exactly2lep/MC/mc_392324.C1N2_WZ_400p0_300p0_2L2J_2L7.exactly2lep.root"
+      },
+      {
+        "checksum": "adler32:fe670a46",
+        "size": 2728020,
+        "uri": "root://eospublic.cern.ch//eos/opendata/atlas/OutreachDatasets/2020-08-19/exactly2lep/MC/mc_392326.C1N2_WZ_100p0_0p0_2L2J_2L7.exactly2lep.root"
+      },
+      {
+        "checksum": "adler32:4c35fa96",
+        "size": 2839029,
+        "uri": "root://eospublic.cern.ch//eos/opendata/atlas/OutreachDatasets/2020-08-19/exactly2lep/MC/mc_392330.C1N2_WZ_200p0_100p0_2L2J_2L7.exactly2lep.root"
+      },
+      {
+        "checksum": "adler32:68fb9834",
+        "size": 837148,
+        "uri": "root://eospublic.cern.ch//eos/opendata/atlas/OutreachDatasets/2020-08-19/exactly2lep/MC/mc_392332.C1N2_WZ_500p0_300p0_2L2J_2L7.exactly2lep.root"
+      },
+      {
+        "checksum": "adler32:31dae73c",
+        "size": 898086,
+        "uri": "root://eospublic.cern.ch//eos/opendata/atlas/OutreachDatasets/2020-08-19/exactly2lep/MC/mc_392354.C1N2_WZ_600_100_2L2J_2L7.exactly2lep.root"
+      },
+      {
+        "checksum": "adler32:91754990",
+        "size": 904721,
+        "uri": "root://eospublic.cern.ch//eos/opendata/atlas/OutreachDatasets/2020-08-19/exactly2lep/MC/mc_392356.C1N2_WZ_600_0_2L2J_2L7.exactly2lep.root"
+      },
+      {
+        "checksum": "adler32:032ad9af",
+        "size": 726766,
+        "uri": "root://eospublic.cern.ch//eos/opendata/atlas/OutreachDatasets/2020-08-19/exactly2lep/MC/mc_392361.C1N2_WZ_700_400_2L2J_2L7.exactly2lep.root"
+      },
+      {
+        "checksum": "adler32:3145af38",
+        "size": 893678,
+        "uri": "root://eospublic.cern.ch//eos/opendata/atlas/OutreachDatasets/2020-08-19/exactly2lep/MC/mc_392364.C1N2_WZ_700_100_2L2J_2L7.exactly2lep.root"
+      },
+      {
+        "checksum": "adler32:4541687d",
+        "size": 913002,
+        "uri": "root://eospublic.cern.ch//eos/opendata/atlas/OutreachDatasets/2020-08-19/exactly2lep/MC/mc_392365.C1N2_WZ_700_0_2L2J_2L7.exactly2lep.root"
+      },
+      {
+        "checksum": "adler32:02abef9e",
+        "size": 3261551,
+        "uri": "root://eospublic.cern.ch//eos/opendata/atlas/OutreachDatasets/2020-08-19/exactly2lep/MC/mc_392501.C1C1_SlepSnu_x0p50_200p0_100p0_2L8.exactly2lep.root"
+      },
+      {
+        "checksum": "adler32:412929f5",
+        "size": 1119325,
+        "uri": "root://eospublic.cern.ch//eos/opendata/atlas/OutreachDatasets/2020-08-19/exactly2lep/MC/mc_392502.C1C1_SlepSnu_x0p50_200p0_150p0_2L8.exactly2lep.root"
+      },
+      {
+        "checksum": "adler32:b08f3d65",
+        "size": 3759227,
+        "uri": "root://eospublic.cern.ch//eos/opendata/atlas/OutreachDatasets/2020-08-19/exactly2lep/MC/mc_392504.C1C1_SlepSnu_x0p50_300p0_100p0_2L8.exactly2lep.root"
+      },
+      {
+        "checksum": "adler32:f26d22f4",
+        "size": 1132529,
+        "uri": "root://eospublic.cern.ch//eos/opendata/atlas/OutreachDatasets/2020-08-19/exactly2lep/MC/mc_392506.C1C1_SlepSnu_x0p50_300p0_250p0_2L8.exactly2lep.root"
+      },
+      {
+        "checksum": "adler32:d2826c44",
+        "size": 4099887,
+        "uri": "root://eospublic.cern.ch//eos/opendata/atlas/OutreachDatasets/2020-08-19/exactly2lep/MC/mc_392507.C1C1_SlepSnu_x0p50_400p0_100p0_2L8.exactly2lep.root"
+      },
+      {
+        "checksum": "adler32:6e685d8b",
+        "size": 3454790,
+        "uri": "root://eospublic.cern.ch//eos/opendata/atlas/OutreachDatasets/2020-08-19/exactly2lep/MC/mc_392509.C1C1_SlepSnu_x0p50_400p0_300p0_2L8.exactly2lep.root"
+      },
+      {
+        "checksum": "adler32:685c7646",
+        "size": 4079690,
+        "uri": "root://eospublic.cern.ch//eos/opendata/atlas/OutreachDatasets/2020-08-19/exactly2lep/MC/mc_392513.C1C1_SlepSnu_x0p50_500p0_300p0_2L8.exactly2lep.root"
+      },
+      {
+        "checksum": "adler32:24537b0a",
+        "size": 4259274,
+        "uri": "root://eospublic.cern.ch//eos/opendata/atlas/OutreachDatasets/2020-08-19/exactly2lep/MC/mc_392517.C1C1_SlepSnu_x0p50_600p0_300p0_2L8.exactly2lep.root"
+      },
+      {
+        "checksum": "adler32:6df09555",
+        "size": 4335178,
+        "uri": "root://eospublic.cern.ch//eos/opendata/atlas/OutreachDatasets/2020-08-19/exactly2lep/MC/mc_392518.C1C1_SlepSnu_x0p50_700p0_1p0_2L8.exactly2lep.root"
+      },
+      {
+        "checksum": "adler32:cc6b7add",
+        "size": 4333456,
+        "uri": "root://eospublic.cern.ch//eos/opendata/atlas/OutreachDatasets/2020-08-19/exactly2lep/MC/mc_392521.C1C1_SlepSnu_x0p50_700p0_300p0_2L8.exactly2lep.root"
+      },
+      {
+        "checksum": "adler32:db56b6af",
+        "size": 1339650,
+        "uri": "root://eospublic.cern.ch//eos/opendata/atlas/OutreachDatasets/2020-08-19/exactly2lep/MC/mc_392916.SlepSlep_direct_100p5_1p0_2L8.exactly2lep.root"
+      },
+      {
+        "checksum": "adler32:a22a2883",
+        "size": 1225615,
+        "uri": "root://eospublic.cern.ch//eos/opendata/atlas/OutreachDatasets/2020-08-19/exactly2lep/MC/mc_392918.SlepSlep_direct_200p5_1p0_2L8.exactly2lep.root"
+      },
+      {
+        "checksum": "adler32:79c40ef3",
+        "size": 1614437,
+        "uri": "root://eospublic.cern.ch//eos/opendata/atlas/OutreachDatasets/2020-08-19/exactly2lep/MC/mc_392920.SlepSlep_direct_300p5_1p0_2L8.exactly2lep.root"
+      },
+      {
+        "checksum": "adler32:a69af41f",
+        "size": 1485693,
+        "uri": "root://eospublic.cern.ch//eos/opendata/atlas/OutreachDatasets/2020-08-19/exactly2lep/MC/mc_392924.SlepSlep_direct_500p5_1p0_2L8.exactly2lep.root"
+      },
+      {
+        "checksum": "adler32:8b5feadf",
+        "size": 1219206,
+        "uri": "root://eospublic.cern.ch//eos/opendata/atlas/OutreachDatasets/2020-08-19/exactly2lep/MC/mc_392925.SlepSlep_direct_100p0_50p0_2L8.exactly2lep.root"
+      },
+      {
+        "checksum": "adler32:7cbc7035",
+        "size": 1503058,
+        "uri": "root://eospublic.cern.ch//eos/opendata/atlas/OutreachDatasets/2020-08-19/exactly2lep/MC/mc_392936.SlepSlep_direct_200p0_100p0_2L8.exactly2lep.root"
+      },
+      {
+        "checksum": "adler32:8902fb54",
+        "size": 1642176,
+        "uri": "root://eospublic.cern.ch//eos/opendata/atlas/OutreachDatasets/2020-08-19/exactly2lep/MC/mc_392942.SlepSlep_direct_500p0_100p0_2L8.exactly2lep.root"
+      },
+      {
+        "checksum": "adler32:52caf6ef",
+        "size": 1545540,
+        "uri": "root://eospublic.cern.ch//eos/opendata/atlas/OutreachDatasets/2020-08-19/exactly2lep/MC/mc_392951.SlepSlep_direct_300p0_200p0_2L8.exactly2lep.root"
+      },
+      {
+        "checksum": "adler32:ba26611f",
+        "size": 1584004,
+        "uri": "root://eospublic.cern.ch//eos/opendata/atlas/OutreachDatasets/2020-08-19/exactly2lep/MC/mc_392962.SlepSlep_direct_400p0_300p0_2L8.exactly2lep.root"
+      },
+      {
+        "checksum": "adler32:aed7f95b",
+        "size": 1670772,
+        "uri": "root://eospublic.cern.ch//eos/opendata/atlas/OutreachDatasets/2020-08-19/exactly2lep/MC/mc_392964.SlepSlep_direct_500p0_300p0_2L8.exactly2lep.root"
+      },
+      {
+        "checksum": "adler32:8e50f3d2",
+        "size": 1666902,
+        "uri": "root://eospublic.cern.ch//eos/opendata/atlas/OutreachDatasets/2020-08-19/exactly2lep/MC/mc_392982.SlepSlep_direct_600p0_1p0_2L8.exactly2lep.root"
+      },
+      {
+        "checksum": "adler32:59e2b7a6",
+        "size": 1672353,
+        "uri": "root://eospublic.cern.ch//eos/opendata/atlas/OutreachDatasets/2020-08-19/exactly2lep/MC/mc_392985.SlepSlep_direct_600p0_300p0_2L8.exactly2lep.root"
+      },
+      {
+        "checksum": "adler32:278ff6d6",
+        "size": 1671858,
+        "uri": "root://eospublic.cern.ch//eos/opendata/atlas/OutreachDatasets/2020-08-19/exactly2lep/MC/mc_392996.SlepSlep_direct_700p0_1p0_2L8.exactly2lep.root"
+      },
+      {
+        "checksum": "adler32:dbebef27",
+        "size": 1696951,
+        "uri": "root://eospublic.cern.ch//eos/opendata/atlas/OutreachDatasets/2020-08-19/exactly2lep/MC/mc_392999.SlepSlep_direct_700p0_300p0_2L8.exactly2lep.root"
+      },
+      {
+        "checksum": "adler32:74504fa5",
+        "size": 829867881,
+        "uri": "root://eospublic.cern.ch//eos/opendata/atlas/OutreachDatasets/2020-08-19/exactly2lep/MC/mc_410000.ttbar_lep.exactly2lep.root"
+      },
+      {
+        "checksum": "adler32:1484bd3c",
+        "size": 9968984,
+        "uri": "root://eospublic.cern.ch//eos/opendata/atlas/OutreachDatasets/2020-08-19/exactly2lep/MC/mc_410011.single_top_tchan.exactly2lep.root"
+      },
+      {
+        "checksum": "adler32:6de096ec",
+        "size": 10551126,
+        "uri": "root://eospublic.cern.ch//eos/opendata/atlas/OutreachDatasets/2020-08-19/exactly2lep/MC/mc_410012.single_antitop_tchan.exactly2lep.root"
+      },
+      {
+        "checksum": "adler32:9cd0aea1",
+        "size": 43712870,
+        "uri": "root://eospublic.cern.ch//eos/opendata/atlas/OutreachDatasets/2020-08-19/exactly2lep/MC/mc_410013.single_top_wtchan.exactly2lep.root"
+      },
+      {
+        "checksum": "adler32:2ce93d72",
+        "size": 44313784,
+        "uri": "root://eospublic.cern.ch//eos/opendata/atlas/OutreachDatasets/2020-08-19/exactly2lep/MC/mc_410014.single_antitop_wtchan.exactly2lep.root"
+      },
+      {
+        "checksum": "adler32:0f2c36b6",
+        "size": 1963386,
+        "uri": "root://eospublic.cern.ch//eos/opendata/atlas/OutreachDatasets/2020-08-19/exactly2lep/MC/mc_410025.single_top_schan.exactly2lep.root"
+      },
+      {
+        "checksum": "adler32:e88b7954",
+        "size": 2085976,
+        "uri": "root://eospublic.cern.ch//eos/opendata/atlas/OutreachDatasets/2020-08-19/exactly2lep/MC/mc_410026.single_antitop_schan.exactly2lep.root"
+      },
+      {
+        "checksum": "adler32:9933424f",
+        "size": 166405997,
+        "uri": "root://eospublic.cern.ch//eos/opendata/atlas/OutreachDatasets/2020-08-19/exactly2lep/MC/mc_410155.ttW.exactly2lep.root"
+      },
+      {
+        "checksum": "adler32:a9542cc6",
+        "size": 198265962,
+        "uri": "root://eospublic.cern.ch//eos/opendata/atlas/OutreachDatasets/2020-08-19/exactly2lep/MC/mc_410218.ttee.exactly2lep.root"
+      },
+      {
+        "checksum": "adler32:fd9fff4d",
+        "size": 140710111,
+        "uri": "root://eospublic.cern.ch//eos/opendata/atlas/OutreachDatasets/2020-08-19/exactly2lep/MC/mc_410219.ttmumu.exactly2lep.root"
       }
     ],
     "license": {
@@ -53,7 +1102,7 @@
       ]
     },
     "usage": {
-      "description": "This dataset is provided by the ATLAS Collaboration <strong>only for educational purposes and is not suited for scientific publications</strong>.\n You can access these data through the ATLAS Virtual Machine and Software.\n More documentation is available at:",
+      "description": "<p>This dataset is provided as a zipped tarball (<code>exactly2lep.zip</code>) and as a list of unzipped individually-accessible ROOT files containing the collision data (such as <code>data_A.exactly2lep.root</code>) and the simulated data (such as <code>mc_301215.ZPrime2000_ee.exactly2lep.root</code>). You can use either the tarball or the individual ROOT files.</p> <p>This dataset is provided by the ATLAS Collaboration <strong>only for educational purposes and is not suited for scientific publications</strong>.\n You can access these data through the ATLAS Virtual Machine and Software.\n More documentation is available at:</p>",
       "links": [
         {
           "description": "The ATLAS Open Data documentation for 13 TeV release",


### PR DESCRIPTION
Offer individual ROOT files for ATLAS 2020 education datasets to make the access easier, all the while keeping the original zip tarball.

Closes cernopendata/data-curation#257