### PR TITLE
docs(developing): fix the fixtures docs command example file path

### DIFF
--- a/DEVELOPING.rst
+++ b/DEVELOPING.rst
@@ -153,7 +153,7 @@ Upload the locally-modified file into your instance:
 
    $ docker exec -i -t opendatacernch-web-1 cernopendata fixtures docs \
         --mode insert-or-replace \
-        -f data/docs/lhcb-about/lhcb-about.json
+        -f /content/data/docs/lhcb-about/lhcb-about.json
 
 Note that, similarly as for records, we are uploading document JSON files,
 using the `fixtures docs` command. Even if you would like to change only the


### PR DESCRIPTION
The example used a host-relative path, but the command runs inside the
web pod where the repository is mounted under /content. Use the in-pod
absolute path so the document JSON and its associated Markdown content
file are resolved.

Closes #3747

