### PR TITLE
build(docker): upgrade cernopendata-portal to 0.13.0

### DIFF
--- a/DEVELOPING.rst
+++ b/DEVELOPING.rst
@@ -45,7 +45,7 @@ follows:
 
    $ git clone https://github.com/cernopendata/opendata.cern.ch
    $ git clone https://github.com/cernopendata/cernopendata-portal
-   $ cd cernopendata-portal && git checkout -B stable v0.2.9
+   $ cd cernopendata-portal && git checkout -B release-v0.13.0 v0.13.0
    $ cd ../opendata.cern.ch
    $ docker compose pull
    $ docker compose up -d
@@ -55,7 +55,7 @@ follows:
 
 This will create a running instance of the CERN Open Data portal with a
 relatively empty content. The portal will be accessible locally at
-`http://127.0.0.1:500 <http://127.0.0.1:5000>`_.
+`http://127.0.0.1:8000 <http://127.0.0.1:8000>`_.
 
 If you would like to stop and delete your local instance, you can do:
 
@@ -83,8 +83,8 @@ Upload the locally-modified file into your instance:
         --mode insert-or-replace \
         -f /content/data/records/cms-primary-datasets.json
 
-You can then check your changes at `http://127.0.0.1:500
-<http://127.0.0.1:5000>`_.
+You can then check your changes at `http://127.0.0.1:8000
+<http://127.0.0.1:8000>`_.
 
 Note that you can take advantage of shell scripting if you would like to upload
 all experiment records locally, for example for ATLAS:
@@ -160,8 +160,8 @@ using the `fixtures docs` command. Even if you would like to change only the
 document content that is living in the associated Markdown files, the document
 JSON file is to be uploaded.
 
-You can then check your changes at `http://127.0.0.1:500
-<http://127.0.0.1:5000>`_.
+You can then check your changes at `http://127.0.0.1:8000
+<http://127.0.0.1:8000>`_.
 
 Working with documents: Markdown
 ================================

--- a/docker-compose-override.yml
+++ b/docker-compose-override.yml
@@ -1,7 +1,7 @@
 # -*- coding: utf-8 -*-
 #
 # This file is part of CERN Open Data Portal.
-# Copyright (C) 2015, 2016, 2017, 2018, 2021, 2022, 2023, 2024, 2025 CERN.
+# Copyright (C) 2015, 2016, 2017, 2018, 2021, 2022, 2023, 2024, 2025, 2026 CERN.
 #
 # CERN Open Data Portal is free software; you can redistribute it
 # and/or modify it under the terms of the GNU General Public License as
@@ -30,15 +30,14 @@ services:
       - TEMPLATES_AUTO_RELOAD=True
     command: bash -c "/content/scripts/start-server-debug.sh"
     restart: "unless-stopped"
-    image: registry.cern.ch/cernopendata/cernopendata-portal:0.2.9
+    image: registry.cern.ch/cernopendata/cernopendata-portal:0.13.0
     volumes:
       - ../opendata.cern.ch:/content
       - ./cernopendata:/code/cernopendata
       - ./scripts:/code/scripts
       - ./tests:/code/tests
   mq:
-    profiles:
-      - donotstart
+    restart: "unless-stopped"
   proxy:
     profiles:
       - donotstart


### PR DESCRIPTION
Upgrade CERN Open Data portal version to 0.13.0 and change local
development server to use port 8000 in order to avoid conflicts with
port 5000 on macOS.

Additionally, plug the MQ service back to avoid unnecessary slow-downs
when accessing the detailed record pages. The MQ is needed by the
invenio-stats module that came in as part of the upgrade.
