### PR TITLE
feat(records): adding ATLAS dataset for paper ATLAS-EXOT-2020-27

### DIFF
--- a/data/records/atlas-ATL-EXOT-2020-27.json
+++ b/data/records/atlas-ATL-EXOT-2020-27.json
@@ -1,7 +1,7 @@
 [
     {
         "abstract": {
-            "description": "<p>A statistical combination of various searches for pair-produced leptoquarks is presented, using the full LHC Run 2 (2015-2018) data set of 139fb^-1 collected with the ATLAS detector from proton-proton collisions at a centre-of-mass energy of 13TeV. All possible decays of the leptoquarks into quarks of the third generation and charged or neutral leptons of any generation are investigated. Since no significant deviations from the Standard Model expectation are observed in any of the individual analyses, combined exclusion limits are set on the production cross-sections for scalar and vector leptoquarks. The resulting lower bounds on leptoquark masses exceed those from the individual analyses by up to 100 GeV, depending on the signal hypothesis.</p>"
+            "description": "<p>This record contains statistical workspaces used in a combination of various searches for pair-produced leptoquarks using the full LHC Run 2 (2015-2018) data set of 139fb^-1 collected with the ATLAS detector from proton-proton collisions at a centre-of-mass energy of 13TeV. All possible decays of the leptoquarks into quarks of the third generation and charged or neutral leptons of any generation are investigated. The list of publications used as input for the combination is:</p>"
         },
         "accelerator": "CERN-LHC",
         "collaboration": {
@@ -22,55 +22,65 @@
             "number_of_files": 10,
             "size": 725979756
         },
-        "doi": "10.1016/j.physletb.2024.138736",
+        "doi": "?????",
         "experiment": "ATLAS",
         "files": [
             {
+                "description": "Statistical workspaces for LQ3d model with scalar LQs with electric charge 1/3 coupling to third-generation fermions. The tarball contains workspaces from JHEP 05 (2021) 093 (subdirectory: 'Sbottom_bbMET'), JHEP 06 (2021) 179 (subdirectory: 'ttauttau'), Phys. Rev. D 104, (2021) 112005 (subdirectory: 'StopStau').",
                 "checksum": "adler32:466b422a",
                 "size": 74923637,
                 "uri": "root://eospublic.cern.ch//eos/opendata/atlas/upload/LQCombLikelihoods/LQ3d.tar.gz"
             },
             {
+                "description": "Statistical workspaces for LQ3u model with scalar LQs with electric charge 2/3 coupling to third-generation fermions. The tarball contains workspaces from Eur. Phys. J. C 80 (2020) 737 (subdirectory: 'Stop0L'), Eur. Phys. J. C 83 (2023) 1075 (subdirectory: 'btaubtau'), Phys. Rev. D 104, (2021) 112005 (subdirectory: 'StopStau').",
                 "checksum": "adler32:ccbd9eff",
                 "size": 132815663,
                 "uri": "root://eospublic.cern.ch//eos/opendata/atlas/upload/LQCombLikelihoods/LQ3u.tar.gz"
             },
             {
+                "description": "Statistical workspaces for LQXd_el model with scalar LQs with electric charge 1/3 coupling to third-generation quarks and first-generation leptons. The tarball contains workspaces from JHEP 05 (2021) 093 (subdirectory: 'Sbottom_bbMET'), Eur. Phys. J. C 81 (2021) 313 (subdirectory: 'tete_boosted'), Eur. Phys. J. C 84 (2024) 818 (subdirectory: 'tete'), JHEP 06 (2023) 188 (subdirectory: 'tebnu').",
                 "checksum": "adler32:eb550c21",
                 "size": 35389835,
                 "uri": "root://eospublic.cern.ch//eos/opendata/atlas/upload/LQCombLikelihoods/LQXd_el.tar.gz"
             },
             {
+                "description": "Statistical workspaces for LQXd_mu model with scalar LQs with electric charge 1/3 coupling to third-generation quarks and second-generation leptons. The tarball contains workspaces from JHEP 05 (2021) 093 (subdirectory: 'Sbottom_bbMET'), Eur. Phys. J. C 81 (2021) 313 (subdirectory: 'tmutmu_boosted'), Eur. Phys. J. C 84 (2024) 818 (subdirectory: 'tmutmu'), JHEP 06 (2023) 188 (subdirectory: 'tmubnu').",
                 "checksum": "adler32:731cb44a",
                 "size": 33577405,
                 "uri": "root://eospublic.cern.ch//eos/opendata/atlas/upload/LQCombLikelihoods/LQXd_mu.tar.gz"
             },
             {
+                "description": "Statistical workspaces for LQXu_el model with scalar LQs with electric charge 2/3 coupling to third-generation quarks and first-generation leptons. The tarball contains workspaces from Eur. Phys. J. C 80 (2020) 737 (subdirectory: 'Stop0L'), JHEP 10 (2020) 112 (subdirectory: 'bebe'), JHEP 06 (2023) 188 (subdirectory: 'tnube').",
                 "checksum": "adler32:996b4086",
                 "size": 97572739,
                 "uri": "root://eospublic.cern.ch//eos/opendata/atlas/upload/LQCombLikelihoods/LQXu_el.tar.gz"
             },
             {
+                "description": "Statistical workspaces for LQXu_mu model with scalar LQs with electric charge 2/3 coupling to third-generation quarks and second-generation leptons. The tarball contains workspaces from Eur. Phys. J. C 80 (2020) 737 (subdirectory: 'Stop0L'), JHEP 10 (2020) 112 (subdirectory: 'bmubmu'), JHEP 06 (2023) 188 (subdirectory: 'tnubmu').",
                 "checksum": "adler32:1d189692",
                 "size": 94003627,
                 "uri": "root://eospublic.cern.ch//eos/opendata/atlas/upload/LQCombLikelihoods/LQXu_mu.tar.gz"
             },
             {
+                "description": "Statistical workspaces for U1_min model with vector U1 LQs in the minimal coupling scenario. The tarball contains workspaces from Eur. Phys. J. C 80 (2020) 737 (subdirectory: 'Stop0L'), Eur. Phys. J. C 83 (2023) 1075 (subdirectory: 'btaubtau'), Phys. Rev. D 104, (2021) 112005 (subdirectory: 'StopStau').",
                 "checksum": "adler32:c6fe300e",
                 "size": 129704692,
                 "uri": "root://eospublic.cern.ch//eos/opendata/atlas/upload/LQCombLikelihoods/U1_min.tar.gz"
             },
             {
+                "description": "Statistical workspaces for U1tilde_min model with vector U1tilde LQs in the minimal coupling scenario. The tarball contains workspaces from JHEP 06 (2021) 179 (subdirectory: 'ttauttau').",
                 "checksum": "adler32:c8effd80",
                 "size": 3203464,
                 "uri": "root://eospublic.cern.ch//eos/opendata/atlas/upload/LQCombLikelihoods/U1tilde_min.tar.gz"
             },
             {
+                "description": "Statistical workspaces for U1_YM model with vector U1 LQs in the Yang-Mills coupling scenario. The tarball contains workspaces from Eur. Phys. J. C 80 (2020) 737 (subdirectory: 'Stop0L'), Eur. Phys. J. C 83 (2023) 1075 (subdirectory: 'btaubtau'), Phys. Rev. D 104, (2021) 112005 (subdirectory: 'StopStau').",
                 "checksum": "adler32:d51f7c81",
                 "size": 121223171,
                 "uri": "root://eospublic.cern.ch//eos/opendata/atlas/upload/LQCombLikelihoods/U1_YM.tar.gz"
             },
             {
+                "description": "Statistical workspaces for U1tilde_YM model with vector U1tilde LQs in the Yang-Mills coupling scenario. The tarball contains workspaces from JHEP 06 (2021) 179 (subdirectory: 'ttauttau').",
                 "checksum": "adler32:309b905c",
                 "size": 3565523,
                 "uri": "root://eospublic.cern.ch//eos/opendata/atlas/upload/LQCombLikelihoods/U1tilde_YM.tar.gz"
@@ -83,7 +93,7 @@
             },
             {
                 "description": "Published Paper in Physics Letters B",
-                "url": "https://www.sciencedirect.com/science/article/pii/S0370269324002946?via%3Dihub"
+                "url": "10.1016/j.physletb.2024.138736"
             }
         ],
         "publisher": "CERN Open Data Portal",
@@ -96,7 +106,13 @@
             ]
         },
         "usage": {
-            "description": "Statistical workspaces in pyhf json format for various leptoquark signal hypotheses."
+            "description": "The statistical workspaces are provided in pyhf json format. They are collected in individual tarballs per leptoquark model. Some signal model parameters are encoded in the workspace names (e.g. LQ mass in GeV, BR(LQ->q+l).",
+            "links": [
+                {
+                    "description": "pyhf Documentation",
+                    "url": "https://pyhf.readthedocs.io/en/latest/"
+                }
+            ]
         }
     }
 ]


### PR DESCRIPTION
Dear Open Data experts,

We would like to make the statistical workspaces of the ATLAS Run2 Leptoquark Combination publicly available. These workspaces have been used in Phys. Lett. B 854 (2024) 138736. Thanks to Zach, the files in question have already been copied to the staging area in /eos/opendata/atlas/upload/LQCombLikelihoods.
We have also created the record JSON skeleton and filled it out to the best of our knowledge. Please let us know in case more information is needed.

Thanks for your help.
Cheers,
Volker