### PR TITLE
fix(records): make all records comply with the JSON schema

### DIFF
--- a/data/records/jade-author-list.json
+++ b/data/records/jade-author-list.json
@@ -524,7 +524,6 @@
       "2018"
     ],
     "date_published": "2023",
-    "description": "This is a list of JADE Collaboration authors as given in Eur.Phys.J. C73 (2013) no.3, 2332. The list contains affiliations as given in Eur.Phys.J. C73 (2013) no.3, 2332.",
     "distribution": {
       "formats": [
         "pdf"


### PR DESCRIPTION
Fix the last remaining schema violations (stray trailing colons in the
CMS cross section keys and a misplaced JADE top-level description) so
that every record now validates against the JSON schema.

