### PR TITLE
fix(records): add create date to phenix records (extracted from pdf)

### DIFF
--- a/data/records/phenix-emcal-finding-pi0s-and-photons.json
+++ b/data/records/phenix-emcal-finding-pi0s-and-photons.json
@@ -187,6 +187,9 @@
         "variable": "z"
       }
     ],
+    "date_created": [
+      "2015"
+    ],
     "date_published": "2021",
     "distribution": {
       "formats": [


### PR DESCRIPTION
Date extracted from the pdf, page 2
```
These files were produced using a small fraction of the √sNN =200 GeV p+Au data collected
by PHENIX in 2015.
```
