### PR TITLE
Update link to atlas-FTAG-2023-05.json

### DIFF
--- a/AUTHORS.rst
+++ b/AUTHORS.rst
@@ -17,6 +17,7 @@ The list of contributors in alphabetical order:
 - `Audrius Mecionis <https://orcid.org/0000-0002-3759-1663>`_
 - `Clemens Lange <https://github.com/clelange>`_
 - `Daan Rosendal <https://github.com/DaanRosendal>`_
+- `Dan Guest <https://github.com/dguest>`_
 - `Dana Alsharif <https://github.com/danaalsharif>`_
 - `David Horvát <https://github.com/biscgit>`_
 - `Diego Rodriguez <https://orcid.org/0000-0003-0649-2002>`_

--- a/data/records/atlas-FTAG-2023-05.json
+++ b/data/records/atlas-FTAG-2023-05.json
@@ -65,7 +65,7 @@
         },
         {
           "description": "ATLAS GN2 paper ATLAS-FTAG-2023-05",
-          "url": "http://example.org"
+          "url": "https://atlas.web.cern.ch/Atlas/GROUPS/PHYSICS/PAPERS/FTAG-2023-05/"
         }
       ]
     }


### PR DESCRIPTION
The old link here was pointing to example.com

This was part of #3735 which was never resolved

Attention @WeiShengL, @zlmarshall, @tiborsimko 