### PR TITLE
fix(records): List paper arXiv link more prominently

### DIFF
--- a/data/records/atlas-FTAG-2023-05.json
+++ b/data/records/atlas-FTAG-2023-05.json
@@ -1,7 +1,7 @@
 [
   {
     "abstract": {
-      "description": "<p>Flavour-tagging — the task of identifying the flavour of jets — is essential for many physics analyses at the ATLAS experiment. This dataset, released for public use, can be used to train and evaluate machine learning models for jet flavour-tagging at ATLAS. It aims to facilitate broader interest and further development of innovative machine learning techniques to improve flavour-tagging performance.</p>\n<p>The dataset consists of approximately 50 million events from simulated top quark pair production at a centre-of-mass energy of 13.6 TeV. It is stored in HDF5 format and contains structured event-level, jet-level, track-level and truth hadron information. This dataset is designed to be compatible with the flavour-tagging algorithm development pipeline used at ATLAS, and is supported by accompanying instructions and example configurations provided in open-source repositories.</p>\n<p>To improve usability, the dataset is split into three mutually exclusive HDF5 files:</p>\n<ul>\n<li><code>mc-flavtag-ttbar-small.h5</code> — ~1.36 million events (~5.6 million jets)</li>\n<li><code>mc-flavtag-ttbar-medium.h5</code> — ~6.23 million events (~25.6 million jets)</li>\n<li><code>mc-flavtag-ttbar-large.h5</code> — ~41.1 million events (~168 million jets)</li>\n</ul>\n<p>Downloading all three files will provide access to the complete dataset. The smaller subsets are useful for quick exploration or prototyping workflows.</p>"
+      "description": "<p>Flavour-tagging — the task of identifying heavy flavor jets — is essential for many physics analyses at the ATLAS experiment. This dataset, released for public use, can be used to train and evaluate machine learning models for jet flavour-tagging, as described in <a href=\"https://arxiv.org/abs/2505.19689\">arXiv:2505.19689</a>. It aims broaden interest and further development of innovative machine learning techniques to improve flavour-tagging performance.</p>\n<p>The dataset consists of approximately 50 million events from simulated top quark pair production at a centre-of-mass energy of 13.6 TeV. It is stored in HDF5 format and contains structured event-level, jet-level, track-level and truth hadron information. This dataset is designed to be compatible with the flavour-tagging algorithm development pipeline used at ATLAS, and is supported by accompanying instructions and example configurations provided in open-source repositories.</p>\n<p>To improve usability, the dataset is split into three mutually exclusive HDF5 files:</p>\n<ul>\n<li><code>mc-flavtag-ttbar-small.h5</code> — ~1.36 million events (~5.6 million jets)</li>\n<li><code>mc-flavtag-ttbar-medium.h5</code> — ~6.23 million events (~25.6 million jets)</li>\n<li><code>mc-flavtag-ttbar-large.h5</code> — ~41.1 million events (~168 million jets)</li>\n</ul>\n<p>Downloading all three files will provide access to the complete dataset. The smaller subsets are useful for quick exploration or prototyping workflows.</p>"
     },
     "accelerator": "CERN-LHC",
     "collaboration": {
@@ -10,6 +10,10 @@
     "collections": [
       "ATLAS-Derived-Datasets"
     ],
+    "collision_information": {
+      "energy": "13.6TeV",
+      "type": "pp"
+    },
     "date_published": "2025",
     "distribution": {
       "formats": [
@@ -64,8 +68,12 @@
           "url": "https://gitlab.cern.ch/atlas/open-data/transforming-jet-flavor"
         },
         {
-          "description": "ATLAS GN2 paper ATLAS-FTAG-2023-05",
+          "description": "ATLAS-FTAG-2023-05",
           "url": "https://atlas.web.cern.ch/Atlas/GROUPS/PHYSICS/PAPERS/FTAG-2023-05/"
+        },
+        {
+          "description": "arXiv:2505.19689",
+          "url": "https://arxiv.org/abs/2505.19689"
         }
       ]
     }


### PR DESCRIPTION
The first person I pointed this record to immediately asked for an arXiv link. I don't blame him: the link is buried within a CERN page which is linked with minimal description at the bottom of the page.

I also cleaned up the language a bit.