### PR TITLE
Add LHCb dijet and sv-tagged dijet ntuple records

### DIFF
--- a/data/records/lhcb-ntuples-run2-dijets.json
+++ b/data/records/lhcb-ntuples-run2-dijets.json
@@ -1,0 +1,671 @@
+[
+  {
+    "abstract": {
+      "description": "<p>Data from proton-proton (pp) collisions collected by the LHCb experiment filtered to produce ntuples for analyzing dijet events.</p> <p> Ntuples are created using DaVinci version v46r11 and the Analysis Productions batch processing system. Quantities saved to the ntuple are specified during the request phase and detailed in the code configuration files attached below.</p>"
+    },
+    "accelerator": "CERN-LHC",
+    "collaboration": {
+      "name": "LHCb collaboration"
+    },
+    "collections": [
+      "LHCb-Collision-Datasets"
+    ],
+    "date_created": [
+      "2015",
+      "2016",
+      "2017"
+    ],
+    "date_published": "2026",
+    "date_reprocessed": "2026",
+    "distribution": {
+      "formats": [
+        "py",
+        "yaml"
+      ],
+      "number_files": 3,
+      "size": 3327
+    },
+    "doi": "10.7483/OPENDATA.LHCB.CGFF.E7X9",
+    "experiment": [
+      "LHCb"
+    ],
+    "files": [
+      {
+        "checksum": "adler32:2972fb3c",
+        "size": 741,
+        "uri": "root://eospublic.cern.ch//eos/opendata/lhcb/CollisionNtuples/OPENDATA.LHCB.CGFF.E7X9/inputs/dijets_run2/dijets.py"
+      },
+      {
+        "checksum": "adler32:f1068f1d",
+        "size": 1464,
+        "uri": "root://eospublic.cern.ch//eos/opendata/lhcb/CollisionNtuples/OPENDATA.LHCB.CGFF.E7X9/inputs/dijets_run2/dijets.yaml"
+      },
+      {
+        "checksum": "adler32:be234c43",
+        "size": 1122,
+        "uri": "root://eospublic.cern.ch//eos/opendata/lhcb/CollisionNtuples/OPENDATA.LHCB.CGFF.E7X9/inputs/dijets_run2/info.yaml"
+      }
+    ],
+    "methodology": {
+      "description": "These ntuples were produced from the LHCb Open Data Ntupling Service user request 6000. Please see the input configuration files attached below."
+    },
+    "publisher": "CERN Open Data Portal",
+    "recid": "94000",
+    "relations": [
+      {
+        "recid": "94001",
+        "type": "isParentOf"
+      },
+      {
+        "recid": "94002",
+        "type": "isParentOf"
+      },
+      {
+        "recid": "94003",
+        "type": "isParentOf"
+      },
+      {
+        "recid": "94004",
+        "type": "isParentOf"
+      },
+      {
+        "recid": "94005",
+        "type": "isParentOf"
+      },
+      {
+        "recid": "94006",
+        "type": "isParentOf"
+      }
+    ],
+    "title": "DiJet Ntuples 6000",
+    "type": {
+      "primary": "Dataset",
+      "secondary": [
+        "Collision"
+      ]
+    },
+    "usage": {
+      "description": "<p>Ntuples and instructions are provided in the links under Related datasets. They are ready to be downloaded and used for analysis. If these do not suit your needs, you can clone and amend this ntupling request here:",
+      "links": [
+        {
+          "description": "LHCb Open Data Ntupling Service",
+          "url": "https://opendata-lhcb-ntupling-service.app.cern.ch/"
+        },
+        {
+          "description": "LHCb Open Data Ntupling Service Usage Guide",
+          "url": "https://lhcb-opendata-guide.web.cern.ch/ntupling-service/"
+        },
+        {
+          "description": "Jet fragmentation analysis example",
+          "url": "https://github.com/lhcb-opendata-examples/jet-fragmentation"
+        }
+      ]
+    }
+  },
+  {
+    "abstract": {
+      "description": "Data from proton-proton (pp) collisions collected by the LHCb experiment filtered to produce ntuples for analyzing dijet events."
+    },
+    "accelerator": "CERN-LHC",
+    "collaboration": {
+      "name": "LHCb collaboration"
+    },
+    "collections": [
+      "LHCb-Collision-Datasets"
+    ],
+    "collision_information": {
+      "energy": "13TeV",
+      "type": "pp"
+    },
+    "date_created": [
+      "2015"
+    ],
+    "date_published": "2026",
+    "date_reprocessed": "2026",
+    "distribution": {
+      "formats": [
+        "root"
+      ],
+      "number_files": 2,
+      "size": 7540164180
+    },
+    "experiment": [
+      "LHCb"
+    ],
+    "files": [
+      {
+        "checksum": "adler32:4b242380",
+        "size": 7029057719,
+        "uri": "root://eospublic.cern.ch//eos/opendata/lhcb/CollisionNtuples/OPENDATA.LHCB.CGFF.E7X9/outputs/real-production/00392998_00000001_1.dvntuple.root"
+      },
+      {
+        "checksum": "adler32:435d51fc",
+        "size": 511106461,
+        "uri": "root://eospublic.cern.ch//eos/opendata/lhcb/CollisionNtuples/OPENDATA.LHCB.CGFF.E7X9/outputs/real-production/00392998_00000002_1.dvntuple.root"
+      }
+    ],
+    "magnet_polarity": "MagDown",
+    "methodology": {
+      "description": "<p>These ntuples were produced from the LHCb Open Data Ntupling Service user request 6000. Please see the input configuration files <a href=\"/record/94000\">here</a>.</p>"
+    },
+    "publisher": "CERN Open Data Portal",
+    "recid": "94001",
+    "relations": [
+      {
+        "recid": "94000",
+        "type": "isChildOf"
+      }
+    ],
+    "run_period": [
+      "2015"
+    ],
+    "stripping": {
+      "stream": "EW",
+      "version": "stripping24r2"
+    },
+    "title": "DiJet Ntuples 6000 -- 2015 Magnet Down",
+    "type": {
+      "primary": "Dataset",
+      "secondary": [
+        "Collision"
+      ]
+    },
+    "usage": {
+      "description": "<p>You can use these ntuples with <a href=\"https://root.cern.ch/\">ROOT</a> data analysis framework. See documentation and examples here:</p>",
+      "links": [
+        {
+          "description": "LHCb Open Data Ntupling Service Usage Guide",
+          "url": "https://lhcb-opendata-guide.web.cern.ch/ntupling-service/"
+        },
+        {
+          "description": "First LHCb Open Data and Ntuple Wizard Workshop",
+          "url": "https://indico.cern.ch/event/1429526/timetable/#20241022.detailed"
+        },
+        {
+          "description": "Jet fragmentation analysis example",
+          "url": "https://github.com/lhcb-opendata-examples/jet-fragmentation"
+        }
+      ]
+    }
+  },
+  {
+    "abstract": {
+      "description": "Data from proton-proton (pp) collisions collected by the LHCb experiment filtered to produce ntuples for analyzing dijet events."
+    },
+    "accelerator": "CERN-LHC",
+    "collaboration": {
+      "name": "LHCb collaboration"
+    },
+    "collections": [
+      "LHCb-Collision-Datasets"
+    ],
+    "collision_information": {
+      "energy": "13TeV",
+      "type": "pp"
+    },
+    "date_created": [
+      "2015"
+    ],
+    "date_published": "2026",
+    "date_reprocessed": "2026",
+    "distribution": {
+      "formats": [
+        "root"
+      ],
+      "number_files": 1,
+      "size": 5745180854
+    },
+    "experiment": [
+      "LHCb"
+    ],
+    "files": [
+      {
+        "checksum": "adler32:f2cf5cd9",
+        "size": 5745180854,
+        "uri": "root://eospublic.cern.ch//eos/opendata/lhcb/CollisionNtuples/OPENDATA.LHCB.CGFF.E7X9/outputs/real-production/00392999_00000001_1.dvntuple.root"
+      }
+    ],
+    "magnet_polarity": "MagUp",
+    "methodology": {
+      "description": "<p>These ntuples were produced from the LHCb Open Data Ntupling Service user request 6000. Please see the input configuration files <a href=\"/record/94000\">here</a>.</p>"
+    },
+    "publisher": "CERN Open Data Portal",
+    "recid": "94002",
+    "relations": [
+      {
+        "recid": "94000",
+        "type": "isChildOf"
+      }
+    ],
+    "run_period": [
+      "2015"
+    ],
+    "stripping": {
+      "stream": "EW",
+      "version": "stripping24r2"
+    },
+    "title": "DiJet Ntuples 6000 -- 2015 Magnet Up",
+    "type": {
+      "primary": "Dataset",
+      "secondary": [
+        "Collision"
+      ]
+    },
+    "usage": {
+      "description": "<p>You can use these ntuples with <a href=\"https://root.cern.ch/\">ROOT</a> data analysis framework. See documentation and examples here:</p>",
+      "links": [
+        {
+          "description": "LHCb Open Data Ntupling Service Usage Guide",
+          "url": "https://lhcb-opendata-guide.web.cern.ch/ntupling-service/"
+        },
+        {
+          "description": "First LHCb Open Data and Ntuple Wizard Workshop",
+          "url": "https://indico.cern.ch/event/1429526/timetable/#20241022.detailed"
+        },
+        {
+          "description": "Jet fragmentation analysis example",
+          "url": "https://github.com/lhcb-opendata-examples/jet-fragmentation"
+        }
+      ]
+    }
+  },
+  {
+    "abstract": {
+      "description": "Data from proton-proton (pp) collisions collected by the LHCb experiment filtered to produce ntuples for analyzing dijet events."
+    },
+    "accelerator": "CERN-LHC",
+    "collaboration": {
+      "name": "LHCb collaboration"
+    },
+    "collections": [
+      "LHCb-Collision-Datasets"
+    ],
+    "collision_information": {
+      "energy": "13TeV",
+      "type": "pp"
+    },
+    "date_created": [
+      "2016"
+    ],
+    "date_published": "2026",
+    "date_reprocessed": "2026",
+    "distribution": {
+      "formats": [
+        "root"
+      ],
+      "number_files": 5,
+      "size": 35657789758
+    },
+    "experiment": [
+      "LHCb"
+    ],
+    "files": [
+      {
+        "checksum": "adler32:0feaeb5a",
+        "size": 7061819125,
+        "uri": "root://eospublic.cern.ch//eos/opendata/lhcb/CollisionNtuples/OPENDATA.LHCB.CGFF.E7X9/outputs/real-production/00393003_00000001_1.dvntuple.root"
+      },
+      {
+        "checksum": "adler32:94d491a1",
+        "size": 7098149782,
+        "uri": "root://eospublic.cern.ch//eos/opendata/lhcb/CollisionNtuples/OPENDATA.LHCB.CGFF.E7X9/outputs/real-production/00393003_00000002_1.dvntuple.root"
+      },
+      {
+        "checksum": "adler32:0231f58c",
+        "size": 7140939068,
+        "uri": "root://eospublic.cern.ch//eos/opendata/lhcb/CollisionNtuples/OPENDATA.LHCB.CGFF.E7X9/outputs/real-production/00393003_00000003_1.dvntuple.root"
+      },
+      {
+        "checksum": "adler32:89731e99",
+        "size": 7214645813,
+        "uri": "root://eospublic.cern.ch//eos/opendata/lhcb/CollisionNtuples/OPENDATA.LHCB.CGFF.E7X9/outputs/real-production/00393003_00000004_1.dvntuple.root"
+      },
+      {
+        "checksum": "adler32:70712f14",
+        "size": 7142235970,
+        "uri": "root://eospublic.cern.ch//eos/opendata/lhcb/CollisionNtuples/OPENDATA.LHCB.CGFF.E7X9/outputs/real-production/00393003_00000005_1.dvntuple.root"
+      }
+    ],
+    "magnet_polarity": "MagDown",
+    "methodology": {
+      "description": "<p>These ntuples were produced from the LHCb Open Data Ntupling Service user request 6000. Please see the input configuration files <a href=\"/record/94000\">here</a>.</p>"
+    },
+    "publisher": "CERN Open Data Portal",
+    "recid": "94003",
+    "relations": [
+      {
+        "recid": "94000",
+        "type": "isChildOf"
+      }
+    ],
+    "run_period": [
+      "2016"
+    ],
+    "stripping": {
+      "stream": "EW",
+      "version": "stripping28r2"
+    },
+    "title": "DiJet Ntuples 6000 -- 2016 Magnet Down",
+    "type": {
+      "primary": "Dataset",
+      "secondary": [
+        "Collision"
+      ]
+    },
+    "usage": {
+      "description": "<p>You can use these ntuples with <a href=\"https://root.cern.ch/\">ROOT</a> data analysis framework. See documentation and examples here:</p>",
+      "links": [
+        {
+          "description": "LHCb Open Data Ntupling Service Usage Guide",
+          "url": "https://lhcb-opendata-guide.web.cern.ch/ntupling-service/"
+        },
+        {
+          "description": "First LHCb Open Data and Ntuple Wizard Workshop",
+          "url": "https://indico.cern.ch/event/1429526/timetable/#20241022.detailed"
+        },
+        {
+          "description": "Jet fragmentation analysis example",
+          "url": "https://github.com/lhcb-opendata-examples/jet-fragmentation"
+        }
+      ]
+    }
+  },
+  {
+    "abstract": {
+      "description": "Data from proton-proton (pp) collisions collected by the LHCb experiment filtered to produce ntuples for analyzing dijet events."
+    },
+    "accelerator": "CERN-LHC",
+    "collaboration": {
+      "name": "LHCb collaboration"
+    },
+    "collections": [
+      "LHCb-Collision-Datasets"
+    ],
+    "collision_information": {
+      "energy": "13TeV",
+      "type": "pp"
+    },
+    "date_created": [
+      "2016"
+    ],
+    "date_published": "2026",
+    "date_reprocessed": "2026",
+    "distribution": {
+      "formats": [
+        "root"
+      ],
+      "number_files": 5,
+      "size": 31631746013
+    },
+    "experiment": [
+      "LHCb"
+    ],
+    "files": [
+      {
+        "checksum": "adler32:b307aaea",
+        "size": 7066682432,
+        "uri": "root://eospublic.cern.ch//eos/opendata/lhcb/CollisionNtuples/OPENDATA.LHCB.CGFF.E7X9/outputs/real-production/00393002_00000001_1.dvntuple.root"
+      },
+      {
+        "checksum": "adler32:e701c789",
+        "size": 7084165568,
+        "uri": "root://eospublic.cern.ch//eos/opendata/lhcb/CollisionNtuples/OPENDATA.LHCB.CGFF.E7X9/outputs/real-production/00393002_00000002_1.dvntuple.root"
+      },
+      {
+        "checksum": "adler32:29fe39a6",
+        "size": 7111913505,
+        "uri": "root://eospublic.cern.ch//eos/opendata/lhcb/CollisionNtuples/OPENDATA.LHCB.CGFF.E7X9/outputs/real-production/00393002_00000003_1.dvntuple.root"
+      },
+      {
+        "checksum": "adler32:8bedacd5",
+        "size": 7181137865,
+        "uri": "root://eospublic.cern.ch//eos/opendata/lhcb/CollisionNtuples/OPENDATA.LHCB.CGFF.E7X9/outputs/real-production/00393002_00000004_1.dvntuple.root"
+      },
+      {
+        "checksum": "adler32:a4dbeed4",
+        "size": 3187846643,
+        "uri": "root://eospublic.cern.ch//eos/opendata/lhcb/CollisionNtuples/OPENDATA.LHCB.CGFF.E7X9/outputs/real-production/00393002_00000005_1.dvntuple.root"
+      }
+    ],
+    "magnet_polarity": "MagUp",
+    "methodology": {
+      "description": "<p>These ntuples were produced from the LHCb Open Data Ntupling Service user request 6000. Please see the input configuration files <a href=\"/record/94000\">here</a>.</p>"
+    },
+    "publisher": "CERN Open Data Portal",
+    "recid": "94004",
+    "relations": [
+      {
+        "recid": "94000",
+        "type": "isChildOf"
+      }
+    ],
+    "run_period": [
+      "2016"
+    ],
+    "stripping": {
+      "stream": "EW",
+      "version": "stripping28r2"
+    },
+    "title": "DiJet Ntuples 6000 -- 2016 Magnet Up",
+    "type": {
+      "primary": "Dataset",
+      "secondary": [
+        "Collision"
+      ]
+    },
+    "usage": {
+      "description": "<p>You can use these ntuples with <a href=\"https://root.cern.ch/\">ROOT</a> data analysis framework. See documentation and examples here:</p>",
+      "links": [
+        {
+          "description": "LHCb Open Data Ntupling Service Usage Guide",
+          "url": "https://lhcb-opendata-guide.web.cern.ch/ntupling-service/"
+        },
+        {
+          "description": "First LHCb Open Data and Ntuple Wizard Workshop",
+          "url": "https://indico.cern.ch/event/1429526/timetable/#20241022.detailed"
+        },
+        {
+          "description": "Jet fragmentation analysis example",
+          "url": "https://github.com/lhcb-opendata-examples/jet-fragmentation"
+        }
+      ]
+    }
+  },
+  {
+    "abstract": {
+      "description": "Data from proton-proton (pp) collisions collected by the LHCb experiment filtered to produce ntuples for analyzing dijet events."
+    },
+    "accelerator": "CERN-LHC",
+    "collaboration": {
+      "name": "LHCb collaboration"
+    },
+    "collections": [
+      "LHCb-Collision-Datasets"
+    ],
+    "collision_information": {
+      "energy": "13TeV",
+      "type": "pp"
+    },
+    "date_created": [
+      "2017"
+    ],
+    "date_published": "2026",
+    "date_reprocessed": "2026",
+    "distribution": {
+      "formats": [
+        "root"
+      ],
+      "number_files": 5,
+      "size": 29121627811
+    },
+    "experiment": [
+      "LHCb"
+    ],
+    "files": [
+      {
+        "checksum": "adler32:0b207a3c",
+        "size": 7058416870,
+        "uri": "root://eospublic.cern.ch//eos/opendata/lhcb/CollisionNtuples/OPENDATA.LHCB.CGFF.E7X9/outputs/real-production/00393006_00000001_1.dvntuple.root"
+      },
+      {
+        "checksum": "adler32:6e1e1d9a",
+        "size": 7057276835,
+        "uri": "root://eospublic.cern.ch//eos/opendata/lhcb/CollisionNtuples/OPENDATA.LHCB.CGFF.E7X9/outputs/real-production/00393006_00000002_1.dvntuple.root"
+      },
+      {
+        "checksum": "adler32:afdca817",
+        "size": 7156337690,
+        "uri": "root://eospublic.cern.ch//eos/opendata/lhcb/CollisionNtuples/OPENDATA.LHCB.CGFF.E7X9/outputs/real-production/00393006_00000003_1.dvntuple.root"
+      },
+      {
+        "checksum": "adler32:6091833b",
+        "size": 7118388155,
+        "uri": "root://eospublic.cern.ch//eos/opendata/lhcb/CollisionNtuples/OPENDATA.LHCB.CGFF.E7X9/outputs/real-production/00393006_00000004_1.dvntuple.root"
+      },
+      {
+        "checksum": "adler32:938259b5",
+        "size": 731208261,
+        "uri": "root://eospublic.cern.ch//eos/opendata/lhcb/CollisionNtuples/OPENDATA.LHCB.CGFF.E7X9/outputs/real-production/00393006_00000005_1.dvntuple.root"
+      }
+    ],
+    "magnet_polarity": "MagDown",
+    "methodology": {
+      "description": "<p>These ntuples were produced from the LHCb Open Data Ntupling Service user request 6000. Please see the input configuration files <a href=\"/record/94000\">here</a>.</p>"
+    },
+    "publisher": "CERN Open Data Portal",
+    "recid": "94005",
+    "relations": [
+      {
+        "recid": "94000",
+        "type": "isChildOf"
+      }
+    ],
+    "run_period": [
+      "2017"
+    ],
+    "stripping": {
+      "stream": "EW",
+      "version": "stripping29r2"
+    },
+    "title": "DiJet Ntuples 6000 -- 2017 Magnet Down",
+    "type": {
+      "primary": "Dataset",
+      "secondary": [
+        "Collision"
+      ]
+    },
+    "usage": {
+      "description": "<p>You can use these ntuples with <a href=\"https://root.cern.ch/\">ROOT</a> data analysis framework. See documentation and examples here:</p>",
+      "links": [
+        {
+          "description": "LHCb Open Data Ntupling Service Usage Guide",
+          "url": "https://lhcb-opendata-guide.web.cern.ch/ntupling-service/"
+        },
+        {
+          "description": "First LHCb Open Data and Ntuple Wizard Workshop",
+          "url": "https://indico.cern.ch/event/1429526/timetable/#20241022.detailed"
+        },
+        {
+          "description": "Jet fragmentation analysis example",
+          "url": "https://github.com/lhcb-opendata-examples/jet-fragmentation"
+        }
+      ]
+    }
+  },
+  {
+    "abstract": {
+      "description": "Data from proton-proton (pp) collisions collected by the LHCb experiment filtered to produce ntuples for analyzing dijet events."
+    },
+    "accelerator": "CERN-LHC",
+    "collaboration": {
+      "name": "LHCb collaboration"
+    },
+    "collections": [
+      "LHCb-Collision-Datasets"
+    ],
+    "collision_information": {
+      "energy": "13TeV",
+      "type": "pp"
+    },
+    "date_created": [
+      "2017"
+    ],
+    "date_published": "2026",
+    "date_reprocessed": "2026",
+    "distribution": {
+      "formats": [
+        "root"
+      ],
+      "number_files": 4,
+      "size": 27220618080
+    },
+    "experiment": [
+      "LHCb"
+    ],
+    "files": [
+      {
+        "checksum": "adler32:9dfdbbf7",
+        "size": 7028357680,
+        "uri": "root://eospublic.cern.ch//eos/opendata/lhcb/CollisionNtuples/OPENDATA.LHCB.CGFF.E7X9/outputs/real-production/00393007_00000001_1.dvntuple.root"
+      },
+      {
+        "checksum": "adler32:bb85a6fa",
+        "size": 7073418974,
+        "uri": "root://eospublic.cern.ch//eos/opendata/lhcb/CollisionNtuples/OPENDATA.LHCB.CGFF.E7X9/outputs/real-production/00393007_00000002_1.dvntuple.root"
+      },
+      {
+        "checksum": "adler32:125e7100",
+        "size": 7076789656,
+        "uri": "root://eospublic.cern.ch//eos/opendata/lhcb/CollisionNtuples/OPENDATA.LHCB.CGFF.E7X9/outputs/real-production/00393007_00000003_1.dvntuple.root"
+      },
+      {
+        "checksum": "adler32:0024e4f1",
+        "size": 6042051770,
+        "uri": "root://eospublic.cern.ch//eos/opendata/lhcb/CollisionNtuples/OPENDATA.LHCB.CGFF.E7X9/outputs/real-production/00393007_00000004_1.dvntuple.root"
+      }
+    ],
+    "magnet_polarity": "MagUp",
+    "methodology": {
+      "description": "<p>These ntuples were produced from the LHCb Open Data Ntupling Service user request 6000. Please see the input configuration files <a href=\"/record/94000\">here</a>.</p>"
+    },
+    "publisher": "CERN Open Data Portal",
+    "recid": "94006",
+    "relations": [
+      {
+        "recid": "94000",
+        "type": "isChildOf"
+      }
+    ],
+    "run_period": [
+      "2017"
+    ],
+    "stripping": {
+      "stream": "EW",
+      "version": "stripping29r2"
+    },
+    "title": "DiJet Ntuples 6000 -- 2017 Magnet Up",
+    "type": {
+      "primary": "Dataset",
+      "secondary": [
+        "Collision"
+      ]
+    },
+    "usage": {
+      "description": "<p>You can use these ntuples with <a href=\"https://root.cern.ch/\">ROOT</a> data analysis framework. See documentation and examples here:</p>",
+      "links": [
+        {
+          "description": "LHCb Open Data Ntupling Service Usage Guide",
+          "url": "https://lhcb-opendata-guide.web.cern.ch/ntupling-service/"
+        },
+        {
+          "description": "First LHCb Open Data and Ntuple Wizard Workshop",
+          "url": "https://indico.cern.ch/event/1429526/timetable/#20241022.detailed"
+        },
+        {
+          "description": "Jet fragmentation analysis example",
+          "url": "https://github.com/lhcb-opendata-examples/jet-fragmentation"
+        }
+      ]
+    }
+  }
+]

--- a/data/records/lhcb-ntuples-run2-sv-tagged-dijets.json
+++ b/data/records/lhcb-ntuples-run2-sv-tagged-dijets.json
@@ -1,0 +1,631 @@
+[
+  {
+    "abstract": {
+      "description": "<p>Data from proton-proton (pp) collisions collected by the LHCb experiment filtered to produce ntuples for analyzing dijet events where the jets are tagged such that they contain a secondary vertex likely originating from a heavy flavor decay.</p> <p> Ntuples are created using DaVinci version v46r11 and the Analysis Productions batch processing system. Quantities saved to the ntuple are specified during the request phase and detailed in the code configuration files attached below.</p>"
+    },
+    "accelerator": "CERN-LHC",
+    "collaboration": {
+      "name": "LHCb collaboration"
+    },
+    "collections": [
+      "LHCb-Collision-Datasets"
+    ],
+    "date_created": [
+      "2015",
+      "2016",
+      "2017"
+    ],
+    "date_published": "2026",
+    "date_reprocessed": "2026",
+    "distribution": {
+      "formats": [
+        "py",
+        "yaml"
+      ],
+      "number_files": 3,
+      "size": 3509
+    },
+    "doi": "10.7483/OPENDATA.LHCB.C11J.UO8N",
+    "experiment": [
+      "LHCb"
+    ],
+    "files": [
+      {
+        "checksum": "adler32:453a0659",
+        "size": 769,
+        "uri": "root://eospublic.cern.ch//eos/opendata/lhcb/CollisionNtuples/OPENDATA.LHCB.C11J.UO8N/inputs/tagged_dijets_run2/dijets.py"
+      },
+      {
+        "checksum": "adler32:e5529fb2",
+        "size": 1510,
+        "uri": "root://eospublic.cern.ch//eos/opendata/lhcb/CollisionNtuples/OPENDATA.LHCB.C11J.UO8N/inputs/tagged_dijets_run2/dijets.yaml"
+      },
+      {
+        "checksum": "adler32:c1e66bb1",
+        "size": 1230,
+        "uri": "root://eospublic.cern.ch//eos/opendata/lhcb/CollisionNtuples/OPENDATA.LHCB.C11J.UO8N/inputs/tagged_dijets_run2/info.yaml"
+      }
+    ],
+    "methodology": {
+      "description": "These ntuples were produced from the LHCb Open Data Ntupling Service user request 5970. Please see the input configuration files attached below."
+    },
+    "publisher": "CERN Open Data Portal",
+    "recid": "94007",
+    "relations": [
+      {
+        "recid": "94008",
+        "type": "isParentOf"
+      },
+      {
+        "recid": "94009",
+        "type": "isParentOf"
+      },
+      {
+        "recid": "94010",
+        "type": "isParentOf"
+      },
+      {
+        "recid": "94011",
+        "type": "isParentOf"
+      },
+      {
+        "recid": "94012",
+        "type": "isParentOf"
+      },
+      {
+        "recid": "94013",
+        "type": "isParentOf"
+      }
+    ],
+    "title": "SV Tagged DiJet Ntuples 5970",
+    "type": {
+      "primary": "Dataset",
+      "secondary": [
+        "Collision"
+      ]
+    },
+    "usage": {
+      "description": "<p>Ntuples and instructions are provided in the links under Related datasets. They are ready to be downloaded and used for analysis. If these do not suit your needs, you can clone and amend this ntupling request here:",
+      "links": [
+        {
+          "description": "LHCb Open Data Ntupling Service",
+          "url": "https://opendata-lhcb-ntupling-service.app.cern.ch/"
+        },
+        {
+          "description": "LHCb Open Data Ntupling Service Usage Guide",
+          "url": "https://lhcb-opendata-guide.web.cern.ch/ntupling-service/"
+        },
+        {
+          "description": "Jet fragmentation analysis example",
+          "url": "https://github.com/lhcb-opendata-examples/jet-fragmentation"
+        }
+      ]
+    }
+  },
+  {
+    "abstract": {
+      "description": "Data from proton-proton (pp) collisions collected by the LHCb experiment filtered to produce ntuples for analyzing dijet events where the jets are tagged such that they contain a secondary vertex likely originating from a heavy flavor decay."
+    },
+    "accelerator": "CERN-LHC",
+    "collaboration": {
+      "name": "LHCb collaboration"
+    },
+    "collections": [
+      "LHCb-Collision-Datasets"
+    ],
+    "collision_information": {
+      "energy": "13TeV",
+      "type": "pp"
+    },
+    "date_created": [
+      "2015"
+    ],
+    "date_published": "2026",
+    "date_reprocessed": "2026",
+    "distribution": {
+      "formats": [
+        "root"
+      ],
+      "number_files": 1,
+      "size": 3362745891
+    },
+    "experiment": [
+      "LHCb"
+    ],
+    "files": [
+      {
+        "checksum": "adler32:065419b4",
+        "size": 3362745891,
+        "uri": "root://eospublic.cern.ch//eos/opendata/lhcb/CollisionNtuples/OPENDATA.LHCB.C11J.UO8N/outputs/real-production/00394032_00000001_1.dvntuple.root"
+      }
+    ],
+    "magnet_polarity": "MagDown",
+    "methodology": {
+      "description": "<p>These ntuples were produced from the LHCb Open Data Ntupling Service user request 5970. Please see the input configuration files <a href=\"/record/94007\">here</a>.</p>"
+    },
+    "publisher": "CERN Open Data Portal",
+    "recid": "94008",
+    "relations": [
+      {
+        "recid": "94007",
+        "type": "isChildOf"
+      }
+    ],
+    "run_period": [
+      "2015"
+    ],
+    "stripping": {
+      "stream": "BHADRONCOMPLETEEVENT",
+      "version": "stripping24r2"
+    },
+    "title": "SV Tagged DiJet Ntuples 5970 -- 2015 Magnet Down",
+    "type": {
+      "primary": "Dataset",
+      "secondary": [
+        "Collision"
+      ]
+    },
+    "usage": {
+      "description": "<p>You can use these ntuples with <a href=\"https://root.cern.ch/\">ROOT</a> data analysis framework. See documentation and examples here:</p>",
+      "links": [
+        {
+          "description": "LHCb Open Data Ntupling Service Usage Guide",
+          "url": "https://lhcb-opendata-guide.web.cern.ch/ntupling-service/"
+        },
+        {
+          "description": "First LHCb Open Data and Ntuple Wizard Workshop",
+          "url": "https://indico.cern.ch/event/1429526/timetable/#20241022.detailed"
+        },
+        {
+          "description": "Jet fragmentation analysis example",
+          "url": "https://github.com/lhcb-opendata-examples/jet-fragmentation"
+        }
+      ]
+    }
+  },
+  {
+    "abstract": {
+      "description": "Data from proton-proton (pp) collisions collected by the LHCb experiment filtered to produce ntuples for analyzing dijet events where the jets are tagged such that they contain a secondary vertex likely originating from a heavy flavor decay."
+    },
+    "accelerator": "CERN-LHC",
+    "collaboration": {
+      "name": "LHCb collaboration"
+    },
+    "collections": [
+      "LHCb-Collision-Datasets"
+    ],
+    "collision_information": {
+      "energy": "13TeV",
+      "type": "pp"
+    },
+    "date_created": [
+      "2015"
+    ],
+    "date_published": "2026",
+    "date_reprocessed": "2026",
+    "distribution": {
+      "formats": [
+        "root"
+      ],
+      "number_files": 1,
+      "size": 2584449418
+    },
+    "experiment": [
+      "LHCb"
+    ],
+    "files": [
+      {
+        "checksum": "adler32:a49d06bd",
+        "size": 2584449418,
+        "uri": "root://eospublic.cern.ch//eos/opendata/lhcb/CollisionNtuples/OPENDATA.LHCB.C11J.UO8N/outputs/real-production/00394031_00000001_1.dvntuple.root"
+      }
+    ],
+    "magnet_polarity": "MagUp",
+    "methodology": {
+      "description": "<p>These ntuples were produced from the LHCb Open Data Ntupling Service user request 5970. Please see the input configuration files <a href=\"/record/94007\">here</a>.</p>"
+    },
+    "publisher": "CERN Open Data Portal",
+    "recid": "94009",
+    "relations": [
+      {
+        "recid": "94007",
+        "type": "isChildOf"
+      }
+    ],
+    "run_period": [
+      "2015"
+    ],
+    "stripping": {
+      "stream": "BHADRONCOMPLETEEVENT",
+      "version": "stripping24r2"
+    },
+    "title": "SV Tagged DiJet Ntuples 5970 -- 2015 Magnet Up",
+    "type": {
+      "primary": "Dataset",
+      "secondary": [
+        "Collision"
+      ]
+    },
+    "usage": {
+      "description": "<p>You can use these ntuples with <a href=\"https://root.cern.ch/\">ROOT</a> data analysis framework. See documentation and examples here:</p>",
+      "links": [
+        {
+          "description": "LHCb Open Data Ntupling Service Usage Guide",
+          "url": "https://lhcb-opendata-guide.web.cern.ch/ntupling-service/"
+        },
+        {
+          "description": "First LHCb Open Data and Ntuple Wizard Workshop",
+          "url": "https://indico.cern.ch/event/1429526/timetable/#20241022.detailed"
+        },
+        {
+          "description": "Jet fragmentation analysis example",
+          "url": "https://github.com/lhcb-opendata-examples/jet-fragmentation"
+        }
+      ]
+    }
+  },
+  {
+    "abstract": {
+      "description": "Data from proton-proton (pp) collisions collected by the LHCb experiment filtered to produce ntuples for analyzing dijet events where the jets are tagged such that they contain a secondary vertex likely originating from a heavy flavor decay."
+    },
+    "accelerator": "CERN-LHC",
+    "collaboration": {
+      "name": "LHCb collaboration"
+    },
+    "collections": [
+      "LHCb-Collision-Datasets"
+    ],
+    "collision_information": {
+      "energy": "13TeV",
+      "type": "pp"
+    },
+    "date_created": [
+      "2016"
+    ],
+    "date_published": "2026",
+    "date_reprocessed": "2026",
+    "distribution": {
+      "formats": [
+        "root"
+      ],
+      "number_files": 3,
+      "size": 19848476632
+    },
+    "experiment": [
+      "LHCb"
+    ],
+    "files": [
+      {
+        "checksum": "adler32:45587deb",
+        "size": 6640182527,
+        "uri": "root://eospublic.cern.ch//eos/opendata/lhcb/CollisionNtuples/OPENDATA.LHCB.C11J.UO8N/outputs/real-production/00394036_00000001_1.dvntuple.root"
+      },
+      {
+        "checksum": "adler32:002fcf4a",
+        "size": 6669191828,
+        "uri": "root://eospublic.cern.ch//eos/opendata/lhcb/CollisionNtuples/OPENDATA.LHCB.C11J.UO8N/outputs/real-production/00394036_00000002_1.dvntuple.root"
+      },
+      {
+        "checksum": "adler32:6b17f7d9",
+        "size": 6539102277,
+        "uri": "root://eospublic.cern.ch//eos/opendata/lhcb/CollisionNtuples/OPENDATA.LHCB.C11J.UO8N/outputs/real-production/00394036_00000003_1.dvntuple.root"
+      }
+    ],
+    "magnet_polarity": "MagDown",
+    "methodology": {
+      "description": "<p>These ntuples were produced from the LHCb Open Data Ntupling Service user request 5970. Please see the input configuration files <a href=\"/record/94007\">here</a>.</p>"
+    },
+    "publisher": "CERN Open Data Portal",
+    "recid": "94010",
+    "relations": [
+      {
+        "recid": "94007",
+        "type": "isChildOf"
+      }
+    ],
+    "run_period": [
+      "2016"
+    ],
+    "stripping": {
+      "stream": "BHADRONCOMPLETEEVENT",
+      "version": "stripping28r2"
+    },
+    "title": "SV Tagged DiJet Ntuples 5970 -- 2016 Magnet Down",
+    "type": {
+      "primary": "Dataset",
+      "secondary": [
+        "Collision"
+      ]
+    },
+    "usage": {
+      "description": "<p>You can use these ntuples with <a href=\"https://root.cern.ch/\">ROOT</a> data analysis framework. See documentation and examples here:</p>",
+      "links": [
+        {
+          "description": "LHCb Open Data Ntupling Service Usage Guide",
+          "url": "https://lhcb-opendata-guide.web.cern.ch/ntupling-service/"
+        },
+        {
+          "description": "First LHCb Open Data and Ntuple Wizard Workshop",
+          "url": "https://indico.cern.ch/event/1429526/timetable/#20241022.detailed"
+        },
+        {
+          "description": "Jet fragmentation analysis example",
+          "url": "https://github.com/lhcb-opendata-examples/jet-fragmentation"
+        }
+      ]
+    }
+  },
+  {
+    "abstract": {
+      "description": "Data from proton-proton (pp) collisions collected by the LHCb experiment filtered to produce ntuples for analyzing dijet events where the jets are tagged such that they contain a secondary vertex likely originating from a heavy flavor decay."
+    },
+    "accelerator": "CERN-LHC",
+    "collaboration": {
+      "name": "LHCb collaboration"
+    },
+    "collections": [
+      "LHCb-Collision-Datasets"
+    ],
+    "collision_information": {
+      "energy": "13TeV",
+      "type": "pp"
+    },
+    "date_created": [
+      "2016"
+    ],
+    "date_published": "2026",
+    "date_reprocessed": "2026",
+    "distribution": {
+      "formats": [
+        "root"
+      ],
+      "number_files": 3,
+      "size": 18542640319
+    },
+    "experiment": [
+      "LHCb"
+    ],
+    "files": [
+      {
+        "checksum": "adler32:ebc5d749",
+        "size": 6652657118,
+        "uri": "root://eospublic.cern.ch//eos/opendata/lhcb/CollisionNtuples/OPENDATA.LHCB.C11J.UO8N/outputs/real-production/00394035_00000001_1.dvntuple.root"
+      },
+      {
+        "checksum": "adler32:1a635c63",
+        "size": 6680448104,
+        "uri": "root://eospublic.cern.ch//eos/opendata/lhcb/CollisionNtuples/OPENDATA.LHCB.C11J.UO8N/outputs/real-production/00394035_00000002_1.dvntuple.root"
+      },
+      {
+        "checksum": "adler32:968b164f",
+        "size": 5209535097,
+        "uri": "root://eospublic.cern.ch//eos/opendata/lhcb/CollisionNtuples/OPENDATA.LHCB.C11J.UO8N/outputs/real-production/00394035_00000003_1.dvntuple.root"
+      }
+    ],
+    "magnet_polarity": "MagUp",
+    "methodology": {
+      "description": "<p>These ntuples were produced from the LHCb Open Data Ntupling Service user request 5970. Please see the input configuration files <a href=\"/record/94007\">here</a>.</p>"
+    },
+    "publisher": "CERN Open Data Portal",
+    "recid": "94011",
+    "relations": [
+      {
+        "recid": "94007",
+        "type": "isChildOf"
+      }
+    ],
+    "run_period": [
+      "2016"
+    ],
+    "stripping": {
+      "stream": "BHADRONCOMPLETEEVENT",
+      "version": "stripping28r2"
+    },
+    "title": "SV Tagged DiJet Ntuples 5970 -- 2016 Magnet Up",
+    "type": {
+      "primary": "Dataset",
+      "secondary": [
+        "Collision"
+      ]
+    },
+    "usage": {
+      "description": "<p>You can use these ntuples with <a href=\"https://root.cern.ch/\">ROOT</a> data analysis framework. See documentation and examples here:</p>",
+      "links": [
+        {
+          "description": "LHCb Open Data Ntupling Service Usage Guide",
+          "url": "https://lhcb-opendata-guide.web.cern.ch/ntupling-service/"
+        },
+        {
+          "description": "First LHCb Open Data and Ntuple Wizard Workshop",
+          "url": "https://indico.cern.ch/event/1429526/timetable/#20241022.detailed"
+        },
+        {
+          "description": "Jet fragmentation analysis example",
+          "url": "https://github.com/lhcb-opendata-examples/jet-fragmentation"
+        }
+      ]
+    }
+  },
+  {
+    "abstract": {
+      "description": "Data from proton-proton (pp) collisions collected by the LHCb experiment filtered to produce ntuples for analyzing dijet events where the jets are tagged such that they contain a secondary vertex likely originating from a heavy flavor decay."
+    },
+    "accelerator": "CERN-LHC",
+    "collaboration": {
+      "name": "LHCb collaboration"
+    },
+    "collections": [
+      "LHCb-Collision-Datasets"
+    ],
+    "collision_information": {
+      "energy": "13TeV",
+      "type": "pp"
+    },
+    "date_created": [
+      "2017"
+    ],
+    "date_published": "2026",
+    "date_reprocessed": "2026",
+    "distribution": {
+      "formats": [
+        "root"
+      ],
+      "number_files": 3,
+      "size": 19608202292
+    },
+    "experiment": [
+      "LHCb"
+    ],
+    "files": [
+      {
+        "checksum": "adler32:fb3c5db2",
+        "size": 6711032278,
+        "uri": "root://eospublic.cern.ch//eos/opendata/lhcb/CollisionNtuples/OPENDATA.LHCB.C11J.UO8N/outputs/real-production/00394040_00000001_1.dvntuple.root"
+      },
+      {
+        "checksum": "adler32:5926e330",
+        "size": 6688625933,
+        "uri": "root://eospublic.cern.ch//eos/opendata/lhcb/CollisionNtuples/OPENDATA.LHCB.C11J.UO8N/outputs/real-production/00394040_00000002_1.dvntuple.root"
+      },
+      {
+        "checksum": "adler32:007e4d74",
+        "size": 6208544081,
+        "uri": "root://eospublic.cern.ch//eos/opendata/lhcb/CollisionNtuples/OPENDATA.LHCB.C11J.UO8N/outputs/real-production/00394040_00000003_1.dvntuple.root"
+      }
+    ],
+    "magnet_polarity": "MagDown",
+    "methodology": {
+      "description": "<p>These ntuples were produced from the LHCb Open Data Ntupling Service user request 5970. Please see the input configuration files <a href=\"/record/94007\">here</a>.</p>"
+    },
+    "publisher": "CERN Open Data Portal",
+    "recid": "94012",
+    "relations": [
+      {
+        "recid": "94007",
+        "type": "isChildOf"
+      }
+    ],
+    "run_period": [
+      "2017"
+    ],
+    "stripping": {
+      "stream": "BHADRONCOMPLETEEVENT",
+      "version": "stripping29r2"
+    },
+    "title": "SV Tagged DiJet Ntuples 5970 -- 2017 Magnet Down",
+    "type": {
+      "primary": "Dataset",
+      "secondary": [
+        "Collision"
+      ]
+    },
+    "usage": {
+      "description": "<p>You can use these ntuples with <a href=\"https://root.cern.ch/\">ROOT</a> data analysis framework. See documentation and examples here:</p>",
+      "links": [
+        {
+          "description": "LHCb Open Data Ntupling Service Usage Guide",
+          "url": "https://lhcb-opendata-guide.web.cern.ch/ntupling-service/"
+        },
+        {
+          "description": "First LHCb Open Data and Ntuple Wizard Workshop",
+          "url": "https://indico.cern.ch/event/1429526/timetable/#20241022.detailed"
+        },
+        {
+          "description": "Jet fragmentation analysis example",
+          "url": "https://github.com/lhcb-opendata-examples/jet-fragmentation"
+        }
+      ]
+    }
+  },
+  {
+    "abstract": {
+      "description": "Data from proton-proton (pp) collisions collected by the LHCb experiment filtered to produce ntuples for analyzing dijet events where the jets are tagged such that they contain a secondary vertex likely originating from a heavy flavor decay."
+    },
+    "accelerator": "CERN-LHC",
+    "collaboration": {
+      "name": "LHCb collaboration"
+    },
+    "collections": [
+      "LHCb-Collision-Datasets"
+    ],
+    "collision_information": {
+      "energy": "13TeV",
+      "type": "pp"
+    },
+    "date_created": [
+      "2017"
+    ],
+    "date_published": "2026",
+    "date_reprocessed": "2026",
+    "distribution": {
+      "formats": [
+        "root"
+      ],
+      "number_files": 3,
+      "size": 16379598573
+    },
+    "experiment": [
+      "LHCb"
+    ],
+    "files": [
+      {
+        "checksum": "adler32:056d71ae",
+        "size": 6722499514,
+        "uri": "root://eospublic.cern.ch//eos/opendata/lhcb/CollisionNtuples/OPENDATA.LHCB.C11J.UO8N/outputs/real-production/00394039_00000001_1.dvntuple.root"
+      },
+      {
+        "checksum": "adler32:af8aa34c",
+        "size": 4476811285,
+        "uri": "root://eospublic.cern.ch//eos/opendata/lhcb/CollisionNtuples/OPENDATA.LHCB.C11J.UO8N/outputs/real-production/00394039_00000002_1.dvntuple.root"
+      },
+      {
+        "checksum": "adler32:012be388",
+        "size": 5180287774,
+        "uri": "root://eospublic.cern.ch//eos/opendata/lhcb/CollisionNtuples/OPENDATA.LHCB.C11J.UO8N/outputs/real-production/00394039_00000003_1.dvntuple.root"
+      }
+    ],
+    "magnet_polarity": "MagUp",
+    "methodology": {
+      "description": "<p>These ntuples were produced from the LHCb Open Data Ntupling Service user request 5970. Please see the input configuration files <a href=\"/record/94007\">here</a>.</p>"
+    },
+    "publisher": "CERN Open Data Portal",
+    "recid": "94013",
+    "relations": [
+      {
+        "recid": "94007",
+        "type": "isChildOf"
+      }
+    ],
+    "run_period": [
+      "2017"
+    ],
+    "stripping": {
+      "stream": "BHADRONCOMPLETEEVENT",
+      "version": "stripping29r2"
+    },
+    "title": "SV Tagged DiJet Ntuples 5970 -- 2017 Magnet Up",
+    "type": {
+      "primary": "Dataset",
+      "secondary": [
+        "Collision"
+      ]
+    },
+    "usage": {
+      "description": "<p>You can use these ntuples with <a href=\"https://root.cern.ch/\">ROOT</a> data analysis framework. See documentation and examples here:</p>",
+      "links": [
+        {
+          "description": "LHCb Open Data Ntupling Service Usage Guide",
+          "url": "https://lhcb-opendata-guide.web.cern.ch/ntupling-service/"
+        },
+        {
+          "description": "First LHCb Open Data and Ntuple Wizard Workshop",
+          "url": "https://indico.cern.ch/event/1429526/timetable/#20241022.detailed"
+        },
+        {
+          "description": "Jet fragmentation analysis example",
+          "url": "https://github.com/lhcb-opendata-examples/jet-fragmentation"
+        }
+      ]
+    }
+  }
+]


### PR DESCRIPTION
feat(records): add records for dijet and sv-tagged dijet ntuples produced from the LHCb Ntupling Service.

TODOs:

- Assign and update placeholder DOIs for both records
- Copy output files to permanent storage and replace URI paths in both records
- Copy input files for both records into permanent storage and fix placeholder checksums, byte sizes, and URIs
- Fix placeholder recids (they were just assigned so I could do local testing)

cc @tiborsimko, @pietnogga 