### PR TITLE
feat(records): adding ATLAS dataset for the PUB note ATL_SOFT_PUB-2025-03

### DIFF
--- a/data/records/atlas-ATL-SOFT-PUB-2025-003.json
+++ b/data/records/atlas-ATL-SOFT-PUB-2025-003.json
@@ -1,0 +1,68 @@
+[
+  {
+    "abstract": {
+      "description": "<p> For the upcoming high luminosity runs at ATLAS, it is necessary to replace the full calorimeter simulation with the fast calorimeter simulation in almost all cases. The current ATLAS fast calorimeter simulation, AtlFast3, uses parametric approaches to speed up the computing time significantly. Even though AtlFast3 generally achieves a high degree of accuracy, further quality improvements within the fast calorimeter simulation are necessary to enable this replacement. Here, we present a new voxelization scheme for fast calorimeter simulation of electromagnetic photon showers in the ATLAS Lar barrel. This updated discretization significantly reduces several artifacts previously observed in reconstructed photon shower shapes and can be used to train modern generative machine learning models for the ATLAS fast calorimeter simulation. This work contains two different voxelizations, a non-regular but smaller binning and dataset with more voxels that are binned in a regular scheme. Both voxelizations were performed for a 1.5M event training dataset and a 1.5 M validation dataset. This dataset is intended to be used to evaluate generative calorimeter simulation models on a real world dataset. Models that reproduce this dataset fast, accurately and with low memory requirements, can be straightforwardly used within the future ATLAS fast calorimeter simulation, as long as they are provided in the ONNX format. While this work concentrates on photons, extensions to other particle types are foreseen in future developments.</p>"
+    },
+    "accelerator": "CERN-LHC",
+    "collaboration": {
+      "name": "ATLAS collaboration"
+    },
+    "date_published": "2025",
+    "distribution": {
+      "formats": [
+        "hdf5"
+      ],
+      "number_events": 6000000,
+      "number_files": 4,
+      "size": 26011336844
+    },
+    "doi": "10.7483/OPENDATA.ATLAS.8CT0.8CWA",
+    "experiment": [
+      "ATLAS"
+    ],
+    "files": [
+      {
+        "checksum": "adler32:3472e2b0",
+        "size": 3906395883,
+        "uri": "root://eospublic.cern.ch//eos/opendata/atlas/software-2025/voxelization_3761/default_dataset_full_trn.hdf5"
+      },
+      {
+        "checksum": "adler32:333f7c50",
+        "size": 3907641808,
+        "uri": "root://eospublic.cern.ch//eos/opendata/atlas/software-2025/voxelization_3761/default_dataset_full_val.hdf5"
+      },
+      {
+        "checksum": "adler32:bab4d993",
+        "size": 9098962904,
+        "uri": "root://eospublic.cern.ch//eos/opendata/atlas/software-2025/voxelization_3761/regular_dataset_full_trn.hdf5"
+      },
+      {
+        "checksum": "adler32:e51b16d7",
+        "size": 9098336249,
+        "uri": "root://eospublic.cern.ch//eos/opendata/atlas/software-2025/voxelization_3761/regular_dataset_full_val.hdf5"
+      }
+    ],
+    "links": [
+      {
+        "description": "ATLAS PUB-NOTE: ATL-SOFT-PUB-2025-003",
+        "url": "https://atlas.web.cern.ch/Atlas/GROUPS/PHYSICS/PUBNOTES/ATL-SOFT-PUB-2025-003/"
+      },
+      {
+        "description": "Showcase repository",
+        "url": "https://gitlab.cern.ch/atlas-simulation-team/datasetshowcase"
+      }
+    ],
+    "publisher": "CERN Open Data Portal",
+    "recid": "93941",
+    "title": "Photon showers in the ATLAS fast calorimeter simulation: A voxelized dataset with minimized information loss and improved ML models",
+    "type": {
+      "primary": "Dataset",
+      "secondary": [
+        "Simulated"
+      ]
+    },
+    "usage": {
+      "description": "</p>If this dataset is used in a publication, please cite this dataset record along with the accompanying PUB-NOTE <a href=\"https://atlas.web.cern.ch/Atlas/GROUPS/PHYSICS/PUBNOTES/ATL-SOFT-PUB-2025-003/\">ATL-SOFT-PUB-2025-003</a>.</p>"
+    }
+  }
+]


### PR DESCRIPTION
Hi, 

recently the dataset that accompanies the ATLAS PUB note ATL-SOFT-PUB-2025-003 was approved and I would like to upload the corresponding [files](https://cernbox.cern.ch/files/spaces/eos/atlas/atlascerngroupdisk/proj-simul/AF4/Development/FrozenShowerInputSamplesContinuousEnergy/PUB_note_DS) to the CERN opendata platform. The are located at `/eos/atlas/atlascerngroupdisk/proj-simul/AF4/Development/FrozenShowerInputSamplesContinuousEnergy/PUB_note_DS/*`

I was already in contact with Zach and created a record JSON skeleton that is the content of this merge request. I was told, that the file information can be added automatically, so I filled only the other entries. If you need more than that, please tell me so that I can add additional entries.

Cheers Florian