### PR TITLE
feat(records): add three LHCb author lists for LHC Run 2

### DIFF
--- a/data/records/lhcb-author-list-2015.json
+++ b/data/records/lhcb-author-list-2015.json
@@ -1,0 +1,3650 @@
+[
+  {
+    "authors": [
+      {
+        "affiliation": "CERN",
+        "inspireid": "INSPIRE-00258707",
+        "name": "Aaij, Roel"
+      },
+      {
+        "affiliation": "U. Santiago de Compostela (main)",
+        "inspireid": "INSPIRE-00194077",
+        "name": "Adeva, Bernardo"
+      },
+      {
+        "affiliation": "Bristol U.",
+        "inspireid": "INSPIRE-00060950",
+        "name": "Adinolfi, Marco"
+      },
+      {
+        "affiliation": "Liverpool U.",
+        "inspireid": "INSPIRE-00061029",
+        "name": "Affolder, Anthony"
+      },
+      {
+        "affiliation": "Clermont-Ferrand U.",
+        "inspireid": "INSPIRE-00061185",
+        "name": "Ajaltouni, Ziad"
+      },
+      {
+        "affiliation": "Marseille, CPPM",
+        "inspireid": "INSPIRE-00277451",
+        "name": "Akar, Simon"
+      },
+      {
+        "affiliation": "Rio de Janeiro Federal U.",
+        "inspireid": "INSPIRE-00055208",
+        "name": "Akiba, Kazuyoshi"
+      },
+      {
+        "affiliation": "Tech. U., Dortmund (main)",
+        "inspireid": "INSPIRE-00259834",
+        "name": "Albrecht, Johannes"
+      },
+      {
+        "affiliation": "CERN",
+        "inspireid": "INSPIRE-00257446",
+        "name": "Alessio, Federico"
+      },
+      {
+        "affiliation": "Glasgow U.",
+        "inspireid": "INSPIRE-00160626",
+        "name": "Alexander, Michael"
+      },
+      {
+        "affiliation": "Nikhef, Amsterdam",
+        "inspireid": "INSPIRE-00340938",
+        "name": "Ali, Suvayu"
+      },
+      {
+        "affiliation": "Authors affiliated with an institute formerly covered by a cooperation agreement with CERN.",
+        "inspireid": "INSPIRE-00061628",
+        "name": "Alkhazov, Georgy"
+      },
+      {
+        "affiliation": "Imperial Coll., London",
+        "inspireid": "INSPIRE-00259650",
+        "name": "Alvarez Cartelle, Paula"
+      },
+      {
+        "affiliation": "Cincinnati U.",
+        "inspireid": "INSPIRE-00258623",
+        "name": "Alves Jr, Antonio Augusto"
+      },
+      {
+        "affiliation": "Rio de Janeiro Federal U.",
+        "inspireid": "INSPIRE-00061842",
+        "name": "Amato, Sandra"
+      },
+      {
+        "affiliation": "INFN, Padua",
+        "inspireid": "INSPIRE-00041447",
+        "name": "Amerio, Silvia"
+      },
+      {
+        "affiliation": "Orsay, LAL",
+        "inspireid": "INSPIRE-00260470",
+        "name": "Amhis, Yasmine"
+      },
+      {
+        "affiliation": "Ecole Polytechnique, Lausanne",
+        "inspireid": "INSPIRE-00451766",
+        "name": "An, Liupan"
+      },
+      {
+        "affiliation": "INFN, Florence",
+        "inspireid": "INSPIRE-00357120",
+        "name": "Anderlini, Lucio"
+      },
+      {
+        "affiliation": "Ecole Polytechnique, Lausanne",
+        "inspireid": "INSPIRE-00536702",
+        "name": "Andreassi, Guido"
+      },
+      {
+        "affiliation": "INFN, Ferrara; Ferrara U.",
+        "inspireid": "INSPIRE-00042608",
+        "name": "Andreotti, Mirco"
+      },
+      {
+        "affiliation": "Maryland U., College Park",
+        "inspireid": "INSPIRE-00387304",
+        "name": "Andrews, Jason"
+      },
+      {
+        "affiliation": "Manchester U.",
+        "inspireid": "INSPIRE-00193766",
+        "name": "Appleby, Robert"
+      },
+      {
+        "affiliation": "CERN",
+        "inspireid": "INSPIRE-00340940",
+        "name": "Archilli, Flavio"
+      },
+      {
+        "affiliation": "Authors affiliated with an institute formerly covered by a cooperation agreement with CERN.",
+        "inspireid": "INSPIRE-00320358",
+        "name": "Artamonov, Alexander"
+      },
+      {
+        "affiliation": "Syracuse U.",
+        "inspireid": "INSPIRE-00063052",
+        "name": "Artuso, Marina"
+      },
+      {
+        "affiliation": "Marseille, CPPM",
+        "inspireid": "INSPIRE-00257456",
+        "name": "Aslanides, Elie"
+      },
+      {
+        "affiliation": "INFN, Rome; Basilicata U., Potenza",
+        "inspireid": "INSPIRE-00258647",
+        "name": "Auriemma, Giulio"
+      },
+      {
+        "affiliation": "Clermont-Ferrand U.",
+        "inspireid": "INSPIRE-00387320",
+        "name": "Baalouch, Marouen"
+      },
+      {
+        "affiliation": "Heidelberg U.",
+        "inspireid": "INSPIRE-00257758",
+        "name": "Bachmann, Sebastian"
+      },
+      {
+        "affiliation": "Warwick U.",
+        "inspireid": "INSPIRE-00041629",
+        "name": "Back, John"
+      },
+      {
+        "affiliation": "U. Barcelona (main); Ramon Llull U., Barcelona",
+        "inspireid": "INSPIRE-00387629",
+        "name": "Badalov, Alexey"
+      },
+      {
+        "affiliation": "Rio de Janeiro, Pont. U. Catol.",
+        "inspireid": "INSPIRE-00357139",
+        "name": "Baesso, Clarissa"
+      },
+      {
+        "affiliation": "INFN, Ferrara; CERN",
+        "inspireid": "INSPIRE-00210350",
+        "name": "Baldini, Wander"
+      },
+      {
+        "affiliation": "Manchester U.",
+        "inspireid": "INSPIRE-00064590",
+        "name": "Barlow, Roger"
+      },
+      {
+        "affiliation": "CERN",
+        "inspireid": "INSPIRE-00295950",
+        "name": "Barschel, Colin"
+      },
+      {
+        "affiliation": "Orsay, LAL",
+        "inspireid": "INSPIRE-00257536",
+        "name": "Barsuk, Sergey"
+      },
+      {
+        "affiliation": "CERN",
+        "inspireid": "INSPIRE-00340962",
+        "name": "Barter, William"
+      },
+      {
+        "affiliation": "NCBJ, Swierk",
+        "inspireid": "INSPIRE-00387971",
+        "name": "Batozskaya, Varvara"
+      },
+      {
+        "affiliation": "Ecole Polytechnique, Lausanne",
+        "inspireid": "INSPIRE-00451956",
+        "name": "Battista, Vincenzo"
+      },
+      {
+        "affiliation": "Ecole Polytechnique, Lausanne",
+        "inspireid": "INSPIRE-00065250",
+        "name": "Bay, Aurelio"
+      },
+      {
+        "affiliation": "Annecy, LAPP",
+        "inspireid": "INSPIRE-00399871",
+        "name": "Beaucourt, Leo"
+      },
+      {
+        "affiliation": "Glasgow U.",
+        "inspireid": "INSPIRE-00340975",
+        "name": "Beddow, John"
+      },
+      {
+        "affiliation": "INFN, Pisa",
+        "inspireid": "INSPIRE-00065532",
+        "name": "Bedeschi, Franco"
+      },
+      {
+        "affiliation": "Rio de Janeiro, CBPF",
+        "inspireid": "INSPIRE-00065546",
+        "name": "Bediaga, Ignacio"
+      },
+      {
+        "affiliation": "Nikhef, Amsterdam",
+        "inspireid": "INSPIRE-00522548",
+        "name": "Bel, Lennaert"
+      },
+      {
+        "affiliation": "Ecole Polytechnique, Lausanne",
+        "inspireid": "INSPIRE-00536729",
+        "name": "Bellee, Violaine"
+      },
+      {
+        "affiliation": "INFN, Milan Bicocca; Milan Bicocca U.",
+        "inspireid": "INSPIRE-00536743",
+        "name": "Belloli, Nicoletta"
+      },
+      {
+        "affiliation": "Authors affiliated with an institute formerly covered by a cooperation agreement with CERN.",
+        "inspireid": "INSPIRE-00258730",
+        "name": "Belyaev, Ivan"
+      },
+      {
+        "affiliation": "Frascati",
+        "inspireid": "INSPIRE-00258283",
+        "name": "Bencivenni, Giovanni"
+      },
+      {
+        "affiliation": "Paris U., VI-VII",
+        "inspireid": "INSPIRE-00052383",
+        "name": "Ben-Haim, Eli"
+      },
+      {
+        "affiliation": "CERN",
+        "inspireid": "INSPIRE-00341004",
+        "name": "Benson, Sean"
+      },
+      {
+        "affiliation": "Bristol U.",
+        "inspireid": "INSPIRE-00344672",
+        "name": "Benton, Jack"
+      },
+      {
+        "affiliation": "Authors affiliated with an institute formerly covered by a cooperation agreement with CERN.",
+        "inspireid": "INSPIRE-00202631",
+        "name": "Berezhnoy, Alexander"
+      },
+      {
+        "affiliation": "Zurich U.",
+        "inspireid": "INSPIRE-00066526",
+        "name": "Bernet, Roland"
+      },
+      {
+        "affiliation": "INFN, Padua",
+        "inspireid": "INSPIRE-00173823",
+        "name": "Bertolin, Alessandro"
+      },
+      {
+        "affiliation": "CERN",
+        "inspireid": "INSPIRE-00001810",
+        "name": "Bettler, Marc-Olivier"
+      },
+      {
+        "affiliation": "Birmingham U.",
+        "inspireid": "INSPIRE-00000685",
+        "name": "Bifani, Simone"
+      },
+      {
+        "affiliation": "Paris U., VI-VII",
+        "inspireid": "INSPIRE-00067095",
+        "name": "Billoir, Pierre"
+      },
+      {
+        "affiliation": "Manchester U.",
+        "inspireid": "INSPIRE-00344700",
+        "name": "Bird, Thomas"
+      },
+      {
+        "affiliation": "Tech. U., Dortmund (main)",
+        "inspireid": "INSPIRE-00522660",
+        "name": "Birnkraut, Alex"
+      },
+      {
+        "affiliation": "Manchester U.",
+        "inspireid": "INSPIRE-00160399",
+        "name": "Bitadze, Alexander"
+      },
+      {
+        "affiliation": "INFN, Florence; U. Modena (main)",
+        "inspireid": "INSPIRE-00258210",
+        "name": "Bizzeti, Andrea"
+      },
+      {
+        "affiliation": "Warwick U.",
+        "inspireid": "INSPIRE-00261950",
+        "name": "Blake, Thomas"
+      },
+      {
+        "affiliation": "Ecole Polytechnique, Lausanne",
+        "inspireid": "INSPIRE-00067348",
+        "name": "Blanc, Frederic"
+      },
+      {
+        "affiliation": "Heidelberg, Max Planck Inst.",
+        "inspireid": "INSPIRE-00257778",
+        "name": "Blouw, Johan"
+      },
+      {
+        "affiliation": "Syracuse U.",
+        "inspireid": "INSPIRE-00067685",
+        "name": "Blusk, Steven"
+      },
+      {
+        "affiliation": "INFN, Rome",
+        "inspireid": "INSPIRE-00067707",
+        "name": "Bocci, Valerio"
+      },
+      {
+        "affiliation": "Authors affiliated with an institute formerly covered by a cooperation agreement with CERN.",
+        "inspireid": "INSPIRE-00259423",
+        "name": "Bondar, Alexander"
+      },
+      {
+        "affiliation": "Authors affiliated with an institute formerly covered by a cooperation agreement with CERN.; CERN",
+        "inspireid": "INSPIRE-00317412",
+        "name": "Bondar, Nikolay"
+      },
+      {
+        "affiliation": "INFN, Cagliari",
+        "inspireid": "INSPIRE-00258110",
+        "name": "Bonivento, Walter"
+      },
+      {
+        "affiliation": "Manchester U.",
+        "inspireid": "INSPIRE-00261856",
+        "name": "Borghi, Silvia"
+      },
+      {
+        "affiliation": "U. Santiago de Compostela (main)",
+        "inspireid": "INSPIRE-00388228",
+        "name": "Borsato, Martino"
+      },
+      {
+        "affiliation": "Liverpool U.",
+        "inspireid": "INSPIRE-00068684",
+        "name": "Bowcock, Themistocles"
+      },
+      {
+        "affiliation": "Zurich U.",
+        "inspireid": "INSPIRE-00388407",
+        "name": "Bowen, Espen Eie"
+      },
+      {
+        "affiliation": "INFN, Ferrara; CERN",
+        "inspireid": "INSPIRE-00068846",
+        "name": "Bozzi, Concezio"
+      },
+      {
+        "affiliation": "Heidelberg U.",
+        "inspireid": "INSPIRE-00470092",
+        "name": "Braun, Svende"
+      },
+      {
+        "affiliation": "Heidelberg U.",
+        "inspireid": "INSPIRE-00257919",
+        "name": "Britsch, Markward"
+      },
+      {
+        "affiliation": "Syracuse U.",
+        "inspireid": "INSPIRE-00295976",
+        "name": "Britton, Thomas"
+      },
+      {
+        "affiliation": "Manchester U.",
+        "inspireid": "INSPIRE-00369499",
+        "name": "Brodzicka, Jolanta"
+      },
+      {
+        "affiliation": "Bristol U.",
+        "inspireid": "INSPIRE-00172248",
+        "name": "Brook, Nicholas"
+      },
+      {
+        "affiliation": "Bristol U.",
+        "inspireid": "INSPIRE-00536755",
+        "name": "Buchanan, Emma"
+      },
+      {
+        "affiliation": "Manchester U.",
+        "inspireid": "INSPIRE-00545500",
+        "name": "Burr, Christopher"
+      },
+      {
+        "affiliation": "Rio de Janeiro Federal U.",
+        "inspireid": "INSPIRE-00260792",
+        "name": "Bursche, Albert"
+      },
+      {
+        "affiliation": "CERN",
+        "inspireid": "INSPIRE-00259860",
+        "name": "Buytaert, Jan"
+      },
+      {
+        "affiliation": "INFN, Cagliari",
+        "inspireid": "INSPIRE-00258132",
+        "name": "Cadeddu, Sandro"
+      },
+      {
+        "affiliation": "INFN, Ferrara; Ferrara U.",
+        "inspireid": "INSPIRE-00070550",
+        "name": "Calabrese, Roberto"
+      },
+      {
+        "affiliation": "INFN, Milan Bicocca; Milan Bicocca U.",
+        "inspireid": "INSPIRE-00258504",
+        "name": "Calvi, Marta"
+      },
+      {
+        "affiliation": "U. Barcelona (main); Ramon Llull U., Barcelona",
+        "inspireid": "INSPIRE-00259475",
+        "name": "Calvo Gomez, Miriam"
+      },
+      {
+        "affiliation": "Frascati",
+        "inspireid": "INSPIRE-00258299",
+        "name": "Campana, Pierluigi"
+      },
+      {
+        "affiliation": "CERN",
+        "inspireid": "INSPIRE-00388548",
+        "name": "Campora Perez, Daniel Hugo"
+      },
+      {
+        "affiliation": "Manchester U.",
+        "inspireid": "INSPIRE-00452150",
+        "name": "Capriotti, Lorenzo"
+      },
+      {
+        "affiliation": "INFN, Bologna; Bologna U.",
+        "inspireid": "INSPIRE-00258058",
+        "name": "Carbone, Angelo"
+      },
+      {
+        "affiliation": "Rome U., Tor Vergata",
+        "inspireid": "INSPIRE-00258566",
+        "name": "Carboni, Giovanni"
+      },
+      {
+        "affiliation": "INFN, Genoa; Genoa U.",
+        "inspireid": "INSPIRE-00259930",
+        "name": "Cardinale, Roberta"
+      },
+      {
+        "affiliation": "INFN, Cagliari",
+        "inspireid": "INSPIRE-00071030",
+        "name": "Cardini, Alessandro"
+      },
+      {
+        "affiliation": "INFN, Milan Bicocca; Milan Bicocca U.",
+        "inspireid": "INSPIRE-00452332",
+        "name": "Carniti, Paolo"
+      },
+      {
+        "affiliation": "Edinburgh U.",
+        "inspireid": "INSPIRE-00160267",
+        "name": "Carson, Laurence"
+      },
+      {
+        "affiliation": "Liverpool U.",
+        "inspireid": "INSPIRE-00071483",
+        "name": "Casse, Gianluigi"
+      },
+      {
+        "affiliation": "INFN, Milan Bicocca; Milan Bicocca U.",
+        "inspireid": "INSPIRE-00399968",
+        "name": "Cassina, Lorenzo"
+      },
+      {
+        "affiliation": "Ecole Polytechnique, Lausanne",
+        "inspireid": "INSPIRE-00388630",
+        "name": "Castillo Garcia, Lucia"
+      },
+      {
+        "affiliation": "CERN",
+        "inspireid": "INSPIRE-00071656",
+        "name": "Cattaneo, Marco"
+      },
+      {
+        "affiliation": "Tech. U., Dortmund (main)",
+        "inspireid": "INSPIRE-00344761",
+        "name": "Cauet, Christophe"
+      },
+      {
+        "affiliation": "INFN, Genoa; Genoa U.",
+        "inspireid": "INSPIRE-00452703",
+        "name": "Cavallero, Giovanni"
+      },
+      {
+        "affiliation": "INFN, Pisa; Pisa, Scuola Normale Superiore",
+        "inspireid": "INSPIRE-00041990",
+        "name": "Cenci, Riccardo"
+      },
+      {
+        "affiliation": "Paris U., VI-VII",
+        "inspireid": "INSPIRE-00054561",
+        "name": "Charles, Matthew"
+      },
+      {
+        "affiliation": "CERN",
+        "inspireid": "INSPIRE-00259892",
+        "name": "Charpentier, Philippe"
+      },
+      {
+        "affiliation": "Annecy, LAPP",
+        "inspireid": "INSPIRE-02701689",
+        "name": "Chefdeville, Maximilien"
+      },
+      {
+        "affiliation": "Manchester U.",
+        "inspireid": "INSPIRE-00400187",
+        "name": "Chen, Shanzhen"
+      },
+      {
+        "affiliation": "Oxford U.",
+        "inspireid": "INSPIRE-00388653",
+        "name": "Cheung, Shu Faye"
+      },
+      {
+        "affiliation": "Zurich U.",
+        "inspireid": "INSPIRE-00260804",
+        "name": "Chiapolini, Nicola"
+      },
+      {
+        "affiliation": "Zurich U.",
+        "inspireid": "INSPIRE-00344777",
+        "name": "Chrzaszcz, Marcin"
+      },
+      {
+        "affiliation": "Frascati",
+        "name": "Ciambrone, Paolo"
+      },
+      {
+        "affiliation": "CERN",
+        "inspireid": "INSPIRE-00259661",
+        "name": "Cid Vidal, Xabier"
+      },
+      {
+        "affiliation": "Nikhef, Amsterdam",
+        "inspireid": "INSPIRE-00344785",
+        "name": "Ciezarek, Gregory"
+      },
+      {
+        "affiliation": "Edinburgh U.",
+        "inspireid": "INSPIRE-00073694",
+        "name": "Clarke, Peter"
+      },
+      {
+        "affiliation": "CERN",
+        "inspireid": "INSPIRE-00021864",
+        "name": "Clemencic, Marco"
+      },
+      {
+        "affiliation": "Cambridge U.",
+        "inspireid": "INSPIRE-00261009",
+        "name": "Cliff, Harry"
+      },
+      {
+        "affiliation": "CERN",
+        "inspireid": "INSPIRE-00259955",
+        "name": "Closier, Joel"
+      },
+      {
+        "affiliation": "CERN",
+        "inspireid": "INSPIRE-00262900",
+        "name": "Coco, Victor"
+      },
+      {
+        "affiliation": "Marseille, CPPM",
+        "inspireid": "INSPIRE-00257463",
+        "name": "Cogan, Julien"
+      },
+      {
+        "affiliation": "Clermont-Ferrand U.",
+        "inspireid": "INSPIRE-00305695",
+        "name": "Cogneras, Eric"
+      },
+      {
+        "affiliation": "INFN, Cagliari; Cagliari U.",
+        "inspireid": "INSPIRE-00452873",
+        "name": "Cogoni, Violetta"
+      },
+      {
+        "affiliation": "Bucharest, IFIN-HH",
+        "inspireid": "INSPIRE-00453049",
+        "name": "Cojocariu, Lucian"
+      },
+      {
+        "affiliation": "CERN",
+        "inspireid": "INSPIRE-00259967",
+        "name": "Collins, Paula"
+      },
+      {
+        "affiliation": "Heidelberg U.",
+        "inspireid": "INSPIRE-00259490",
+        "name": "Comerma-Montells, Albert"
+      },
+      {
+        "affiliation": "CERN",
+        "inspireid": "INSPIRE-00262791",
+        "name": "Contu, Andrea"
+      },
+      {
+        "affiliation": "Bristol U.",
+        "inspireid": "INSPIRE-00345167",
+        "name": "Cook, Andrew"
+      },
+      {
+        "affiliation": "Bristol U.",
+        "inspireid": "INSPIRE-00260947",
+        "name": "Coombes, Matthew"
+      },
+      {
+        "affiliation": "U. Barcelona (main)",
+        "inspireid": "INSPIRE-00388698",
+        "name": "Coquereau, Samuel"
+      },
+      {
+        "affiliation": "CERN",
+        "inspireid": "INSPIRE-00259985",
+        "name": "Corti, Gloria"
+      },
+      {
+        "affiliation": "INFN, Ferrara; Ferrara U.",
+        "inspireid": "INSPIRE-00453205",
+        "name": "Corvo, Marco"
+      },
+      {
+        "affiliation": "CERN",
+        "inspireid": "INSPIRE-00345186",
+        "name": "Couturier, Benjamin"
+      },
+      {
+        "affiliation": "Edinburgh U.",
+        "inspireid": "INSPIRE-00261246",
+        "name": "Cowan, Greig"
+      },
+      {
+        "affiliation": "Edinburgh U.",
+        "inspireid": "INSPIRE-00357145",
+        "name": "Craik, Daniel Charles"
+      },
+      {
+        "affiliation": "Warwick U.",
+        "inspireid": "INSPIRE-00453257",
+        "name": "Crocombe, Andrew"
+      },
+      {
+        "affiliation": "Rio de Janeiro, Pont. U. Catol.",
+        "inspireid": "INSPIRE-00388812",
+        "name": "Cruz Torres, Melissa Maria"
+      },
+      {
+        "affiliation": "Imperial Coll., London",
+        "inspireid": "INSPIRE-00357159",
+        "name": "Cunliffe, Samuel"
+      },
+      {
+        "affiliation": "Imperial Coll., London",
+        "inspireid": "INSPIRE-00261251",
+        "name": "Currie, Robert"
+      },
+      {
+        "affiliation": "Nikhef, Amsterdam",
+        "name": "Dall'Occo, Elena"
+      },
+      {
+        "affiliation": "Bristol U.",
+        "inspireid": "INSPIRE-00043651",
+        "name": "Dalseno, Jeremy"
+      },
+      {
+        "affiliation": "CERN",
+        "inspireid": "INSPIRE-00207542",
+        "name": "D'Ambrosio, Carmelo"
+      },
+      {
+        "affiliation": "Heidelberg U.",
+        "inspireid": "INSPIRE-00522530",
+        "name": "d'Argent, Philippe"
+      },
+      {
+        "affiliation": "Nikhef, Amsterdam",
+        "inspireid": "INSPIRE-00341020",
+        "name": "David, Pieter"
+      },
+      {
+        "affiliation": "Cincinnati U.",
+        "inspireid": "INSPIRE-00389020",
+        "name": "Davis, Adam"
+      },
+      {
+        "affiliation": "Rio de Janeiro Federal U.",
+        "inspireid": "INSPIRE-00341212",
+        "name": "De Aguiar Francisco, Oscar"
+      },
+      {
+        "affiliation": "Marseille, CPPM",
+        "inspireid": "INSPIRE-00341032",
+        "name": "De Bruyn, Kristof"
+      },
+      {
+        "affiliation": "Manchester U.",
+        "inspireid": "INSPIRE-00258572",
+        "name": "De Capua, Stefano"
+      },
+      {
+        "affiliation": "Heidelberg U.",
+        "inspireid": "INSPIRE-00260810",
+        "name": "De Cian, Michel"
+      },
+      {
+        "affiliation": "Rio de Janeiro, CBPF",
+        "inspireid": "INSPIRE-00107943",
+        "name": "De Miranda, Jussara"
+      },
+      {
+        "affiliation": "Rio de Janeiro Federal U.",
+        "inspireid": "INSPIRE-00115169",
+        "name": "De Paula, Leandro"
+      },
+      {
+        "affiliation": "Frascati",
+        "inspireid": "INSPIRE-00258414",
+        "name": "De Simone, Patrizia"
+      },
+      {
+        "affiliation": "Nikhef, Amsterdam",
+        "inspireid": "INSPIRE-00400290",
+        "name": "de Vries, Jacco"
+      },
+      {
+        "affiliation": "Glasgow U.",
+        "inspireid": "INSPIRE-00453317",
+        "name": "Dean, Cameron Thomas"
+      },
+      {
+        "affiliation": "Annecy, LAPP",
+        "inspireid": "INSPIRE-00257320",
+        "name": "Decamp, Daniel"
+      },
+      {
+        "affiliation": "Tech. U., Dortmund (main)",
+        "inspireid": "INSPIRE-00341054",
+        "name": "Deckenhoff, Mirko"
+      },
+      {
+        "affiliation": "Paris U., VI-VII",
+        "inspireid": "INSPIRE-00070041",
+        "name": "Del Buono, Luigi"
+      },
+      {
+        "affiliation": "Annecy, LAPP",
+        "inspireid": "INSPIRE-00389141",
+        "name": "D\\'el\\'eage, Nicolas"
+      },
+      {
+        "affiliation": "Tech. U., Dortmund (main)",
+        "inspireid": "INSPIRE-00536774",
+        "name": "Demmer, Moritz"
+      },
+      {
+        "affiliation": "Authors affiliated with an institute formerly covered by a cooperation agreement with CERN.",
+        "inspireid": "INSPIRE-00144686",
+        "name": "Derkach, Denis"
+      },
+      {
+        "affiliation": "Clermont-Ferrand U.",
+        "inspireid": "INSPIRE-00257367",
+        "name": "Deschamps, Olivier"
+      },
+      {
+        "affiliation": "CERN",
+        "inspireid": "INSPIRE-00258140",
+        "name": "Dettori, Francesco"
+      },
+      {
+        "affiliation": "INFN, Milan",
+        "inspireid": "INSPIRE-00266843",
+        "name": "Dey, Biplab"
+      },
+      {
+        "affiliation": "CERN",
+        "inspireid": "INSPIRE-00010940",
+        "name": "Di Canto, Angelo"
+      },
+      {
+        "affiliation": "CERN",
+        "inspireid": "INSPIRE-00260011",
+        "name": "Dijkstra, Hans"
+      },
+      {
+        "affiliation": "Liverpool U.",
+        "inspireid": "INSPIRE-00261885",
+        "name": "Donleavy, Stephanie"
+      },
+      {
+        "affiliation": "CERN",
+        "inspireid": "INSPIRE-00341074",
+        "name": "Dordei, Francesca"
+      },
+      {
+        "affiliation": "Ecole Polytechnique, Lausanne",
+        "inspireid": "INSPIRE-00000328",
+        "name": "Dorigo, Mirco"
+      },
+      {
+        "affiliation": "Rio de Janeiro, CBPF",
+        "inspireid": "INSPIRE-00257176",
+        "name": "dos Reis, Alberto"
+      },
+      {
+        "affiliation": "U. Santiago de Compostela (main)",
+        "inspireid": "INSPIRE-00341088",
+        "name": "Dosil Su\\'arez, Alvaro"
+      },
+      {
+        "affiliation": "Kharkov, KIPT",
+        "inspireid": "INSPIRE-00260913",
+        "name": "Dovbnya, Anatoliy"
+      },
+      {
+        "affiliation": "Liverpool U.",
+        "inspireid": "INSPIRE-00399892",
+        "name": "Dreimanis, Karlis"
+      },
+      {
+        "affiliation": "Nikhef, Amsterdam",
+        "inspireid": "INSPIRE-00536780",
+        "name": "Dufour, Laurent"
+      },
+      {
+        "affiliation": "Manchester U.",
+        "inspireid": "INSPIRE-00400045",
+        "name": "Dujany, Giulio"
+      },
+      {
+        "affiliation": "CERN",
+        "inspireid": "INSPIRE-00389556",
+        "name": "Durante, Paolo"
+      },
+      {
+        "affiliation": "Authors affiliated with an institute formerly covered by a cooperation agreement with CERN.",
+        "inspireid": "INSPIRE-00077380",
+        "name": "Dzhelyadin, Rustem"
+      },
+      {
+        "affiliation": "Cracow, INP",
+        "inspireid": "INSPIRE-00341115",
+        "name": "Dziurda, Agnieszka"
+      },
+      {
+        "affiliation": "Authors affiliated with an institute formerly covered by a cooperation agreement with CERN.",
+        "inspireid": "INSPIRE-00341144",
+        "name": "Dzyuba, Alexey"
+      },
+      {
+        "affiliation": "Rutherford",
+        "inspireid": "INSPIRE-00078816",
+        "name": "Easo, Sajan"
+      },
+      {
+        "affiliation": "Imperial Coll., London",
+        "inspireid": "INSPIRE-00058834",
+        "name": "Egede, Ulrik"
+      },
+      {
+        "affiliation": "Authors affiliated with an institute formerly covered by a cooperation agreement with CERN.",
+        "inspireid": "INSPIRE-00259251",
+        "name": "Egorychev, Victor"
+      },
+      {
+        "affiliation": "Authors affiliated with an institute formerly covered by a cooperation agreement with CERN.",
+        "inspireid": "INSPIRE-00302446",
+        "name": "Eidelman, Semen"
+      },
+      {
+        "affiliation": "Edinburgh U.",
+        "inspireid": "INSPIRE-00079238",
+        "name": "Eisenhardt, Stephan"
+      },
+      {
+        "affiliation": "Tech. U., Dortmund (main)",
+        "inspireid": "INSPIRE-00389721",
+        "name": "Eitschberger, Ulrich"
+      },
+      {
+        "affiliation": "Tech. U., Dortmund (main)",
+        "inspireid": "INSPIRE-00341158",
+        "name": "Ekelhof, Robert"
+      },
+      {
+        "affiliation": "Glasgow U.",
+        "inspireid": "INSPIRE-00015467",
+        "name": "Eklund, Lars"
+      },
+      {
+        "affiliation": "Clermont-Ferrand U.",
+        "inspireid": "INSPIRE-00357167",
+        "name": "El Rifai, Ibrahim"
+      },
+      {
+        "affiliation": "Zurich U.",
+        "inspireid": "INSPIRE-00341160",
+        "name": "Elsasser, Christian"
+      },
+      {
+        "affiliation": "Syracuse U.",
+        "inspireid": "INSPIRE-00400105",
+        "name": "Ely, Scott"
+      },
+      {
+        "affiliation": "Heidelberg U.",
+        "inspireid": "INSPIRE-00238345",
+        "name": "Esen, Sevda"
+      },
+      {
+        "affiliation": "Cambridge U.",
+        "inspireid": "INSPIRE-00400160",
+        "name": "Evans, Hannah Mary"
+      },
+      {
+        "affiliation": "Oxford U.",
+        "inspireid": "INSPIRE-00452003",
+        "name": "Evans, Timothy"
+      },
+      {
+        "affiliation": "INFN, Bologna",
+        "inspireid": "INSPIRE-00296108",
+        "name": "Falabella, Antonio"
+      },
+      {
+        "affiliation": "CERN",
+        "inspireid": "INSPIRE-00257792",
+        "name": "F\\\"arber, Christian"
+      },
+      {
+        "affiliation": "Birmingham U.",
+        "inspireid": "INSPIRE-00400287",
+        "name": "Farley, Nathanael"
+      },
+      {
+        "affiliation": "Liverpool U.",
+        "inspireid": "INSPIRE-00257989",
+        "name": "Farry, Stephen"
+      },
+      {
+        "affiliation": "Liverpool U.",
+        "inspireid": "INSPIRE-00452191",
+        "name": "Fay, Robert"
+      },
+      {
+        "affiliation": "Edinburgh U.",
+        "inspireid": "INSPIRE-00389899",
+        "name": "Ferguson, Dianne"
+      },
+      {
+        "affiliation": "U. Santiago de Compostela (main)",
+        "inspireid": "INSPIRE-00259681",
+        "name": "Fernandez Albor, Victor"
+      },
+      {
+        "affiliation": "INFN, Bologna; Bologna U.",
+        "inspireid": "INSPIRE-00522680",
+        "name": "Ferrari, Fabio"
+      },
+      {
+        "affiliation": "Rio de Janeiro, CBPF",
+        "inspireid": "INSPIRE-00257190",
+        "name": "Ferreira Rodrigues, Fernando"
+      },
+      {
+        "affiliation": "CERN",
+        "inspireid": "INSPIRE-00159865",
+        "name": "Ferro-Luzzi, Massimiliano"
+      },
+      {
+        "affiliation": "Authors affiliated with an institute formerly covered by a cooperation agreement with CERN.",
+        "inspireid": "INSPIRE-00259378",
+        "name": "Filippov, Sergey"
+      },
+      {
+        "affiliation": "INFN, Ferrara; CERN; Ferrara U.",
+        "inspireid": "INSPIRE-00390028",
+        "name": "Fiore, Marco"
+      },
+      {
+        "affiliation": "INFN, Ferrara; Ferrara U.",
+        "inspireid": "INSPIRE-00017773",
+        "name": "Fiorini, Massimiliano"
+      },
+      {
+        "affiliation": "AGH-UST, Krakow",
+        "inspireid": "INSPIRE-00452328",
+        "name": "Firlej, Miroslaw"
+      },
+      {
+        "affiliation": "Ecole Polytechnique, Lausanne",
+        "inspireid": "INSPIRE-00261277",
+        "name": "Fitzpatrick, Conor"
+      },
+      {
+        "affiliation": "AGH-UST, Krakow",
+        "inspireid": "INSPIRE-00452523",
+        "name": "Fiutowski, Tomasz"
+      },
+      {
+        "affiliation": "Orsay, LAL; Ecole Polytechnique",
+        "inspireid": "INSPIRE-00081683",
+        "name": "Fleuret, Frederic"
+      },
+      {
+        "affiliation": "CERN",
+        "inspireid": "INSPIRE-00430519",
+        "name": "Fohl, Klaus"
+      },
+      {
+        "affiliation": "Heidelberg, Max Planck Inst.",
+        "inspireid": "INSPIRE-00341209",
+        "name": "Fontana, Marianna"
+      },
+      {
+        "affiliation": "INFN, Genoa; Genoa U.",
+        "inspireid": "INSPIRE-00081845",
+        "name": "Fontanelli, Flavio"
+      },
+      {
+        "affiliation": "Syracuse U.",
+        "inspireid": "INSPIRE-00545531",
+        "name": "Forshaw, Dean Charles"
+      },
+      {
+        "affiliation": "CERN",
+        "inspireid": "INSPIRE-00260047",
+        "name": "Forty, Roger"
+      },
+      {
+        "affiliation": "Liverpool U.",
+        "inspireid": "INSPIRE-00582273",
+        "name": "Franco Lima, Vinicius"
+      },
+      {
+        "affiliation": "CERN",
+        "inspireid": "INSPIRE-00260763",
+        "name": "Frank, Markus"
+      },
+      {
+        "affiliation": "CERN",
+        "inspireid": "INSPIRE-00260067",
+        "name": "Frei, Christoph"
+      },
+      {
+        "affiliation": "INFN, Florence",
+        "inspireid": "INSPIRE-00258246",
+        "name": "Frosini, Maddalena"
+      },
+      {
+        "affiliation": "INFN, Milan; U. Milan (main)",
+        "inspireid": "INSPIRE-00390117",
+        "name": "Fu, Jinlin"
+      },
+      {
+        "affiliation": "Rome U., Tor Vergata",
+        "inspireid": "INSPIRE-00390286",
+        "name": "Furfaro, Emiliano"
+      },
+      {
+        "affiliation": "U. Santiago de Compostela (main)",
+        "inspireid": "INSPIRE-00259710",
+        "name": "Gallas Torreira, Abraham"
+      },
+      {
+        "affiliation": "INFN, Bologna; Bologna U.",
+        "inspireid": "INSPIRE-00178050",
+        "name": "Galli, Domenico"
+      },
+      {
+        "affiliation": "INFN, Padua",
+        "inspireid": "INSPIRE-00293740",
+        "name": "Gallorini, Stefano"
+      },
+      {
+        "affiliation": "Edinburgh U.",
+        "inspireid": "INSPIRE-00150884",
+        "name": "Gambetta, Silvia"
+      },
+      {
+        "affiliation": "Rio de Janeiro Federal U.",
+        "inspireid": "INSPIRE-00083458",
+        "name": "Gandelman, Miriam"
+      },
+      {
+        "affiliation": "Oxford U.",
+        "inspireid": "INSPIRE-00262802",
+        "name": "Gandini, Paolo"
+      },
+      {
+        "affiliation": "Tsinghua U., Beijing, CHEP",
+        "inspireid": "INSPIRE-00257210",
+        "name": "Gao, Yuanning"
+      },
+      {
+        "affiliation": "U. Santiago de Compostela (main)",
+        "inspireid": "INSPIRE-00452833",
+        "name": "Garc\\'ia Pardi\\~nas, Juli\\'an"
+      },
+      {
+        "affiliation": "Cambridge U.",
+        "inspireid": "INSPIRE-00024997",
+        "name": "Garra Tico, Jordi"
+      },
+      {
+        "affiliation": "U. Barcelona (main)",
+        "inspireid": "INSPIRE-00157725",
+        "name": "Garrido, Lluis"
+      },
+      {
+        "affiliation": "Cambridge U.",
+        "inspireid": "INSPIRE-00582295",
+        "name": "Garsed, Philip John"
+      },
+      {
+        "affiliation": "U. Barcelona (main)",
+        "inspireid": "INSPIRE-00259509",
+        "name": "Gascon, David"
+      },
+      {
+        "affiliation": "CERN",
+        "inspireid": "INSPIRE-00083907",
+        "name": "Gaspar, Clara"
+      },
+      {
+        "affiliation": "Tech. U., Dortmund (main)",
+        "inspireid": "INSPIRE-00400383",
+        "name": "Gavardi, Laura"
+      },
+      {
+        "affiliation": "Clermont-Ferrand U.",
+        "inspireid": "INSPIRE-00452964",
+        "name": "Gazzoni, Giulio"
+      },
+      {
+        "affiliation": "Heidelberg U.",
+        "inspireid": "INSPIRE-00522692",
+        "name": "Gerick, David"
+      },
+      {
+        "affiliation": "Heidelberg U.",
+        "inspireid": "INSPIRE-00357178",
+        "name": "Gersabeck, Evelina"
+      },
+      {
+        "affiliation": "Manchester U.",
+        "inspireid": "INSPIRE-00192519",
+        "name": "Gersabeck, Marco"
+      },
+      {
+        "affiliation": "Warwick U.",
+        "inspireid": "INSPIRE-00043636",
+        "name": "Gershon, Timothy"
+      },
+      {
+        "affiliation": "Annecy, LAPP",
+        "inspireid": "INSPIRE-00084545",
+        "name": "Ghez, Philippe"
+      },
+      {
+        "affiliation": "Ecole Polytechnique, Lausanne",
+        "inspireid": "INSPIRE-00390510",
+        "name": "Gian\\`\\i, Sebastiana"
+      },
+      {
+        "affiliation": "Cambridge U.",
+        "inspireid": "INSPIRE-00179031",
+        "name": "Gibson, Valerie"
+      },
+      {
+        "affiliation": "NCBJ, Swierk",
+        "name": "Giemza, Henryk Karol"
+      },
+      {
+        "affiliation": "Ecole Polytechnique, Lausanne",
+        "name": "Girard, Olivier G\\\"oran"
+      },
+      {
+        "affiliation": "Bucharest, IFIN-HH",
+        "inspireid": "INSPIRE-00390574",
+        "name": "Giubega, Lavinia-Helena"
+      },
+      {
+        "affiliation": "CERN",
+        "inspireid": "INSPIRE-00260081",
+        "name": "Gligorov, Vladimir"
+      },
+      {
+        "affiliation": "Rio de Janeiro, Pont. U. Catol.",
+        "inspireid": "INSPIRE-00262964",
+        "name": "G\\\"obel, Carla"
+      },
+      {
+        "affiliation": "U. Barcelona (main); Ramon Llull U., Barcelona",
+        "name": "Golobardes, Elisabet"
+      },
+      {
+        "affiliation": "Authors affiliated with an institute formerly covered by a cooperation agreement with CERN.",
+        "inspireid": "INSPIRE-00261070",
+        "name": "Golubkov, Dmitry"
+      },
+      {
+        "affiliation": "Imperial Coll., London; Authors affiliated with an institute formerly covered by a cooperation agreement with CERN.; CERN",
+        "inspireid": "INSPIRE-00259263",
+        "name": "Golutvin, Andrey"
+      },
+      {
+        "affiliation": "Rio de Janeiro, CBPF; Rio de Janeiro Federal U.; UFTM, Uberaba",
+        "inspireid": "INSPIRE-00257143",
+        "name": "Gomes, Alvaro"
+      },
+      {
+        "affiliation": "INFN, Milan Bicocca; Milan Bicocca U.",
+        "inspireid": "INSPIRE-00400552",
+        "name": "Gotti, Claudio"
+      },
+      {
+        "affiliation": "Clermont-Ferrand U.",
+        "inspireid": "INSPIRE-00259524",
+        "name": "Grabalosa G\\'andara, Marc"
+      },
+      {
+        "affiliation": "U. Barcelona (main)",
+        "inspireid": "INSPIRE-00259536",
+        "name": "Graciani Diaz, Ricardo"
+      },
+      {
+        "affiliation": "CERN",
+        "inspireid": "INSPIRE-00246283",
+        "name": "Granado Cardoso, Luis Alberto"
+      },
+      {
+        "affiliation": "U. Barcelona (main)",
+        "inspireid": "INSPIRE-00086454",
+        "name": "Graug\\'es, Eugeni"
+      },
+      {
+        "affiliation": "Zurich U.",
+        "inspireid": "INSPIRE-00453214",
+        "name": "Graverini, Elena"
+      },
+      {
+        "affiliation": "INFN, Florence",
+        "inspireid": "INSPIRE-00086506",
+        "name": "Graziani, Giacomo"
+      },
+      {
+        "affiliation": "Bucharest, IFIN-HH",
+        "inspireid": "INSPIRE-00259115",
+        "name": "Grecu, Alexandru Tudor"
+      },
+      {
+        "affiliation": "Birmingham U.",
+        "inspireid": "INSPIRE-00390620",
+        "name": "Griffith, Peter"
+      },
+      {
+        "affiliation": "Heidelberg U.",
+        "inspireid": "INSPIRE-00390672",
+        "name": "Grillo, Lucia"
+      },
+      {
+        "affiliation": "Rostock U.",
+        "inspireid": "INSPIRE-00264595",
+        "name": "Gr\\\"unberg, Oliver"
+      },
+      {
+        "affiliation": "Syracuse U.",
+        "inspireid": "INSPIRE-00262919",
+        "name": "Gui, Bin"
+      },
+      {
+        "affiliation": "Authors affiliated with an institute formerly covered by a cooperation agreement with CERN.",
+        "inspireid": "INSPIRE-00259385",
+        "name": "Gushchin, Evgeny"
+      },
+      {
+        "affiliation": "Authors affiliated with an institute formerly covered by a cooperation agreement with CERN.; CERN",
+        "inspireid": "INSPIRE-00259449",
+        "name": "Guz, Yury"
+      },
+      {
+        "affiliation": "CERN",
+        "inspireid": "INSPIRE-00260098",
+        "name": "Gys, Thierry"
+      },
+      {
+        "affiliation": "Oxford U.",
+        "inspireid": "INSPIRE-00536800",
+        "name": "Hadavizadeh, Thomas"
+      },
+      {
+        "affiliation": "Clermont-Ferrand U.",
+        "inspireid": "INSPIRE-00341268",
+        "name": "Hadjivasiliou, Christos"
+      },
+      {
+        "affiliation": "Ecole Polytechnique, Lausanne",
+        "inspireid": "INSPIRE-00260534",
+        "name": "Haefeli, Guido"
+      },
+      {
+        "affiliation": "CERN",
+        "inspireid": "INSPIRE-00341278",
+        "name": "Haen, Christophe"
+      },
+      {
+        "affiliation": "Cambridge U.",
+        "inspireid": "INSPIRE-00261030",
+        "name": "Haines, Susan"
+      },
+      {
+        "affiliation": "Imperial Coll., London",
+        "inspireid": "INSPIRE-00357187",
+        "name": "Hall, Samuel"
+      },
+      {
+        "affiliation": "Maryland U., College Park",
+        "name": "Hamilton, Phoebe Meredith"
+      },
+      {
+        "affiliation": "Heidelberg U.",
+        "inspireid": "INSPIRE-00400676",
+        "name": "Han, Xiaoxue"
+      },
+      {
+        "affiliation": "Heidelberg U.",
+        "inspireid": "INSPIRE-00046350",
+        "name": "Hansmann-Menzemer, Stephanie"
+      },
+      {
+        "affiliation": "Oxford U.",
+        "inspireid": "INSPIRE-00088706",
+        "name": "Harnew, Neville"
+      },
+      {
+        "affiliation": "Bristol U.",
+        "inspireid": "INSPIRE-00357202",
+        "name": "Harnew, Samuel"
+      },
+      {
+        "affiliation": "Manchester U.",
+        "inspireid": "INSPIRE-00341289",
+        "name": "Harrison, Jonathan"
+      },
+      {
+        "affiliation": "CERN",
+        "inspireid": "INSPIRE-00257559",
+        "name": "He, Jibo"
+      },
+      {
+        "affiliation": "Ecole Polytechnique, Lausanne",
+        "inspireid": "INSPIRE-00002216",
+        "name": "Head, Timothy"
+      },
+      {
+        "affiliation": "Nikhef, Amsterdam",
+        "inspireid": "INSPIRE-00341307",
+        "name": "Heijne, Veerle"
+      },
+      {
+        "affiliation": "Aachen, Tech. Hochsch.",
+        "inspireid": "INSPIRE-00007870",
+        "name": "Heister, Arno"
+      },
+      {
+        "affiliation": "Liverpool U.",
+        "inspireid": "INSPIRE-00014964",
+        "name": "Hennessy, Karol"
+      },
+      {
+        "affiliation": "Clermont-Ferrand U.",
+        "inspireid": "INSPIRE-00257379",
+        "name": "Henrard, Pierre"
+      },
+      {
+        "affiliation": "Paris U., VI-VII",
+        "inspireid": "INSPIRE-00390866",
+        "name": "Henry, Louis"
+      },
+      {
+        "affiliation": "U. Santiago de Compostela (main)",
+        "inspireid": "INSPIRE-00089867",
+        "name": "Hernando Morata, Jose Angel"
+      },
+      {
+        "affiliation": "Rostock U.",
+        "inspireid": "INSPIRE-00390793",
+        "name": "He\\ss, Miriam"
+      },
+      {
+        "affiliation": "Rio de Janeiro Federal U.",
+        "inspireid": "INSPIRE-00028041",
+        "name": "Hicheur, Adl\\`ene"
+      },
+      {
+        "affiliation": "Oxford U.",
+        "inspireid": "INSPIRE-00357210",
+        "name": "Hill, Donal"
+      },
+      {
+        "affiliation": "Clermont-Ferrand U.",
+        "inspireid": "INSPIRE-00357228",
+        "name": "Hoballah, Mostafa"
+      },
+      {
+        "affiliation": "Manchester U.",
+        "inspireid": "INSPIRE-00390934",
+        "name": "Hombach, Christoph"
+      },
+      {
+        "affiliation": "Ecole Polytechnique, Lausanne",
+        "inspireid": "INSPIRE-00257330",
+        "name": "Hopchev, Plamen Hristov"
+      },
+      {
+        "affiliation": "Nikhef, Amsterdam",
+        "inspireid": "INSPIRE-00091582",
+        "name": "Hulsbergen, Wouter"
+      },
+      {
+        "affiliation": "Imperial Coll., London",
+        "inspireid": "INSPIRE-00453346",
+        "name": "Humair, Thibaud"
+      },
+      {
+        "affiliation": "Oxford U.",
+        "inspireid": "INSPIRE-00015167",
+        "name": "Hussain, Nazim"
+      },
+      {
+        "affiliation": "Liverpool U.",
+        "inspireid": "INSPIRE-00091737",
+        "name": "Hutchcroft, David"
+      },
+      {
+        "affiliation": "AGH-UST, Krakow",
+        "inspireid": "INSPIRE-00091920",
+        "name": "Idzik, Marek"
+      },
+      {
+        "affiliation": "MIT",
+        "inspireid": "INSPIRE-00258006",
+        "name": "Ilten, Philip"
+      },
+      {
+        "affiliation": "Authors affiliated with an institute formerly covered by a cooperation agreement with CERN.",
+        "name": "Inyakin, Alexander"
+      },
+      {
+        "affiliation": "CERN",
+        "inspireid": "INSPIRE-00260123",
+        "name": "Jacobsson, Richard"
+      },
+      {
+        "affiliation": "Heidelberg U.",
+        "inspireid": "INSPIRE-00019345",
+        "name": "Jaeger, Andreas"
+      },
+      {
+        "affiliation": "Oxford U.",
+        "inspireid": "INSPIRE-00363060",
+        "name": "Jalocha, Pawel"
+      },
+      {
+        "affiliation": "Nikhef, Amsterdam",
+        "inspireid": "INSPIRE-00258761",
+        "name": "Jans, Eddy"
+      },
+      {
+        "affiliation": "Maryland U., College Park",
+        "inspireid": "INSPIRE-00144300",
+        "name": "Jawahery, Abolhassan"
+      },
+      {
+        "affiliation": "Oxford U.",
+        "inspireid": "INSPIRE-00042030",
+        "name": "John, Malcolm"
+      },
+      {
+        "affiliation": "CERN",
+        "inspireid": "INSPIRE-00262837",
+        "name": "Johnson, Daniel"
+      },
+      {
+        "affiliation": "Cambridge U.",
+        "inspireid": "INSPIRE-00261047",
+        "name": "Jones, Christopher"
+      },
+      {
+        "affiliation": "CERN",
+        "inspireid": "INSPIRE-00093928",
+        "name": "Joram, Christian"
+      },
+      {
+        "affiliation": "CERN",
+        "inspireid": "INSPIRE-00260147",
+        "name": "Jost, Beat"
+      },
+      {
+        "affiliation": "Syracuse U.",
+        "inspireid": "INSPIRE-00400750",
+        "name": "Jurik, Nathan"
+      },
+      {
+        "affiliation": "Kharkov, KIPT",
+        "inspireid": "INSPIRE-00341378",
+        "name": "Kandybei, Sergii"
+      },
+      {
+        "affiliation": "Marseille, CPPM",
+        "inspireid": "INSPIRE-00390979",
+        "name": "Kanso, Walaa"
+      },
+      {
+        "affiliation": "CERN",
+        "inspireid": "INSPIRE-00341385",
+        "name": "Karacson, Matthias"
+      },
+      {
+        "affiliation": "CERN",
+        "inspireid": "INSPIRE-00016225",
+        "name": "Karbach, Moritz"
+      },
+      {
+        "affiliation": "Glasgow U.",
+        "inspireid": "INSPIRE-00453516",
+        "name": "Karodia, Sarah"
+      },
+      {
+        "affiliation": "Heidelberg U.",
+        "inspireid": "INSPIRE-00522728",
+        "name": "Kecke, Matthieu"
+      },
+      {
+        "affiliation": "Syracuse U.",
+        "inspireid": "INSPIRE-00391054",
+        "name": "Kelsey, Matthew"
+      },
+      {
+        "affiliation": "Birmingham U.",
+        "inspireid": "INSPIRE-00185253",
+        "name": "Kenyon, Ian"
+      },
+      {
+        "affiliation": "CERN",
+        "inspireid": "INSPIRE-00239270",
+        "name": "Kenzie, Matthew"
+      },
+      {
+        "affiliation": "NIKHEF, Amsterdam + Vrije U., Amsterdam",
+        "inspireid": "INSPIRE-00258866",
+        "name": "Ketel, Tjeerd"
+      },
+      {
+        "affiliation": "Authors affiliated with an institute formerly covered by a cooperation agreement with CERN.",
+        "inspireid": "INSPIRE-00545552",
+        "name": "Khairullin, Egor"
+      },
+      {
+        "affiliation": "INFN, Milan Bicocca; CERN; Milan Bicocca U.",
+        "inspireid": "INSPIRE-00257475",
+        "name": "Khanji, Basem"
+      },
+      {
+        "affiliation": "Ecole Polytechnique, Lausanne",
+        "inspireid": "INSPIRE-00391108",
+        "name": "Khurewathanakul, Chitsanu"
+      },
+      {
+        "affiliation": "Aachen, Tech. Hochsch.",
+        "inspireid": "INSPIRE-00545568",
+        "name": "Kirn, Thomas"
+      },
+      {
+        "affiliation": "Manchester U.",
+        "inspireid": "INSPIRE-00391174",
+        "name": "Klaver, Suzanne"
+      },
+      {
+        "affiliation": "NCBJ, Swierk",
+        "inspireid": "INSPIRE-00400854",
+        "name": "Klimaszewski, Konrad"
+      },
+      {
+        "affiliation": "Heidelberg U.",
+        "inspireid": "INSPIRE-00453628",
+        "name": "Kolpin, Michael"
+      },
+      {
+        "affiliation": "Ecole Polytechnique, Lausanne",
+        "inspireid": "INSPIRE-00341394",
+        "name": "Komarov, Ilya"
+      },
+      {
+        "affiliation": "NIKHEF, Amsterdam + Vrije U., Amsterdam",
+        "inspireid": "INSPIRE-00341431",
+        "name": "Koopman, Rose"
+      },
+      {
+        "affiliation": "Nikhef, Amsterdam; CERN",
+        "inspireid": "INSPIRE-00058578",
+        "name": "Koppenburg, Patrick"
+      },
+      {
+        "affiliation": "Authors affiliated with an institute formerly covered by a cooperation agreement with CERN.",
+        "inspireid": "INSPIRE-00259339",
+        "name": "Korolev, Mikhail"
+      },
+      {
+        "affiliation": "Clermont-Ferrand U.",
+        "inspireid": "INSPIRE-00536810",
+        "name": "Kozeiha, Mohamad"
+      },
+      {
+        "affiliation": "Authors affiliated with an institute formerly covered by a cooperation agreement with CERN.",
+        "inspireid": "INSPIRE-00259390",
+        "name": "Kravchuk, Leonid"
+      },
+      {
+        "affiliation": "Heidelberg U.",
+        "inspireid": "INSPIRE-00341449",
+        "name": "Kreplin, Katharina"
+      },
+      {
+        "affiliation": "Warwick U.",
+        "inspireid": "INSPIRE-00041048",
+        "name": "Kreps, Michal"
+      },
+      {
+        "affiliation": "Authors affiliated with an institute formerly covered by a cooperation agreement with CERN.",
+        "inspireid": "INSPIRE-00257824",
+        "name": "Krokovny, Pavel"
+      },
+      {
+        "affiliation": "Tech. U., Dortmund (main)",
+        "inspireid": "INSPIRE-00257624",
+        "name": "Kruse, Florian"
+      },
+      {
+        "affiliation": "NCBJ, Swierk",
+        "inspireid": "INSPIRE-00437507",
+        "name": "Krzemien, Wojciech"
+      },
+      {
+        "affiliation": "Cracow, INP; AGH-UST, Cracow",
+        "inspireid": "INSPIRE-00256649",
+        "name": "Kucewicz, Wojciech"
+      },
+      {
+        "affiliation": "Cracow, INP",
+        "inspireid": "INSPIRE-00258880",
+        "name": "Kucharczyk, Marcin"
+      },
+      {
+        "affiliation": "Authors affiliated with an institute formerly covered by a cooperation agreement with CERN.",
+        "inspireid": "INSPIRE-00341500",
+        "name": "Kudryavtsev, Vasily"
+      },
+      {
+        "affiliation": "Ecole Polytechnique, Lausanne",
+        "inspireid": "INSPIRE-00536823",
+        "name": "Kuonen, Axel Kevin"
+      },
+      {
+        "affiliation": "NCBJ, Swierk",
+        "inspireid": "INSPIRE-00099216",
+        "name": "Kurek, Krzysztof"
+      },
+      {
+        "affiliation": "Authors affiliated with an institute formerly covered by a cooperation agreement with CERN.",
+        "inspireid": "INSPIRE-00259275",
+        "name": "Kvaratskheliya, Tengiz"
+      },
+      {
+        "affiliation": "CERN",
+        "inspireid": "INSPIRE-00260180",
+        "name": "Lacarrere, Daniel"
+      },
+      {
+        "affiliation": "Manchester U.; CERN",
+        "inspireid": "INSPIRE-00099630",
+        "name": "Lafferty, George"
+      },
+      {
+        "affiliation": "INFN, Cagliari",
+        "inspireid": "INSPIRE-00258150",
+        "name": "Lai, Adriano"
+      },
+      {
+        "affiliation": "Edinburgh U.",
+        "inspireid": "INSPIRE-00341510",
+        "name": "Lambert, Dean"
+      },
+      {
+        "affiliation": "Frascati",
+        "inspireid": "INSPIRE-00258442",
+        "name": "Lanfranchi, Gaia"
+      },
+      {
+        "affiliation": "Warwick U.",
+        "inspireid": "INSPIRE-00003200",
+        "name": "Langenbruch, Christoph"
+      },
+      {
+        "affiliation": "CERN",
+        "inspireid": "INSPIRE-00391212",
+        "name": "Langhans, Benedikt"
+      },
+      {
+        "affiliation": "Warwick U.",
+        "inspireid": "INSPIRE-00041615",
+        "name": "Latham, Thomas"
+      },
+      {
+        "affiliation": "Birmingham U.",
+        "inspireid": "INSPIRE-00100355",
+        "name": "Lazzeroni, Cristina"
+      },
+      {
+        "affiliation": "Marseille, CPPM",
+        "inspireid": "INSPIRE-00083087",
+        "name": "Le Gac, Renaud"
+      },
+      {
+        "affiliation": "Annecy, LAPP",
+        "inspireid": "INSPIRE-00100857",
+        "name": "Lees, Jean-Pierre"
+      },
+      {
+        "affiliation": "Clermont-Ferrand U.",
+        "inspireid": "INSPIRE-00041022",
+        "name": "Lef\\`evre, Regis"
+      },
+      {
+        "affiliation": "Authors affiliated with an institute formerly covered by a cooperation agreement with CERN.; CERN",
+        "inspireid": "INSPIRE-00100871",
+        "name": "Leflat, Alexander"
+      },
+      {
+        "affiliation": "Orsay, LAL",
+        "inspireid": "INSPIRE-00144068",
+        "name": "Lefran\\c{c}ois, Jacques"
+      },
+      {
+        "affiliation": "Marseille, CPPM",
+        "inspireid": "INSPIRE-00101253",
+        "name": "Leroy, Olivier"
+      },
+      {
+        "affiliation": "Cracow, INP",
+        "inspireid": "INSPIRE-00101288",
+        "name": "Lesiak, Tadeusz"
+      },
+      {
+        "affiliation": "Heidelberg U.",
+        "inspireid": "INSPIRE-00391255",
+        "name": "Leverington, Blake"
+      },
+      {
+        "affiliation": "Orsay, LAL",
+        "inspireid": "INSPIRE-00385568",
+        "name": "Li, Yiming"
+      },
+      {
+        "affiliation": "Authors affiliated with an institute formerly covered by a cooperation agreement with CERN.",
+        "inspireid": "INSPIRE-00400931",
+        "name": "Likhomanenko, Tatiana"
+      },
+      {
+        "affiliation": "Liverpool U.",
+        "inspireid": "INSPIRE-00296000",
+        "name": "Liles, Myfanwy"
+      },
+      {
+        "affiliation": "CERN",
+        "inspireid": "INSPIRE-00101983",
+        "name": "Lindner, Rolf"
+      },
+      {
+        "affiliation": "CERN",
+        "inspireid": "INSPIRE-00257832",
+        "name": "Linn, Christian"
+      },
+      {
+        "affiliation": "Zurich U.",
+        "inspireid": "INSPIRE-00401052",
+        "name": "Lionetto, Federica"
+      },
+      {
+        "affiliation": "INFN, Cagliari",
+        "inspireid": "INSPIRE-00257250",
+        "name": "Liu, Bo"
+      },
+      {
+        "affiliation": "Tsinghua U., Beijing, CHEP",
+        "inspireid": "INSPIRE-00536834",
+        "name": "Liu, Xuesong"
+      },
+      {
+        "affiliation": "Warwick U.",
+        "inspireid": "INSPIRE-00536847",
+        "name": "Loh, David"
+      },
+      {
+        "affiliation": "Glasgow U.",
+        "inspireid": "INSPIRE-00391330",
+        "name": "Longstaff, Iain"
+      },
+      {
+        "affiliation": "Rio de Janeiro Federal U.",
+        "inspireid": "INSPIRE-00341531",
+        "name": "Lopes, Jose"
+      },
+      {
+        "affiliation": "INFN, Padua; U. Padua (main)",
+        "inspireid": "INSPIRE-00102927",
+        "name": "Lucchesi, Donatella"
+      },
+      {
+        "affiliation": "U. Santiago de Compostela (main)",
+        "inspireid": "INSPIRE-00522703",
+        "name": "Lucio Martinez, Miriam"
+      },
+      {
+        "affiliation": "Edinburgh U.",
+        "inspireid": "INSPIRE-00391426",
+        "name": "Luo, Haofei"
+      },
+      {
+        "affiliation": "INFN, Padua",
+        "inspireid": "INSPIRE-00453739",
+        "name": "Lupato, Anna"
+      },
+      {
+        "affiliation": "INFN, Ferrara; Ferrara U.",
+        "inspireid": "INSPIRE-00103142",
+        "name": "Luppi, Eleonora"
+      },
+      {
+        "affiliation": "Oxford U.",
+        "inspireid": "INSPIRE-00391442",
+        "name": "Lupton, Oliver"
+      },
+      {
+        "affiliation": "INFN, Pisa; Pisa, Scuola Normale Superiore",
+        "inspireid": "INSPIRE-00103157",
+        "name": "Lusiani, Alberto"
+      },
+      {
+        "affiliation": "Beijing, GUCAS",
+        "inspireid": "INSPIRE-00385243",
+        "name": "Lyu, Xiao-Rui"
+      },
+      {
+        "affiliation": "Orsay, LAL",
+        "inspireid": "INSPIRE-00103518",
+        "name": "Machefert, Frederic"
+      },
+      {
+        "affiliation": "Bucharest, IFIN-HH",
+        "inspireid": "INSPIRE-00054830",
+        "name": "Maciuc, Florin"
+      },
+      {
+        "affiliation": "Authors affiliated with an institute formerly covered by a cooperation agreement with CERN.",
+        "inspireid": "INSPIRE-00259220",
+        "name": "Maev, Oleg"
+      },
+      {
+        "affiliation": "Manchester U.",
+        "inspireid": "INSPIRE-00536855",
+        "name": "Maguire, Kevin"
+      },
+      {
+        "affiliation": "Oxford U.",
+        "inspireid": "INSPIRE-00040960",
+        "name": "Malde, Sneha"
+      },
+      {
+        "affiliation": "Authors affiliated with an institute formerly covered by a cooperation agreement with CERN.",
+        "inspireid": "INSPIRE-00401169",
+        "name": "Malinin, Alexander"
+      },
+      {
+        "affiliation": "Orsay, LAL",
+        "inspireid": "INSPIRE-00057054",
+        "name": "Manca, Giulia"
+      },
+      {
+        "affiliation": "Marseille, CPPM",
+        "inspireid": "INSPIRE-00042821",
+        "name": "Mancinelli, Giampiero"
+      },
+      {
+        "affiliation": "Syracuse U.",
+        "inspireid": "INSPIRE-00219863",
+        "name": "Manning, Peter Michael"
+      },
+      {
+        "affiliation": "Clermont-Ferrand U.",
+        "inspireid": "INSPIRE-00391509",
+        "name": "Maratas, Jan Mickelle"
+      },
+      {
+        "affiliation": "Annecy, LAPP",
+        "inspireid": "INSPIRE-00219901",
+        "name": "Marchand, Jean Fran\\c{c}ois"
+      },
+      {
+        "affiliation": "INFN, Bologna",
+        "inspireid": "INSPIRE-00258060",
+        "name": "Marconi, Umberto"
+      },
+      {
+        "affiliation": "U. Barcelona (main)",
+        "inspireid": "INSPIRE-00391574",
+        "name": "Marin Benito, Carla"
+      },
+      {
+        "affiliation": "INFN, Pisa; CERN; Pisa, Scuola Normale Superiore",
+        "inspireid": "INSPIRE-00367766",
+        "name": "Marino, Pietro"
+      },
+      {
+        "affiliation": "Heidelberg U.",
+        "inspireid": "INSPIRE-00145236",
+        "name": "Marks, J\\\"org"
+      },
+      {
+        "affiliation": "INFN, Rome",
+        "inspireid": "INSPIRE-00258664",
+        "name": "Martellotti, Giuseppe"
+      },
+      {
+        "affiliation": "Marseille, CPPM",
+        "inspireid": "INSPIRE-00536869",
+        "name": "Martin, Morgan"
+      },
+      {
+        "affiliation": "Ecole Polytechnique, Lausanne",
+        "inspireid": "INSPIRE-00144085",
+        "name": "Martinelli, Maurizio"
+      },
+      {
+        "affiliation": "U. Santiago de Compostela (main)",
+        "inspireid": "INSPIRE-00259733",
+        "name": "Martinez Santos, Diego"
+      },
+      {
+        "affiliation": "Valencia U., IFIC",
+        "inspireid": "INSPIRE-00105212",
+        "name": "Martinez Vidal, Fernando"
+      },
+      {
+        "affiliation": "Rio de Janeiro Federal U.",
+        "inspireid": "INSPIRE-00391627",
+        "name": "Martins Tostes, Danielle"
+      },
+      {
+        "affiliation": "Rio de Janeiro, CBPF",
+        "inspireid": "INSPIRE-00271814",
+        "name": "Massafferri, Andr\\'e"
+      },
+      {
+        "affiliation": "CERN",
+        "inspireid": "INSPIRE-00334839",
+        "name": "Matev, Rosen"
+      },
+      {
+        "affiliation": "Warwick U.",
+        "inspireid": "INSPIRE-00522716",
+        "name": "Mathad, Abhijit"
+      },
+      {
+        "affiliation": "CERN",
+        "inspireid": "INSPIRE-00258028",
+        "name": "Mathe, Zoltan"
+      },
+      {
+        "affiliation": "INFN, Milan Bicocca",
+        "inspireid": "INSPIRE-00258531",
+        "name": "Matteuzzi, Clara"
+      },
+      {
+        "affiliation": "Zurich U.",
+        "inspireid": "INSPIRE-00640989",
+        "name": "Mauri, Andrea"
+      },
+      {
+        "affiliation": "Ecole Polytechnique, Lausanne",
+        "inspireid": "INSPIRE-00453958",
+        "name": "Maurin, Brice"
+      },
+      {
+        "affiliation": "Birmingham U.",
+        "inspireid": "INSPIRE-00259401",
+        "name": "Mazurov, Alexander"
+      },
+      {
+        "affiliation": "Imperial Coll., London",
+        "inspireid": "INSPIRE-00391673",
+        "name": "McCann, Michael"
+      },
+      {
+        "affiliation": "Birmingham U.",
+        "inspireid": "INSPIRE-00357255",
+        "name": "McCarthy, James"
+      },
+      {
+        "affiliation": "Manchester U.",
+        "inspireid": "INSPIRE-00391741",
+        "name": "McNab, Andrew"
+      },
+      {
+        "affiliation": "University Coll., Dublin",
+        "inspireid": "INSPIRE-00106463",
+        "name": "McNulty, Ronan"
+      },
+      {
+        "affiliation": "Cincinnati U.",
+        "inspireid": "INSPIRE-00106491",
+        "name": "Meadows, Brian"
+      },
+      {
+        "affiliation": "Tech. U., Dortmund (main)",
+        "inspireid": "INSPIRE-00391774",
+        "name": "Meier, Frank"
+      },
+      {
+        "affiliation": "Heidelberg U.",
+        "inspireid": "INSPIRE-00296019",
+        "name": "Meissner, Marco"
+      },
+      {
+        "affiliation": "NCBJ, Swierk",
+        "inspireid": "INSPIRE-00385848",
+        "name": "Melnychuk, Dmytro"
+      },
+      {
+        "affiliation": "Nikhef, Amsterdam",
+        "inspireid": "INSPIRE-00106980",
+        "name": "Merk, Marcel"
+      },
+      {
+        "affiliation": "INFN, Padua",
+        "inspireid": "INSPIRE-00536870",
+        "name": "Michielin, Emanuele"
+      },
+      {
+        "affiliation": "Colombia, U. Natl.",
+        "inspireid": "INSPIRE-00028258",
+        "name": "Milanes, Diego Alejandro"
+      },
+      {
+        "affiliation": "Annecy, LAPP",
+        "inspireid": "INSPIRE-00201357",
+        "name": "Minard, Marie-Noelle"
+      },
+      {
+        "affiliation": "Authors affiliated with an institute formerly covered by a cooperation agreement with CERN.",
+        "name": "Mineev, Oleg"
+      },
+      {
+        "affiliation": "Heidelberg U.",
+        "inspireid": "INSPIRE-00522733",
+        "name": "Mitzel, Dominik Stefan"
+      },
+      {
+        "affiliation": "Rio de Janeiro, Pont. U. Catol.",
+        "inspireid": "INSPIRE-00341603",
+        "name": "Molina Rodriguez, Josue"
+      },
+      {
+        "affiliation": "Colombia, U. Natl.",
+        "inspireid": "INSPIRE-00536885",
+        "name": "Monroy, Igancio Alberto"
+      },
+      {
+        "affiliation": "Clermont-Ferrand U.",
+        "inspireid": "INSPIRE-00257390",
+        "name": "Monteil, Stephane"
+      },
+      {
+        "affiliation": "INFN, Padua",
+        "inspireid": "INSPIRE-00108754",
+        "name": "Morandin, Mauro"
+      },
+      {
+        "affiliation": "AGH-UST, Krakow",
+        "inspireid": "INSPIRE-00258909",
+        "name": "Morawski, Piotr"
+      },
+      {
+        "affiliation": "Marseille, CPPM",
+        "inspireid": "INSPIRE-00391840",
+        "name": "Mord\\`a, Alessandro"
+      },
+      {
+        "affiliation": "INFN, Pisa; Pisa, Scuola Normale Superiore",
+        "inspireid": "INSPIRE-00016418",
+        "name": "Morello, Michael Joseph"
+      },
+      {
+        "affiliation": "AGH-UST, Krakow",
+        "inspireid": "INSPIRE-00453992",
+        "name": "Moron, Jakub"
+      },
+      {
+        "affiliation": "Edinburgh U.",
+        "inspireid": "INSPIRE-00401257",
+        "name": "Morris, Adam Benjamin"
+      },
+      {
+        "affiliation": "Syracuse U.",
+        "inspireid": "INSPIRE-00109283",
+        "name": "Mountain, Raymond"
+      },
+      {
+        "affiliation": "Edinburgh U.",
+        "inspireid": "INSPIRE-00194050",
+        "name": "Muheim, Franz"
+      },
+      {
+        "affiliation": "Manchester U.",
+        "name": "M\\\"uller, Dominik"
+      },
+      {
+        "affiliation": "Tech. U., Dortmund (main)",
+        "inspireid": "INSPIRE-00522744",
+        "name": "M\\\"uller, Janine"
+      },
+      {
+        "affiliation": "Zurich U.",
+        "inspireid": "INSPIRE-00185464",
+        "name": "M\\\"uller, Katharina"
+      },
+      {
+        "affiliation": "Tech. U., Dortmund (main)",
+        "inspireid": "INSPIRE-00522759",
+        "name": "M\\\"uller, Vanessa"
+      },
+      {
+        "affiliation": "INFN, Bologna",
+        "inspireid": "INSPIRE-00024830",
+        "name": "Mussini, Manuel"
+      },
+      {
+        "affiliation": "Ecole Polytechnique, Lausanne",
+        "inspireid": "INSPIRE-00341624",
+        "name": "Muster, Bastien"
+      },
+      {
+        "affiliation": "Bristol U.",
+        "inspireid": "INSPIRE-00260976",
+        "name": "Naik, Paras"
+      },
+      {
+        "affiliation": "Ecole Polytechnique, Lausanne",
+        "inspireid": "INSPIRE-00171856",
+        "name": "Nakada, Tatsuya"
+      },
+      {
+        "affiliation": "Rutherford",
+        "inspireid": "INSPIRE-00110346",
+        "name": "Nandakumar, Raja"
+      },
+      {
+        "affiliation": "Oxford U.",
+        "inspireid": "INSPIRE-00536909",
+        "name": "Nandi, Anita"
+      },
+      {
+        "affiliation": "Rio de Janeiro Federal U.",
+        "inspireid": "INSPIRE-00140157",
+        "name": "Nasteva, Irina"
+      },
+      {
+        "affiliation": "Edinburgh U.",
+        "inspireid": "INSPIRE-00260601",
+        "name": "Needham, Matthew"
+      },
+      {
+        "affiliation": "INFN, Milan; U. Milan (main)",
+        "inspireid": "INSPIRE-00045899",
+        "name": "Neri, Nicola"
+      },
+      {
+        "affiliation": "Heidelberg U.",
+        "inspireid": "INSPIRE-00391914",
+        "name": "Neubert, Sebastian"
+      },
+      {
+        "affiliation": "CERN",
+        "inspireid": "INSPIRE-00260260",
+        "name": "Neufeld, Niko"
+      },
+      {
+        "affiliation": "Heidelberg U.",
+        "inspireid": "INSPIRE-00452189",
+        "name": "Neuner, Max"
+      },
+      {
+        "affiliation": "Authors affiliated with an institute formerly covered by a cooperation agreement with CERN.",
+        "name": "Neustroev, Petr"
+      },
+      {
+        "affiliation": "Ecole Polytechnique, Lausanne",
+        "inspireid": "INSPIRE-00341638",
+        "name": "Nguyen, Anh Duc"
+      },
+      {
+        "affiliation": "Ecole Polytechnique, Lausanne; Hanoi U. of Sci.",
+        "inspireid": "INSPIRE-00341643",
+        "name": "Nguyen-Mau, Chung"
+      },
+      {
+        "affiliation": "Clermont-Ferrand U.",
+        "inspireid": "INSPIRE-00257403",
+        "name": "Niess, Valentin"
+      },
+      {
+        "affiliation": "Aachen, Tech. Hochsch.",
+        "inspireid": "INSPIRE-00409248",
+        "name": "Nieswand, Simon"
+      },
+      {
+        "affiliation": "Tech. U., Dortmund (main)",
+        "inspireid": "INSPIRE-00392011",
+        "name": "Niet, Ramon"
+      },
+      {
+        "affiliation": "Authors affiliated with an institute formerly covered by a cooperation agreement with CERN.",
+        "inspireid": "INSPIRE-00259364",
+        "name": "Nikitin, Nikolay"
+      },
+      {
+        "affiliation": "Heidelberg U.",
+        "inspireid": "INSPIRE-00341653",
+        "name": "Nikodem, Thomas"
+      },
+      {
+        "affiliation": "Authors affiliated with an institute formerly covered by a cooperation agreement with CERN.",
+        "inspireid": "INSPIRE-00344272",
+        "name": "Novoselov, Alexey"
+      },
+      {
+        "affiliation": "AGH-UST, Krakow",
+        "inspireid": "INSPIRE-00258945",
+        "name": "Oblakowska-Mucha, Agnieszka"
+      },
+      {
+        "affiliation": "Authors affiliated with an institute formerly covered by a cooperation agreement with CERN.",
+        "inspireid": "INSPIRE-00191751",
+        "name": "Obraztsov, Vladimir"
+      },
+      {
+        "affiliation": "Frascati",
+        "inspireid": "INSPIRE-00341669",
+        "name": "Ogilvy, Stephen"
+      },
+      {
+        "affiliation": "Warwick U.",
+        "inspireid": "INSPIRE-00401396",
+        "name": "O'Hanlon, Daniel Patrick"
+      },
+      {
+        "affiliation": "Cambridge U.",
+        "inspireid": "INSPIRE-00112910",
+        "name": "Oldeman, Rudolf"
+      },
+      {
+        "affiliation": "U. Groningen, VSI",
+        "inspireid": "INSPIRE-00113159",
+        "name": "Onderwater, Gerco"
+      },
+      {
+        "affiliation": "Rio de Janeiro, CBPF",
+        "inspireid": "INSPIRE-00452200",
+        "name": "Osorio Rodrigues, Bruno"
+      },
+      {
+        "affiliation": "Rio de Janeiro Federal U.",
+        "inspireid": "INSPIRE-00218196",
+        "name": "Otalora Goicochea, Juan Martin"
+      },
+      {
+        "affiliation": "CERN",
+        "inspireid": "INSPIRE-00452222",
+        "name": "Otto, Adam"
+      },
+      {
+        "affiliation": "Imperial Coll., London",
+        "inspireid": "INSPIRE-00341671",
+        "name": "Owen, Patrick"
+      },
+      {
+        "affiliation": "Valencia U., IFIC",
+        "inspireid": "INSPIRE-00042432",
+        "name": "Oyanguren, Maria Aranzazu"
+      },
+      {
+        "affiliation": "INFN, Bari; Bari U.",
+        "inspireid": "INSPIRE-00114021",
+        "name": "Palano, Antimo"
+      },
+      {
+        "affiliation": "INFN, Milan; U. Milan (main)",
+        "inspireid": "INSPIRE-00029448",
+        "name": "Palombo, Fernando"
+      },
+      {
+        "affiliation": "Frascati",
+        "inspireid": "INSPIRE-00259914",
+        "name": "Palutan, Matteo"
+      },
+      {
+        "affiliation": "CERN",
+        "inspireid": "INSPIRE-00260278",
+        "name": "Panman, Jacob"
+      },
+      {
+        "affiliation": "Rutherford",
+        "inspireid": "INSPIRE-00261218",
+        "name": "Papanestis, Antonios"
+      },
+      {
+        "affiliation": "Glasgow U.",
+        "inspireid": "INSPIRE-00043195",
+        "name": "Pappagallo, Marco"
+      },
+      {
+        "affiliation": "INFN, Ferrara; Ferrara U.",
+        "inspireid": "INSPIRE-00401494",
+        "name": "Pappalardo, Luciano"
+      },
+      {
+        "affiliation": "Cincinnati U.",
+        "name": "Pappenheimer, Cheryl"
+      },
+      {
+        "affiliation": "Maryland U., College Park",
+        "inspireid": "INSPIRE-00206947",
+        "name": "Parker, William"
+      },
+      {
+        "affiliation": "Manchester U.",
+        "inspireid": "INSPIRE-00160233",
+        "name": "Parkes, Christopher"
+      },
+      {
+        "affiliation": "INFN, Florence",
+        "inspireid": "INSPIRE-00114920",
+        "name": "Passaleva, Giovanni"
+      },
+      {
+        "affiliation": "Liverpool U.",
+        "inspireid": "INSPIRE-00115039",
+        "name": "Patel, Girish"
+      },
+      {
+        "affiliation": "Imperial Coll., London",
+        "inspireid": "INSPIRE-00227343",
+        "name": "Patel, Mitesh"
+      },
+      {
+        "affiliation": "INFN, Genoa; Genoa U.",
+        "inspireid": "INSPIRE-00115095",
+        "name": "Patrignani, Claudia"
+      },
+      {
+        "affiliation": "Manchester U.; Rutherford",
+        "inspireid": "INSPIRE-00392044",
+        "name": "Pearce, Alex"
+      },
+      {
+        "affiliation": "Nikhef, Amsterdam",
+        "inspireid": "INSPIRE-00173740",
+        "name": "Pellegrino, Antonio"
+      },
+      {
+        "affiliation": "INFN, Rome; U. Rome La Sapienza (main)",
+        "inspireid": "INSPIRE-00226158",
+        "name": "Penso, Gianni"
+      },
+      {
+        "affiliation": "CERN",
+        "inspireid": "INSPIRE-00296179",
+        "name": "Pepe Altarelli, Monica"
+      },
+      {
+        "affiliation": "INFN, Bologna; Bologna U.",
+        "inspireid": "INSPIRE-00258083",
+        "name": "Perazzini, Stefano"
+      },
+      {
+        "affiliation": "Clermont-Ferrand U.",
+        "inspireid": "INSPIRE-00115778",
+        "name": "Perret, Pascal"
+      },
+      {
+        "affiliation": "Birmingham U.",
+        "inspireid": "INSPIRE-00392110",
+        "name": "Pescatore, Luca"
+      },
+      {
+        "affiliation": "Bristol U.",
+        "inspireid": "INSPIRE-00311357",
+        "name": "Petridis, Konstantinos"
+      },
+      {
+        "affiliation": "INFN, Genoa; Genoa U.",
+        "inspireid": "INSPIRE-00116050",
+        "name": "Petrolini, Alessandro"
+      },
+      {
+        "affiliation": "INFN, Milan; U. Milan (main)",
+        "inspireid": "INSPIRE-00522770",
+        "name": "Petruzzo, Marco"
+      },
+      {
+        "affiliation": "U. Barcelona (main)",
+        "inspireid": "INSPIRE-00259574",
+        "name": "Picatoste Olloqui, Eduardo"
+      },
+      {
+        "affiliation": "Annecy, LAPP",
+        "inspireid": "INSPIRE-00257359",
+        "name": "Pietrzyk, Boleslaw"
+      },
+      {
+        "affiliation": "INFN, Rome",
+        "inspireid": "INSPIRE-00258670",
+        "name": "Pinci, Davide"
+      },
+      {
+        "affiliation": "INFN, Genoa; Genoa U.",
+        "inspireid": "INSPIRE-00401637",
+        "name": "Pistone, Alessandro"
+      },
+      {
+        "affiliation": "Heidelberg U.",
+        "inspireid": "INSPIRE-00536921",
+        "name": "Piucci, Alessio"
+      },
+      {
+        "affiliation": "Edinburgh U.",
+        "inspireid": "INSPIRE-00144540",
+        "name": "Playfer, Stephen"
+      },
+      {
+        "affiliation": "U. Santiago de Compostela (main)",
+        "inspireid": "INSPIRE-00259765",
+        "name": "Plo Casasus, Maximo"
+      },
+      {
+        "affiliation": "CERN",
+        "inspireid": "INSPIRE-00522785",
+        "name": "Poikela, Tuomas"
+      },
+      {
+        "affiliation": "Paris U., VI-VII",
+        "inspireid": "INSPIRE-00041883",
+        "name": "Polci, Francesco"
+      },
+      {
+        "affiliation": "Warwick U.; Authors affiliated with an institute formerly covered by a cooperation agreement with CERN.",
+        "inspireid": "INSPIRE-00180587",
+        "name": "Poluektov, Anton"
+      },
+      {
+        "affiliation": "Syracuse U.",
+        "inspireid": "INSPIRE-00392262",
+        "name": "Polyakov, Ivan"
+      },
+      {
+        "affiliation": "Rio de Janeiro Federal U.",
+        "inspireid": "INSPIRE-00117142",
+        "name": "Polycarpo, Erica"
+      },
+      {
+        "affiliation": "Authors affiliated with an institute formerly covered by a cooperation agreement with CERN.",
+        "inspireid": "INSPIRE-00392309",
+        "name": "Popov, Alexander"
+      },
+      {
+        "affiliation": "Heidelberg, Max Planck Inst.; CERN",
+        "inspireid": "INSPIRE-00257709",
+        "name": "Popov, Dmitry"
+      },
+      {
+        "affiliation": "Bucharest, IFIN-HH",
+        "inspireid": "INSPIRE-00259165",
+        "name": "Popovici, Bogdan"
+      },
+      {
+        "affiliation": "Rio de Janeiro Federal U.",
+        "inspireid": "INSPIRE-00260620",
+        "name": "Potterat, C\\'edric"
+      },
+      {
+        "affiliation": "Bristol U.",
+        "inspireid": "INSPIRE-00401700",
+        "name": "Price, Eugenia"
+      },
+      {
+        "affiliation": "Liverpool U.",
+        "inspireid": "INSPIRE-00287010",
+        "name": "Price, Joseph David"
+      },
+      {
+        "affiliation": "U. Santiago de Compostela (main)",
+        "inspireid": "INSPIRE-00341705",
+        "name": "Prisciandaro, Jessica"
+      },
+      {
+        "affiliation": "Liverpool U.",
+        "inspireid": "INSPIRE-00392320",
+        "name": "Pritchard, Adrian"
+      },
+      {
+        "affiliation": "Bristol U.",
+        "inspireid": "INSPIRE-00392372",
+        "name": "Prouve, Claire"
+      },
+      {
+        "affiliation": "Kiev, INR",
+        "inspireid": "INSPIRE-00046375",
+        "name": "Pugatch, Valery"
+      },
+      {
+        "affiliation": "Ecole Polytechnique, Lausanne",
+        "inspireid": "INSPIRE-00259590",
+        "name": "Puig Navarro, Albert"
+      },
+      {
+        "affiliation": "INFN, Pisa; U. Pisa (main)",
+        "inspireid": "INSPIRE-00118078",
+        "name": "Punzi, Giovanni"
+      },
+      {
+        "affiliation": "Oxford U.",
+        "inspireid": "INSPIRE-00257268",
+        "name": "Qian, Wenbin"
+      },
+      {
+        "affiliation": "Orsay, LAL; Bristol U.",
+        "inspireid": "INSPIRE-00453676",
+        "name": "Quagliani, Renato"
+      },
+      {
+        "affiliation": "Cracow, INP",
+        "inspireid": "INSPIRE-00392425",
+        "name": "Rachwal, Bartlomiej"
+      },
+      {
+        "affiliation": "Bristol U.",
+        "inspireid": "INSPIRE-00050460",
+        "name": "Rademacker, Jonas"
+      },
+      {
+        "affiliation": "INFN, Pisa",
+        "inspireid": "INSPIRE-00041956",
+        "name": "Rama, Matteo"
+      },
+      {
+        "affiliation": "Rio de Janeiro Federal U.",
+        "inspireid": "INSPIRE-00024740",
+        "name": "Rangel, Murilo"
+      },
+      {
+        "affiliation": "Kharkov, KIPT",
+        "inspireid": "INSPIRE-00260925",
+        "name": "Raniuk, Iurii"
+      },
+      {
+        "affiliation": "NIKHEF, Amsterdam + Vrije U., Amsterdam",
+        "inspireid": "INSPIRE-00119187",
+        "name": "Raven, Gerhard"
+      },
+      {
+        "affiliation": "Imperial Coll., London",
+        "inspireid": "INSPIRE-00453784",
+        "name": "Redi, Federico"
+      },
+      {
+        "affiliation": "Manchester U.",
+        "inspireid": "INSPIRE-00392459",
+        "name": "Reichert, Stefanie"
+      },
+      {
+        "affiliation": "Orsay, LAL",
+        "inspireid": "INSPIRE-00545590",
+        "name": "Renaudin, Victor"
+      },
+      {
+        "affiliation": "Rutherford",
+        "inspireid": "INSPIRE-00119926",
+        "name": "Ricciardi, Stefania"
+      },
+      {
+        "affiliation": "Bristol U.",
+        "inspireid": "INSPIRE-00401830",
+        "name": "Richards, Sophie"
+      },
+      {
+        "affiliation": "CERN",
+        "inspireid": "INSPIRE-00401943",
+        "name": "Rihl, Mariana"
+      },
+      {
+        "affiliation": "Liverpool U.; CERN",
+        "inspireid": "INSPIRE-00034500",
+        "name": "Rinnert, Kurt"
+      },
+      {
+        "affiliation": "U. Barcelona (main)",
+        "inspireid": "INSPIRE-00357276",
+        "name": "Rives Molina, Vicente"
+      },
+      {
+        "affiliation": "Orsay, LAL; CERN",
+        "inspireid": "INSPIRE-00050542",
+        "name": "Robbe, Patrick"
+      },
+      {
+        "affiliation": "Rio de Janeiro, CBPF",
+        "inspireid": "INSPIRE-00392508",
+        "name": "Rodrigues, Ana Barbara"
+      },
+      {
+        "affiliation": "Manchester U.",
+        "inspireid": "INSPIRE-00306714",
+        "name": "Rodrigues, Eduardo"
+      },
+      {
+        "affiliation": "Colombia, U. Natl.",
+        "inspireid": "INSPIRE-00120769",
+        "name": "Rodriguez Lopez, Jairo Alexis"
+      },
+      {
+        "affiliation": "Manchester U.",
+        "inspireid": "INSPIRE-00259789",
+        "name": "Rodriguez Perez, Pablo"
+      },
+      {
+        "affiliation": "Authors affiliated with an institute formerly covered by a cooperation agreement with CERN.",
+        "inspireid": "INSPIRE-00582700",
+        "name": "Rogozhnikov, Alexey"
+      },
+      {
+        "affiliation": "CERN",
+        "inspireid": "INSPIRE-00346259",
+        "name": "Roiser, Stefan"
+      },
+      {
+        "affiliation": "Authors affiliated with an institute formerly covered by a cooperation agreement with CERN.",
+        "inspireid": "INSPIRE-00259690",
+        "name": "Romanovskiy, Vladimir"
+      },
+      {
+        "affiliation": "U. Santiago de Compostela (main)",
+        "inspireid": "INSPIRE-00357288",
+        "name": "Romero Vidal, Antonio"
+      },
+      {
+        "affiliation": "University Coll., Dublin",
+        "inspireid": "INSPIRE-00536933",
+        "name": "Ronayne, John William"
+      },
+      {
+        "affiliation": "INFN, Padua",
+        "inspireid": "INSPIRE-00036330",
+        "name": "Rotondo, Marcello"
+      },
+      {
+        "affiliation": "CERN",
+        "inspireid": "INSPIRE-00260315",
+        "name": "Ruf, Thomas"
+      },
+      {
+        "affiliation": "Valencia U., IFIC",
+        "inspireid": "INSPIRE-00392538",
+        "name": "Ruiz Valls, Pablo"
+      },
+      {
+        "affiliation": "U. Santiago de Compostela (main)",
+        "inspireid": "INSPIRE-00193814",
+        "name": "Saborido Silva, Juan Jose"
+      },
+      {
+        "affiliation": "Authors affiliated with an institute formerly covered by a cooperation agreement with CERN.",
+        "inspireid": "INSPIRE-00207799",
+        "name": "Sagidova, Naylya"
+      },
+      {
+        "affiliation": "INFN, Cagliari; Cagliari U.",
+        "inspireid": "INSPIRE-00258160",
+        "name": "Saitta, Biagio"
+      },
+      {
+        "affiliation": "Rio de Janeiro Federal U.",
+        "inspireid": "INSPIRE-00287090",
+        "name": "Salustino Guimaraes, Valdir"
+      },
+      {
+        "affiliation": "Valencia U., IFIC",
+        "inspireid": "INSPIRE-00454015",
+        "name": "Sanchez Mayordomo, Carlos"
+      },
+      {
+        "affiliation": "U. Santiago de Compostela (main)",
+        "inspireid": "INSPIRE-00357296",
+        "name": "Sanmartin Sedes, Brais"
+      },
+      {
+        "affiliation": "INFN, Rome",
+        "inspireid": "INSPIRE-00258681",
+        "name": "Santacesaria, Roberta"
+      },
+      {
+        "affiliation": "U. Santiago de Compostela (main)",
+        "inspireid": "INSPIRE-00306219",
+        "name": "Santamarina Rios, Cibran"
+      },
+      {
+        "affiliation": "Frascati",
+        "inspireid": "INSPIRE-00536947",
+        "name": "Santimaria, Marco"
+      },
+      {
+        "affiliation": "Rome U., Tor Vergata",
+        "inspireid": "INSPIRE-00038249",
+        "name": "Santovetti, Emanuele"
+      },
+      {
+        "affiliation": "Frascati; U. Rome La Sapienza (main)",
+        "inspireid": "INSPIRE-00028229",
+        "name": "Sarti, Alessio"
+      },
+      {
+        "affiliation": "INFN, Rome; Basilicata U., Potenza",
+        "inspireid": "INSPIRE-00258690",
+        "name": "Satriano, Celestina"
+      },
+      {
+        "affiliation": "Rome U., Tor Vergata",
+        "inspireid": "INSPIRE-00258614",
+        "name": "Satta, Alessia"
+      },
+      {
+        "affiliation": "Bristol U.",
+        "inspireid": "INSPIRE-00402066",
+        "name": "Saunders, Daniel Martin"
+      },
+      {
+        "affiliation": "Authors affiliated with an institute formerly covered by a cooperation agreement with CERN.",
+        "inspireid": "INSPIRE-00259293",
+        "name": "Savrina, Darya"
+      },
+      {
+        "affiliation": "Aachen, Tech. Hochsch.",
+        "inspireid": "INSPIRE-00123779",
+        "name": "Schael, Stefan"
+      },
+      {
+        "affiliation": "CERN",
+        "inspireid": "INSPIRE-00257856",
+        "name": "Schiller, Manuel"
+      },
+      {
+        "affiliation": "CERN",
+        "inspireid": "INSPIRE-00357303",
+        "name": "Schindler, Heinrich"
+      },
+      {
+        "affiliation": "Tech. U., Dortmund (main)",
+        "inspireid": "INSPIRE-00346274",
+        "name": "Schlupp, Maximilian"
+      },
+      {
+        "affiliation": "Heidelberg, Max Planck Inst.",
+        "inspireid": "INSPIRE-00124172",
+        "name": "Schmelling, Michael"
+      },
+      {
+        "affiliation": "Tech. U., Dortmund (main)",
+        "inspireid": "INSPIRE-00522799",
+        "name": "Schmelzer, Timon"
+      },
+      {
+        "affiliation": "CERN",
+        "inspireid": "INSPIRE-00260343",
+        "name": "Schmidt, Burkhard"
+      },
+      {
+        "affiliation": "Ecole Polytechnique, Lausanne",
+        "inspireid": "INSPIRE-00155864",
+        "name": "Schneider, Olivier"
+      },
+      {
+        "affiliation": "CERN",
+        "inspireid": "INSPIRE-00171861",
+        "name": "Schopper, Andreas"
+      },
+      {
+        "affiliation": "Ecole Polytechnique, Lausanne",
+        "inspireid": "INSPIRE-00536951",
+        "name": "Schubiger, Maxime"
+      },
+      {
+        "affiliation": "Orsay, LAL",
+        "inspireid": "INSPIRE-00124570",
+        "name": "Schune, Marie Helene"
+      },
+      {
+        "affiliation": "CERN",
+        "inspireid": "INSPIRE-00260360",
+        "name": "Schwemmer, Rainer"
+      },
+      {
+        "affiliation": "Frascati",
+        "inspireid": "INSPIRE-00038235",
+        "name": "Sciascia, Barbara"
+      },
+      {
+        "affiliation": "INFN, Rome; U. Rome La Sapienza (main)",
+        "inspireid": "INSPIRE-00262979",
+        "name": "Sciubba, Adalberto"
+      },
+      {
+        "affiliation": "Authors affiliated with an institute formerly covered by a cooperation agreement with CERN.",
+        "inspireid": "INSPIRE-00259305",
+        "name": "Semennikov, Alexander"
+      },
+      {
+        "affiliation": "Birmingham U.",
+        "inspireid": "INSPIRE-00184370",
+        "name": "Sergi, Antonino"
+      },
+      {
+        "affiliation": "Zurich U.",
+        "inspireid": "INSPIRE-00258830",
+        "name": "Serra, Nicola"
+      },
+      {
+        "affiliation": "Marseille, CPPM",
+        "inspireid": "INSPIRE-00144713",
+        "name": "Serrano, Justine"
+      },
+      {
+        "affiliation": "INFN, Padua",
+        "inspireid": "INSPIRE-00454148",
+        "name": "Sestini, Lorenzo"
+      },
+      {
+        "affiliation": "INFN, Milan Bicocca",
+        "inspireid": "INSPIRE-00341737",
+        "name": "Seyfert, Paul"
+      },
+      {
+        "affiliation": "Authors affiliated with an institute formerly covered by a cooperation agreement with CERN.",
+        "inspireid": "INSPIRE-00200269",
+        "name": "Shapkin, Mikhail"
+      },
+      {
+        "affiliation": "Authors affiliated with an institute formerly covered by a cooperation agreement with CERN.",
+        "inspireid": "INSPIRE-00005552",
+        "name": "Shcheglov, Yury"
+      },
+      {
+        "affiliation": "Liverpool U.",
+        "inspireid": "INSPIRE-00125751",
+        "name": "Shears, Tara"
+      },
+      {
+        "affiliation": "Authors affiliated with an institute formerly covered by a cooperation agreement with CERN.",
+        "inspireid": "INSPIRE-00072482",
+        "name": "Shekhtman, Lev"
+      },
+      {
+        "affiliation": "Authors affiliated with an institute formerly covered by a cooperation agreement with CERN.",
+        "inspireid": "INSPIRE-00259319",
+        "name": "Shevchenko, Vladimir"
+      },
+      {
+        "affiliation": "Tech. U., Dortmund (main)",
+        "inspireid": "INSPIRE-00262026",
+        "name": "Shires, Alexander"
+      },
+      {
+        "affiliation": "INFN, Ferrara; Ferrara U.",
+        "inspireid": "INSPIRE-00536966",
+        "name": "Siddi, Benedetto Gianluca"
+      },
+      {
+        "affiliation": "Zurich U.",
+        "inspireid": "INSPIRE-00341765",
+        "name": "Silva Coutinho, Rafael"
+      },
+      {
+        "affiliation": "Rio de Janeiro Federal U.",
+        "inspireid": "INSPIRE-00536971",
+        "name": "Silva de Oliveira, Luiz Gustavo"
+      },
+      {
+        "affiliation": "INFN, Padua; U. Padua (main)",
+        "inspireid": "INSPIRE-00042241",
+        "name": "Simi, Gabriele"
+      },
+      {
+        "affiliation": "Cambridge U.",
+        "inspireid": "INSPIRE-00392577",
+        "name": "Sirendi, Marek"
+      },
+      {
+        "affiliation": "Bristol U.",
+        "inspireid": "INSPIRE-00392618",
+        "name": "Skidmore, Nicola"
+      },
+      {
+        "affiliation": "Syracuse U.",
+        "inspireid": "INSPIRE-00165164",
+        "name": "Skwarnicki, Tomasz"
+      },
+      {
+        "affiliation": "Imperial Coll., London",
+        "inspireid": "INSPIRE-00266880",
+        "name": "Smith, Eluned"
+      },
+      {
+        "affiliation": "Edinburgh U.",
+        "inspireid": "INSPIRE-00536980",
+        "name": "Smith, Iwan Thomas"
+      },
+      {
+        "affiliation": "Cambridge U.",
+        "inspireid": "INSPIRE-00392666",
+        "name": "Smith, Jackson"
+      },
+      {
+        "affiliation": "Manchester U.",
+        "inspireid": "INSPIRE-00342046",
+        "name": "Smith, Mark"
+      },
+      {
+        "affiliation": "Nikhef, Amsterdam",
+        "inspireid": "INSPIRE-00042145",
+        "name": "Snoek, Hella"
+      },
+      {
+        "affiliation": "Cincinnati U.; CERN",
+        "inspireid": "INSPIRE-00127570",
+        "name": "Sokoloff, Michael"
+      },
+      {
+        "affiliation": "Glasgow U.",
+        "inspireid": "INSPIRE-00160205",
+        "name": "Soler, Paul"
+      },
+      {
+        "affiliation": "Ecole Polytechnique, Lausanne",
+        "inspireid": "INSPIRE-00262033",
+        "name": "Soomro, Fatima"
+      },
+      {
+        "affiliation": "Bristol U.",
+        "inspireid": "INSPIRE-00357314",
+        "name": "Souza, Daniel"
+      },
+      {
+        "affiliation": "Rio de Janeiro Federal U.",
+        "inspireid": "INSPIRE-00257205",
+        "name": "Souza De Paula, Bruno"
+      },
+      {
+        "affiliation": "Tech. U., Dortmund (main)",
+        "inspireid": "INSPIRE-00128007",
+        "name": "Spaan, Bernhard"
+      },
+      {
+        "affiliation": "Authors affiliated with an institute formerly covered by a cooperation agreement with CERN.",
+        "name": "Spiridenkov, Eduard"
+      },
+      {
+        "affiliation": "Glasgow U.",
+        "inspireid": "INSPIRE-00042860",
+        "name": "Spradlin, Patrick"
+      },
+      {
+        "affiliation": "CERN",
+        "inspireid": "INSPIRE-00402283",
+        "name": "Sridharan, Srikanth"
+      },
+      {
+        "affiliation": "CERN",
+        "inspireid": "INSPIRE-00260412",
+        "name": "Stagni, Federico"
+      },
+      {
+        "affiliation": "Heidelberg U.",
+        "inspireid": "INSPIRE-00402270",
+        "name": "Stahl, Marian"
+      },
+      {
+        "affiliation": "CERN",
+        "inspireid": "INSPIRE-00257861",
+        "name": "Stahl, Sascha"
+      },
+      {
+        "affiliation": "Imperial Coll., London",
+        "inspireid": "INSPIRE-00537009",
+        "name": "Stefkova, Slavomira"
+      },
+      {
+        "affiliation": "Zurich U.",
+        "inspireid": "INSPIRE-00260853",
+        "name": "Steinkamp, Olaf"
+      },
+      {
+        "affiliation": "Authors affiliated with an institute formerly covered by a cooperation agreement with CERN.",
+        "inspireid": "INSPIRE-00010650",
+        "name": "Stenyakin, Oleg"
+      },
+      {
+        "affiliation": "Oxford U.",
+        "inspireid": "INSPIRE-00392718",
+        "name": "Stevenson, Scott"
+      },
+      {
+        "affiliation": "Bucharest, IFIN-HH",
+        "inspireid": "INSPIRE-00259172",
+        "name": "Stoica, Sabin"
+      },
+      {
+        "affiliation": "Syracuse U.; CERN",
+        "inspireid": "INSPIRE-00160900",
+        "name": "Stone, Sheldon"
+      },
+      {
+        "affiliation": "Zurich U.",
+        "inspireid": "INSPIRE-00004591",
+        "name": "Storaci, Barbara"
+      },
+      {
+        "affiliation": "INFN, Pisa; U. Pisa (main)",
+        "inspireid": "INSPIRE-00003424",
+        "name": "Stracka, Simone"
+      },
+      {
+        "affiliation": "Bucharest, IFIN-HH",
+        "inspireid": "INSPIRE-00341791",
+        "name": "Straticiuc, Mihai"
+      },
+      {
+        "affiliation": "Zurich U.",
+        "inspireid": "INSPIRE-00129260",
+        "name": "Straumann, Ulrich"
+      },
+      {
+        "affiliation": "Cincinnati U.",
+        "inspireid": "INSPIRE-00327085",
+        "name": "Sun, Liang"
+      },
+      {
+        "affiliation": "Imperial Coll., London",
+        "inspireid": "INSPIRE-00392760",
+        "name": "Sutcliffe, William"
+      },
+      {
+        "affiliation": "AGH-UST, Krakow",
+        "inspireid": "INSPIRE-00454405",
+        "name": "Swientek, Krzysztof"
+      },
+      {
+        "affiliation": "Tech. U., Dortmund (main)",
+        "inspireid": "INSPIRE-00341824",
+        "name": "Swientek, Stefan"
+      },
+      {
+        "affiliation": "NIKHEF, Amsterdam + Vrije U., Amsterdam",
+        "inspireid": "INSPIRE-00392811",
+        "name": "Syropoulos, Vasileios"
+      },
+      {
+        "affiliation": "NCBJ, Swierk",
+        "inspireid": "INSPIRE-00259072",
+        "name": "Szczekowski, Marek"
+      },
+      {
+        "affiliation": "AGH-UST, Krakow",
+        "inspireid": "INSPIRE-00258964",
+        "name": "Szumlak, Tomasz"
+      },
+      {
+        "affiliation": "Marseille, CPPM",
+        "inspireid": "INSPIRE-00506770",
+        "name": "Tayduganov, Andrey"
+      },
+      {
+        "affiliation": "Tech. U., Dortmund (main)",
+        "inspireid": "INSPIRE-00522805",
+        "name": "Tekampe, Tobias"
+      },
+      {
+        "affiliation": "Orsay, LAL",
+        "inspireid": "INSPIRE-00357320",
+        "name": "Teklishyn, Maksym"
+      },
+      {
+        "affiliation": "INFN, Ferrara; Ferrara U.",
+        "inspireid": "INSPIRE-00391939",
+        "name": "Tellarini, Giulia"
+      },
+      {
+        "affiliation": "CERN",
+        "inspireid": "INSPIRE-00131170",
+        "name": "Teubert, Frederic"
+      },
+      {
+        "affiliation": "Oxford U.",
+        "inspireid": "INSPIRE-00261224",
+        "name": "Thomas, Christopher"
+      },
+      {
+        "affiliation": "CERN",
+        "inspireid": "INSPIRE-00260424",
+        "name": "Thomas, Eric"
+      },
+      {
+        "affiliation": "Annecy, LAPP",
+        "inspireid": "INSPIRE-00131575",
+        "name": "Tisserand, Vincent"
+      },
+      {
+        "affiliation": "Annecy, LAPP",
+        "inspireid": "INSPIRE-00036863",
+        "name": "T'Jampens, Stephane"
+      },
+      {
+        "affiliation": "Ecole Polytechnique, Lausanne",
+        "inspireid": "INSPIRE-00260879",
+        "name": "Tobin, Mark"
+      },
+      {
+        "affiliation": "Cincinnati U.",
+        "inspireid": "INSPIRE-00454530",
+        "name": "Todd, Jacob"
+      },
+      {
+        "affiliation": "NIKHEF, Amsterdam + Vrije U., Amsterdam",
+        "inspireid": "INSPIRE-00357337",
+        "name": "Tolk, Siim"
+      },
+      {
+        "affiliation": "INFN, Ferrara; Ferrara U.",
+        "inspireid": "INSPIRE-00392023",
+        "name": "Tomassetti, Luca"
+      },
+      {
+        "affiliation": "CERN",
+        "inspireid": "INSPIRE-00053184",
+        "name": "Tonelli, Diego"
+      },
+      {
+        "affiliation": "Annecy, LAPP",
+        "inspireid": "INSPIRE-00341842",
+        "name": "Tournefier, Edwige"
+      },
+      {
+        "affiliation": "Ecole Polytechnique, Lausanne",
+        "inspireid": "INSPIRE-00040682",
+        "name": "Tourneur, Stephane"
+      },
+      {
+        "affiliation": "Ecole Polytechnique, Lausanne",
+        "inspireid": "INSPIRE-00369170",
+        "name": "Trabelsi, Karim"
+      },
+      {
+        "affiliation": "Ecole Polytechnique, Lausanne",
+        "inspireid": "INSPIRE-00260665",
+        "name": "Tran, Minh T\\^am"
+      },
+      {
+        "affiliation": "Zurich U.",
+        "inspireid": "INSPIRE-00392146",
+        "name": "Tresch, Marco"
+      },
+      {
+        "affiliation": "CERN",
+        "inspireid": "INSPIRE-00454660",
+        "name": "Trisovic, Ana"
+      },
+      {
+        "affiliation": "Marseille, CPPM",
+        "inspireid": "INSPIRE-00257520",
+        "name": "Tsaregorodtsev, Andrei"
+      },
+      {
+        "affiliation": "Nikhef, Amsterdam",
+        "inspireid": "INSPIRE-00357349",
+        "name": "Tsopelas, Panagiotis"
+      },
+      {
+        "affiliation": "Nikhef, Amsterdam; CERN",
+        "inspireid": "INSPIRE-00258853",
+        "name": "Tuning, Niels"
+      },
+      {
+        "affiliation": "NCBJ, Swierk",
+        "inspireid": "INSPIRE-00045795",
+        "name": "Ukleja, Artur"
+      },
+      {
+        "affiliation": "Authors affiliated with an institute formerly covered by a cooperation agreement with CERN.",
+        "inspireid": "INSPIRE-00392208",
+        "name": "Ustyuzhanin, Andrey"
+      },
+      {
+        "affiliation": "Heidelberg U.",
+        "inspireid": "INSPIRE-00133105",
+        "name": "Uwer, Ulrich"
+      },
+      {
+        "affiliation": "INFN, Cagliari; CERN; Cagliari U.",
+        "inspireid": "INSPIRE-00454790",
+        "name": "Vacca, Claudia"
+      },
+      {
+        "affiliation": "INFN, Bologna",
+        "inspireid": "INSPIRE-00258091",
+        "name": "Vagnoni, Vincenzo"
+      },
+      {
+        "affiliation": "CERN",
+        "inspireid": "INSPIRE-00582822",
+        "name": "Valat, Sebastien"
+      },
+      {
+        "affiliation": "INFN, Bologna",
+        "inspireid": "INSPIRE-00258103",
+        "name": "Valenti, Giovanni"
+      },
+      {
+        "affiliation": "Orsay, LAL",
+        "inspireid": "INSPIRE-00392294",
+        "name": "Vallier, Alexis"
+      },
+      {
+        "affiliation": "Nikhef, Amsterdam",
+        "inspireid": "INSPIRE-00032419",
+        "name": "van Beuzekom, Martinus"
+      },
+      {
+        "affiliation": "CERN",
+        "inspireid": "INSPIRE-00260103",
+        "name": "van Herwijnen, Eric"
+      },
+      {
+        "affiliation": "Nikhef, Amsterdam",
+        "inspireid": "INSPIRE-00296057",
+        "name": "van Leerdam, Jeroen"
+      },
+      {
+        "affiliation": "Nikhef, Amsterdam",
+        "inspireid": "INSPIRE-00260865",
+        "name": "van Tilburg, Jeroen"
+      },
+      {
+        "affiliation": "Nikhef, Amsterdam",
+        "inspireid": "INSPIRE-00545618",
+        "name": "van Veghel, Maarten"
+      },
+      {
+        "affiliation": "Frascati",
+        "inspireid": "INSPIRE-00259633",
+        "name": "Vazquez Gomez, Ricardo"
+      },
+      {
+        "affiliation": "U. Santiago de Compostela (main)",
+        "inspireid": "INSPIRE-00259816",
+        "name": "Vazquez Regueiro, Pablo"
+      },
+      {
+        "affiliation": "U. Santiago de Compostela (main)",
+        "inspireid": "INSPIRE-00392390",
+        "name": "V\\'azquez Sierra, Carlos"
+      },
+      {
+        "affiliation": "INFN, Ferrara",
+        "inspireid": "INSPIRE-00258200",
+        "name": "Vecchi, Stefania"
+      },
+      {
+        "affiliation": "Bristol U.",
+        "inspireid": "INSPIRE-00318722",
+        "name": "Velthuis, Jaap"
+      },
+      {
+        "affiliation": "INFN, Florence; U. Urbino (main)",
+        "inspireid": "INSPIRE-00258261",
+        "name": "Veltri, Michele"
+      },
+      {
+        "affiliation": "Ecole Polytechnique, Lausanne",
+        "inspireid": "INSPIRE-00357350",
+        "name": "Veneziano, Giovanni"
+      },
+      {
+        "affiliation": "Heidelberg U.",
+        "inspireid": "INSPIRE-00014030",
+        "name": "Vesterinen, Mika"
+      },
+      {
+        "affiliation": "Orsay, LAL",
+        "inspireid": "INSPIRE-00257597",
+        "name": "Viaud, Benoit"
+      },
+      {
+        "affiliation": "Rio de Janeiro Federal U.",
+        "inspireid": "INSPIRE-00341866",
+        "name": "Vieira, Daniel"
+      },
+      {
+        "affiliation": "U. Santiago de Compostela (main)",
+        "inspireid": "INSPIRE-00455170",
+        "name": "Vieites Diaz, Maria"
+      },
+      {
+        "affiliation": "U. Barcelona (main)",
+        "inspireid": "INSPIRE-00259644",
+        "name": "Vilasis-Cardona, Xavier"
+      },
+      {
+        "affiliation": "Zurich U.",
+        "inspireid": "INSPIRE-00260888",
+        "name": "Vollhardt, Achim"
+      },
+      {
+        "affiliation": "Bristol U.",
+        "inspireid": "INSPIRE-00260988",
+        "name": "Voong, David"
+      },
+      {
+        "affiliation": "Authors affiliated with an institute formerly covered by a cooperation agreement with CERN.",
+        "inspireid": "INSPIRE-00312898",
+        "name": "Vorobyev, Alexey"
+      },
+      {
+        "affiliation": "Authors affiliated with an institute formerly covered by a cooperation agreement with CERN.",
+        "inspireid": "INSPIRE-00341883",
+        "name": "Vorobyev, Vitaly"
+      },
+      {
+        "affiliation": "Authors affiliated with an institute formerly covered by a cooperation agreement with CERN.",
+        "name": "Voropaev, Nikolai"
+      },
+      {
+        "affiliation": "Rostock U.",
+        "inspireid": "INSPIRE-00000638",
+        "name": "Vo\\ss, Christian"
+      },
+      {
+        "affiliation": "Rostock U.",
+        "inspireid": "INSPIRE-00134615",
+        "name": "Waldi, Roland"
+      },
+      {
+        "affiliation": "Warwick U.",
+        "inspireid": "INSPIRE-00384763",
+        "name": "Wallace, Charlotte"
+      },
+      {
+        "affiliation": "University Coll., Dublin",
+        "inspireid": "INSPIRE-00357370",
+        "name": "Wallace, Ronan"
+      },
+      {
+        "affiliation": "INFN, Pisa",
+        "inspireid": "INSPIRE-00134726",
+        "name": "Walsh, John"
+      },
+      {
+        "affiliation": "Syracuse U.",
+        "inspireid": "INSPIRE-00262940",
+        "name": "Wang, Jianchun"
+      },
+      {
+        "affiliation": "Cambridge U.",
+        "inspireid": "INSPIRE-00144738",
+        "name": "Ward, David"
+      },
+      {
+        "affiliation": "Birmingham U.",
+        "inspireid": "INSPIRE-00146172",
+        "name": "Watson, Nigel"
+      },
+      {
+        "affiliation": "Imperial Coll., London",
+        "inspireid": "INSPIRE-00135220",
+        "name": "Websdale, David"
+      },
+      {
+        "affiliation": "Zurich U.",
+        "inspireid": "INSPIRE-00522810",
+        "name": "Weiden, Andreas"
+      },
+      {
+        "affiliation": "CERN",
+        "inspireid": "INSPIRE-00261160",
+        "name": "Whitehead, Mark"
+      },
+      {
+        "affiliation": "Warwick U.",
+        "inspireid": "INSPIRE-00341892",
+        "name": "Wicht, Jean"
+      },
+      {
+        "affiliation": "Oxford U.; CERN",
+        "inspireid": "INSPIRE-00262885",
+        "name": "Wilkinson, Guy"
+      },
+      {
+        "affiliation": "Syracuse U.",
+        "inspireid": "INSPIRE-00452781",
+        "name": "Wilkinson, Michael K."
+      },
+      {
+        "affiliation": "MIT",
+        "inspireid": "INSPIRE-00342010",
+        "name": "Williams, Mike"
+      },
+      {
+        "affiliation": "Birmingham U.",
+        "inspireid": "INSPIRE-00261177",
+        "name": "Williams, Matthew"
+      },
+      {
+        "affiliation": "CERN",
+        "inspireid": "INSPIRE-00136085",
+        "name": "Williams, Mark Richard James"
+      },
+      {
+        "affiliation": "Birmingham U.",
+        "inspireid": "INSPIRE-00537010",
+        "name": "Williams, Timothy"
+      },
+      {
+        "affiliation": "Rutherford",
+        "inspireid": "INSPIRE-00136130",
+        "name": "Wilson, Fergus"
+      },
+      {
+        "affiliation": "Maryland U., College Park",
+        "inspireid": "INSPIRE-00392586",
+        "name": "Wimberley, Jack"
+      },
+      {
+        "affiliation": "Tech. U., Dortmund (main)",
+        "inspireid": "INSPIRE-00257673",
+        "name": "Wishahi, Julian"
+      },
+      {
+        "affiliation": "NCBJ, Swierk",
+        "inspireid": "INSPIRE-00136336",
+        "name": "Wislicki, Wojciech"
+      },
+      {
+        "affiliation": "Cracow, INP",
+        "inspireid": "INSPIRE-00258926",
+        "name": "Witek, Mariusz"
+      },
+      {
+        "affiliation": "Orsay, LAL",
+        "inspireid": "INSPIRE-00136673",
+        "name": "Wormser, Guy"
+      },
+      {
+        "affiliation": "Cambridge U.",
+        "inspireid": "INSPIRE-00261140",
+        "name": "Wotton, Stephen"
+      },
+      {
+        "affiliation": "Glasgow U.",
+        "inspireid": "INSPIRE-00160280",
+        "name": "Wraight, Kenneth"
+      },
+      {
+        "affiliation": "Cambridge U.",
+        "inspireid": "INSPIRE-00341913",
+        "name": "Wright, Simon"
+      },
+      {
+        "affiliation": "CERN",
+        "inspireid": "INSPIRE-00260456",
+        "name": "Wyllie, Kenneth"
+      },
+      {
+        "affiliation": "CCNU, Wuhan, Inst. Part. Phys.",
+        "inspireid": "INSPIRE-00025656",
+        "name": "Xie, Yuehong"
+      },
+      {
+        "affiliation": "Ecole Polytechnique, Lausanne",
+        "inspireid": "INSPIRE-00455305",
+        "name": "Xu, Zhirui"
+      },
+      {
+        "affiliation": "Tsinghua U., Beijing, CHEP",
+        "inspireid": "INSPIRE-00257282",
+        "name": "Yang, Zhenwei"
+      },
+      {
+        "affiliation": "CCNU, Wuhan, Inst. Part. Phys.",
+        "inspireid": "INSPIRE-00038031",
+        "name": "Yin, Hang"
+      },
+      {
+        "affiliation": "CCNU, Wuhan, Inst. Part. Phys.; Hunan U.",
+        "inspireid": "INSPIRE-00447456",
+        "name": "Yu, Jiesheng"
+      },
+      {
+        "affiliation": "Authors affiliated with an institute formerly covered by a cooperation agreement with CERN.",
+        "inspireid": "INSPIRE-00341946",
+        "name": "Yuan, Xuhao"
+      },
+      {
+        "affiliation": "Authors affiliated with an institute formerly covered by a cooperation agreement with CERN.",
+        "inspireid": "INSPIRE-00200283",
+        "name": "Yushchenko, Oleg"
+      },
+      {
+        "affiliation": "INFN, Bologna",
+        "inspireid": "INSPIRE-00341950",
+        "name": "Zangoli, Maria"
+      },
+      {
+        "affiliation": "Heidelberg, Max Planck Inst.; Authors affiliated with an institute formerly covered by a cooperation agreement with CERN.",
+        "inspireid": "INSPIRE-00357381",
+        "name": "Zavertyaev, Mikhail"
+      },
+      {
+        "affiliation": "Tsinghua U., Beijing, CHEP",
+        "inspireid": "INSPIRE-00043581",
+        "name": "Zhang, Liming"
+      },
+      {
+        "affiliation": "Orsay, LAL",
+        "inspireid": "INSPIRE-00257306",
+        "name": "Zhang, Yanxi"
+      },
+      {
+        "affiliation": "Heidelberg U.",
+        "inspireid": "INSPIRE-00217483",
+        "name": "Zhelezov, Alexey"
+      },
+      {
+        "affiliation": "Beijing, GUCAS",
+        "inspireid": "INSPIRE-00138380",
+        "name": "Zheng, Yangheng"
+      },
+      {
+        "affiliation": "Authors affiliated with an institute formerly covered by a cooperation agreement with CERN.",
+        "inspireid": "INSPIRE-00392752",
+        "name": "Zhokhov, Anatoly"
+      },
+      {
+        "affiliation": "Tsinghua U., Beijing, CHEP",
+        "inspireid": "INSPIRE-00296049",
+        "name": "Zhong, Liang"
+      },
+      {
+        "affiliation": "Aachen, Tech. Hochsch.",
+        "inspireid": "INSPIRE-00170284",
+        "name": "Zhukov, Valery"
+      },
+      {
+        "affiliation": "INFN, Bologna; Bologna U.",
+        "inspireid": "INSPIRE-00040570",
+        "name": "Zucchelli, Stefano"
+      }
+    ],
+    "collaboration": {
+      "name": "LHCb collaboration"
+    },
+    "collections": [
+      "Author-Lists"
+    ],
+    "date_created": [
+      "2015"
+    ],
+    "date_published": "2026",
+    "experiment": [
+      "LHCb"
+    ],
+    "publisher": "CERN Open Data Portal",
+    "recid": "457",
+    "title": "LHCb author list for the LHCb 2015 open data release",
+    "type": {
+      "primary": "Documentation",
+      "secondary": [
+        "Authors"
+      ]
+    }
+  }
+]

--- a/data/records/lhcb-author-list-2016.json
+++ b/data/records/lhcb-author-list-2016.json
@@ -1,0 +1,3875 @@
+[
+  {
+    "authors": [
+      {
+        "affiliation": "CERN",
+        "inspireid": "INSPIRE-00258707",
+        "name": "Aaij, Roel"
+      },
+      {
+        "affiliation": "U. Santiago de Compostela (main)",
+        "inspireid": "INSPIRE-00194077",
+        "name": "Adeva, Bernardo"
+      },
+      {
+        "affiliation": "Bristol U.",
+        "inspireid": "INSPIRE-00060950",
+        "name": "Adinolfi, Marco"
+      },
+      {
+        "affiliation": "Clermont-Ferrand U.",
+        "inspireid": "INSPIRE-00061185",
+        "name": "Ajaltouni, Ziad"
+      },
+      {
+        "affiliation": "Cincinnati U.",
+        "inspireid": "INSPIRE-00277451",
+        "name": "Akar, Simon"
+      },
+      {
+        "affiliation": "Rio de Janeiro Federal U.",
+        "inspireid": "INSPIRE-00055208",
+        "name": "Akiba, Kazuyoshi"
+      },
+      {
+        "affiliation": "Tech. U., Dortmund (main)",
+        "inspireid": "INSPIRE-00259834",
+        "name": "Albrecht, Johannes"
+      },
+      {
+        "affiliation": "CERN",
+        "inspireid": "INSPIRE-00257446",
+        "name": "Alessio, Federico"
+      },
+      {
+        "affiliation": "Glasgow U.",
+        "inspireid": "INSPIRE-00160626",
+        "name": "Alexander, Michael"
+      },
+      {
+        "affiliation": "Nikhef, Amsterdam",
+        "inspireid": "INSPIRE-00340938",
+        "name": "Ali, Suvayu"
+      },
+      {
+        "affiliation": "Authors affiliated with an institute formerly covered by a cooperation agreement with CERN.",
+        "inspireid": "INSPIRE-00061628",
+        "name": "Alkhazov, Georgy"
+      },
+      {
+        "affiliation": "Imperial Coll., London",
+        "inspireid": "INSPIRE-00259650",
+        "name": "Alvarez Cartelle, Paula"
+      },
+      {
+        "affiliation": "Cincinnati U.",
+        "inspireid": "INSPIRE-00258623",
+        "name": "Alves Jr, Antonio Augusto"
+      },
+      {
+        "affiliation": "Rio de Janeiro Federal U.",
+        "inspireid": "INSPIRE-00061842",
+        "name": "Amato, Sandra"
+      },
+      {
+        "affiliation": "INFN, Padua",
+        "inspireid": "INSPIRE-00041447",
+        "name": "Amerio, Silvia"
+      },
+      {
+        "affiliation": "Orsay, LAL",
+        "inspireid": "INSPIRE-00260470",
+        "name": "Amhis, Yasmine"
+      },
+      {
+        "affiliation": "Tsinghua U., Beijing, CHEP",
+        "inspireid": "INSPIRE-00451766",
+        "name": "An, Liupan"
+      },
+      {
+        "affiliation": "INFN, Florence",
+        "inspireid": "INSPIRE-00357120",
+        "name": "Anderlini, Lucio"
+      },
+      {
+        "affiliation": "Ecole Polytechnique, Lausanne",
+        "inspireid": "INSPIRE-00536702",
+        "name": "Andreassi, Guido"
+      },
+      {
+        "affiliation": "INFN, Ferrara; Ferrara U.",
+        "inspireid": "INSPIRE-00042608",
+        "name": "Andreotti, Mirco"
+      },
+      {
+        "affiliation": "Maryland U., College Park",
+        "inspireid": "INSPIRE-00387304",
+        "name": "Andrews, Jason"
+      },
+      {
+        "affiliation": "Manchester U.",
+        "inspireid": "INSPIRE-00193766",
+        "name": "Appleby, Robert"
+      },
+      {
+        "affiliation": "Nikhef, Amsterdam",
+        "inspireid": "INSPIRE-00340940",
+        "name": "Archilli, Flavio"
+      },
+      {
+        "affiliation": "Marseille, CPPM",
+        "inspireid": "INSPIRE-00582095",
+        "name": "Arnau Romeu, Joan"
+      },
+      {
+        "affiliation": "Authors affiliated with an institute formerly covered by a cooperation agreement with CERN.",
+        "inspireid": "INSPIRE-00320358",
+        "name": "Artamonov, Alexander"
+      },
+      {
+        "affiliation": "Syracuse U.",
+        "inspireid": "INSPIRE-00063052",
+        "name": "Artuso, Marina"
+      },
+      {
+        "affiliation": "Marseille, CPPM",
+        "inspireid": "INSPIRE-00257456",
+        "name": "Aslanides, Elie"
+      },
+      {
+        "affiliation": "INFN, Rome",
+        "inspireid": "INSPIRE-00258647",
+        "name": "Auriemma, Giulio"
+      },
+      {
+        "affiliation": "Clermont-Ferrand U.",
+        "inspireid": "INSPIRE-00387320",
+        "name": "Baalouch, Marouen"
+      },
+      {
+        "affiliation": "Manchester U.",
+        "inspireid": "INSPIRE-00582103",
+        "name": "Babuschkin, Igor"
+      },
+      {
+        "affiliation": "Heidelberg U.",
+        "inspireid": "INSPIRE-00257758",
+        "name": "Bachmann, Sebastian"
+      },
+      {
+        "affiliation": "Warwick U.",
+        "inspireid": "INSPIRE-00041629",
+        "name": "Back, John"
+      },
+      {
+        "affiliation": "U. Barcelona (main); Ramon Llull U., Barcelona",
+        "inspireid": "INSPIRE-00387629",
+        "name": "Badalov, Alexey"
+      },
+      {
+        "affiliation": "Rio de Janeiro, Pont. U. Catol.",
+        "inspireid": "INSPIRE-00357139",
+        "name": "Baesso, Clarissa"
+      },
+      {
+        "affiliation": "Imperial Coll., London",
+        "inspireid": "INSPIRE-00582112",
+        "name": "Baker, Sophie"
+      },
+      {
+        "affiliation": "Orsay, LAL; Ecole Polytechnique",
+        "inspireid": "INSPIRE-00202437",
+        "name": "Balagura, Vladislav"
+      },
+      {
+        "affiliation": "INFN, Ferrara",
+        "inspireid": "INSPIRE-00210350",
+        "name": "Baldini, Wander"
+      },
+      {
+        "affiliation": "Authors affiliated with an institute formerly covered by a cooperation agreement with CERN.",
+        "name": "Baranov, Alexander"
+      },
+      {
+        "affiliation": "Manchester U.",
+        "inspireid": "INSPIRE-00064590",
+        "name": "Barlow, Roger"
+      },
+      {
+        "affiliation": "CERN",
+        "inspireid": "INSPIRE-00295950",
+        "name": "Barschel, Colin"
+      },
+      {
+        "affiliation": "Orsay, LAL",
+        "inspireid": "INSPIRE-00257536",
+        "name": "Barsuk, Sergey"
+      },
+      {
+        "affiliation": "Manchester U.",
+        "inspireid": "INSPIRE-00340962",
+        "name": "Barter, William"
+      },
+      {
+        "affiliation": "Authors affiliated with an institute formerly covered by a cooperation agreement with CERN.",
+        "name": "Baryshnikov, Fedor"
+      },
+      {
+        "affiliation": "NCBJ, Swierk",
+        "inspireid": "INSPIRE-00387971",
+        "name": "Batozskaya, Varvara"
+      },
+      {
+        "affiliation": "Ecole Polytechnique, Lausanne",
+        "inspireid": "INSPIRE-00451956",
+        "name": "Battista, Vincenzo"
+      },
+      {
+        "affiliation": "Ecole Polytechnique, Lausanne",
+        "inspireid": "INSPIRE-00065250",
+        "name": "Bay, Aurelio"
+      },
+      {
+        "affiliation": "Annecy, LAPP",
+        "inspireid": "INSPIRE-00399871",
+        "name": "Beaucourt, Leo"
+      },
+      {
+        "affiliation": "Glasgow U.",
+        "inspireid": "INSPIRE-00340975",
+        "name": "Beddow, John"
+      },
+      {
+        "affiliation": "INFN, Pisa",
+        "inspireid": "INSPIRE-00065532",
+        "name": "Bedeschi, Franco"
+      },
+      {
+        "affiliation": "Rio de Janeiro, CBPF",
+        "inspireid": "INSPIRE-00065546",
+        "name": "Bediaga, Ignacio"
+      },
+      {
+        "affiliation": "Syracuse U.",
+        "name": "Beiter, Andrew"
+      },
+      {
+        "affiliation": "Nikhef, Amsterdam",
+        "inspireid": "INSPIRE-00522548",
+        "name": "Bel, Lennaert"
+      },
+      {
+        "affiliation": "Ecole Polytechnique, Lausanne",
+        "inspireid": "INSPIRE-00536729",
+        "name": "Bellee, Violaine"
+      },
+      {
+        "affiliation": "INFN, Milan Bicocca; Milan Bicocca U.",
+        "inspireid": "INSPIRE-00536743",
+        "name": "Belloli, Nicoletta"
+      },
+      {
+        "affiliation": "Authors affiliated with an institute formerly covered by a cooperation agreement with CERN.",
+        "inspireid": "INSPIRE-00259437",
+        "name": "Belous, Konstantin"
+      },
+      {
+        "affiliation": "Authors affiliated with an institute formerly covered by a cooperation agreement with CERN.",
+        "inspireid": "INSPIRE-00258730",
+        "name": "Belyaev, Ivan"
+      },
+      {
+        "affiliation": "Frascati",
+        "inspireid": "INSPIRE-00258283",
+        "name": "Bencivenni, Giovanni"
+      },
+      {
+        "affiliation": "Paris U., VI-VII",
+        "inspireid": "INSPIRE-00052383",
+        "name": "Ben-Haim, Eli"
+      },
+      {
+        "affiliation": "Nikhef, Amsterdam",
+        "inspireid": "INSPIRE-00341004",
+        "name": "Benson, Sean"
+      },
+      {
+        "affiliation": "Aachen, Tech. Hochsch.",
+        "name": "Beranek, Sarah"
+      },
+      {
+        "affiliation": "Authors affiliated with an institute formerly covered by a cooperation agreement with CERN.",
+        "inspireid": "INSPIRE-00202631",
+        "name": "Berezhnoy, Alexander"
+      },
+      {
+        "affiliation": "Zurich U.",
+        "inspireid": "INSPIRE-00066526",
+        "name": "Bernet, Roland"
+      },
+      {
+        "affiliation": "INFN, Padua",
+        "inspireid": "INSPIRE-00173823",
+        "name": "Bertolin, Alessandro"
+      },
+      {
+        "affiliation": "Zurich U.",
+        "inspireid": "INSPIRE-00362040",
+        "name": "Betancourt, Christopher"
+      },
+      {
+        "affiliation": "INFN, Bologna",
+        "inspireid": "INSPIRE-00582132",
+        "name": "Betti, Federico"
+      },
+      {
+        "affiliation": "CERN",
+        "inspireid": "INSPIRE-00001810",
+        "name": "Bettler, Marc-Olivier"
+      },
+      {
+        "affiliation": "Zurich U.",
+        "inspireid": "INSPIRE-00582143",
+        "name": "Bezshyiko, Iaroslava"
+      },
+      {
+        "affiliation": "Birmingham U.",
+        "inspireid": "INSPIRE-00000685",
+        "name": "Bifani, Simone"
+      },
+      {
+        "affiliation": "Paris U., VI-VII",
+        "inspireid": "INSPIRE-00067095",
+        "name": "Billoir, Pierre"
+      },
+      {
+        "affiliation": "Manchester U.",
+        "inspireid": "INSPIRE-00344700",
+        "name": "Bird, Thomas"
+      },
+      {
+        "affiliation": "Tech. U., Dortmund (main)",
+        "inspireid": "INSPIRE-00522660",
+        "name": "Birnkraut, Alex"
+      },
+      {
+        "affiliation": "Manchester U.",
+        "inspireid": "INSPIRE-00160399",
+        "name": "Bitadze, Alexander"
+      },
+      {
+        "affiliation": "INFN, Florence; U. Modena (main)",
+        "inspireid": "INSPIRE-00258210",
+        "name": "Bizzeti, Andrea"
+      },
+      {
+        "affiliation": "Warwick U.",
+        "inspireid": "INSPIRE-00261950",
+        "name": "Blake, Thomas"
+      },
+      {
+        "affiliation": "Ecole Polytechnique, Lausanne",
+        "inspireid": "INSPIRE-00067348",
+        "name": "Blanc, Frederic"
+      },
+      {
+        "affiliation": "Heidelberg, Max Planck Inst.",
+        "inspireid": "INSPIRE-00257778",
+        "name": "Blouw, Johan"
+      },
+      {
+        "affiliation": "Syracuse U.",
+        "inspireid": "INSPIRE-00067685",
+        "name": "Blusk, Steven"
+      },
+      {
+        "affiliation": "INFN, Rome",
+        "inspireid": "INSPIRE-00067707",
+        "name": "Bocci, Valerio"
+      },
+      {
+        "affiliation": "MIT",
+        "inspireid": "INSPIRE-00582163",
+        "name": "Boettcher, Thomas"
+      },
+      {
+        "affiliation": "Authors affiliated with an institute formerly covered by a cooperation agreement with CERN.",
+        "inspireid": "INSPIRE-00259423",
+        "name": "Bondar, Alexander"
+      },
+      {
+        "affiliation": "Authors affiliated with an institute formerly covered by a cooperation agreement with CERN.; CERN",
+        "inspireid": "INSPIRE-00317412",
+        "name": "Bondar, Nikolay"
+      },
+      {
+        "affiliation": "INFN, Cagliari",
+        "inspireid": "INSPIRE-00258110",
+        "name": "Bonivento, Walter"
+      },
+      {
+        "affiliation": "Authors affiliated with an institute formerly covered by a cooperation agreement with CERN.",
+        "inspireid": "INSPIRE-00265100",
+        "name": "Bordyuzhin, Igor"
+      },
+      {
+        "affiliation": "INFN, Milan Bicocca; Milan Bicocca U.",
+        "inspireid": "INSPIRE-00582175",
+        "name": "Borgheresi, Alessio"
+      },
+      {
+        "affiliation": "Manchester U.",
+        "inspireid": "INSPIRE-00261856",
+        "name": "Borghi, Silvia"
+      },
+      {
+        "affiliation": "Authors affiliated with an institute formerly covered by a cooperation agreement with CERN.",
+        "inspireid": "INSPIRE-00537084",
+        "name": "Borisyak, Maxim"
+      },
+      {
+        "affiliation": "U. Santiago de Compostela (main)",
+        "inspireid": "INSPIRE-00388228",
+        "name": "Borsato, Martino"
+      },
+      {
+        "affiliation": "Orsay, LAL",
+        "inspireid": "INSPIRE-00249614",
+        "name": "Bossu, Francesco"
+      },
+      {
+        "affiliation": "Aachen, Tech. Hochsch.",
+        "inspireid": "INSPIRE-00582188",
+        "name": "Boubdir, Meriem"
+      },
+      {
+        "affiliation": "Liverpool U.",
+        "inspireid": "INSPIRE-00068684",
+        "name": "Bowcock, Themistocles"
+      },
+      {
+        "affiliation": "Zurich U.",
+        "inspireid": "INSPIRE-00388407",
+        "name": "Bowen, Espen Eie"
+      },
+      {
+        "affiliation": "INFN, Ferrara; CERN",
+        "inspireid": "INSPIRE-00068846",
+        "name": "Bozzi, Concezio"
+      },
+      {
+        "affiliation": "Heidelberg U.",
+        "inspireid": "INSPIRE-00470092",
+        "name": "Braun, Svende"
+      },
+      {
+        "affiliation": "Heidelberg U.",
+        "inspireid": "INSPIRE-00257919",
+        "name": "Britsch, Markward"
+      },
+      {
+        "affiliation": "Syracuse U.",
+        "inspireid": "INSPIRE-00295976",
+        "name": "Britton, Thomas"
+      },
+      {
+        "affiliation": "Manchester U.",
+        "inspireid": "INSPIRE-00369499",
+        "name": "Brodzicka, Jolanta"
+      },
+      {
+        "affiliation": "Bristol U.",
+        "inspireid": "INSPIRE-00536755",
+        "name": "Buchanan, Emma"
+      },
+      {
+        "affiliation": "Manchester U.",
+        "inspireid": "INSPIRE-00545500",
+        "name": "Burr, Christopher"
+      },
+      {
+        "affiliation": "INFN, Cagliari; Cagliari U.",
+        "inspireid": "INSPIRE-00260792",
+        "name": "Bursche, Albert"
+      },
+      {
+        "affiliation": "CERN",
+        "inspireid": "INSPIRE-00259860",
+        "name": "Buytaert, Jan"
+      },
+      {
+        "affiliation": "INFN, Cagliari",
+        "inspireid": "INSPIRE-00258132",
+        "name": "Cadeddu, Sandro"
+      },
+      {
+        "affiliation": "INFN, Ferrara; Ferrara U.",
+        "inspireid": "INSPIRE-00070550",
+        "name": "Calabrese, Roberto"
+      },
+      {
+        "affiliation": "INFN, Milan Bicocca; Milan Bicocca U.",
+        "inspireid": "INSPIRE-00258504",
+        "name": "Calvi, Marta"
+      },
+      {
+        "affiliation": "U. Barcelona (main); Ramon Llull U., Barcelona",
+        "inspireid": "INSPIRE-00259475",
+        "name": "Calvo Gomez, Miriam"
+      },
+      {
+        "affiliation": "U. Barcelona (main); Ramon Llull U., Barcelona",
+        "inspireid": "INSPIRE-00259480",
+        "name": "Camboni, Alessandro"
+      },
+      {
+        "affiliation": "Frascati",
+        "inspireid": "INSPIRE-00258299",
+        "name": "Campana, Pierluigi"
+      },
+      {
+        "affiliation": "CERN",
+        "inspireid": "INSPIRE-00388548",
+        "name": "Campora Perez, Daniel Hugo"
+      },
+      {
+        "affiliation": "Manchester U.",
+        "inspireid": "INSPIRE-00452150",
+        "name": "Capriotti, Lorenzo"
+      },
+      {
+        "affiliation": "INFN, Bologna; Bologna U.",
+        "inspireid": "INSPIRE-00258058",
+        "name": "Carbone, Angelo"
+      },
+      {
+        "affiliation": "Rome U., Tor Vergata",
+        "inspireid": "INSPIRE-00258566",
+        "name": "Carboni, Giovanni"
+      },
+      {
+        "affiliation": "INFN, Genoa; Genoa U.",
+        "inspireid": "INSPIRE-00259930",
+        "name": "Cardinale, Roberta"
+      },
+      {
+        "affiliation": "INFN, Cagliari",
+        "inspireid": "INSPIRE-00071030",
+        "name": "Cardini, Alessandro"
+      },
+      {
+        "affiliation": "INFN, Milan Bicocca; Milan Bicocca U.",
+        "inspireid": "INSPIRE-00452332",
+        "name": "Carniti, Paolo"
+      },
+      {
+        "affiliation": "Edinburgh U.",
+        "inspireid": "INSPIRE-00160267",
+        "name": "Carson, Laurence"
+      },
+      {
+        "affiliation": "Liverpool U.",
+        "inspireid": "INSPIRE-00071483",
+        "name": "Casse, Gianluigi"
+      },
+      {
+        "affiliation": "INFN, Milan Bicocca; Milan Bicocca U.",
+        "inspireid": "INSPIRE-00399968",
+        "name": "Cassina, Lorenzo"
+      },
+      {
+        "affiliation": "Oxford U.",
+        "inspireid": "INSPIRE-00388630",
+        "name": "Castillo Garcia, Lucia"
+      },
+      {
+        "affiliation": "CERN",
+        "inspireid": "INSPIRE-00071656",
+        "name": "Cattaneo, Marco"
+      },
+      {
+        "affiliation": "INFN, Genoa; Genoa U.",
+        "inspireid": "INSPIRE-00452703",
+        "name": "Cavallero, Giovanni"
+      },
+      {
+        "affiliation": "INFN, Pisa; Pisa, Scuola Normale Superiore",
+        "inspireid": "INSPIRE-00041990",
+        "name": "Cenci, Riccardo"
+      },
+      {
+        "affiliation": "Paris U., VI-VII",
+        "inspireid": "INSPIRE-00054561",
+        "name": "Charles, Matthew"
+      },
+      {
+        "affiliation": "CERN",
+        "inspireid": "INSPIRE-00259892",
+        "name": "Charpentier, Philippe"
+      },
+      {
+        "affiliation": "Birmingham U.",
+        "inspireid": "INSPIRE-00582193",
+        "name": "Chatzikonstantinidis, Georgios"
+      },
+      {
+        "affiliation": "Annecy, LAPP",
+        "inspireid": "INSPIRE-02701689",
+        "name": "Chefdeville, Maximilien"
+      },
+      {
+        "affiliation": "Manchester U.",
+        "inspireid": "INSPIRE-00400187",
+        "name": "Chen, Shanzhen"
+      },
+      {
+        "affiliation": "Oxford U.",
+        "inspireid": "INSPIRE-00388653",
+        "name": "Cheung, Shu Faye"
+      },
+      {
+        "affiliation": "U. Santiago de Compostela (main)",
+        "inspireid": "INSPIRE-00369648",
+        "name": "Chobanova, Veronika"
+      },
+      {
+        "affiliation": "Zurich U.",
+        "inspireid": "INSPIRE-00344777",
+        "name": "Chrzaszcz, Marcin"
+      },
+      {
+        "affiliation": "Authors affiliated with an institute formerly covered by a cooperation agreement with CERN.",
+        "name": "Chubykin, Aleksei"
+      },
+      {
+        "affiliation": "Frascati",
+        "name": "Ciambrone, Paolo"
+      },
+      {
+        "affiliation": "U. Santiago de Compostela (main)",
+        "inspireid": "INSPIRE-00259661",
+        "name": "Cid Vidal, Xabier"
+      },
+      {
+        "affiliation": "Nikhef, Amsterdam",
+        "inspireid": "INSPIRE-00344785",
+        "name": "Ciezarek, Gregory"
+      },
+      {
+        "affiliation": "Edinburgh U.",
+        "inspireid": "INSPIRE-00073694",
+        "name": "Clarke, Peter"
+      },
+      {
+        "affiliation": "CERN",
+        "inspireid": "INSPIRE-00021864",
+        "name": "Clemencic, Marco"
+      },
+      {
+        "affiliation": "Cambridge U.",
+        "inspireid": "INSPIRE-00261009",
+        "name": "Cliff, Harry"
+      },
+      {
+        "affiliation": "CERN",
+        "inspireid": "INSPIRE-00259955",
+        "name": "Closier, Joel"
+      },
+      {
+        "affiliation": "Cincinnati U.",
+        "inspireid": "INSPIRE-00262900",
+        "name": "Coco, Victor"
+      },
+      {
+        "affiliation": "Marseille, CPPM",
+        "inspireid": "INSPIRE-00257463",
+        "name": "Cogan, Julien"
+      },
+      {
+        "affiliation": "Clermont-Ferrand U.",
+        "inspireid": "INSPIRE-00305695",
+        "name": "Cogneras, Eric"
+      },
+      {
+        "affiliation": "INFN, Cagliari; CERN; Cagliari U.",
+        "inspireid": "INSPIRE-00452873",
+        "name": "Cogoni, Violetta"
+      },
+      {
+        "affiliation": "Bucharest, IFIN-HH",
+        "inspireid": "INSPIRE-00453049",
+        "name": "Cojocariu, Lucian"
+      },
+      {
+        "affiliation": "CERN",
+        "inspireid": "INSPIRE-00259967",
+        "name": "Collins, Paula"
+      },
+      {
+        "affiliation": "Heidelberg U.",
+        "inspireid": "INSPIRE-00259490",
+        "name": "Comerma-Montells, Albert"
+      },
+      {
+        "affiliation": "CERN",
+        "inspireid": "INSPIRE-00262791",
+        "name": "Contu, Andrea"
+      },
+      {
+        "affiliation": "Bristol U.",
+        "inspireid": "INSPIRE-00345167",
+        "name": "Cook, Andrew"
+      },
+      {
+        "affiliation": "CERN",
+        "name": "Coombs, George"
+      },
+      {
+        "affiliation": "U. Barcelona (main)",
+        "inspireid": "INSPIRE-00388698",
+        "name": "Coquereau, Samuel"
+      },
+      {
+        "affiliation": "CERN",
+        "inspireid": "INSPIRE-00259985",
+        "name": "Corti, Gloria"
+      },
+      {
+        "affiliation": "INFN, Ferrara; Ferrara U.",
+        "inspireid": "INSPIRE-00453205",
+        "name": "Corvo, Marco"
+      },
+      {
+        "affiliation": "Warwick U.",
+        "inspireid": "INSPIRE-00582238",
+        "name": "Costa Sobral, Cayo Mar"
+      },
+      {
+        "affiliation": "CERN",
+        "inspireid": "INSPIRE-00345186",
+        "name": "Couturier, Benjamin"
+      },
+      {
+        "affiliation": "Edinburgh U.",
+        "inspireid": "INSPIRE-00261246",
+        "name": "Cowan, Greig"
+      },
+      {
+        "affiliation": "Edinburgh U.",
+        "inspireid": "INSPIRE-00357145",
+        "name": "Craik, Daniel Charles"
+      },
+      {
+        "affiliation": "Warwick U.",
+        "inspireid": "INSPIRE-00453257",
+        "name": "Crocombe, Andrew"
+      },
+      {
+        "affiliation": "Rio de Janeiro, Pont. U. Catol.",
+        "inspireid": "INSPIRE-00388812",
+        "name": "Cruz Torres, Melissa Maria"
+      },
+      {
+        "affiliation": "Edinburgh U.",
+        "inspireid": "INSPIRE-00261251",
+        "name": "Currie, Robert"
+      },
+      {
+        "affiliation": "Rio de Janeiro Federal U.",
+        "inspireid": "INSPIRE-00175941",
+        "name": "Da Cunha Marinho, Franciole"
+      },
+      {
+        "affiliation": "Nikhef, Amsterdam",
+        "name": "Dall'Occo, Elena"
+      },
+      {
+        "affiliation": "Bristol U.",
+        "inspireid": "INSPIRE-00043651",
+        "name": "Dalseno, Jeremy"
+      },
+      {
+        "affiliation": "CERN",
+        "inspireid": "INSPIRE-00207542",
+        "name": "D'Ambrosio, Carmelo"
+      },
+      {
+        "affiliation": "Heidelberg U.",
+        "inspireid": "INSPIRE-00522530",
+        "name": "d'Argent, Philippe"
+      },
+      {
+        "affiliation": "Nikhef, Amsterdam",
+        "inspireid": "INSPIRE-00341020",
+        "name": "David, Pieter"
+      },
+      {
+        "affiliation": "Tsinghua U., Beijing, CHEP",
+        "inspireid": "INSPIRE-00389020",
+        "name": "Davis, Adam"
+      },
+      {
+        "affiliation": "Marseille, CPPM",
+        "inspireid": "INSPIRE-00341032",
+        "name": "De Bruyn, Kristof"
+      },
+      {
+        "affiliation": "Manchester U.",
+        "inspireid": "INSPIRE-00258572",
+        "name": "De Capua, Stefano"
+      },
+      {
+        "affiliation": "Heidelberg U.",
+        "inspireid": "INSPIRE-00260810",
+        "name": "De Cian, Michel"
+      },
+      {
+        "affiliation": "Rio de Janeiro, CBPF",
+        "inspireid": "INSPIRE-00107943",
+        "name": "De Miranda, Jussara"
+      },
+      {
+        "affiliation": "Rio de Janeiro Federal U.",
+        "inspireid": "INSPIRE-00115169",
+        "name": "De Paula, Leandro"
+      },
+      {
+        "affiliation": "INFN, Bari; Bari U.",
+        "inspireid": "INSPIRE-00532670",
+        "name": "De Serio, Marilisa"
+      },
+      {
+        "affiliation": "Frascati",
+        "inspireid": "INSPIRE-00258414",
+        "name": "De Simone, Patrizia"
+      },
+      {
+        "affiliation": "Nikhef, Amsterdam",
+        "inspireid": "INSPIRE-00400290",
+        "name": "de Vries, Jacco"
+      },
+      {
+        "affiliation": "Glasgow U.",
+        "inspireid": "INSPIRE-00453317",
+        "name": "Dean, Cameron Thomas"
+      },
+      {
+        "affiliation": "Annecy, LAPP",
+        "inspireid": "INSPIRE-00257320",
+        "name": "Decamp, Daniel"
+      },
+      {
+        "affiliation": "Tech. U., Dortmund (main)",
+        "inspireid": "INSPIRE-00341054",
+        "name": "Deckenhoff, Mirko"
+      },
+      {
+        "affiliation": "Paris U., VI-VII",
+        "inspireid": "INSPIRE-00070041",
+        "name": "Del Buono, Luigi"
+      },
+      {
+        "affiliation": "Annecy, LAPP",
+        "inspireid": "INSPIRE-00389141",
+        "name": "D\\'el\\'eage, Nicolas"
+      },
+      {
+        "affiliation": "Tech. U., Dortmund (main)",
+        "inspireid": "INSPIRE-00536774",
+        "name": "Demmer, Moritz"
+      },
+      {
+        "affiliation": "AGH-UST, Krakow",
+        "inspireid": "INSPIRE-00582240",
+        "name": "Dendek, Adam"
+      },
+      {
+        "affiliation": "Authors affiliated with an institute formerly covered by a cooperation agreement with CERN.",
+        "inspireid": "INSPIRE-00144686",
+        "name": "Derkach, Denis"
+      },
+      {
+        "affiliation": "Clermont-Ferrand U.",
+        "inspireid": "INSPIRE-00257367",
+        "name": "Deschamps, Olivier"
+      },
+      {
+        "affiliation": "CERN",
+        "inspireid": "INSPIRE-00258140",
+        "name": "Dettori, Francesco"
+      },
+      {
+        "affiliation": "INFN, Milan",
+        "inspireid": "INSPIRE-00266843",
+        "name": "Dey, Biplab"
+      },
+      {
+        "affiliation": "CERN",
+        "inspireid": "INSPIRE-00010940",
+        "name": "Di Canto, Angelo"
+      },
+      {
+        "affiliation": "CERN",
+        "inspireid": "INSPIRE-00260011",
+        "name": "Dijkstra, Hans"
+      },
+      {
+        "affiliation": "CERN",
+        "inspireid": "INSPIRE-00341074",
+        "name": "Dordei, Francesca"
+      },
+      {
+        "affiliation": "Ecole Polytechnique, Lausanne",
+        "inspireid": "INSPIRE-00000328",
+        "name": "Dorigo, Mirco"
+      },
+      {
+        "affiliation": "Rio de Janeiro, CBPF",
+        "inspireid": "INSPIRE-00257176",
+        "name": "dos Reis, Alberto"
+      },
+      {
+        "affiliation": "U. Santiago de Compostela (main)",
+        "inspireid": "INSPIRE-00341088",
+        "name": "Dosil Su\\'arez, Alvaro"
+      },
+      {
+        "affiliation": "Kharkov, KIPT",
+        "inspireid": "INSPIRE-00260913",
+        "name": "Dovbnya, Anatoliy"
+      },
+      {
+        "affiliation": "Liverpool U.",
+        "inspireid": "INSPIRE-00399892",
+        "name": "Dreimanis, Karlis"
+      },
+      {
+        "affiliation": "Nikhef, Amsterdam",
+        "inspireid": "INSPIRE-00536780",
+        "name": "Dufour, Laurent"
+      },
+      {
+        "affiliation": "Manchester U.",
+        "inspireid": "INSPIRE-00400045",
+        "name": "Dujany, Giulio"
+      },
+      {
+        "affiliation": "CERN",
+        "inspireid": "INSPIRE-00545510",
+        "name": "Dungs, Kevin"
+      },
+      {
+        "affiliation": "CERN",
+        "inspireid": "INSPIRE-00389556",
+        "name": "Durante, Paolo"
+      },
+      {
+        "affiliation": "Authors affiliated with an institute formerly covered by a cooperation agreement with CERN.",
+        "inspireid": "INSPIRE-00077380",
+        "name": "Dzhelyadin, Rustem"
+      },
+      {
+        "affiliation": "CERN",
+        "inspireid": "INSPIRE-00341115",
+        "name": "Dziurda, Agnieszka"
+      },
+      {
+        "affiliation": "Authors affiliated with an institute formerly covered by a cooperation agreement with CERN.",
+        "inspireid": "INSPIRE-00341144",
+        "name": "Dzyuba, Alexey"
+      },
+      {
+        "affiliation": "Rutherford",
+        "inspireid": "INSPIRE-00078816",
+        "name": "Easo, Sajan"
+      },
+      {
+        "affiliation": "Edinburgh U.",
+        "inspireid": "INSPIRE-00036986",
+        "name": "Ebert, Marcus"
+      },
+      {
+        "affiliation": "Imperial Coll., London",
+        "inspireid": "INSPIRE-00058834",
+        "name": "Egede, Ulrik"
+      },
+      {
+        "affiliation": "Authors affiliated with an institute formerly covered by a cooperation agreement with CERN.",
+        "inspireid": "INSPIRE-00259251",
+        "name": "Egorychev, Victor"
+      },
+      {
+        "affiliation": "Authors affiliated with an institute formerly covered by a cooperation agreement with CERN.",
+        "inspireid": "INSPIRE-00302446",
+        "name": "Eidelman, Semen"
+      },
+      {
+        "affiliation": "Edinburgh U.",
+        "inspireid": "INSPIRE-00079238",
+        "name": "Eisenhardt, Stephan"
+      },
+      {
+        "affiliation": "Tech. U., Dortmund (main)",
+        "inspireid": "INSPIRE-00389721",
+        "name": "Eitschberger, Ulrich"
+      },
+      {
+        "affiliation": "Tech. U., Dortmund (main)",
+        "inspireid": "INSPIRE-00341158",
+        "name": "Ekelhof, Robert"
+      },
+      {
+        "affiliation": "Glasgow U.",
+        "inspireid": "INSPIRE-00015467",
+        "name": "Eklund, Lars"
+      },
+      {
+        "affiliation": "Syracuse U.",
+        "inspireid": "INSPIRE-00400105",
+        "name": "Ely, Scott"
+      },
+      {
+        "affiliation": "Heidelberg U.",
+        "inspireid": "INSPIRE-00238345",
+        "name": "Esen, Sevda"
+      },
+      {
+        "affiliation": "Cambridge U.",
+        "inspireid": "INSPIRE-00400160",
+        "name": "Evans, Hannah Mary"
+      },
+      {
+        "affiliation": "Oxford U.",
+        "inspireid": "INSPIRE-00452003",
+        "name": "Evans, Timothy"
+      },
+      {
+        "affiliation": "INFN, Bologna",
+        "inspireid": "INSPIRE-00296108",
+        "name": "Falabella, Antonio"
+      },
+      {
+        "affiliation": "CERN",
+        "inspireid": "INSPIRE-00257792",
+        "name": "F\\\"arber, Christian"
+      },
+      {
+        "affiliation": "Birmingham U.",
+        "inspireid": "INSPIRE-00400287",
+        "name": "Farley, Nathanael"
+      },
+      {
+        "affiliation": "Liverpool U.",
+        "inspireid": "INSPIRE-00257989",
+        "name": "Farry, Stephen"
+      },
+      {
+        "affiliation": "Liverpool U.",
+        "inspireid": "INSPIRE-00452191",
+        "name": "Fay, Robert"
+      },
+      {
+        "affiliation": "INFN, Milan Bicocca; Milan Bicocca U.",
+        "inspireid": "INSPIRE-00582259",
+        "name": "Fazzini, Davide"
+      },
+      {
+        "affiliation": "Edinburgh U.",
+        "inspireid": "INSPIRE-00389899",
+        "name": "Ferguson, Dianne"
+      },
+      {
+        "affiliation": "U. Barcelona (main)",
+        "name": "Fernandez, Gerard"
+      },
+      {
+        "affiliation": "U. Santiago de Compostela (main)",
+        "inspireid": "INSPIRE-00582260",
+        "name": "Fernandez Prieto, Antonio"
+      },
+      {
+        "affiliation": "INFN, Bologna; CERN; Bologna U.",
+        "inspireid": "INSPIRE-00522680",
+        "name": "Ferrari, Fabio"
+      },
+      {
+        "affiliation": "Rio de Janeiro Federal U.",
+        "inspireid": "INSPIRE-00257190",
+        "name": "Ferreira Rodrigues, Fernando"
+      },
+      {
+        "affiliation": "CERN",
+        "inspireid": "INSPIRE-00159865",
+        "name": "Ferro-Luzzi, Massimiliano"
+      },
+      {
+        "affiliation": "Authors affiliated with an institute formerly covered by a cooperation agreement with CERN.",
+        "inspireid": "INSPIRE-00259378",
+        "name": "Filippov, Sergey"
+      },
+      {
+        "affiliation": "INFN, Bari",
+        "inspireid": "INSPIRE-00262271",
+        "name": "Fini, Rosa Anna"
+      },
+      {
+        "affiliation": "INFN, Ferrara; Ferrara U.",
+        "inspireid": "INSPIRE-00390028",
+        "name": "Fiore, Marco"
+      },
+      {
+        "affiliation": "INFN, Ferrara; Ferrara U.",
+        "inspireid": "INSPIRE-00017773",
+        "name": "Fiorini, Massimiliano"
+      },
+      {
+        "affiliation": "AGH-UST, Krakow",
+        "inspireid": "INSPIRE-00452328",
+        "name": "Firlej, Miroslaw"
+      },
+      {
+        "affiliation": "Ecole Polytechnique, Lausanne",
+        "inspireid": "INSPIRE-00261277",
+        "name": "Fitzpatrick, Conor"
+      },
+      {
+        "affiliation": "AGH-UST, Krakow",
+        "inspireid": "INSPIRE-00452523",
+        "name": "Fiutowski, Tomasz"
+      },
+      {
+        "affiliation": "Orsay, LAL; Ecole Polytechnique",
+        "inspireid": "INSPIRE-00081683",
+        "name": "Fleuret, Frederic"
+      },
+      {
+        "affiliation": "CERN",
+        "inspireid": "INSPIRE-00430519",
+        "name": "Fohl, Klaus"
+      },
+      {
+        "affiliation": "INFN, Cagliari; CERN",
+        "inspireid": "INSPIRE-00341209",
+        "name": "Fontana, Marianna"
+      },
+      {
+        "affiliation": "INFN, Genoa; Genoa U.",
+        "inspireid": "INSPIRE-00081845",
+        "name": "Fontanelli, Flavio"
+      },
+      {
+        "affiliation": "Syracuse U.",
+        "inspireid": "INSPIRE-00545531",
+        "name": "Forshaw, Dean Charles"
+      },
+      {
+        "affiliation": "CERN",
+        "inspireid": "INSPIRE-00260047",
+        "name": "Forty, Roger"
+      },
+      {
+        "affiliation": "Liverpool U.",
+        "inspireid": "INSPIRE-00582273",
+        "name": "Franco Lima, Vinicius"
+      },
+      {
+        "affiliation": "CERN",
+        "inspireid": "INSPIRE-00260763",
+        "name": "Frank, Markus"
+      },
+      {
+        "affiliation": "CERN",
+        "inspireid": "INSPIRE-00260067",
+        "name": "Frei, Christoph"
+      },
+      {
+        "affiliation": "INFN, Milan; U. Milan (main)",
+        "inspireid": "INSPIRE-00390117",
+        "name": "Fu, Jinlin"
+      },
+      {
+        "affiliation": "CERN",
+        "inspireid": "INSPIRE-00082952",
+        "name": "Funk, Wolfgang"
+      },
+      {
+        "affiliation": "Rome U., Tor Vergata",
+        "inspireid": "INSPIRE-00390286",
+        "name": "Furfaro, Emiliano"
+      },
+      {
+        "affiliation": "U. Santiago de Compostela (main)",
+        "inspireid": "INSPIRE-00259710",
+        "name": "Gallas Torreira, Abraham"
+      },
+      {
+        "affiliation": "INFN, Bologna; Bologna U.",
+        "inspireid": "INSPIRE-00178050",
+        "name": "Galli, Domenico"
+      },
+      {
+        "affiliation": "INFN, Padua",
+        "inspireid": "INSPIRE-00293740",
+        "name": "Gallorini, Stefano"
+      },
+      {
+        "affiliation": "Edinburgh U.",
+        "inspireid": "INSPIRE-00150884",
+        "name": "Gambetta, Silvia"
+      },
+      {
+        "affiliation": "Rio de Janeiro Federal U.",
+        "inspireid": "INSPIRE-00083458",
+        "name": "Gandelman, Miriam"
+      },
+      {
+        "affiliation": "Oxford U.",
+        "inspireid": "INSPIRE-00262802",
+        "name": "Gandini, Paolo"
+      },
+      {
+        "affiliation": "Tsinghua U., Beijing, CHEP",
+        "inspireid": "INSPIRE-00257210",
+        "name": "Gao, Yuanning"
+      },
+      {
+        "affiliation": "Valencia U., IFIC",
+        "inspireid": "INSPIRE-00582283",
+        "name": "Garcia Martin, Luis Miguel"
+      },
+      {
+        "affiliation": "U. Santiago de Compostela (main)",
+        "inspireid": "INSPIRE-00452833",
+        "name": "Garc\\'ia Pardi\\~nas, Juli\\'an"
+      },
+      {
+        "affiliation": "Cambridge U.",
+        "inspireid": "INSPIRE-00024997",
+        "name": "Garra Tico, Jordi"
+      },
+      {
+        "affiliation": "U. Barcelona (main)",
+        "inspireid": "INSPIRE-00157725",
+        "name": "Garrido, Lluis"
+      },
+      {
+        "affiliation": "Cambridge U.",
+        "inspireid": "INSPIRE-00582295",
+        "name": "Garsed, Philip John"
+      },
+      {
+        "affiliation": "U. Barcelona (main)",
+        "inspireid": "INSPIRE-00259509",
+        "name": "Gascon, David"
+      },
+      {
+        "affiliation": "CERN",
+        "inspireid": "INSPIRE-00083907",
+        "name": "Gaspar, Clara"
+      },
+      {
+        "affiliation": "Tech. U., Dortmund (main)",
+        "inspireid": "INSPIRE-00400383",
+        "name": "Gavardi, Laura"
+      },
+      {
+        "affiliation": "Clermont-Ferrand U.",
+        "inspireid": "INSPIRE-00452964",
+        "name": "Gazzoni, Giulio"
+      },
+      {
+        "affiliation": "Heidelberg U.",
+        "inspireid": "INSPIRE-00522692",
+        "name": "Gerick, David"
+      },
+      {
+        "affiliation": "Heidelberg U.",
+        "inspireid": "INSPIRE-00357178",
+        "name": "Gersabeck, Evelina"
+      },
+      {
+        "affiliation": "Manchester U.",
+        "inspireid": "INSPIRE-00192519",
+        "name": "Gersabeck, Marco"
+      },
+      {
+        "affiliation": "Warwick U.",
+        "inspireid": "INSPIRE-00043636",
+        "name": "Gershon, Timothy"
+      },
+      {
+        "affiliation": "Annecy, LAPP",
+        "inspireid": "INSPIRE-00084545",
+        "name": "Ghez, Philippe"
+      },
+      {
+        "affiliation": "Ecole Polytechnique, Lausanne",
+        "inspireid": "INSPIRE-00390510",
+        "name": "Gian\\`\\i, Sebastiana"
+      },
+      {
+        "affiliation": "Cambridge U.",
+        "inspireid": "INSPIRE-00179031",
+        "name": "Gibson, Valerie"
+      },
+      {
+        "affiliation": "NCBJ, Swierk",
+        "name": "Giemza, Henryk Karol"
+      },
+      {
+        "affiliation": "Ecole Polytechnique, Lausanne",
+        "name": "Girard, Olivier G\\\"oran"
+      },
+      {
+        "affiliation": "Bucharest, IFIN-HH",
+        "inspireid": "INSPIRE-00390574",
+        "name": "Giubega, Lavinia-Helena"
+      },
+      {
+        "affiliation": "Edinburgh U.",
+        "inspireid": "INSPIRE-00582300",
+        "name": "Gizdov, Konstantin"
+      },
+      {
+        "affiliation": "Paris U., VI-VII",
+        "inspireid": "INSPIRE-00260081",
+        "name": "Gligorov, Vladimir"
+      },
+      {
+        "affiliation": "Rio de Janeiro, Pont. U. Catol.",
+        "inspireid": "INSPIRE-00262964",
+        "name": "G\\\"obel, Carla"
+      },
+      {
+        "affiliation": "U. Barcelona (main); Ramon Llull U., Barcelona",
+        "name": "Golobardes, Elisabet"
+      },
+      {
+        "affiliation": "Authors affiliated with an institute formerly covered by a cooperation agreement with CERN.",
+        "inspireid": "INSPIRE-00261070",
+        "name": "Golubkov, Dmitry"
+      },
+      {
+        "affiliation": "Imperial Coll., London; Authors affiliated with an institute formerly covered by a cooperation agreement with CERN.; CERN",
+        "inspireid": "INSPIRE-00259263",
+        "name": "Golutvin, Andrey"
+      },
+      {
+        "affiliation": "Rio de Janeiro, CBPF; Rio de Janeiro Federal U.; UFTM, Uberaba",
+        "inspireid": "INSPIRE-00257143",
+        "name": "Gomes, Alvaro"
+      },
+      {
+        "affiliation": "Authors affiliated with an institute formerly covered by a cooperation agreement with CERN.",
+        "inspireid": "INSPIRE-00048110",
+        "name": "Gorelov, Igor Vladimirovich"
+      },
+      {
+        "affiliation": "INFN, Milan Bicocca; Milan Bicocca U.",
+        "inspireid": "INSPIRE-00400552",
+        "name": "Gotti, Claudio"
+      },
+      {
+        "affiliation": "Nikhef, Amsterdam",
+        "name": "Govorkova, Ekaterina"
+      },
+      {
+        "affiliation": "U. Barcelona (main)",
+        "inspireid": "INSPIRE-00259536",
+        "name": "Graciani Diaz, Ricardo"
+      },
+      {
+        "affiliation": "CERN",
+        "inspireid": "INSPIRE-00246283",
+        "name": "Granado Cardoso, Luis Alberto"
+      },
+      {
+        "affiliation": "U. Barcelona (main)",
+        "inspireid": "INSPIRE-00086454",
+        "name": "Graug\\'es, Eugeni"
+      },
+      {
+        "affiliation": "Zurich U.",
+        "inspireid": "INSPIRE-00453214",
+        "name": "Graverini, Elena"
+      },
+      {
+        "affiliation": "INFN, Florence",
+        "inspireid": "INSPIRE-00086506",
+        "name": "Graziani, Giacomo"
+      },
+      {
+        "affiliation": "Bucharest, IFIN-HH",
+        "inspireid": "INSPIRE-00259115",
+        "name": "Grecu, Alexandru Tudor"
+      },
+      {
+        "affiliation": "Aachen, Tech. Hochsch.",
+        "name": "Greim, Roman"
+      },
+      {
+        "affiliation": "INFN, Cagliari",
+        "inspireid": "INSPIRE-00390620",
+        "name": "Griffith, Peter"
+      },
+      {
+        "affiliation": "INFN, Milan Bicocca; CERN; Milan Bicocca U.",
+        "inspireid": "INSPIRE-00390672",
+        "name": "Grillo, Lucia"
+      },
+      {
+        "affiliation": "Oxford U.",
+        "inspireid": "INSPIRE-00582316",
+        "name": "Gruberg Cazon, Barak Raimond"
+      },
+      {
+        "affiliation": "Rostock U.",
+        "inspireid": "INSPIRE-00264595",
+        "name": "Gr\\\"unberg, Oliver"
+      },
+      {
+        "affiliation": "Authors affiliated with an institute formerly covered by a cooperation agreement with CERN.",
+        "inspireid": "INSPIRE-00259385",
+        "name": "Gushchin, Evgeny"
+      },
+      {
+        "affiliation": "Authors affiliated with an institute formerly covered by a cooperation agreement with CERN.",
+        "inspireid": "INSPIRE-00259449",
+        "name": "Guz, Yury"
+      },
+      {
+        "affiliation": "CERN",
+        "inspireid": "INSPIRE-00260098",
+        "name": "Gys, Thierry"
+      },
+      {
+        "affiliation": "Oxford U.",
+        "inspireid": "INSPIRE-00536800",
+        "name": "Hadavizadeh, Thomas"
+      },
+      {
+        "affiliation": "Clermont-Ferrand U.",
+        "inspireid": "INSPIRE-00341268",
+        "name": "Hadjivasiliou, Christos"
+      },
+      {
+        "affiliation": "Ecole Polytechnique, Lausanne",
+        "inspireid": "INSPIRE-00260534",
+        "name": "Haefeli, Guido"
+      },
+      {
+        "affiliation": "CERN",
+        "inspireid": "INSPIRE-00341278",
+        "name": "Haen, Christophe"
+      },
+      {
+        "affiliation": "Cambridge U.",
+        "inspireid": "INSPIRE-00261030",
+        "name": "Haines, Susan"
+      },
+      {
+        "affiliation": "Maryland U., College Park",
+        "name": "Hamilton, Phoebe Meredith"
+      },
+      {
+        "affiliation": "Heidelberg U.",
+        "inspireid": "INSPIRE-00400676",
+        "name": "Han, Xiaoxue"
+      },
+      {
+        "affiliation": "Heidelberg U.",
+        "inspireid": "INSPIRE-00046350",
+        "name": "Hansmann-Menzemer, Stephanie"
+      },
+      {
+        "affiliation": "Oxford U.",
+        "inspireid": "INSPIRE-00088706",
+        "name": "Harnew, Neville"
+      },
+      {
+        "affiliation": "Bristol U.",
+        "inspireid": "INSPIRE-00357202",
+        "name": "Harnew, Samuel"
+      },
+      {
+        "affiliation": "Manchester U.",
+        "inspireid": "INSPIRE-00341289",
+        "name": "Harrison, Jonathan"
+      },
+      {
+        "affiliation": "CERN",
+        "inspireid": "INSPIRE-00230526",
+        "name": "Hatch, Mark"
+      },
+      {
+        "affiliation": "Beijing, GUCAS",
+        "inspireid": "INSPIRE-00257559",
+        "name": "He, Jibo"
+      },
+      {
+        "affiliation": "Ecole Polytechnique, Lausanne",
+        "inspireid": "INSPIRE-00002216",
+        "name": "Head, Timothy"
+      },
+      {
+        "affiliation": "Aachen, Tech. Hochsch.",
+        "inspireid": "INSPIRE-00007870",
+        "name": "Heister, Arno"
+      },
+      {
+        "affiliation": "Liverpool U.",
+        "inspireid": "INSPIRE-00014964",
+        "name": "Hennessy, Karol"
+      },
+      {
+        "affiliation": "Clermont-Ferrand U.",
+        "inspireid": "INSPIRE-00257379",
+        "name": "Henrard, Pierre"
+      },
+      {
+        "affiliation": "Paris U., VI-VII",
+        "inspireid": "INSPIRE-00390866",
+        "name": "Henry, Louis"
+      },
+      {
+        "affiliation": "Rostock U.",
+        "inspireid": "INSPIRE-00390793",
+        "name": "He\\ss, Miriam"
+      },
+      {
+        "affiliation": "Rio de Janeiro Federal U.",
+        "inspireid": "INSPIRE-00028041",
+        "name": "Hicheur, Adl\\`ene"
+      },
+      {
+        "affiliation": "Oxford U.",
+        "inspireid": "INSPIRE-00357210",
+        "name": "Hill, Donal"
+      },
+      {
+        "affiliation": "Manchester U.",
+        "inspireid": "INSPIRE-00390934",
+        "name": "Hombach, Christoph"
+      },
+      {
+        "affiliation": "Ecole Polytechnique, Lausanne",
+        "inspireid": "INSPIRE-00257330",
+        "name": "Hopchev, Plamen Hristov"
+      },
+      {
+        "affiliation": "Nikhef, Amsterdam",
+        "inspireid": "INSPIRE-00091582",
+        "name": "Hulsbergen, Wouter"
+      },
+      {
+        "affiliation": "Imperial Coll., London",
+        "inspireid": "INSPIRE-00453346",
+        "name": "Humair, Thibaud"
+      },
+      {
+        "affiliation": "Authors affiliated with an institute formerly covered by a cooperation agreement with CERN.",
+        "inspireid": "INSPIRE-00545541",
+        "name": "Hushchyn, Mikhail"
+      },
+      {
+        "affiliation": "Liverpool U.",
+        "inspireid": "INSPIRE-00091737",
+        "name": "Hutchcroft, David"
+      },
+      {
+        "affiliation": "AGH-UST, Krakow",
+        "inspireid": "INSPIRE-00091920",
+        "name": "Idzik, Marek"
+      },
+      {
+        "affiliation": "MIT",
+        "inspireid": "INSPIRE-00258006",
+        "name": "Ilten, Philip"
+      },
+      {
+        "affiliation": "Authors affiliated with an institute formerly covered by a cooperation agreement with CERN.",
+        "name": "Inyakin, Alexander"
+      },
+      {
+        "affiliation": "CERN",
+        "inspireid": "INSPIRE-00260123",
+        "name": "Jacobsson, Richard"
+      },
+      {
+        "affiliation": "Heidelberg U.",
+        "inspireid": "INSPIRE-00019345",
+        "name": "Jaeger, Andreas"
+      },
+      {
+        "affiliation": "Oxford U.",
+        "inspireid": "INSPIRE-00363060",
+        "name": "Jalocha, Pawel"
+      },
+      {
+        "affiliation": "Nikhef, Amsterdam",
+        "inspireid": "INSPIRE-00258761",
+        "name": "Jans, Eddy"
+      },
+      {
+        "affiliation": "Maryland U., College Park",
+        "inspireid": "INSPIRE-00144300",
+        "name": "Jawahery, Abolhassan"
+      },
+      {
+        "affiliation": "Tsinghua U., Beijing, CHEP",
+        "inspireid": "INSPIRE-00582321",
+        "name": "Jiang, Feng"
+      },
+      {
+        "affiliation": "Oxford U.",
+        "inspireid": "INSPIRE-00042030",
+        "name": "John, Malcolm"
+      },
+      {
+        "affiliation": "CERN",
+        "inspireid": "INSPIRE-00262837",
+        "name": "Johnson, Daniel"
+      },
+      {
+        "affiliation": "Cambridge U.",
+        "inspireid": "INSPIRE-00261047",
+        "name": "Jones, Christopher"
+      },
+      {
+        "affiliation": "CERN",
+        "inspireid": "INSPIRE-00093928",
+        "name": "Joram, Christian"
+      },
+      {
+        "affiliation": "CERN",
+        "inspireid": "INSPIRE-00260147",
+        "name": "Jost, Beat"
+      },
+      {
+        "affiliation": "Oxford U.",
+        "inspireid": "INSPIRE-00400750",
+        "name": "Jurik, Nathan"
+      },
+      {
+        "affiliation": "Kharkov, KIPT",
+        "inspireid": "INSPIRE-00341378",
+        "name": "Kandybei, Sergii"
+      },
+      {
+        "affiliation": "CERN",
+        "inspireid": "INSPIRE-00341385",
+        "name": "Karacson, Matthias"
+      },
+      {
+        "affiliation": "Bristol U.",
+        "inspireid": "INSPIRE-00582332",
+        "name": "Kariuki, James Mwangi"
+      },
+      {
+        "affiliation": "Glasgow U.",
+        "inspireid": "INSPIRE-00453516",
+        "name": "Karodia, Sarah"
+      },
+      {
+        "affiliation": "Heidelberg U.",
+        "inspireid": "INSPIRE-00522728",
+        "name": "Kecke, Matthieu"
+      },
+      {
+        "affiliation": "Syracuse U.",
+        "inspireid": "INSPIRE-00391054",
+        "name": "Kelsey, Matthew"
+      },
+      {
+        "affiliation": "Cambridge U.",
+        "inspireid": "INSPIRE-00239270",
+        "name": "Kenzie, Matthew"
+      },
+      {
+        "affiliation": "NIKHEF, Amsterdam + Vrije U., Amsterdam",
+        "inspireid": "INSPIRE-00258866",
+        "name": "Ketel, Tjeerd"
+      },
+      {
+        "affiliation": "Authors affiliated with an institute formerly covered by a cooperation agreement with CERN.",
+        "inspireid": "INSPIRE-00545552",
+        "name": "Khairullin, Egor"
+      },
+      {
+        "affiliation": "Heidelberg U.",
+        "inspireid": "INSPIRE-00257475",
+        "name": "Khanji, Basem"
+      },
+      {
+        "affiliation": "Ecole Polytechnique, Lausanne",
+        "inspireid": "INSPIRE-00391108",
+        "name": "Khurewathanakul, Chitsanu"
+      },
+      {
+        "affiliation": "Aachen, Tech. Hochsch.",
+        "inspireid": "INSPIRE-00545568",
+        "name": "Kirn, Thomas"
+      },
+      {
+        "affiliation": "Manchester U.",
+        "inspireid": "INSPIRE-00391174",
+        "name": "Klaver, Suzanne"
+      },
+      {
+        "affiliation": "NCBJ, Swierk",
+        "inspireid": "INSPIRE-00400854",
+        "name": "Klimaszewski, Konrad"
+      },
+      {
+        "affiliation": "Heidelberg, Max Planck Inst.",
+        "name": "Klimkovich, Tatsiana"
+      },
+      {
+        "affiliation": "Kiev, INR",
+        "inspireid": "INSPIRE-00582346",
+        "name": "Koliiev, Serhii"
+      },
+      {
+        "affiliation": "Heidelberg U.",
+        "inspireid": "INSPIRE-00453628",
+        "name": "Kolpin, Michael"
+      },
+      {
+        "affiliation": "Ecole Polytechnique, Lausanne",
+        "inspireid": "INSPIRE-00341394",
+        "name": "Komarov, Ilya"
+      },
+      {
+        "affiliation": "Nikhef, Amsterdam",
+        "inspireid": "INSPIRE-00058578",
+        "name": "Koppenburg, Patrick"
+      },
+      {
+        "affiliation": "Authors affiliated with an institute formerly covered by a cooperation agreement with CERN.",
+        "inspireid": "INSPIRE-00259339",
+        "name": "Korolev, Mikhail"
+      },
+      {
+        "affiliation": "Authors affiliated with an institute formerly covered by a cooperation agreement with CERN.",
+        "inspireid": "INSPIRE-00582350",
+        "name": "Kosmyntseva, Alena"
+      },
+      {
+        "affiliation": "Authors affiliated with an institute formerly covered by a cooperation agreement with CERN.",
+        "name": "Kotriakhova, Sofia"
+      },
+      {
+        "affiliation": "Clermont-Ferrand U.",
+        "inspireid": "INSPIRE-00536810",
+        "name": "Kozeiha, Mohamad"
+      },
+      {
+        "affiliation": "Authors affiliated with an institute formerly covered by a cooperation agreement with CERN.",
+        "inspireid": "INSPIRE-00259390",
+        "name": "Kravchuk, Leonid"
+      },
+      {
+        "affiliation": "Heidelberg U.",
+        "inspireid": "INSPIRE-00341449",
+        "name": "Kreplin, Katharina"
+      },
+      {
+        "affiliation": "Warwick U.",
+        "inspireid": "INSPIRE-00041048",
+        "name": "Kreps, Michal"
+      },
+      {
+        "affiliation": "Authors affiliated with an institute formerly covered by a cooperation agreement with CERN.",
+        "inspireid": "INSPIRE-00257824",
+        "name": "Krokovny, Pavel"
+      },
+      {
+        "affiliation": "Tech. U., Dortmund (main)",
+        "inspireid": "INSPIRE-00257624",
+        "name": "Kruse, Florian"
+      },
+      {
+        "affiliation": "NCBJ, Swierk",
+        "inspireid": "INSPIRE-00437507",
+        "name": "Krzemien, Wojciech"
+      },
+      {
+        "affiliation": "Cracow, INP; AGH-UST, Cracow",
+        "inspireid": "INSPIRE-00256649",
+        "name": "Kucewicz, Wojciech"
+      },
+      {
+        "affiliation": "Cracow, INP",
+        "inspireid": "INSPIRE-00258880",
+        "name": "Kucharczyk, Marcin"
+      },
+      {
+        "affiliation": "Authors affiliated with an institute formerly covered by a cooperation agreement with CERN.",
+        "inspireid": "INSPIRE-00341500",
+        "name": "Kudryavtsev, Vasily"
+      },
+      {
+        "affiliation": "Ecole Polytechnique, Lausanne",
+        "inspireid": "INSPIRE-00536823",
+        "name": "Kuonen, Axel Kevin"
+      },
+      {
+        "affiliation": "NCBJ, Swierk",
+        "inspireid": "INSPIRE-00099216",
+        "name": "Kurek, Krzysztof"
+      },
+      {
+        "affiliation": "Authors affiliated with an institute formerly covered by a cooperation agreement with CERN.; CERN",
+        "inspireid": "INSPIRE-00259275",
+        "name": "Kvaratskheliya, Tengiz"
+      },
+      {
+        "affiliation": "CERN",
+        "inspireid": "INSPIRE-00260180",
+        "name": "Lacarrere, Daniel"
+      },
+      {
+        "affiliation": "Manchester U.",
+        "inspireid": "INSPIRE-00099630",
+        "name": "Lafferty, George"
+      },
+      {
+        "affiliation": "INFN, Cagliari",
+        "inspireid": "INSPIRE-00258150",
+        "name": "Lai, Adriano"
+      },
+      {
+        "affiliation": "Frascati",
+        "inspireid": "INSPIRE-00258442",
+        "name": "Lanfranchi, Gaia"
+      },
+      {
+        "affiliation": "Aachen, Tech. Hochsch.",
+        "inspireid": "INSPIRE-00003200",
+        "name": "Langenbruch, Christoph"
+      },
+      {
+        "affiliation": "Warwick U.",
+        "inspireid": "INSPIRE-00041615",
+        "name": "Latham, Thomas"
+      },
+      {
+        "affiliation": "Birmingham U.",
+        "inspireid": "INSPIRE-00100355",
+        "name": "Lazzeroni, Cristina"
+      },
+      {
+        "affiliation": "Marseille, CPPM",
+        "inspireid": "INSPIRE-00083087",
+        "name": "Le Gac, Renaud"
+      },
+      {
+        "affiliation": "Clermont-Ferrand U.",
+        "inspireid": "INSPIRE-00041022",
+        "name": "Lef\\`evre, Regis"
+      },
+      {
+        "affiliation": "Authors affiliated with an institute formerly covered by a cooperation agreement with CERN.; CERN",
+        "inspireid": "INSPIRE-00100871",
+        "name": "Leflat, Alexander"
+      },
+      {
+        "affiliation": "Orsay, LAL",
+        "inspireid": "INSPIRE-00144068",
+        "name": "Lefran\\c{c}ois, Jacques"
+      },
+      {
+        "affiliation": "CERN",
+        "inspireid": "INSPIRE-00582375",
+        "name": "Lemaitre, Florian"
+      },
+      {
+        "affiliation": "Marseille, CPPM",
+        "inspireid": "INSPIRE-00101253",
+        "name": "Leroy, Olivier"
+      },
+      {
+        "affiliation": "Cracow, INP",
+        "inspireid": "INSPIRE-00101288",
+        "name": "Lesiak, Tadeusz"
+      },
+      {
+        "affiliation": "Heidelberg U.",
+        "inspireid": "INSPIRE-00391255",
+        "name": "Leverington, Blake"
+      },
+      {
+        "affiliation": "Tsinghua U., Beijing, CHEP",
+        "inspireid": "INSPIRE-00582384",
+        "name": "Li, Tenglin"
+      },
+      {
+        "affiliation": "Orsay, LAL",
+        "inspireid": "INSPIRE-00385568",
+        "name": "Li, Yiming"
+      },
+      {
+        "affiliation": "Authors affiliated with an institute formerly covered by a cooperation agreement with CERN.",
+        "inspireid": "INSPIRE-00400931",
+        "name": "Likhomanenko, Tatiana"
+      },
+      {
+        "affiliation": "CERN",
+        "inspireid": "INSPIRE-00101983",
+        "name": "Lindner, Rolf"
+      },
+      {
+        "affiliation": "CERN",
+        "inspireid": "INSPIRE-00257832",
+        "name": "Linn, Christian"
+      },
+      {
+        "affiliation": "Zurich U.",
+        "inspireid": "INSPIRE-00401052",
+        "name": "Lionetto, Federica"
+      },
+      {
+        "affiliation": "Tsinghua U., Beijing, CHEP",
+        "inspireid": "INSPIRE-00536834",
+        "name": "Liu, Xuesong"
+      },
+      {
+        "affiliation": "Warwick U.",
+        "inspireid": "INSPIRE-00536847",
+        "name": "Loh, David"
+      },
+      {
+        "affiliation": "Glasgow U.",
+        "inspireid": "INSPIRE-00391330",
+        "name": "Longstaff, Iain"
+      },
+      {
+        "affiliation": "Rio de Janeiro Federal U.",
+        "inspireid": "INSPIRE-00341531",
+        "name": "Lopes, Jose"
+      },
+      {
+        "affiliation": "INFN, Padua; U. Padua (main)",
+        "inspireid": "INSPIRE-00102927",
+        "name": "Lucchesi, Donatella"
+      },
+      {
+        "affiliation": "U. Santiago de Compostela (main)",
+        "inspireid": "INSPIRE-00522703",
+        "name": "Lucio Martinez, Miriam"
+      },
+      {
+        "affiliation": "Edinburgh U.",
+        "inspireid": "INSPIRE-00391426",
+        "name": "Luo, Haofei"
+      },
+      {
+        "affiliation": "INFN, Padua",
+        "inspireid": "INSPIRE-00453739",
+        "name": "Lupato, Anna"
+      },
+      {
+        "affiliation": "INFN, Ferrara; Ferrara U.",
+        "inspireid": "INSPIRE-00103142",
+        "name": "Luppi, Eleonora"
+      },
+      {
+        "affiliation": "CERN",
+        "inspireid": "INSPIRE-00391442",
+        "name": "Lupton, Oliver"
+      },
+      {
+        "affiliation": "INFN, Pisa; Pisa, Scuola Normale Superiore",
+        "inspireid": "INSPIRE-00103157",
+        "name": "Lusiani, Alberto"
+      },
+      {
+        "affiliation": "Beijing, GUCAS",
+        "inspireid": "INSPIRE-00385243",
+        "name": "Lyu, Xiao-Rui"
+      },
+      {
+        "affiliation": "Orsay, LAL",
+        "inspireid": "INSPIRE-00103518",
+        "name": "Machefert, Frederic"
+      },
+      {
+        "affiliation": "Bucharest, IFIN-HH",
+        "inspireid": "INSPIRE-00054830",
+        "name": "Maciuc, Florin"
+      },
+      {
+        "affiliation": "Authors affiliated with an institute formerly covered by a cooperation agreement with CERN.",
+        "inspireid": "INSPIRE-00259220",
+        "name": "Maev, Oleg"
+      },
+      {
+        "affiliation": "Manchester U.",
+        "inspireid": "INSPIRE-00536855",
+        "name": "Maguire, Kevin"
+      },
+      {
+        "affiliation": "Oxford U.",
+        "inspireid": "INSPIRE-00040960",
+        "name": "Malde, Sneha"
+      },
+      {
+        "affiliation": "Authors affiliated with an institute formerly covered by a cooperation agreement with CERN.",
+        "inspireid": "INSPIRE-00401169",
+        "name": "Malinin, Alexander"
+      },
+      {
+        "affiliation": "Authors affiliated with an institute formerly covered by a cooperation agreement with CERN.",
+        "inspireid": "INSPIRE-00582594",
+        "name": "Maltsev, Timofei"
+      },
+      {
+        "affiliation": "INFN, Cagliari; Cagliari U.",
+        "inspireid": "INSPIRE-00057054",
+        "name": "Manca, Giulia"
+      },
+      {
+        "affiliation": "Marseille, CPPM",
+        "inspireid": "INSPIRE-00042821",
+        "name": "Mancinelli, Giampiero"
+      },
+      {
+        "affiliation": "Syracuse U.",
+        "inspireid": "INSPIRE-00219863",
+        "name": "Manning, Peter Michael"
+      },
+      {
+        "affiliation": "Clermont-Ferrand U.; Mindanao State U., Iligan",
+        "inspireid": "INSPIRE-00391509",
+        "name": "Maratas, Jan Mickelle"
+      },
+      {
+        "affiliation": "Annecy, LAPP",
+        "inspireid": "INSPIRE-00219901",
+        "name": "Marchand, Jean Fran\\c{c}ois"
+      },
+      {
+        "affiliation": "INFN, Bologna",
+        "inspireid": "INSPIRE-00258060",
+        "name": "Marconi, Umberto"
+      },
+      {
+        "affiliation": "U. Barcelona (main)",
+        "inspireid": "INSPIRE-00391574",
+        "name": "Marin Benito, Carla"
+      },
+      {
+        "affiliation": "Ecole Polytechnique, Lausanne",
+        "inspireid": "INSPIRE-00582604",
+        "name": "Marinangeli, Matthieu"
+      },
+      {
+        "affiliation": "INFN, Pisa; Pisa, Scuola Normale Superiore",
+        "inspireid": "INSPIRE-00367766",
+        "name": "Marino, Pietro"
+      },
+      {
+        "affiliation": "Heidelberg U.",
+        "inspireid": "INSPIRE-00145236",
+        "name": "Marks, J\\\"org"
+      },
+      {
+        "affiliation": "INFN, Rome",
+        "inspireid": "INSPIRE-00258664",
+        "name": "Martellotti, Giuseppe"
+      },
+      {
+        "affiliation": "Marseille, CPPM",
+        "inspireid": "INSPIRE-00536869",
+        "name": "Martin, Morgan"
+      },
+      {
+        "affiliation": "Ecole Polytechnique, Lausanne",
+        "inspireid": "INSPIRE-00144085",
+        "name": "Martinelli, Maurizio"
+      },
+      {
+        "affiliation": "U. Santiago de Compostela (main)",
+        "inspireid": "INSPIRE-00259733",
+        "name": "Martinez Santos, Diego"
+      },
+      {
+        "affiliation": "Valencia U., IFIC",
+        "inspireid": "INSPIRE-00105212",
+        "name": "Martinez Vidal, Fernando"
+      },
+      {
+        "affiliation": "Rio de Janeiro Federal U.",
+        "inspireid": "INSPIRE-00391627",
+        "name": "Martins Tostes, Danielle"
+      },
+      {
+        "affiliation": "Rio de Janeiro, CBPF",
+        "inspireid": "INSPIRE-00271814",
+        "name": "Massafferri, Andr\\'e"
+      },
+      {
+        "affiliation": "CERN",
+        "inspireid": "INSPIRE-00334839",
+        "name": "Matev, Rosen"
+      },
+      {
+        "affiliation": "Warwick U.",
+        "inspireid": "INSPIRE-00522716",
+        "name": "Mathad, Abhijit"
+      },
+      {
+        "affiliation": "CERN",
+        "inspireid": "INSPIRE-00258028",
+        "name": "Mathe, Zoltan"
+      },
+      {
+        "affiliation": "INFN, Milan Bicocca",
+        "inspireid": "INSPIRE-00258531",
+        "name": "Matteuzzi, Clara"
+      },
+      {
+        "affiliation": "Zurich U.",
+        "inspireid": "INSPIRE-00640989",
+        "name": "Mauri, Andrea"
+      },
+      {
+        "affiliation": "Orsay, LAL; Ecole Polytechnique",
+        "inspireid": "INSPIRE-00257487",
+        "name": "Maurice, Emilie"
+      },
+      {
+        "affiliation": "Ecole Polytechnique, Lausanne",
+        "inspireid": "INSPIRE-00453958",
+        "name": "Maurin, Brice"
+      },
+      {
+        "affiliation": "Birmingham U.",
+        "inspireid": "INSPIRE-00259401",
+        "name": "Mazurov, Alexander"
+      },
+      {
+        "affiliation": "Imperial Coll., London; CERN",
+        "inspireid": "INSPIRE-00391673",
+        "name": "McCann, Michael"
+      },
+      {
+        "affiliation": "Manchester U.",
+        "inspireid": "INSPIRE-00391741",
+        "name": "McNab, Andrew"
+      },
+      {
+        "affiliation": "University Coll., Dublin",
+        "inspireid": "INSPIRE-00106463",
+        "name": "McNulty, Ronan"
+      },
+      {
+        "affiliation": "Cincinnati U.",
+        "inspireid": "INSPIRE-00106491",
+        "name": "Meadows, Brian"
+      },
+      {
+        "affiliation": "Tech. U., Dortmund (main)",
+        "inspireid": "INSPIRE-00391774",
+        "name": "Meier, Frank"
+      },
+      {
+        "affiliation": "Heidelberg U.",
+        "inspireid": "INSPIRE-00296019",
+        "name": "Meissner, Marco"
+      },
+      {
+        "affiliation": "NCBJ, Swierk",
+        "inspireid": "INSPIRE-00385848",
+        "name": "Melnychuk, Dmytro"
+      },
+      {
+        "affiliation": "Nikhef, Amsterdam",
+        "inspireid": "INSPIRE-00106980",
+        "name": "Merk, Marcel"
+      },
+      {
+        "affiliation": "INFN, Milan; U. Milan (main)",
+        "inspireid": "INSPIRE-00582614",
+        "name": "Merli, Andrea"
+      },
+      {
+        "affiliation": "INFN, Padua",
+        "inspireid": "INSPIRE-00536870",
+        "name": "Michielin, Emanuele"
+      },
+      {
+        "affiliation": "Colombia, U. Natl.",
+        "inspireid": "INSPIRE-00028258",
+        "name": "Milanes, Diego Alejandro"
+      },
+      {
+        "affiliation": "Annecy, LAPP",
+        "inspireid": "INSPIRE-00201357",
+        "name": "Minard, Marie-Noelle"
+      },
+      {
+        "affiliation": "Authors affiliated with an institute formerly covered by a cooperation agreement with CERN.",
+        "name": "Mineev, Oleg"
+      },
+      {
+        "affiliation": "Heidelberg U.",
+        "inspireid": "INSPIRE-00522733",
+        "name": "Mitzel, Dominik Stefan"
+      },
+      {
+        "affiliation": "Paris U., VI-VII",
+        "inspireid": "INSPIRE-00582621",
+        "name": "Mogini, Andrea"
+      },
+      {
+        "affiliation": "Rio de Janeiro, CBPF; Zamorano, San Antonio de Oriente",
+        "inspireid": "INSPIRE-00341603",
+        "name": "Molina Rodriguez, Josue"
+      },
+      {
+        "affiliation": "Colombia, U. Natl.",
+        "inspireid": "INSPIRE-00536885",
+        "name": "Monroy, Igancio Alberto"
+      },
+      {
+        "affiliation": "Clermont-Ferrand U.",
+        "inspireid": "INSPIRE-00257390",
+        "name": "Monteil, Stephane"
+      },
+      {
+        "affiliation": "INFN, Padua",
+        "inspireid": "INSPIRE-00108754",
+        "name": "Morandin, Mauro"
+      },
+      {
+        "affiliation": "AGH-UST, Krakow",
+        "inspireid": "INSPIRE-00258909",
+        "name": "Morawski, Piotr"
+      },
+      {
+        "affiliation": "Marseille, CPPM",
+        "inspireid": "INSPIRE-00391840",
+        "name": "Mord\\`a, Alessandro"
+      },
+      {
+        "affiliation": "INFN, Pisa; Pisa, Scuola Normale Superiore",
+        "inspireid": "INSPIRE-00016418",
+        "name": "Morello, Michael Joseph"
+      },
+      {
+        "affiliation": "Authors affiliated with an institute formerly covered by a cooperation agreement with CERN.",
+        "inspireid": "INSPIRE-00582634",
+        "name": "Morgunova, Olga"
+      },
+      {
+        "affiliation": "AGH-UST, Krakow",
+        "inspireid": "INSPIRE-00453992",
+        "name": "Moron, Jakub"
+      },
+      {
+        "affiliation": "Edinburgh U.",
+        "inspireid": "INSPIRE-00401257",
+        "name": "Morris, Adam Benjamin"
+      },
+      {
+        "affiliation": "Syracuse U.",
+        "inspireid": "INSPIRE-00109283",
+        "name": "Mountain, Raymond"
+      },
+      {
+        "affiliation": "Edinburgh U.",
+        "inspireid": "INSPIRE-00194050",
+        "name": "Muheim, Franz"
+      },
+      {
+        "affiliation": "Nikhef, Amsterdam",
+        "inspireid": "INSPIRE-00518699",
+        "name": "Mulder, Mick"
+      },
+      {
+        "affiliation": "Manchester U.",
+        "name": "M\\\"uller, Dominik"
+      },
+      {
+        "affiliation": "Tech. U., Dortmund (main)",
+        "inspireid": "INSPIRE-00522744",
+        "name": "M\\\"uller, Janine"
+      },
+      {
+        "affiliation": "Zurich U.",
+        "inspireid": "INSPIRE-00185464",
+        "name": "M\\\"uller, Katharina"
+      },
+      {
+        "affiliation": "Tech. U., Dortmund (main)",
+        "inspireid": "INSPIRE-00522759",
+        "name": "M\\\"uller, Vanessa"
+      },
+      {
+        "affiliation": "INFN, Bologna",
+        "inspireid": "INSPIRE-00024830",
+        "name": "Mussini, Manuel"
+      },
+      {
+        "affiliation": "Bristol U.",
+        "inspireid": "INSPIRE-00260976",
+        "name": "Naik, Paras"
+      },
+      {
+        "affiliation": "Ecole Polytechnique, Lausanne",
+        "inspireid": "INSPIRE-00171856",
+        "name": "Nakada, Tatsuya"
+      },
+      {
+        "affiliation": "Rutherford",
+        "inspireid": "INSPIRE-00110346",
+        "name": "Nandakumar, Raja"
+      },
+      {
+        "affiliation": "Oxford U.",
+        "inspireid": "INSPIRE-00536909",
+        "name": "Nandi, Anita"
+      },
+      {
+        "affiliation": "Rio de Janeiro Federal U.",
+        "inspireid": "INSPIRE-00140157",
+        "name": "Nasteva, Irina"
+      },
+      {
+        "affiliation": "Edinburgh U.",
+        "inspireid": "INSPIRE-00260601",
+        "name": "Needham, Matthew"
+      },
+      {
+        "affiliation": "INFN, Milan; U. Milan (main)",
+        "inspireid": "INSPIRE-00045899",
+        "name": "Neri, Nicola"
+      },
+      {
+        "affiliation": "Heidelberg U.",
+        "inspireid": "INSPIRE-00391914",
+        "name": "Neubert, Sebastian"
+      },
+      {
+        "affiliation": "CERN",
+        "inspireid": "INSPIRE-00260260",
+        "name": "Neufeld, Niko"
+      },
+      {
+        "affiliation": "Heidelberg U.",
+        "inspireid": "INSPIRE-00452189",
+        "name": "Neuner, Max"
+      },
+      {
+        "affiliation": "Authors affiliated with an institute formerly covered by a cooperation agreement with CERN.",
+        "name": "Neustroev, Petr"
+      },
+      {
+        "affiliation": "Ecole Polytechnique, Lausanne",
+        "inspireid": "INSPIRE-00391987",
+        "name": "Nguyen, Thi Dung"
+      },
+      {
+        "affiliation": "Ecole Polytechnique, Lausanne; Hanoi U. of Sci.",
+        "inspireid": "INSPIRE-00341643",
+        "name": "Nguyen-Mau, Chung"
+      },
+      {
+        "affiliation": "Aachen, Tech. Hochsch.",
+        "inspireid": "INSPIRE-00409248",
+        "name": "Nieswand, Simon"
+      },
+      {
+        "affiliation": "Tech. U., Dortmund (main)",
+        "inspireid": "INSPIRE-00392011",
+        "name": "Niet, Ramon"
+      },
+      {
+        "affiliation": "Authors affiliated with an institute formerly covered by a cooperation agreement with CERN.",
+        "inspireid": "INSPIRE-00259364",
+        "name": "Nikitin, Nikolay"
+      },
+      {
+        "affiliation": "Heidelberg U.",
+        "inspireid": "INSPIRE-00341653",
+        "name": "Nikodem, Thomas"
+      },
+      {
+        "affiliation": "Authors affiliated with an institute formerly covered by a cooperation agreement with CERN.",
+        "inspireid": "INSPIRE-00582642",
+        "name": "Nogay, Alla"
+      },
+      {
+        "affiliation": "Authors affiliated with an institute formerly covered by a cooperation agreement with CERN.",
+        "inspireid": "INSPIRE-00344272",
+        "name": "Novoselov, Alexey"
+      },
+      {
+        "affiliation": "AGH-UST, Krakow",
+        "inspireid": "INSPIRE-00258945",
+        "name": "Oblakowska-Mucha, Agnieszka"
+      },
+      {
+        "affiliation": "Authors affiliated with an institute formerly covered by a cooperation agreement with CERN.",
+        "inspireid": "INSPIRE-00191751",
+        "name": "Obraztsov, Vladimir"
+      },
+      {
+        "affiliation": "Frascati",
+        "inspireid": "INSPIRE-00341669",
+        "name": "Ogilvy, Stephen"
+      },
+      {
+        "affiliation": "Warwick U.",
+        "inspireid": "INSPIRE-00401396",
+        "name": "O'Hanlon, Daniel Patrick"
+      },
+      {
+        "affiliation": "INFN, Cagliari; Cagliari U.",
+        "inspireid": "INSPIRE-00112910",
+        "name": "Oldeman, Rudolf"
+      },
+      {
+        "affiliation": "U. Groningen, VSI",
+        "inspireid": "INSPIRE-00113159",
+        "name": "Onderwater, Gerco"
+      },
+      {
+        "affiliation": "Rio de Janeiro Federal U.",
+        "inspireid": "INSPIRE-00218196",
+        "name": "Otalora Goicochea, Juan Martin"
+      },
+      {
+        "affiliation": "CERN",
+        "inspireid": "INSPIRE-00452222",
+        "name": "Otto, Adam"
+      },
+      {
+        "affiliation": "Zurich U.",
+        "inspireid": "INSPIRE-00341671",
+        "name": "Owen, Patrick"
+      },
+      {
+        "affiliation": "Valencia U., IFIC",
+        "inspireid": "INSPIRE-00042432",
+        "name": "Oyanguren, Maria Aranzazu"
+      },
+      {
+        "affiliation": "Ecole Polytechnique, Lausanne",
+        "inspireid": "INSPIRE-00237142",
+        "name": "Pais, Preema Rennee"
+      },
+      {
+        "affiliation": "INFN, Bari; Bari U.",
+        "inspireid": "INSPIRE-00114021",
+        "name": "Palano, Antimo"
+      },
+      {
+        "affiliation": "Frascati",
+        "inspireid": "INSPIRE-00259914",
+        "name": "Palutan, Matteo"
+      },
+      {
+        "affiliation": "Rutherford",
+        "inspireid": "INSPIRE-00261218",
+        "name": "Papanestis, Antonios"
+      },
+      {
+        "affiliation": "INFN, Bari; Bari U.",
+        "inspireid": "INSPIRE-00043195",
+        "name": "Pappagallo, Marco"
+      },
+      {
+        "affiliation": "INFN, Ferrara; Ferrara U.",
+        "inspireid": "INSPIRE-00401494",
+        "name": "Pappalardo, Luciano"
+      },
+      {
+        "affiliation": "Maryland U., College Park",
+        "inspireid": "INSPIRE-00206947",
+        "name": "Parker, William"
+      },
+      {
+        "affiliation": "Manchester U.",
+        "inspireid": "INSPIRE-00160233",
+        "name": "Parkes, Christopher"
+      },
+      {
+        "affiliation": "INFN, Florence",
+        "inspireid": "INSPIRE-00114920",
+        "name": "Passaleva, Giovanni"
+      },
+      {
+        "affiliation": "INFN, Bari; Bari U.",
+        "inspireid": "INSPIRE-00268178",
+        "name": "Pastore, Alessandra"
+      },
+      {
+        "affiliation": "Liverpool U.",
+        "inspireid": "INSPIRE-00115039",
+        "name": "Patel, Girish"
+      },
+      {
+        "affiliation": "Imperial Coll., London",
+        "inspireid": "INSPIRE-00227343",
+        "name": "Patel, Mitesh"
+      },
+      {
+        "affiliation": "INFN, Bologna; Bologna U.",
+        "inspireid": "INSPIRE-00115095",
+        "name": "Patrignani, Claudia"
+      },
+      {
+        "affiliation": "CERN",
+        "inspireid": "INSPIRE-00392044",
+        "name": "Pearce, Alex"
+      },
+      {
+        "affiliation": "Nikhef, Amsterdam",
+        "inspireid": "INSPIRE-00173740",
+        "name": "Pellegrino, Antonio"
+      },
+      {
+        "affiliation": "INFN, Rome",
+        "inspireid": "INSPIRE-00226158",
+        "name": "Penso, Gianni"
+      },
+      {
+        "affiliation": "CERN",
+        "inspireid": "INSPIRE-00296179",
+        "name": "Pepe Altarelli, Monica"
+      },
+      {
+        "affiliation": "CERN",
+        "inspireid": "INSPIRE-00258083",
+        "name": "Perazzini, Stefano"
+      },
+      {
+        "affiliation": "Clermont-Ferrand U.",
+        "inspireid": "INSPIRE-00115778",
+        "name": "Perret, Pascal"
+      },
+      {
+        "affiliation": "Ecole Polytechnique, Lausanne",
+        "inspireid": "INSPIRE-00392110",
+        "name": "Pescatore, Luca"
+      },
+      {
+        "affiliation": "Bristol U.",
+        "inspireid": "INSPIRE-00311357",
+        "name": "Petridis, Konstantinos"
+      },
+      {
+        "affiliation": "INFN, Genoa; Genoa U.",
+        "inspireid": "INSPIRE-00116050",
+        "name": "Petrolini, Alessandro"
+      },
+      {
+        "affiliation": "Authors affiliated with an institute formerly covered by a cooperation agreement with CERN.",
+        "inspireid": "INSPIRE-00582654",
+        "name": "Petrov, Aleksandr"
+      },
+      {
+        "affiliation": "INFN, Milan; U. Milan (main)",
+        "inspireid": "INSPIRE-00522770",
+        "name": "Petruzzo, Marco"
+      },
+      {
+        "affiliation": "U. Barcelona (main)",
+        "inspireid": "INSPIRE-00259574",
+        "name": "Picatoste Olloqui, Eduardo"
+      },
+      {
+        "affiliation": "Annecy, LAPP",
+        "inspireid": "INSPIRE-00257359",
+        "name": "Pietrzyk, Boleslaw"
+      },
+      {
+        "affiliation": "Cracow, INP",
+        "inspireid": "INSPIRE-00392248",
+        "name": "Pikies, Malgorzata"
+      },
+      {
+        "affiliation": "INFN, Rome",
+        "inspireid": "INSPIRE-00258670",
+        "name": "Pinci, Davide"
+      },
+      {
+        "affiliation": "INFN, Genoa; Genoa U.",
+        "inspireid": "INSPIRE-00401637",
+        "name": "Pistone, Alessandro"
+      },
+      {
+        "affiliation": "Heidelberg U.",
+        "inspireid": "INSPIRE-00536921",
+        "name": "Piucci, Alessio"
+      },
+      {
+        "affiliation": "Bucharest, IFIN-HH",
+        "inspireid": "INSPIRE-00582660",
+        "name": "Placinta, Vlad-Mihai"
+      },
+      {
+        "affiliation": "Edinburgh U.",
+        "inspireid": "INSPIRE-00144540",
+        "name": "Playfer, Stephen"
+      },
+      {
+        "affiliation": "U. Santiago de Compostela (main)",
+        "inspireid": "INSPIRE-00259765",
+        "name": "Plo Casasus, Maximo"
+      },
+      {
+        "affiliation": "CERN",
+        "inspireid": "INSPIRE-00522785",
+        "name": "Poikela, Tuomas"
+      },
+      {
+        "affiliation": "Paris U., VI-VII",
+        "inspireid": "INSPIRE-00041883",
+        "name": "Polci, Francesco"
+      },
+      {
+        "affiliation": "Frascati",
+        "name": "Poli Lener, Marco"
+      },
+      {
+        "affiliation": "Warwick U.; Authors affiliated with an institute formerly covered by a cooperation agreement with CERN.",
+        "inspireid": "INSPIRE-00180587",
+        "name": "Poluektov, Anton"
+      },
+      {
+        "affiliation": "Syracuse U.",
+        "inspireid": "INSPIRE-00392262",
+        "name": "Polyakov, Ivan"
+      },
+      {
+        "affiliation": "Rio de Janeiro Federal U.",
+        "inspireid": "INSPIRE-00117142",
+        "name": "Polycarpo, Erica"
+      },
+      {
+        "affiliation": "Bristol U.",
+        "inspireid": "INSPIRE-00582672",
+        "name": "Pomery, Gabriela Johanna"
+      },
+      {
+        "affiliation": "CERN",
+        "name": "Ponce, Sebastien"
+      },
+      {
+        "affiliation": "Authors affiliated with an institute formerly covered by a cooperation agreement with CERN.",
+        "inspireid": "INSPIRE-00392309",
+        "name": "Popov, Alexander"
+      },
+      {
+        "affiliation": "Heidelberg, Max Planck Inst.; CERN",
+        "inspireid": "INSPIRE-00257709",
+        "name": "Popov, Dmitry"
+      },
+      {
+        "affiliation": "Bucharest, IFIN-HH",
+        "inspireid": "INSPIRE-00259165",
+        "name": "Popovici, Bogdan"
+      },
+      {
+        "affiliation": "Authors affiliated with an institute formerly covered by a cooperation agreement with CERN.",
+        "inspireid": "INSPIRE-00582684",
+        "name": "Poslavskii, Stanislav"
+      },
+      {
+        "affiliation": "Rio de Janeiro Federal U.",
+        "inspireid": "INSPIRE-00260620",
+        "name": "Potterat, C\\'edric"
+      },
+      {
+        "affiliation": "Bristol U.",
+        "inspireid": "INSPIRE-00401700",
+        "name": "Price, Eugenia"
+      },
+      {
+        "affiliation": "Liverpool U.",
+        "inspireid": "INSPIRE-00287010",
+        "name": "Price, Joseph David"
+      },
+      {
+        "affiliation": "U. Santiago de Compostela (main)",
+        "inspireid": "INSPIRE-00341705",
+        "name": "Prisciandaro, Jessica"
+      },
+      {
+        "affiliation": "Liverpool U.",
+        "inspireid": "INSPIRE-00392320",
+        "name": "Pritchard, Adrian"
+      },
+      {
+        "affiliation": "Bristol U.",
+        "inspireid": "INSPIRE-00392372",
+        "name": "Prouve, Claire"
+      },
+      {
+        "affiliation": "Kiev, INR",
+        "inspireid": "INSPIRE-00046375",
+        "name": "Pugatch, Valery"
+      },
+      {
+        "affiliation": "Zurich U.",
+        "inspireid": "INSPIRE-00259590",
+        "name": "Puig Navarro, Albert"
+      },
+      {
+        "affiliation": "INFN, Pisa; U. Pisa (main)",
+        "inspireid": "INSPIRE-00118078",
+        "name": "Punzi, Giovanni"
+      },
+      {
+        "affiliation": "Warwick U.",
+        "inspireid": "INSPIRE-00257268",
+        "name": "Qian, Wenbin"
+      },
+      {
+        "affiliation": "Orsay, LAL; Bristol U.",
+        "inspireid": "INSPIRE-00453676",
+        "name": "Quagliani, Renato"
+      },
+      {
+        "affiliation": "Cracow, INP",
+        "inspireid": "INSPIRE-00392425",
+        "name": "Rachwal, Bartlomiej"
+      },
+      {
+        "affiliation": "Bristol U.",
+        "inspireid": "INSPIRE-00050460",
+        "name": "Rademacker, Jonas"
+      },
+      {
+        "affiliation": "INFN, Pisa",
+        "inspireid": "INSPIRE-00041956",
+        "name": "Rama, Matteo"
+      },
+      {
+        "affiliation": "U. Santiago de Compostela (main)",
+        "inspireid": "INSPIRE-00545589",
+        "name": "Ramos Pernas, Miguel"
+      },
+      {
+        "affiliation": "Rio de Janeiro Federal U.",
+        "inspireid": "INSPIRE-00024740",
+        "name": "Rangel, Murilo"
+      },
+      {
+        "affiliation": "Kharkov, KIPT",
+        "inspireid": "INSPIRE-00260925",
+        "name": "Raniuk, Iurii"
+      },
+      {
+        "affiliation": "Authors affiliated with an institute formerly covered by a cooperation agreement with CERN.",
+        "inspireid": "INSPIRE-00005235",
+        "name": "Ratnikov, Fedor"
+      },
+      {
+        "affiliation": "NIKHEF, Amsterdam + Vrije U., Amsterdam",
+        "inspireid": "INSPIRE-00119187",
+        "name": "Raven, Gerhard"
+      },
+      {
+        "affiliation": "Imperial Coll., London",
+        "inspireid": "INSPIRE-00453784",
+        "name": "Redi, Federico"
+      },
+      {
+        "affiliation": "Tech. U., Dortmund (main)",
+        "inspireid": "INSPIRE-00392459",
+        "name": "Reichert, Stefanie"
+      },
+      {
+        "affiliation": "Valencia U., IFIC",
+        "inspireid": "INSPIRE-00582696",
+        "name": "Remon Alepuz, Clara"
+      },
+      {
+        "affiliation": "Orsay, LAL",
+        "inspireid": "INSPIRE-00545590",
+        "name": "Renaudin, Victor"
+      },
+      {
+        "affiliation": "Rutherford",
+        "inspireid": "INSPIRE-00119926",
+        "name": "Ricciardi, Stefania"
+      },
+      {
+        "affiliation": "Bristol U.",
+        "inspireid": "INSPIRE-00401830",
+        "name": "Richards, Sophie"
+      },
+      {
+        "affiliation": "CERN",
+        "inspireid": "INSPIRE-00401943",
+        "name": "Rihl, Mariana"
+      },
+      {
+        "affiliation": "Liverpool U.",
+        "inspireid": "INSPIRE-00034500",
+        "name": "Rinnert, Kurt"
+      },
+      {
+        "affiliation": "U. Barcelona (main)",
+        "inspireid": "INSPIRE-00357276",
+        "name": "Rives Molina, Vicente"
+      },
+      {
+        "affiliation": "Orsay, LAL; CERN",
+        "inspireid": "INSPIRE-00050542",
+        "name": "Robbe, Patrick"
+      },
+      {
+        "affiliation": "Rio de Janeiro, CBPF",
+        "inspireid": "INSPIRE-00392508",
+        "name": "Rodrigues, Ana Barbara"
+      },
+      {
+        "affiliation": "Cincinnati U.",
+        "inspireid": "INSPIRE-00306714",
+        "name": "Rodrigues, Eduardo"
+      },
+      {
+        "affiliation": "Colombia, U. Natl.",
+        "inspireid": "INSPIRE-00120769",
+        "name": "Rodriguez Lopez, Jairo Alexis"
+      },
+      {
+        "affiliation": "Manchester U.",
+        "inspireid": "INSPIRE-00259789",
+        "name": "Rodriguez Perez, Pablo"
+      },
+      {
+        "affiliation": "Authors affiliated with an institute formerly covered by a cooperation agreement with CERN.",
+        "inspireid": "INSPIRE-00582700",
+        "name": "Rogozhnikov, Alexey"
+      },
+      {
+        "affiliation": "CERN",
+        "inspireid": "INSPIRE-00346259",
+        "name": "Roiser, Stefan"
+      },
+      {
+        "affiliation": "Oxford U.",
+        "inspireid": "INSPIRE-00582716",
+        "name": "Rollings, Alexandra Paige"
+      },
+      {
+        "affiliation": "Authors affiliated with an institute formerly covered by a cooperation agreement with CERN.",
+        "inspireid": "INSPIRE-00259690",
+        "name": "Romanovskiy, Vladimir"
+      },
+      {
+        "affiliation": "U. Santiago de Compostela (main)",
+        "inspireid": "INSPIRE-00357288",
+        "name": "Romero Vidal, Antonio"
+      },
+      {
+        "affiliation": "University Coll., Dublin",
+        "inspireid": "INSPIRE-00536933",
+        "name": "Ronayne, John William"
+      },
+      {
+        "affiliation": "Frascati",
+        "inspireid": "INSPIRE-00036330",
+        "name": "Rotondo, Marcello"
+      },
+      {
+        "affiliation": "Syracuse U.",
+        "inspireid": "INSPIRE-00176709",
+        "name": "Rudolph, Matthew Scott"
+      },
+      {
+        "affiliation": "CERN",
+        "inspireid": "INSPIRE-00260315",
+        "name": "Ruf, Thomas"
+      },
+      {
+        "affiliation": "Valencia U., IFIC",
+        "inspireid": "INSPIRE-00392538",
+        "name": "Ruiz Valls, Pablo"
+      },
+      {
+        "affiliation": "U. Santiago de Compostela (main)",
+        "inspireid": "INSPIRE-00193814",
+        "name": "Saborido Silva, Juan Jose"
+      },
+      {
+        "affiliation": "Authors affiliated with an institute formerly covered by a cooperation agreement with CERN.",
+        "inspireid": "INSPIRE-00582728",
+        "name": "Sadykhov, Elnur"
+      },
+      {
+        "affiliation": "Authors affiliated with an institute formerly covered by a cooperation agreement with CERN.",
+        "inspireid": "INSPIRE-00207799",
+        "name": "Sagidova, Naylya"
+      },
+      {
+        "affiliation": "INFN, Cagliari; Cagliari U.",
+        "inspireid": "INSPIRE-00258160",
+        "name": "Saitta, Biagio"
+      },
+      {
+        "affiliation": "Rio de Janeiro, CBPF",
+        "inspireid": "INSPIRE-00287090",
+        "name": "Salustino Guimaraes, Valdir"
+      },
+      {
+        "affiliation": "Valencia U., IFIC",
+        "inspireid": "INSPIRE-00454015",
+        "name": "Sanchez Mayordomo, Carlos"
+      },
+      {
+        "affiliation": "U. Santiago de Compostela (main)",
+        "inspireid": "INSPIRE-00357296",
+        "name": "Sanmartin Sedes, Brais"
+      },
+      {
+        "affiliation": "INFN, Rome",
+        "inspireid": "INSPIRE-00258681",
+        "name": "Santacesaria, Roberta"
+      },
+      {
+        "affiliation": "U. Santiago de Compostela (main)",
+        "inspireid": "INSPIRE-00306219",
+        "name": "Santamarina Rios, Cibran"
+      },
+      {
+        "affiliation": "Frascati",
+        "inspireid": "INSPIRE-00536947",
+        "name": "Santimaria, Marco"
+      },
+      {
+        "affiliation": "Rome U., Tor Vergata",
+        "inspireid": "INSPIRE-00038249",
+        "name": "Santovetti, Emanuele"
+      },
+      {
+        "affiliation": "Frascati; U. Rome La Sapienza (main)",
+        "inspireid": "INSPIRE-00028229",
+        "name": "Sarti, Alessio"
+      },
+      {
+        "affiliation": "INFN, Rome; Basilicata U., Potenza",
+        "inspireid": "INSPIRE-00258690",
+        "name": "Satriano, Celestina"
+      },
+      {
+        "affiliation": "Rome U., Tor Vergata",
+        "inspireid": "INSPIRE-00258614",
+        "name": "Satta, Alessia"
+      },
+      {
+        "affiliation": "Bristol U.",
+        "inspireid": "INSPIRE-00402066",
+        "name": "Saunders, Daniel Martin"
+      },
+      {
+        "affiliation": "Authors affiliated with an institute formerly covered by a cooperation agreement with CERN.",
+        "inspireid": "INSPIRE-00259293",
+        "name": "Savrina, Darya"
+      },
+      {
+        "affiliation": "Aachen, Tech. Hochsch.",
+        "inspireid": "INSPIRE-00123779",
+        "name": "Schael, Stefan"
+      },
+      {
+        "affiliation": "Tech. U., Dortmund (main)",
+        "inspireid": "INSPIRE-00582732",
+        "name": "Schellenberg, Margarete"
+      },
+      {
+        "affiliation": "Glasgow U.",
+        "inspireid": "INSPIRE-00257856",
+        "name": "Schiller, Manuel"
+      },
+      {
+        "affiliation": "CERN",
+        "inspireid": "INSPIRE-00357303",
+        "name": "Schindler, Heinrich"
+      },
+      {
+        "affiliation": "Tech. U., Dortmund (main)",
+        "inspireid": "INSPIRE-00346274",
+        "name": "Schlupp, Maximilian"
+      },
+      {
+        "affiliation": "Heidelberg, Max Planck Inst.",
+        "inspireid": "INSPIRE-00124172",
+        "name": "Schmelling, Michael"
+      },
+      {
+        "affiliation": "Tech. U., Dortmund (main)",
+        "inspireid": "INSPIRE-00522799",
+        "name": "Schmelzer, Timon"
+      },
+      {
+        "affiliation": "CERN",
+        "inspireid": "INSPIRE-00260343",
+        "name": "Schmidt, Burkhard"
+      },
+      {
+        "affiliation": "Ecole Polytechnique, Lausanne",
+        "inspireid": "INSPIRE-00155864",
+        "name": "Schneider, Olivier"
+      },
+      {
+        "affiliation": "CERN",
+        "inspireid": "INSPIRE-00171861",
+        "name": "Schopper, Andreas"
+      },
+      {
+        "affiliation": "Cincinnati U.",
+        "name": "Schreiner, H.F."
+      },
+      {
+        "affiliation": "Tech. U., Dortmund (main)",
+        "inspireid": "INSPIRE-00582742",
+        "name": "Schubert, Konstantin"
+      },
+      {
+        "affiliation": "Ecole Polytechnique, Lausanne",
+        "inspireid": "INSPIRE-00536951",
+        "name": "Schubiger, Maxime"
+      },
+      {
+        "affiliation": "Orsay, LAL",
+        "inspireid": "INSPIRE-00124570",
+        "name": "Schune, Marie Helene"
+      },
+      {
+        "affiliation": "CERN",
+        "inspireid": "INSPIRE-00260360",
+        "name": "Schwemmer, Rainer"
+      },
+      {
+        "affiliation": "Frascati",
+        "inspireid": "INSPIRE-00038235",
+        "name": "Sciascia, Barbara"
+      },
+      {
+        "affiliation": "INFN, Rome; U. Rome La Sapienza (main)",
+        "inspireid": "INSPIRE-00262979",
+        "name": "Sciubba, Adalberto"
+      },
+      {
+        "affiliation": "Authors affiliated with an institute formerly covered by a cooperation agreement with CERN.",
+        "inspireid": "INSPIRE-00259305",
+        "name": "Semennikov, Alexander"
+      },
+      {
+        "affiliation": "Birmingham U.",
+        "inspireid": "INSPIRE-00184370",
+        "name": "Sergi, Antonino"
+      },
+      {
+        "affiliation": "Zurich U.",
+        "inspireid": "INSPIRE-00258830",
+        "name": "Serra, Nicola"
+      },
+      {
+        "affiliation": "Marseille, CPPM",
+        "inspireid": "INSPIRE-00144713",
+        "name": "Serrano, Justine"
+      },
+      {
+        "affiliation": "INFN, Padua",
+        "inspireid": "INSPIRE-00454148",
+        "name": "Sestini, Lorenzo"
+      },
+      {
+        "affiliation": "INFN, Milan Bicocca",
+        "inspireid": "INSPIRE-00341737",
+        "name": "Seyfert, Paul"
+      },
+      {
+        "affiliation": "Authors affiliated with an institute formerly covered by a cooperation agreement with CERN.",
+        "inspireid": "INSPIRE-00200269",
+        "name": "Shapkin, Mikhail"
+      },
+      {
+        "affiliation": "Authors affiliated with an institute formerly covered by a cooperation agreement with CERN.",
+        "inspireid": "INSPIRE-00005552",
+        "name": "Shcheglov, Yury"
+      },
+      {
+        "affiliation": "Liverpool U.",
+        "inspireid": "INSPIRE-00125751",
+        "name": "Shears, Tara"
+      },
+      {
+        "affiliation": "Authors affiliated with an institute formerly covered by a cooperation agreement with CERN.",
+        "inspireid": "INSPIRE-00072482",
+        "name": "Shekhtman, Lev"
+      },
+      {
+        "affiliation": "Authors affiliated with an institute formerly covered by a cooperation agreement with CERN.",
+        "inspireid": "INSPIRE-00259319",
+        "name": "Shevchenko, Vladimir"
+      },
+      {
+        "affiliation": "INFN, Ferrara; CERN; Ferrara U.",
+        "inspireid": "INSPIRE-00536966",
+        "name": "Siddi, Benedetto Gianluca"
+      },
+      {
+        "affiliation": "Zurich U.",
+        "inspireid": "INSPIRE-00341765",
+        "name": "Silva Coutinho, Rafael"
+      },
+      {
+        "affiliation": "Rio de Janeiro Federal U.",
+        "inspireid": "INSPIRE-00536971",
+        "name": "Silva de Oliveira, Luiz Gustavo"
+      },
+      {
+        "affiliation": "INFN, Padua; U. Padua (main)",
+        "inspireid": "INSPIRE-00042241",
+        "name": "Simi, Gabriele"
+      },
+      {
+        "affiliation": "INFN, Bari; Bari U.",
+        "inspireid": "INSPIRE-00408677",
+        "name": "Simone, Saverio"
+      },
+      {
+        "affiliation": "Cambridge U.",
+        "inspireid": "INSPIRE-00392577",
+        "name": "Sirendi, Marek"
+      },
+      {
+        "affiliation": "Bristol U.",
+        "inspireid": "INSPIRE-00392618",
+        "name": "Skidmore, Nicola"
+      },
+      {
+        "affiliation": "Syracuse U.",
+        "inspireid": "INSPIRE-00165164",
+        "name": "Skwarnicki, Tomasz"
+      },
+      {
+        "affiliation": "Imperial Coll., London",
+        "inspireid": "INSPIRE-00266880",
+        "name": "Smith, Eluned"
+      },
+      {
+        "affiliation": "Edinburgh U.",
+        "inspireid": "INSPIRE-00536980",
+        "name": "Smith, Iwan Thomas"
+      },
+      {
+        "affiliation": "Cambridge U.",
+        "inspireid": "INSPIRE-00392666",
+        "name": "Smith, Jackson"
+      },
+      {
+        "affiliation": "Imperial Coll., London",
+        "inspireid": "INSPIRE-00342046",
+        "name": "Smith, Mark"
+      },
+      {
+        "affiliation": "Rio de Janeiro, CBPF",
+        "inspireid": "INSPIRE-00582750",
+        "name": "Soares Lavra, Lais"
+      },
+      {
+        "affiliation": "Cincinnati U.",
+        "inspireid": "INSPIRE-00127570",
+        "name": "Sokoloff, Michael"
+      },
+      {
+        "affiliation": "Glasgow U.",
+        "inspireid": "INSPIRE-00160205",
+        "name": "Soler, Paul"
+      },
+      {
+        "affiliation": "Rio de Janeiro Federal U.",
+        "inspireid": "INSPIRE-00257205",
+        "name": "Souza De Paula, Bruno"
+      },
+      {
+        "affiliation": "Tech. U., Dortmund (main)",
+        "inspireid": "INSPIRE-00128007",
+        "name": "Spaan, Bernhard"
+      },
+      {
+        "affiliation": "Authors affiliated with an institute formerly covered by a cooperation agreement with CERN.",
+        "name": "Spiridenkov, Eduard"
+      },
+      {
+        "affiliation": "Glasgow U.",
+        "inspireid": "INSPIRE-00042860",
+        "name": "Spradlin, Patrick"
+      },
+      {
+        "affiliation": "CERN",
+        "inspireid": "INSPIRE-00402283",
+        "name": "Sridharan, Srikanth"
+      },
+      {
+        "affiliation": "CERN",
+        "inspireid": "INSPIRE-00260412",
+        "name": "Stagni, Federico"
+      },
+      {
+        "affiliation": "Heidelberg U.",
+        "inspireid": "INSPIRE-00402270",
+        "name": "Stahl, Marian"
+      },
+      {
+        "affiliation": "CERN",
+        "inspireid": "INSPIRE-00257861",
+        "name": "Stahl, Sascha"
+      },
+      {
+        "affiliation": "Ecole Polytechnique, Lausanne",
+        "inspireid": "INSPIRE-00582764",
+        "name": "Stefko, Pavol"
+      },
+      {
+        "affiliation": "Imperial Coll., London",
+        "inspireid": "INSPIRE-00537009",
+        "name": "Stefkova, Slavomira"
+      },
+      {
+        "affiliation": "Zurich U.",
+        "inspireid": "INSPIRE-00260853",
+        "name": "Steinkamp, Olaf"
+      },
+      {
+        "affiliation": "Heidelberg U.",
+        "inspireid": "INSPIRE-00582773",
+        "name": "Stemmle, Simon"
+      },
+      {
+        "affiliation": "Authors affiliated with an institute formerly covered by a cooperation agreement with CERN.",
+        "inspireid": "INSPIRE-00010650",
+        "name": "Stenyakin, Oleg"
+      },
+      {
+        "affiliation": "Tech. U., Dortmund (main)",
+        "inspireid": "INSPIRE-00582780",
+        "name": "Stevens, Holger"
+      },
+      {
+        "affiliation": "Oxford U.",
+        "inspireid": "INSPIRE-00392718",
+        "name": "Stevenson, Scott"
+      },
+      {
+        "affiliation": "Bucharest, IFIN-HH",
+        "inspireid": "INSPIRE-00259172",
+        "name": "Stoica, Sabin"
+      },
+      {
+        "affiliation": "Syracuse U.; CERN",
+        "inspireid": "INSPIRE-00160900",
+        "name": "Stone, Sheldon"
+      },
+      {
+        "affiliation": "Zurich U.",
+        "inspireid": "INSPIRE-00004591",
+        "name": "Storaci, Barbara"
+      },
+      {
+        "affiliation": "INFN, Pisa; U. Pisa (main)",
+        "inspireid": "INSPIRE-00003424",
+        "name": "Stracka, Simone"
+      },
+      {
+        "affiliation": "Ecole Polytechnique, Lausanne",
+        "name": "Stramaglia, Maria Elena"
+      },
+      {
+        "affiliation": "Bucharest, IFIN-HH",
+        "inspireid": "INSPIRE-00341791",
+        "name": "Straticiuc, Mihai"
+      },
+      {
+        "affiliation": "Zurich U.",
+        "inspireid": "INSPIRE-00129260",
+        "name": "Straumann, Ulrich"
+      },
+      {
+        "affiliation": "Wuhan U.",
+        "inspireid": "INSPIRE-00327085",
+        "name": "Sun, Liang"
+      },
+      {
+        "affiliation": "Imperial Coll., London",
+        "inspireid": "INSPIRE-00392760",
+        "name": "Sutcliffe, William"
+      },
+      {
+        "affiliation": "AGH-UST, Krakow",
+        "inspireid": "INSPIRE-00454405",
+        "name": "Swientek, Krzysztof"
+      },
+      {
+        "affiliation": "NIKHEF, Amsterdam + Vrije U., Amsterdam",
+        "inspireid": "INSPIRE-00392811",
+        "name": "Syropoulos, Vasileios"
+      },
+      {
+        "affiliation": "NCBJ, Swierk",
+        "inspireid": "INSPIRE-00259072",
+        "name": "Szczekowski, Marek"
+      },
+      {
+        "affiliation": "AGH-UST, Krakow",
+        "inspireid": "INSPIRE-00258964",
+        "name": "Szumlak, Tomasz"
+      },
+      {
+        "affiliation": "Marseille, CPPM",
+        "inspireid": "INSPIRE-00506770",
+        "name": "Tayduganov, Andrey"
+      },
+      {
+        "affiliation": "Tech. U., Dortmund (main)",
+        "inspireid": "INSPIRE-00522805",
+        "name": "Tekampe, Tobias"
+      },
+      {
+        "affiliation": "INFN, Ferrara; Ferrara U.",
+        "inspireid": "INSPIRE-00391939",
+        "name": "Tellarini, Giulia"
+      },
+      {
+        "affiliation": "CERN",
+        "inspireid": "INSPIRE-00131170",
+        "name": "Teubert, Frederic"
+      },
+      {
+        "affiliation": "CERN",
+        "inspireid": "INSPIRE-00260424",
+        "name": "Thomas, Eric"
+      },
+      {
+        "affiliation": "Imperial Coll., London",
+        "inspireid": "INSPIRE-00582792",
+        "name": "Tilley, Matthew James"
+      },
+      {
+        "affiliation": "Annecy, LAPP",
+        "inspireid": "INSPIRE-00131575",
+        "name": "Tisserand, Vincent"
+      },
+      {
+        "affiliation": "Annecy, LAPP",
+        "inspireid": "INSPIRE-00036863",
+        "name": "T'Jampens, Stephane"
+      },
+      {
+        "affiliation": "Ecole Polytechnique, Lausanne",
+        "inspireid": "INSPIRE-00260879",
+        "name": "Tobin, Mark"
+      },
+      {
+        "affiliation": "Cambridge U.",
+        "inspireid": "INSPIRE-00357337",
+        "name": "Tolk, Siim"
+      },
+      {
+        "affiliation": "INFN, Ferrara; Ferrara U.",
+        "inspireid": "INSPIRE-00392023",
+        "name": "Tomassetti, Luca"
+      },
+      {
+        "affiliation": "CERN",
+        "inspireid": "INSPIRE-00053184",
+        "name": "Tonelli, Diego"
+      },
+      {
+        "affiliation": "Syracuse U.",
+        "inspireid": "INSPIRE-00582806",
+        "name": "Toriello, Francis"
+      },
+      {
+        "affiliation": "Annecy, LAPP",
+        "inspireid": "INSPIRE-00341842",
+        "name": "Tournefier, Edwige"
+      },
+      {
+        "affiliation": "Ecole Polytechnique, Lausanne",
+        "inspireid": "INSPIRE-00040682",
+        "name": "Tourneur, Stephane"
+      },
+      {
+        "affiliation": "Ecole Polytechnique, Lausanne",
+        "inspireid": "INSPIRE-00369170",
+        "name": "Trabelsi, Karim"
+      },
+      {
+        "affiliation": "Glasgow U.",
+        "inspireid": "INSPIRE-00545600",
+        "name": "Traill, Murdo"
+      },
+      {
+        "affiliation": "Ecole Polytechnique, Lausanne",
+        "inspireid": "INSPIRE-00260665",
+        "name": "Tran, Minh T\\^am"
+      },
+      {
+        "affiliation": "Zurich U.",
+        "inspireid": "INSPIRE-00392146",
+        "name": "Tresch, Marco"
+      },
+      {
+        "affiliation": "CERN",
+        "inspireid": "INSPIRE-00454660",
+        "name": "Trisovic, Ana"
+      },
+      {
+        "affiliation": "Marseille, CPPM",
+        "inspireid": "INSPIRE-00257520",
+        "name": "Tsaregorodtsev, Andrei"
+      },
+      {
+        "affiliation": "Nikhef, Amsterdam",
+        "inspireid": "INSPIRE-00357349",
+        "name": "Tsopelas, Panagiotis"
+      },
+      {
+        "affiliation": "Cambridge U.",
+        "inspireid": "INSPIRE-00582818",
+        "name": "Tully, Alison"
+      },
+      {
+        "affiliation": "Nikhef, Amsterdam",
+        "inspireid": "INSPIRE-00258853",
+        "name": "Tuning, Niels"
+      },
+      {
+        "affiliation": "NCBJ, Swierk",
+        "inspireid": "INSPIRE-00045795",
+        "name": "Ukleja, Artur"
+      },
+      {
+        "affiliation": "Authors affiliated with an institute formerly covered by a cooperation agreement with CERN.",
+        "inspireid": "INSPIRE-00392208",
+        "name": "Ustyuzhanin, Andrey"
+      },
+      {
+        "affiliation": "Heidelberg U.",
+        "inspireid": "INSPIRE-00133105",
+        "name": "Uwer, Ulrich"
+      },
+      {
+        "affiliation": "INFN, Cagliari; Cagliari U.",
+        "inspireid": "INSPIRE-00454790",
+        "name": "Vacca, Claudia"
+      },
+      {
+        "affiliation": "INFN, Bologna; CERN",
+        "inspireid": "INSPIRE-00258091",
+        "name": "Vagnoni, Vincenzo"
+      },
+      {
+        "affiliation": "CERN",
+        "inspireid": "INSPIRE-00343831",
+        "name": "Valassi, Andrea"
+      },
+      {
+        "affiliation": "CERN",
+        "inspireid": "INSPIRE-00582822",
+        "name": "Valat, Sebastien"
+      },
+      {
+        "affiliation": "INFN, Bologna",
+        "inspireid": "INSPIRE-00258103",
+        "name": "Valenti, Giovanni"
+      },
+      {
+        "affiliation": "Nikhef, Amsterdam",
+        "inspireid": "INSPIRE-00032419",
+        "name": "van Beuzekom, Martinus"
+      },
+      {
+        "affiliation": "CERN",
+        "inspireid": "INSPIRE-00260103",
+        "name": "van Herwijnen, Eric"
+      },
+      {
+        "affiliation": "Nikhef, Amsterdam",
+        "inspireid": "INSPIRE-00296057",
+        "name": "van Leerdam, Jeroen"
+      },
+      {
+        "affiliation": "Nikhef, Amsterdam",
+        "inspireid": "INSPIRE-00260865",
+        "name": "van Tilburg, Jeroen"
+      },
+      {
+        "affiliation": "Nikhef, Amsterdam",
+        "inspireid": "INSPIRE-00545618",
+        "name": "van Veghel, Maarten"
+      },
+      {
+        "affiliation": "Frascati",
+        "inspireid": "INSPIRE-00259633",
+        "name": "Vazquez Gomez, Ricardo"
+      },
+      {
+        "affiliation": "U. Santiago de Compostela (main)",
+        "inspireid": "INSPIRE-00259816",
+        "name": "Vazquez Regueiro, Pablo"
+      },
+      {
+        "affiliation": "U. Santiago de Compostela (main)",
+        "inspireid": "INSPIRE-00392390",
+        "name": "V\\'azquez Sierra, Carlos"
+      },
+      {
+        "affiliation": "INFN, Ferrara",
+        "inspireid": "INSPIRE-00258200",
+        "name": "Vecchi, Stefania"
+      },
+      {
+        "affiliation": "Bristol U.",
+        "inspireid": "INSPIRE-00318722",
+        "name": "Velthuis, Jaap"
+      },
+      {
+        "affiliation": "INFN, Florence; U. Urbino (main)",
+        "inspireid": "INSPIRE-00258261",
+        "name": "Veltri, Michele"
+      },
+      {
+        "affiliation": "Oxford U.",
+        "inspireid": "INSPIRE-00357350",
+        "name": "Veneziano, Giovanni"
+      },
+      {
+        "affiliation": "Syracuse U.",
+        "inspireid": "INSPIRE-00582834",
+        "name": "Venkateswaran, Aravindhan"
+      },
+      {
+        "affiliation": "Clermont-Ferrand U.",
+        "inspireid": "INSPIRE-00582843",
+        "name": "Vernet, Maxime"
+      },
+      {
+        "affiliation": "Heidelberg U.",
+        "inspireid": "INSPIRE-00014030",
+        "name": "Vesterinen, Mika"
+      },
+      {
+        "affiliation": "CERN",
+        "inspireid": "INSPIRE-00454985",
+        "name": "Viana Barbosa, Joao Vitor"
+      },
+      {
+        "affiliation": "Orsay, LAL",
+        "inspireid": "INSPIRE-00257597",
+        "name": "Viaud, Benoit"
+      },
+      {
+        "affiliation": "Beijing, GUCAS",
+        "inspireid": "INSPIRE-00341866",
+        "name": "Vieira, Daniel"
+      },
+      {
+        "affiliation": "U. Santiago de Compostela (main)",
+        "inspireid": "INSPIRE-00455170",
+        "name": "Vieites Diaz, Maria"
+      },
+      {
+        "affiliation": "Rostock U.",
+        "inspireid": "INSPIRE-00582859",
+        "name": "Viemann, Harald"
+      },
+      {
+        "affiliation": "U. Barcelona (main)",
+        "inspireid": "INSPIRE-00259644",
+        "name": "Vilasis-Cardona, Xavier"
+      },
+      {
+        "affiliation": "Cambridge U.",
+        "inspireid": "INSPIRE-00582862",
+        "name": "Vitti, Marcela"
+      },
+      {
+        "affiliation": "Zurich U.",
+        "inspireid": "INSPIRE-00260888",
+        "name": "Vollhardt, Achim"
+      },
+      {
+        "affiliation": "CERN",
+        "inspireid": "INSPIRE-00582871",
+        "name": "Voneki, Balazs"
+      },
+      {
+        "affiliation": "Authors affiliated with an institute formerly covered by a cooperation agreement with CERN.",
+        "inspireid": "INSPIRE-00312898",
+        "name": "Vorobyev, Alexey"
+      },
+      {
+        "affiliation": "Authors affiliated with an institute formerly covered by a cooperation agreement with CERN.",
+        "inspireid": "INSPIRE-00341883",
+        "name": "Vorobyev, Vitaly"
+      },
+      {
+        "affiliation": "Authors affiliated with an institute formerly covered by a cooperation agreement with CERN.",
+        "name": "Voropaev, Nikolai"
+      },
+      {
+        "affiliation": "Aachen, Tech. Hochsch.",
+        "inspireid": "INSPIRE-00000638",
+        "name": "Vo\\ss, Christian"
+      },
+      {
+        "affiliation": "Rostock U.",
+        "inspireid": "INSPIRE-00134615",
+        "name": "Waldi, Roland"
+      },
+      {
+        "affiliation": "Warwick U.",
+        "inspireid": "INSPIRE-00384763",
+        "name": "Wallace, Charlotte"
+      },
+      {
+        "affiliation": "University Coll., Dublin",
+        "inspireid": "INSPIRE-00357370",
+        "name": "Wallace, Ronan"
+      },
+      {
+        "affiliation": "INFN, Pisa",
+        "inspireid": "INSPIRE-00134726",
+        "name": "Walsh, John"
+      },
+      {
+        "affiliation": "Syracuse U.",
+        "inspireid": "INSPIRE-00262940",
+        "name": "Wang, Jianchun"
+      },
+      {
+        "affiliation": "Cambridge U.",
+        "inspireid": "INSPIRE-00144738",
+        "name": "Ward, David"
+      },
+      {
+        "affiliation": "Liverpool U.",
+        "inspireid": "INSPIRE-00582888",
+        "name": "Wark, Heather Mckenzie"
+      },
+      {
+        "affiliation": "Birmingham U.",
+        "inspireid": "INSPIRE-00146172",
+        "name": "Watson, Nigel"
+      },
+      {
+        "affiliation": "Imperial Coll., London",
+        "inspireid": "INSPIRE-00135220",
+        "name": "Websdale, David"
+      },
+      {
+        "affiliation": "Zurich U.",
+        "inspireid": "INSPIRE-00522810",
+        "name": "Weiden, Andreas"
+      },
+      {
+        "affiliation": "CERN",
+        "inspireid": "INSPIRE-00261160",
+        "name": "Whitehead, Mark"
+      },
+      {
+        "affiliation": "Warwick U.",
+        "inspireid": "INSPIRE-00341892",
+        "name": "Wicht, Jean"
+      },
+      {
+        "affiliation": "Oxford U.; CERN",
+        "inspireid": "INSPIRE-00262885",
+        "name": "Wilkinson, Guy"
+      },
+      {
+        "affiliation": "Syracuse U.",
+        "inspireid": "INSPIRE-00452781",
+        "name": "Wilkinson, Michael K."
+      },
+      {
+        "affiliation": "MIT",
+        "inspireid": "INSPIRE-00342010",
+        "name": "Williams, Mike"
+      },
+      {
+        "affiliation": "Birmingham U.",
+        "inspireid": "INSPIRE-00261177",
+        "name": "Williams, Matthew"
+      },
+      {
+        "affiliation": "CERN",
+        "inspireid": "INSPIRE-00136085",
+        "name": "Williams, Mark Richard James"
+      },
+      {
+        "affiliation": "Birmingham U.",
+        "inspireid": "INSPIRE-00537010",
+        "name": "Williams, Timothy"
+      },
+      {
+        "affiliation": "Rutherford",
+        "inspireid": "INSPIRE-00136130",
+        "name": "Wilson, Fergus"
+      },
+      {
+        "affiliation": "Maryland U., College Park",
+        "inspireid": "INSPIRE-00392586",
+        "name": "Wimberley, Jack"
+      },
+      {
+        "affiliation": "Orsay, LAL",
+        "name": "Winn, Michael Andreas"
+      },
+      {
+        "affiliation": "Tech. U., Dortmund (main)",
+        "inspireid": "INSPIRE-00257673",
+        "name": "Wishahi, Julian"
+      },
+      {
+        "affiliation": "NCBJ, Swierk",
+        "inspireid": "INSPIRE-00136336",
+        "name": "Wislicki, Wojciech"
+      },
+      {
+        "affiliation": "Cracow, INP",
+        "inspireid": "INSPIRE-00258926",
+        "name": "Witek, Mariusz"
+      },
+      {
+        "affiliation": "Orsay, LAL",
+        "inspireid": "INSPIRE-00136673",
+        "name": "Wormser, Guy"
+      },
+      {
+        "affiliation": "Cambridge U.",
+        "inspireid": "INSPIRE-00261140",
+        "name": "Wotton, Stephen"
+      },
+      {
+        "affiliation": "Glasgow U.",
+        "inspireid": "INSPIRE-00160280",
+        "name": "Wraight, Kenneth"
+      },
+      {
+        "affiliation": "CERN",
+        "inspireid": "INSPIRE-00260456",
+        "name": "Wyllie, Kenneth"
+      },
+      {
+        "affiliation": "CCNU, Wuhan, Inst. Part. Phys.",
+        "inspireid": "INSPIRE-00025656",
+        "name": "Xie, Yuehong"
+      },
+      {
+        "affiliation": "Annecy, LAPP",
+        "inspireid": "INSPIRE-00455305",
+        "name": "Xu, Zhirui"
+      },
+      {
+        "affiliation": "Tsinghua U., Beijing, CHEP",
+        "inspireid": "INSPIRE-00257282",
+        "name": "Yang, Zhenwei"
+      },
+      {
+        "affiliation": "Syracuse U.",
+        "inspireid": "INSPIRE-00582891",
+        "name": "Yao, Yuezhe"
+      },
+      {
+        "affiliation": "CCNU, Wuhan, Inst. Part. Phys.",
+        "inspireid": "INSPIRE-00038031",
+        "name": "Yin, Hang"
+      },
+      {
+        "affiliation": "CCNU, Wuhan, Inst. Part. Phys.; Hunan U.",
+        "inspireid": "INSPIRE-00447456",
+        "name": "Yu, Jiesheng"
+      },
+      {
+        "affiliation": "Authors affiliated with an institute formerly covered by a cooperation agreement with CERN.",
+        "inspireid": "INSPIRE-00341946",
+        "name": "Yuan, Xuhao"
+      },
+      {
+        "affiliation": "Authors affiliated with an institute formerly covered by a cooperation agreement with CERN.",
+        "inspireid": "INSPIRE-00200283",
+        "name": "Yushchenko, Oleg"
+      },
+      {
+        "affiliation": "Birmingham U.",
+        "inspireid": "INSPIRE-00582900",
+        "name": "Zarebski, Kristian Alexander"
+      },
+      {
+        "affiliation": "Heidelberg, Max Planck Inst.; Authors affiliated with an institute formerly covered by a cooperation agreement with CERN.",
+        "inspireid": "INSPIRE-00357381",
+        "name": "Zavertyaev, Mikhail"
+      },
+      {
+        "affiliation": "Tsinghua U., Beijing, CHEP",
+        "inspireid": "INSPIRE-00043581",
+        "name": "Zhang, Liming"
+      },
+      {
+        "affiliation": "Orsay, LAL",
+        "inspireid": "INSPIRE-00257306",
+        "name": "Zhang, Yanxi"
+      },
+      {
+        "affiliation": "Heidelberg U.",
+        "inspireid": "INSPIRE-00217483",
+        "name": "Zhelezov, Alexey"
+      },
+      {
+        "affiliation": "Beijing, GUCAS",
+        "inspireid": "INSPIRE-00138380",
+        "name": "Zheng, Yangheng"
+      },
+      {
+        "affiliation": "Tsinghua U., Beijing, CHEP",
+        "inspireid": "INSPIRE-00183811",
+        "name": "Zhu, Xianglei"
+      },
+      {
+        "affiliation": "Authors affiliated with an institute formerly covered by a cooperation agreement with CERN.",
+        "inspireid": "INSPIRE-00170284",
+        "name": "Zhukov, Valery"
+      },
+      {
+        "affiliation": "INFN, Bologna; Bologna U.",
+        "inspireid": "INSPIRE-00040570",
+        "name": "Zucchelli, Stefano"
+      }
+    ],
+    "collaboration": {
+      "name": "LHCb collaboration"
+    },
+    "collections": [
+      "Author-Lists"
+    ],
+    "date_created": [
+      "2016"
+    ],
+    "date_published": "2026",
+    "experiment": [
+      "LHCb"
+    ],
+    "publisher": "CERN Open Data Portal",
+    "recid": "458",
+    "title": "LHCb author list for the LHCb 2016 open data release",
+    "type": {
+      "primary": "Documentation",
+      "secondary": [
+        "Authors"
+      ]
+    }
+  }
+]

--- a/data/records/lhcb-author-list-2017.json
+++ b/data/records/lhcb-author-list-2017.json
@@ -1,0 +1,3927 @@
+[
+  {
+    "authors": [
+      {
+        "affiliation": "CERN",
+        "inspireid": "INSPIRE-00258707",
+        "name": "Aaij, Roel"
+      },
+      {
+        "affiliation": "U. Santiago de Compostela (main)",
+        "inspireid": "INSPIRE-00194077",
+        "name": "Adeva, Bernardo"
+      },
+      {
+        "affiliation": "Bristol U.",
+        "inspireid": "INSPIRE-00060950",
+        "name": "Adinolfi, Marco"
+      },
+      {
+        "affiliation": "Clermont-Ferrand U.",
+        "inspireid": "INSPIRE-00061185",
+        "name": "Ajaltouni, Ziad"
+      },
+      {
+        "affiliation": "Cincinnati U.",
+        "inspireid": "INSPIRE-00277451",
+        "name": "Akar, Simon"
+      },
+      {
+        "affiliation": "Rio de Janeiro Federal U.",
+        "inspireid": "INSPIRE-00055208",
+        "name": "Akiba, Kazuyoshi"
+      },
+      {
+        "affiliation": "Tech. U., Dortmund (main)",
+        "inspireid": "INSPIRE-00259834",
+        "name": "Albrecht, Johannes"
+      },
+      {
+        "affiliation": "CERN",
+        "inspireid": "INSPIRE-00257446",
+        "name": "Alessio, Federico"
+      },
+      {
+        "affiliation": "Glasgow U.",
+        "inspireid": "INSPIRE-00160626",
+        "name": "Alexander, Michael"
+      },
+      {
+        "affiliation": "U. Barcelona (main)",
+        "name": "Alfonso Albero, Alejandro"
+      },
+      {
+        "affiliation": "Nikhef, Amsterdam",
+        "inspireid": "INSPIRE-00340938",
+        "name": "Ali, Suvayu"
+      },
+      {
+        "affiliation": "Authors affiliated with an institute formerly covered by a cooperation agreement with CERN.",
+        "inspireid": "INSPIRE-00061628",
+        "name": "Alkhazov, Georgy"
+      },
+      {
+        "affiliation": "Imperial Coll., London",
+        "inspireid": "INSPIRE-00259650",
+        "name": "Alvarez Cartelle, Paula"
+      },
+      {
+        "affiliation": "Cincinnati U.",
+        "inspireid": "INSPIRE-00258623",
+        "name": "Alves Jr, Antonio Augusto"
+      },
+      {
+        "affiliation": "Rio de Janeiro Federal U.",
+        "inspireid": "INSPIRE-00061842",
+        "name": "Amato, Sandra"
+      },
+      {
+        "affiliation": "INFN, Padua",
+        "inspireid": "INSPIRE-00041447",
+        "name": "Amerio, Silvia"
+      },
+      {
+        "affiliation": "Orsay, LAL",
+        "inspireid": "INSPIRE-00260470",
+        "name": "Amhis, Yasmine"
+      },
+      {
+        "affiliation": "Tsinghua U., Beijing, CHEP",
+        "inspireid": "INSPIRE-00451766",
+        "name": "An, Liupan"
+      },
+      {
+        "affiliation": "INFN, Florence",
+        "inspireid": "INSPIRE-00357120",
+        "name": "Anderlini, Lucio"
+      },
+      {
+        "affiliation": "Ecole Polytechnique, Lausanne",
+        "inspireid": "INSPIRE-00536702",
+        "name": "Andreassi, Guido"
+      },
+      {
+        "affiliation": "INFN, Ferrara; Ferrara U.",
+        "inspireid": "INSPIRE-00042608",
+        "name": "Andreotti, Mirco"
+      },
+      {
+        "affiliation": "Maryland U., College Park",
+        "inspireid": "INSPIRE-00387304",
+        "name": "Andrews, Jason"
+      },
+      {
+        "affiliation": "Manchester U.",
+        "inspireid": "INSPIRE-00193766",
+        "name": "Appleby, Robert"
+      },
+      {
+        "affiliation": "Nikhef, Amsterdam",
+        "inspireid": "INSPIRE-00340940",
+        "name": "Archilli, Flavio"
+      },
+      {
+        "affiliation": "Marseille, CPPM",
+        "inspireid": "INSPIRE-00582095",
+        "name": "Arnau Romeu, Joan"
+      },
+      {
+        "affiliation": "Authors affiliated with an institute formerly covered by a cooperation agreement with CERN.",
+        "inspireid": "INSPIRE-00320358",
+        "name": "Artamonov, Alexander"
+      },
+      {
+        "affiliation": "Syracuse U.",
+        "inspireid": "INSPIRE-00063052",
+        "name": "Artuso, Marina"
+      },
+      {
+        "affiliation": "Marseille, CPPM",
+        "inspireid": "INSPIRE-00257456",
+        "name": "Aslanides, Elie"
+      },
+      {
+        "affiliation": "Zurich U.",
+        "name": "Atzeni, Michele"
+      },
+      {
+        "affiliation": "INFN, Rome",
+        "inspireid": "INSPIRE-00258647",
+        "name": "Auriemma, Giulio"
+      },
+      {
+        "affiliation": "Manchester U.",
+        "inspireid": "INSPIRE-00582103",
+        "name": "Babuschkin, Igor"
+      },
+      {
+        "affiliation": "Heidelberg U.",
+        "inspireid": "INSPIRE-00257758",
+        "name": "Bachmann, Sebastian"
+      },
+      {
+        "affiliation": "Warwick U.",
+        "inspireid": "INSPIRE-00041629",
+        "name": "Back, John"
+      },
+      {
+        "affiliation": "U. Barcelona (main); Ramon Llull U., Barcelona",
+        "inspireid": "INSPIRE-00387629",
+        "name": "Badalov, Alexey"
+      },
+      {
+        "affiliation": "Rio de Janeiro, Pont. U. Catol.",
+        "inspireid": "INSPIRE-00357139",
+        "name": "Baesso, Clarissa"
+      },
+      {
+        "affiliation": "Imperial Coll., London",
+        "inspireid": "INSPIRE-00582112",
+        "name": "Baker, Sophie"
+      },
+      {
+        "affiliation": "Orsay, LAL; Ecole Polytechnique",
+        "inspireid": "INSPIRE-00202437",
+        "name": "Balagura, Vladislav"
+      },
+      {
+        "affiliation": "INFN, Ferrara",
+        "inspireid": "INSPIRE-00210350",
+        "name": "Baldini, Wander"
+      },
+      {
+        "affiliation": "Authors affiliated with an institute formerly covered by a cooperation agreement with CERN.",
+        "name": "Baranov, Alexander"
+      },
+      {
+        "affiliation": "Manchester U.",
+        "inspireid": "INSPIRE-00064590",
+        "name": "Barlow, Roger"
+      },
+      {
+        "affiliation": "CERN",
+        "inspireid": "INSPIRE-00295950",
+        "name": "Barschel, Colin"
+      },
+      {
+        "affiliation": "Orsay, LAL",
+        "inspireid": "INSPIRE-00257536",
+        "name": "Barsuk, Sergey"
+      },
+      {
+        "affiliation": "Manchester U.",
+        "inspireid": "INSPIRE-00340962",
+        "name": "Barter, William"
+      },
+      {
+        "affiliation": "Authors affiliated with an institute formerly covered by a cooperation agreement with CERN.",
+        "name": "Baryshnikov, Fedor"
+      },
+      {
+        "affiliation": "NCBJ, Swierk",
+        "inspireid": "INSPIRE-00387971",
+        "name": "Batozskaya, Varvara"
+      },
+      {
+        "affiliation": "Ecole Polytechnique, Lausanne",
+        "inspireid": "INSPIRE-00451956",
+        "name": "Battista, Vincenzo"
+      },
+      {
+        "affiliation": "Ecole Polytechnique, Lausanne",
+        "inspireid": "INSPIRE-00065250",
+        "name": "Bay, Aurelio"
+      },
+      {
+        "affiliation": "Glasgow U.",
+        "inspireid": "INSPIRE-00340975",
+        "name": "Beddow, John"
+      },
+      {
+        "affiliation": "INFN, Pisa",
+        "inspireid": "INSPIRE-00065532",
+        "name": "Bedeschi, Franco"
+      },
+      {
+        "affiliation": "Rio de Janeiro, CBPF",
+        "inspireid": "INSPIRE-00065546",
+        "name": "Bediaga, Ignacio"
+      },
+      {
+        "affiliation": "Syracuse U.",
+        "name": "Beiter, Andrew"
+      },
+      {
+        "affiliation": "Nikhef, Amsterdam",
+        "inspireid": "INSPIRE-00522548",
+        "name": "Bel, Lennaert"
+      },
+      {
+        "affiliation": "Beijing, GUCAS",
+        "name": "Beliy, Nikita"
+      },
+      {
+        "affiliation": "Ecole Polytechnique, Lausanne",
+        "inspireid": "INSPIRE-00536729",
+        "name": "Bellee, Violaine"
+      },
+      {
+        "affiliation": "INFN, Milan Bicocca; Milan Bicocca U.",
+        "inspireid": "INSPIRE-00536743",
+        "name": "Belloli, Nicoletta"
+      },
+      {
+        "affiliation": "Authors affiliated with an institute formerly covered by a cooperation agreement with CERN.",
+        "inspireid": "INSPIRE-00259437",
+        "name": "Belous, Konstantin"
+      },
+      {
+        "affiliation": "Authors affiliated with an institute formerly covered by a cooperation agreement with CERN.; CERN",
+        "inspireid": "INSPIRE-00258730",
+        "name": "Belyaev, Ivan"
+      },
+      {
+        "affiliation": "Frascati",
+        "inspireid": "INSPIRE-00258283",
+        "name": "Bencivenni, Giovanni"
+      },
+      {
+        "affiliation": "Paris U., VI-VII",
+        "inspireid": "INSPIRE-00052383",
+        "name": "Ben-Haim, Eli"
+      },
+      {
+        "affiliation": "Nikhef, Amsterdam",
+        "inspireid": "INSPIRE-00341004",
+        "name": "Benson, Sean"
+      },
+      {
+        "affiliation": "Aachen, Tech. Hochsch.",
+        "name": "Beranek, Sarah"
+      },
+      {
+        "affiliation": "Authors affiliated with an institute formerly covered by a cooperation agreement with CERN.",
+        "inspireid": "INSPIRE-00202631",
+        "name": "Berezhnoy, Alexander"
+      },
+      {
+        "affiliation": "Zurich U.",
+        "inspireid": "INSPIRE-00066526",
+        "name": "Bernet, Roland"
+      },
+      {
+        "affiliation": "Heidelberg U.",
+        "name": "Berninghoff, Daniel"
+      },
+      {
+        "affiliation": "Syracuse U.",
+        "name": "Bernstein, Harris Conan"
+      },
+      {
+        "affiliation": "Paris U., VI-VII",
+        "name": "Bertholet, Emilie"
+      },
+      {
+        "affiliation": "INFN, Padua",
+        "inspireid": "INSPIRE-00173823",
+        "name": "Bertolin, Alessandro"
+      },
+      {
+        "affiliation": "Zurich U.",
+        "inspireid": "INSPIRE-00362040",
+        "name": "Betancourt, Christopher"
+      },
+      {
+        "affiliation": "INFN, Bologna",
+        "inspireid": "INSPIRE-00582132",
+        "name": "Betti, Federico"
+      },
+      {
+        "affiliation": "CERN",
+        "inspireid": "INSPIRE-00001810",
+        "name": "Bettler, Marc-Olivier"
+      },
+      {
+        "affiliation": "Zurich U.",
+        "inspireid": "INSPIRE-00582143",
+        "name": "Bezshyiko, Iaroslava"
+      },
+      {
+        "affiliation": "Birmingham U.",
+        "inspireid": "INSPIRE-00000685",
+        "name": "Bifani, Simone"
+      },
+      {
+        "affiliation": "Paris U., VI-VII",
+        "inspireid": "INSPIRE-00067095",
+        "name": "Billoir, Pierre"
+      },
+      {
+        "affiliation": "Tech. U., Dortmund (main)",
+        "inspireid": "INSPIRE-00522660",
+        "name": "Birnkraut, Alex"
+      },
+      {
+        "affiliation": "INFN, Florence; U. Modena (main)",
+        "inspireid": "INSPIRE-00258210",
+        "name": "Bizzeti, Andrea"
+      },
+      {
+        "affiliation": "Oxford U.",
+        "name": "Bj\\orn, Mikkel"
+      },
+      {
+        "affiliation": "Warwick U.",
+        "inspireid": "INSPIRE-00261950",
+        "name": "Blake, Thomas"
+      },
+      {
+        "affiliation": "Ecole Polytechnique, Lausanne",
+        "inspireid": "INSPIRE-00067348",
+        "name": "Blanc, Frederic"
+      },
+      {
+        "affiliation": "Syracuse U.",
+        "inspireid": "INSPIRE-00067685",
+        "name": "Blusk, Steven"
+      },
+      {
+        "affiliation": "INFN, Rome",
+        "inspireid": "INSPIRE-00067707",
+        "name": "Bocci, Valerio"
+      },
+      {
+        "affiliation": "MIT",
+        "inspireid": "INSPIRE-00582163",
+        "name": "Boettcher, Thomas"
+      },
+      {
+        "affiliation": "Authors affiliated with an institute formerly covered by a cooperation agreement with CERN.",
+        "inspireid": "INSPIRE-00259423",
+        "name": "Bondar, Alexander"
+      },
+      {
+        "affiliation": "Authors affiliated with an institute formerly covered by a cooperation agreement with CERN.",
+        "inspireid": "INSPIRE-00317412",
+        "name": "Bondar, Nikolay"
+      },
+      {
+        "affiliation": "Manchester U.; CERN",
+        "inspireid": "INSPIRE-00261856",
+        "name": "Borghi, Silvia"
+      },
+      {
+        "affiliation": "Authors affiliated with an institute formerly covered by a cooperation agreement with CERN.",
+        "inspireid": "INSPIRE-00537084",
+        "name": "Borisyak, Maxim"
+      },
+      {
+        "affiliation": "U. Santiago de Compostela (main)",
+        "inspireid": "INSPIRE-00388228",
+        "name": "Borsato, Martino"
+      },
+      {
+        "affiliation": "Orsay, LAL",
+        "inspireid": "INSPIRE-00249614",
+        "name": "Bossu, Francesco"
+      },
+      {
+        "affiliation": "Aachen, Tech. Hochsch.",
+        "inspireid": "INSPIRE-00582188",
+        "name": "Boubdir, Meriem"
+      },
+      {
+        "affiliation": "Liverpool U.",
+        "inspireid": "INSPIRE-00068684",
+        "name": "Bowcock, Themistocles"
+      },
+      {
+        "affiliation": "Zurich U.",
+        "inspireid": "INSPIRE-00388407",
+        "name": "Bowen, Espen Eie"
+      },
+      {
+        "affiliation": "INFN, Ferrara; CERN",
+        "inspireid": "INSPIRE-00068846",
+        "name": "Bozzi, Concezio"
+      },
+      {
+        "affiliation": "Heidelberg U.",
+        "inspireid": "INSPIRE-00470092",
+        "name": "Braun, Svende"
+      },
+      {
+        "affiliation": "CERN",
+        "name": "Brodski, Michael"
+      },
+      {
+        "affiliation": "Cracow, INP",
+        "inspireid": "INSPIRE-00369499",
+        "name": "Brodzicka, Jolanta"
+      },
+      {
+        "affiliation": "INFN, Cagliari",
+        "name": "Brundu, Davide"
+      },
+      {
+        "affiliation": "Bristol U.",
+        "inspireid": "INSPIRE-00536755",
+        "name": "Buchanan, Emma"
+      },
+      {
+        "affiliation": "Manchester U.",
+        "inspireid": "INSPIRE-00545500",
+        "name": "Burr, Christopher"
+      },
+      {
+        "affiliation": "INFN, Cagliari; Cagliari U.",
+        "inspireid": "INSPIRE-00260792",
+        "name": "Bursche, Albert"
+      },
+      {
+        "affiliation": "CERN",
+        "inspireid": "INSPIRE-00259860",
+        "name": "Buytaert, Jan"
+      },
+      {
+        "affiliation": "CERN",
+        "name": "Byczynski, Wiktor"
+      },
+      {
+        "affiliation": "INFN, Cagliari",
+        "inspireid": "INSPIRE-00258132",
+        "name": "Cadeddu, Sandro"
+      },
+      {
+        "affiliation": "Wuhan U.",
+        "name": "Cai, Hao"
+      },
+      {
+        "affiliation": "INFN, Ferrara; Ferrara U.",
+        "inspireid": "INSPIRE-00070550",
+        "name": "Calabrese, Roberto"
+      },
+      {
+        "affiliation": "Birmingham U.",
+        "name": "Calladine, Ryan"
+      },
+      {
+        "affiliation": "INFN, Milan Bicocca; Milan Bicocca U.",
+        "inspireid": "INSPIRE-00258504",
+        "name": "Calvi, Marta"
+      },
+      {
+        "affiliation": "U. Barcelona (main); Ramon Llull U., Barcelona",
+        "inspireid": "INSPIRE-00259475",
+        "name": "Calvo Gomez, Miriam"
+      },
+      {
+        "affiliation": "U. Barcelona (main); Ramon Llull U., Barcelona",
+        "inspireid": "INSPIRE-00259480",
+        "name": "Camboni, Alessandro"
+      },
+      {
+        "affiliation": "Frascati",
+        "inspireid": "INSPIRE-00258299",
+        "name": "Campana, Pierluigi"
+      },
+      {
+        "affiliation": "CERN",
+        "inspireid": "INSPIRE-00388548",
+        "name": "Campora Perez, Daniel Hugo"
+      },
+      {
+        "affiliation": "Manchester U.",
+        "inspireid": "INSPIRE-00452150",
+        "name": "Capriotti, Lorenzo"
+      },
+      {
+        "affiliation": "INFN, Bologna; Bologna U.",
+        "inspireid": "INSPIRE-00258058",
+        "name": "Carbone, Angelo"
+      },
+      {
+        "affiliation": "Rome U., Tor Vergata",
+        "inspireid": "INSPIRE-00258566",
+        "name": "Carboni, Giovanni"
+      },
+      {
+        "affiliation": "INFN, Genoa; Genoa U.",
+        "inspireid": "INSPIRE-00259930",
+        "name": "Cardinale, Roberta"
+      },
+      {
+        "affiliation": "INFN, Cagliari",
+        "inspireid": "INSPIRE-00071030",
+        "name": "Cardini, Alessandro"
+      },
+      {
+        "affiliation": "INFN, Milan Bicocca; Milan Bicocca U.",
+        "inspireid": "INSPIRE-00452332",
+        "name": "Carniti, Paolo"
+      },
+      {
+        "affiliation": "Edinburgh U.",
+        "inspireid": "INSPIRE-00160267",
+        "name": "Carson, Laurence"
+      },
+      {
+        "affiliation": "Liverpool U.",
+        "inspireid": "INSPIRE-00071483",
+        "name": "Casse, Gianluigi"
+      },
+      {
+        "affiliation": "INFN, Milan Bicocca",
+        "inspireid": "INSPIRE-00399968",
+        "name": "Cassina, Lorenzo"
+      },
+      {
+        "affiliation": "CERN",
+        "inspireid": "INSPIRE-00071656",
+        "name": "Cattaneo, Marco"
+      },
+      {
+        "affiliation": "INFN, Genoa; CERN; Genoa U.",
+        "inspireid": "INSPIRE-00452703",
+        "name": "Cavallero, Giovanni"
+      },
+      {
+        "affiliation": "INFN, Pisa; Pisa, Scuola Normale Superiore",
+        "inspireid": "INSPIRE-00041990",
+        "name": "Cenci, Riccardo"
+      },
+      {
+        "affiliation": "Bristol U.",
+        "name": "Chapman, Matthew George"
+      },
+      {
+        "affiliation": "Paris U., VI-VII",
+        "inspireid": "INSPIRE-00054561",
+        "name": "Charles, Matthew"
+      },
+      {
+        "affiliation": "CERN",
+        "inspireid": "INSPIRE-00259892",
+        "name": "Charpentier, Philippe"
+      },
+      {
+        "affiliation": "Birmingham U.",
+        "inspireid": "INSPIRE-00582193",
+        "name": "Chatzikonstantinidis, Georgios"
+      },
+      {
+        "affiliation": "Annecy, LAPP",
+        "inspireid": "INSPIRE-02701689",
+        "name": "Chefdeville, Maximilien"
+      },
+      {
+        "affiliation": "INFN, Cagliari",
+        "inspireid": "INSPIRE-00400187",
+        "name": "Chen, Shanzhen"
+      },
+      {
+        "affiliation": "Oxford U.",
+        "inspireid": "INSPIRE-00388653",
+        "name": "Cheung, Shu Faye"
+      },
+      {
+        "affiliation": "CERN",
+        "name": "Chitic, Stefan-Gabriel"
+      },
+      {
+        "affiliation": "U. Santiago de Compostela (main)",
+        "inspireid": "INSPIRE-00369648",
+        "name": "Chobanova, Veronika"
+      },
+      {
+        "affiliation": "CERN",
+        "inspireid": "INSPIRE-00344777",
+        "name": "Chrzaszcz, Marcin"
+      },
+      {
+        "affiliation": "Authors affiliated with an institute formerly covered by a cooperation agreement with CERN.",
+        "name": "Chubykin, Aleksei"
+      },
+      {
+        "affiliation": "Frascati",
+        "name": "Ciambrone, Paolo"
+      },
+      {
+        "affiliation": "U. Santiago de Compostela (main)",
+        "inspireid": "INSPIRE-00259661",
+        "name": "Cid Vidal, Xabier"
+      },
+      {
+        "affiliation": "CERN",
+        "inspireid": "INSPIRE-00344785",
+        "name": "Ciezarek, Gregory"
+      },
+      {
+        "affiliation": "Edinburgh U.",
+        "inspireid": "INSPIRE-00073694",
+        "name": "Clarke, Peter"
+      },
+      {
+        "affiliation": "CERN",
+        "inspireid": "INSPIRE-00021864",
+        "name": "Clemencic, Marco"
+      },
+      {
+        "affiliation": "Cambridge U.",
+        "inspireid": "INSPIRE-00261009",
+        "name": "Cliff, Harry"
+      },
+      {
+        "affiliation": "CERN",
+        "inspireid": "INSPIRE-00259955",
+        "name": "Closier, Joel"
+      },
+      {
+        "affiliation": "CERN",
+        "inspireid": "INSPIRE-00262900",
+        "name": "Coco, Victor"
+      },
+      {
+        "affiliation": "Marseille, CPPM",
+        "inspireid": "INSPIRE-00257463",
+        "name": "Cogan, Julien"
+      },
+      {
+        "affiliation": "Clermont-Ferrand U.",
+        "inspireid": "INSPIRE-00305695",
+        "name": "Cogneras, Eric"
+      },
+      {
+        "affiliation": "INFN, Cagliari; Cagliari U.",
+        "inspireid": "INSPIRE-00452873",
+        "name": "Cogoni, Violetta"
+      },
+      {
+        "affiliation": "Bucharest, IFIN-HH",
+        "inspireid": "INSPIRE-00453049",
+        "name": "Cojocariu, Lucian"
+      },
+      {
+        "affiliation": "CERN",
+        "inspireid": "INSPIRE-00259967",
+        "name": "Collins, Paula"
+      },
+      {
+        "affiliation": "CERN",
+        "name": "Colombo, Tommaso"
+      },
+      {
+        "affiliation": "Heidelberg U.",
+        "inspireid": "INSPIRE-00259490",
+        "name": "Comerma-Montells, Albert"
+      },
+      {
+        "affiliation": "INFN, Cagliari",
+        "inspireid": "INSPIRE-00262791",
+        "name": "Contu, Andrea"
+      },
+      {
+        "affiliation": "CERN",
+        "name": "Coombs, George"
+      },
+      {
+        "affiliation": "U. Barcelona (main)",
+        "inspireid": "INSPIRE-00388698",
+        "name": "Coquereau, Samuel"
+      },
+      {
+        "affiliation": "CERN",
+        "inspireid": "INSPIRE-00259985",
+        "name": "Corti, Gloria"
+      },
+      {
+        "affiliation": "INFN, Ferrara; Ferrara U.",
+        "inspireid": "INSPIRE-00453205",
+        "name": "Corvo, Marco"
+      },
+      {
+        "affiliation": "Warwick U.",
+        "inspireid": "INSPIRE-00582238",
+        "name": "Costa Sobral, Cayo Mar"
+      },
+      {
+        "affiliation": "CERN",
+        "inspireid": "INSPIRE-00345186",
+        "name": "Couturier, Benjamin"
+      },
+      {
+        "affiliation": "Edinburgh U.",
+        "inspireid": "INSPIRE-00261246",
+        "name": "Cowan, Greig"
+      },
+      {
+        "affiliation": "MIT",
+        "inspireid": "INSPIRE-00357145",
+        "name": "Craik, Daniel Charles"
+      },
+      {
+        "affiliation": "Warwick U.",
+        "inspireid": "INSPIRE-00453257",
+        "name": "Crocombe, Andrew"
+      },
+      {
+        "affiliation": "Rio de Janeiro, CBPF",
+        "inspireid": "INSPIRE-00388812",
+        "name": "Cruz Torres, Melissa Maria"
+      },
+      {
+        "affiliation": "Edinburgh U.",
+        "inspireid": "INSPIRE-00261251",
+        "name": "Currie, Robert"
+      },
+      {
+        "affiliation": "Rio de Janeiro Federal U.",
+        "inspireid": "INSPIRE-00175941",
+        "name": "Da Cunha Marinho, Franciole"
+      },
+      {
+        "affiliation": "Los Alamos",
+        "name": "Da Silva, Cesar Luiz"
+      },
+      {
+        "affiliation": "Nikhef, Amsterdam",
+        "name": "Dall'Occo, Elena"
+      },
+      {
+        "affiliation": "Bristol U.",
+        "inspireid": "INSPIRE-00043651",
+        "name": "Dalseno, Jeremy"
+      },
+      {
+        "affiliation": "CERN",
+        "inspireid": "INSPIRE-00207542",
+        "name": "D'Ambrosio, Carmelo"
+      },
+      {
+        "affiliation": "Heidelberg U.",
+        "inspireid": "INSPIRE-00522530",
+        "name": "d'Argent, Philippe"
+      },
+      {
+        "affiliation": "Tsinghua U., Beijing, CHEP",
+        "inspireid": "INSPIRE-00389020",
+        "name": "Davis, Adam"
+      },
+      {
+        "affiliation": "CERN",
+        "inspireid": "INSPIRE-00341212",
+        "name": "De Aguiar Francisco, Oscar"
+      },
+      {
+        "affiliation": "CERN",
+        "inspireid": "INSPIRE-00341032",
+        "name": "De Bruyn, Kristof"
+      },
+      {
+        "affiliation": "Manchester U.",
+        "inspireid": "INSPIRE-00258572",
+        "name": "De Capua, Stefano"
+      },
+      {
+        "affiliation": "Heidelberg U.",
+        "inspireid": "INSPIRE-00260810",
+        "name": "De Cian, Michel"
+      },
+      {
+        "affiliation": "Rio de Janeiro, CBPF",
+        "inspireid": "INSPIRE-00107943",
+        "name": "De Miranda, Jussara"
+      },
+      {
+        "affiliation": "Rio de Janeiro Federal U.",
+        "inspireid": "INSPIRE-00115169",
+        "name": "De Paula, Leandro"
+      },
+      {
+        "affiliation": "INFN, Bari; Bari U.",
+        "inspireid": "INSPIRE-00532670",
+        "name": "De Serio, Marilisa"
+      },
+      {
+        "affiliation": "Frascati",
+        "inspireid": "INSPIRE-00258414",
+        "name": "De Simone, Patrizia"
+      },
+      {
+        "affiliation": "Nikhef, Amsterdam",
+        "inspireid": "INSPIRE-00400290",
+        "name": "de Vries, Jacco"
+      },
+      {
+        "affiliation": "Glasgow U.",
+        "inspireid": "INSPIRE-00453317",
+        "name": "Dean, Cameron Thomas"
+      },
+      {
+        "affiliation": "Annecy, LAPP",
+        "inspireid": "INSPIRE-00257320",
+        "name": "Decamp, Daniel"
+      },
+      {
+        "affiliation": "Paris U., VI-VII",
+        "inspireid": "INSPIRE-00070041",
+        "name": "Del Buono, Luigi"
+      },
+      {
+        "affiliation": "Cambridge U.",
+        "name": "Delaney, Blaise"
+      },
+      {
+        "affiliation": "Heidelberg, Max Planck Inst.",
+        "name": "Dembinski, Hans Peter"
+      },
+      {
+        "affiliation": "Tech. U., Dortmund (main)",
+        "inspireid": "INSPIRE-00536774",
+        "name": "Demmer, Moritz"
+      },
+      {
+        "affiliation": "AGH-UST, Krakow",
+        "inspireid": "INSPIRE-00582240",
+        "name": "Dendek, Adam"
+      },
+      {
+        "affiliation": "Authors affiliated with an institute formerly covered by a cooperation agreement with CERN.",
+        "inspireid": "INSPIRE-00144686",
+        "name": "Derkach, Denis"
+      },
+      {
+        "affiliation": "Clermont-Ferrand U.",
+        "inspireid": "INSPIRE-00257367",
+        "name": "Deschamps, Olivier"
+      },
+      {
+        "affiliation": "Liverpool U.",
+        "inspireid": "INSPIRE-00258140",
+        "name": "Dettori, Francesco"
+      },
+      {
+        "affiliation": "CCNU, Wuhan, Inst. Part. Phys.",
+        "inspireid": "INSPIRE-00266843",
+        "name": "Dey, Biplab"
+      },
+      {
+        "affiliation": "CERN",
+        "inspireid": "INSPIRE-00010940",
+        "name": "Di Canto, Angelo"
+      },
+      {
+        "affiliation": "Frascati",
+        "name": "Di Nezza, Pasquale"
+      },
+      {
+        "affiliation": "CERN",
+        "inspireid": "INSPIRE-00260011",
+        "name": "Dijkstra, Hans"
+      },
+      {
+        "affiliation": "CERN",
+        "inspireid": "INSPIRE-00341074",
+        "name": "Dordei, Francesca"
+      },
+      {
+        "affiliation": "CERN",
+        "inspireid": "INSPIRE-00000328",
+        "name": "Dorigo, Mirco"
+      },
+      {
+        "affiliation": "Rio de Janeiro, CBPF",
+        "inspireid": "INSPIRE-00257176",
+        "name": "dos Reis, Alberto"
+      },
+      {
+        "affiliation": "U. Santiago de Compostela (main)",
+        "inspireid": "INSPIRE-00341088",
+        "name": "Dosil Su\\'arez, Alvaro"
+      },
+      {
+        "affiliation": "Glasgow U.",
+        "name": "Douglas, Lauren"
+      },
+      {
+        "affiliation": "Kharkov, KIPT",
+        "inspireid": "INSPIRE-00260913",
+        "name": "Dovbnya, Anatoliy"
+      },
+      {
+        "affiliation": "Liverpool U.",
+        "inspireid": "INSPIRE-00399892",
+        "name": "Dreimanis, Karlis"
+      },
+      {
+        "affiliation": "Nikhef, Amsterdam",
+        "inspireid": "INSPIRE-00536780",
+        "name": "Dufour, Laurent"
+      },
+      {
+        "affiliation": "Paris U., VI-VII",
+        "inspireid": "INSPIRE-00400045",
+        "name": "Dujany, Giulio"
+      },
+      {
+        "affiliation": "CERN",
+        "inspireid": "INSPIRE-00389556",
+        "name": "Durante, Paolo"
+      },
+      {
+        "affiliation": "Los Alamos",
+        "name": "Durham, John Matthew"
+      },
+      {
+        "affiliation": "Manchester U.",
+        "name": "Dutta, Deepanwita"
+      },
+      {
+        "affiliation": "Authors affiliated with an institute formerly covered by a cooperation agreement with CERN.",
+        "inspireid": "INSPIRE-00077380",
+        "name": "Dzhelyadin, Rustem"
+      },
+      {
+        "affiliation": "Heidelberg U.",
+        "name": "Dziewiecki, Michal"
+      },
+      {
+        "affiliation": "CERN",
+        "inspireid": "INSPIRE-00341115",
+        "name": "Dziurda, Agnieszka"
+      },
+      {
+        "affiliation": "Authors affiliated with an institute formerly covered by a cooperation agreement with CERN.",
+        "inspireid": "INSPIRE-00341144",
+        "name": "Dzyuba, Alexey"
+      },
+      {
+        "affiliation": "Rutherford",
+        "inspireid": "INSPIRE-00078816",
+        "name": "Easo, Sajan"
+      },
+      {
+        "affiliation": "Imperial Coll., London",
+        "inspireid": "INSPIRE-00058834",
+        "name": "Egede, Ulrik"
+      },
+      {
+        "affiliation": "Authors affiliated with an institute formerly covered by a cooperation agreement with CERN.",
+        "inspireid": "INSPIRE-00259251",
+        "name": "Egorychev, Victor"
+      },
+      {
+        "affiliation": "Authors affiliated with an institute formerly covered by a cooperation agreement with CERN.",
+        "inspireid": "INSPIRE-00302446",
+        "name": "Eidelman, Semen"
+      },
+      {
+        "affiliation": "Edinburgh U.",
+        "inspireid": "INSPIRE-00079238",
+        "name": "Eisenhardt, Stephan"
+      },
+      {
+        "affiliation": "Tech. U., Dortmund (main)",
+        "inspireid": "INSPIRE-00389721",
+        "name": "Eitschberger, Ulrich"
+      },
+      {
+        "affiliation": "Tech. U., Dortmund (main)",
+        "inspireid": "INSPIRE-00341158",
+        "name": "Ekelhof, Robert"
+      },
+      {
+        "affiliation": "Glasgow U.",
+        "inspireid": "INSPIRE-00015467",
+        "name": "Eklund, Lars"
+      },
+      {
+        "affiliation": "Syracuse U.",
+        "inspireid": "INSPIRE-00400105",
+        "name": "Ely, Scott"
+      },
+      {
+        "affiliation": "Bucharest, IFIN-HH",
+        "name": "Ene, Alexandru"
+      },
+      {
+        "affiliation": "Aachen, Tech. Hochsch.",
+        "name": "Escher, Stephan"
+      },
+      {
+        "affiliation": "Nikhef, Amsterdam",
+        "inspireid": "INSPIRE-00238345",
+        "name": "Esen, Sevda"
+      },
+      {
+        "affiliation": "Cambridge U.",
+        "inspireid": "INSPIRE-00400160",
+        "name": "Evans, Hannah Mary"
+      },
+      {
+        "affiliation": "Oxford U.",
+        "inspireid": "INSPIRE-00452003",
+        "name": "Evans, Timothy"
+      },
+      {
+        "affiliation": "INFN, Bologna",
+        "inspireid": "INSPIRE-00296108",
+        "name": "Falabella, Antonio"
+      },
+      {
+        "affiliation": "CERN",
+        "inspireid": "INSPIRE-00257792",
+        "name": "F\\\"arber, Christian"
+      },
+      {
+        "affiliation": "Birmingham U.",
+        "inspireid": "INSPIRE-00400287",
+        "name": "Farley, Nathanael"
+      },
+      {
+        "affiliation": "Liverpool U.",
+        "inspireid": "INSPIRE-00257989",
+        "name": "Farry, Stephen"
+      },
+      {
+        "affiliation": "INFN, Milan Bicocca; Milan Bicocca U.",
+        "inspireid": "INSPIRE-00582259",
+        "name": "Fazzini, Davide"
+      },
+      {
+        "affiliation": "Rome U., Tor Vergata",
+        "name": "Federici, Luca"
+      },
+      {
+        "affiliation": "Nikhef, Amsterdam",
+        "name": "Feo, Mauricio"
+      },
+      {
+        "affiliation": "U. Barcelona (main)",
+        "name": "Fernandez, Gerard"
+      },
+      {
+        "affiliation": "CERN",
+        "name": "Fernandez Declara, Placido"
+      },
+      {
+        "affiliation": "U. Santiago de Compostela (main)",
+        "inspireid": "INSPIRE-00582260",
+        "name": "Fernandez Prieto, Antonio"
+      },
+      {
+        "affiliation": "INFN, Bologna; Bologna U.",
+        "inspireid": "INSPIRE-00522680",
+        "name": "Ferrari, Fabio"
+      },
+      {
+        "affiliation": "Ecole Polytechnique, Lausanne",
+        "name": "Ferreira Lopes, Lino"
+      },
+      {
+        "affiliation": "Rio de Janeiro Federal U.",
+        "inspireid": "INSPIRE-00257190",
+        "name": "Ferreira Rodrigues, Fernando"
+      },
+      {
+        "affiliation": "CERN",
+        "inspireid": "INSPIRE-00159865",
+        "name": "Ferro-Luzzi, Massimiliano"
+      },
+      {
+        "affiliation": "Authors affiliated with an institute formerly covered by a cooperation agreement with CERN.",
+        "inspireid": "INSPIRE-00259378",
+        "name": "Filippov, Sergey"
+      },
+      {
+        "affiliation": "INFN, Bari",
+        "inspireid": "INSPIRE-00262271",
+        "name": "Fini, Rosa Anna"
+      },
+      {
+        "affiliation": "INFN, Ferrara; Ferrara U.",
+        "inspireid": "INSPIRE-00017773",
+        "name": "Fiorini, Massimiliano"
+      },
+      {
+        "affiliation": "AGH-UST, Krakow",
+        "inspireid": "INSPIRE-00452328",
+        "name": "Firlej, Miroslaw"
+      },
+      {
+        "affiliation": "Ecole Polytechnique, Lausanne",
+        "inspireid": "INSPIRE-00261277",
+        "name": "Fitzpatrick, Conor"
+      },
+      {
+        "affiliation": "AGH-UST, Krakow",
+        "inspireid": "INSPIRE-00452523",
+        "name": "Fiutowski, Tomasz"
+      },
+      {
+        "affiliation": "Orsay, LAL; Ecole Polytechnique",
+        "inspireid": "INSPIRE-00081683",
+        "name": "Fleuret, Frederic"
+      },
+      {
+        "affiliation": "INFN, Cagliari; CERN",
+        "inspireid": "INSPIRE-00341209",
+        "name": "Fontana, Marianna"
+      },
+      {
+        "affiliation": "INFN, Genoa; Genoa U.",
+        "inspireid": "INSPIRE-00081845",
+        "name": "Fontanelli, Flavio"
+      },
+      {
+        "affiliation": "CERN",
+        "inspireid": "INSPIRE-00260047",
+        "name": "Forty, Roger"
+      },
+      {
+        "affiliation": "Liverpool U.",
+        "inspireid": "INSPIRE-00582273",
+        "name": "Franco Lima, Vinicius"
+      },
+      {
+        "affiliation": "CERN",
+        "inspireid": "INSPIRE-00260763",
+        "name": "Frank, Markus"
+      },
+      {
+        "affiliation": "CERN",
+        "inspireid": "INSPIRE-00260067",
+        "name": "Frei, Christoph"
+      },
+      {
+        "affiliation": "INFN, Milan; U. Milan (main)",
+        "inspireid": "INSPIRE-00390117",
+        "name": "Fu, Jinlin"
+      },
+      {
+        "affiliation": "CERN",
+        "inspireid": "INSPIRE-00082952",
+        "name": "Funk, Wolfgang"
+      },
+      {
+        "affiliation": "Rome U., Tor Vergata",
+        "inspireid": "INSPIRE-00390286",
+        "name": "Furfaro, Emiliano"
+      },
+      {
+        "affiliation": "Edinburgh U.",
+        "name": "Gabriel, Emmy"
+      },
+      {
+        "affiliation": "U. Santiago de Compostela (main)",
+        "inspireid": "INSPIRE-00259710",
+        "name": "Gallas Torreira, Abraham"
+      },
+      {
+        "affiliation": "INFN, Bologna; Bologna U.",
+        "inspireid": "INSPIRE-00178050",
+        "name": "Galli, Domenico"
+      },
+      {
+        "affiliation": "INFN, Padua",
+        "inspireid": "INSPIRE-00293740",
+        "name": "Gallorini, Stefano"
+      },
+      {
+        "affiliation": "Edinburgh U.",
+        "inspireid": "INSPIRE-00150884",
+        "name": "Gambetta, Silvia"
+      },
+      {
+        "affiliation": "Rio de Janeiro Federal U.",
+        "inspireid": "INSPIRE-00083458",
+        "name": "Gandelman, Miriam"
+      },
+      {
+        "affiliation": "INFN, Milan",
+        "inspireid": "INSPIRE-00262802",
+        "name": "Gandini, Paolo"
+      },
+      {
+        "affiliation": "Tsinghua U., Beijing, CHEP",
+        "inspireid": "INSPIRE-00257210",
+        "name": "Gao, Yuanning"
+      },
+      {
+        "affiliation": "Valencia U., IFIC",
+        "inspireid": "INSPIRE-00582283",
+        "name": "Garcia Martin, Luis Miguel"
+      },
+      {
+        "affiliation": "U. Santiago de Compostela (main)",
+        "inspireid": "INSPIRE-00452833",
+        "name": "Garc\\'ia Pardi\\~nas, Juli\\'an"
+      },
+      {
+        "affiliation": "Cambridge U.",
+        "inspireid": "INSPIRE-00024997",
+        "name": "Garra Tico, Jordi"
+      },
+      {
+        "affiliation": "U. Barcelona (main)",
+        "inspireid": "INSPIRE-00157725",
+        "name": "Garrido, Lluis"
+      },
+      {
+        "affiliation": "U. Barcelona (main)",
+        "inspireid": "INSPIRE-00259509",
+        "name": "Gascon, David"
+      },
+      {
+        "affiliation": "CERN",
+        "inspireid": "INSPIRE-00083907",
+        "name": "Gaspar, Clara"
+      },
+      {
+        "affiliation": "Tech. U., Dortmund (main)",
+        "inspireid": "INSPIRE-00400383",
+        "name": "Gavardi, Laura"
+      },
+      {
+        "affiliation": "Clermont-Ferrand U.",
+        "inspireid": "INSPIRE-00452964",
+        "name": "Gazzoni, Giulio"
+      },
+      {
+        "affiliation": "Heidelberg U.",
+        "inspireid": "INSPIRE-00522692",
+        "name": "Gerick, David"
+      },
+      {
+        "affiliation": "Manchester U.",
+        "inspireid": "INSPIRE-00357178",
+        "name": "Gersabeck, Evelina"
+      },
+      {
+        "affiliation": "Manchester U.",
+        "inspireid": "INSPIRE-00192519",
+        "name": "Gersabeck, Marco"
+      },
+      {
+        "affiliation": "Warwick U.",
+        "inspireid": "INSPIRE-00043636",
+        "name": "Gershon, Timothy"
+      },
+      {
+        "affiliation": "Annecy, LAPP",
+        "inspireid": "INSPIRE-00084545",
+        "name": "Ghez, Philippe"
+      },
+      {
+        "affiliation": "Ecole Polytechnique, Lausanne",
+        "inspireid": "INSPIRE-00390510",
+        "name": "Gian\\`\\i, Sebastiana"
+      },
+      {
+        "affiliation": "Cambridge U.",
+        "inspireid": "INSPIRE-00179031",
+        "name": "Gibson, Valerie"
+      },
+      {
+        "affiliation": "NCBJ, Swierk",
+        "name": "Giemza, Henryk Karol"
+      },
+      {
+        "affiliation": "Ecole Polytechnique, Lausanne",
+        "name": "Girard, Olivier G\\\"oran"
+      },
+      {
+        "affiliation": "Bucharest, IFIN-HH",
+        "inspireid": "INSPIRE-00390574",
+        "name": "Giubega, Lavinia-Helena"
+      },
+      {
+        "affiliation": "Edinburgh U.",
+        "inspireid": "INSPIRE-00582300",
+        "name": "Gizdov, Konstantin"
+      },
+      {
+        "affiliation": "Paris U., VI-VII",
+        "inspireid": "INSPIRE-00260081",
+        "name": "Gligorov, Vladimir"
+      },
+      {
+        "affiliation": "Rio de Janeiro, Pont. U. Catol.",
+        "inspireid": "INSPIRE-00262964",
+        "name": "G\\\"obel, Carla"
+      },
+      {
+        "affiliation": "U. Barcelona (main); Ramon Llull U., Barcelona",
+        "name": "Golobardes, Elisabet"
+      },
+      {
+        "affiliation": "Authors affiliated with an institute formerly covered by a cooperation agreement with CERN.",
+        "inspireid": "INSPIRE-00261070",
+        "name": "Golubkov, Dmitry"
+      },
+      {
+        "affiliation": "Imperial Coll., London; Authors affiliated with an institute formerly covered by a cooperation agreement with CERN.",
+        "inspireid": "INSPIRE-00259263",
+        "name": "Golutvin, Andrey"
+      },
+      {
+        "affiliation": "Rio de Janeiro, CBPF; Rio de Janeiro Federal U.; UFTM, Uberaba",
+        "inspireid": "INSPIRE-00257143",
+        "name": "Gomes, Alvaro"
+      },
+      {
+        "affiliation": "Authors affiliated with an institute formerly covered by a cooperation agreement with CERN.",
+        "inspireid": "INSPIRE-00048110",
+        "name": "Gorelov, Igor Vladimirovich"
+      },
+      {
+        "affiliation": "INFN, Milan Bicocca; Milan Bicocca U.",
+        "inspireid": "INSPIRE-00400552",
+        "name": "Gotti, Claudio"
+      },
+      {
+        "affiliation": "Nikhef, Amsterdam",
+        "name": "Govorkova, Ekaterina"
+      },
+      {
+        "affiliation": "Heidelberg U.",
+        "name": "Grabowski, Jascha Peter"
+      },
+      {
+        "affiliation": "U. Barcelona (main)",
+        "inspireid": "INSPIRE-00259536",
+        "name": "Graciani Diaz, Ricardo"
+      },
+      {
+        "affiliation": "CERN",
+        "inspireid": "INSPIRE-00246283",
+        "name": "Granado Cardoso, Luis Alberto"
+      },
+      {
+        "affiliation": "U. Barcelona (main)",
+        "inspireid": "INSPIRE-00086454",
+        "name": "Graug\\'es, Eugeni"
+      },
+      {
+        "affiliation": "Zurich U.",
+        "inspireid": "INSPIRE-00453214",
+        "name": "Graverini, Elena"
+      },
+      {
+        "affiliation": "INFN, Florence",
+        "inspireid": "INSPIRE-00086506",
+        "name": "Graziani, Giacomo"
+      },
+      {
+        "affiliation": "Bucharest, IFIN-HH",
+        "inspireid": "INSPIRE-00259115",
+        "name": "Grecu, Alexandru Tudor"
+      },
+      {
+        "affiliation": "Aachen, Tech. Hochsch.",
+        "name": "Greim, Roman"
+      },
+      {
+        "affiliation": "INFN, Cagliari",
+        "inspireid": "INSPIRE-00390620",
+        "name": "Griffith, Peter"
+      },
+      {
+        "affiliation": "Manchester U.",
+        "inspireid": "INSPIRE-00390672",
+        "name": "Grillo, Lucia"
+      },
+      {
+        "affiliation": "CERN",
+        "name": "Gruber, Lukas"
+      },
+      {
+        "affiliation": "Oxford U.",
+        "inspireid": "INSPIRE-00582316",
+        "name": "Gruberg Cazon, Barak Raimond"
+      },
+      {
+        "affiliation": "Rostock U.",
+        "inspireid": "INSPIRE-00264595",
+        "name": "Gr\\\"unberg, Oliver"
+      },
+      {
+        "affiliation": "Authors affiliated with an institute formerly covered by a cooperation agreement with CERN.",
+        "inspireid": "INSPIRE-00259385",
+        "name": "Gushchin, Evgeny"
+      },
+      {
+        "affiliation": "Authors affiliated with an institute formerly covered by a cooperation agreement with CERN.",
+        "inspireid": "INSPIRE-00259449",
+        "name": "Guz, Yury"
+      },
+      {
+        "affiliation": "CERN",
+        "inspireid": "INSPIRE-00260098",
+        "name": "Gys, Thierry"
+      },
+      {
+        "affiliation": "Oxford U.",
+        "inspireid": "INSPIRE-00536800",
+        "name": "Hadavizadeh, Thomas"
+      },
+      {
+        "affiliation": "Clermont-Ferrand U.",
+        "inspireid": "INSPIRE-00341268",
+        "name": "Hadjivasiliou, Christos"
+      },
+      {
+        "affiliation": "Ecole Polytechnique, Lausanne",
+        "inspireid": "INSPIRE-00260534",
+        "name": "Haefeli, Guido"
+      },
+      {
+        "affiliation": "CERN",
+        "inspireid": "INSPIRE-00341278",
+        "name": "Haen, Christophe"
+      },
+      {
+        "affiliation": "Cambridge U.",
+        "inspireid": "INSPIRE-00261030",
+        "name": "Haines, Susan"
+      },
+      {
+        "affiliation": "Maryland U., College Park",
+        "name": "Hamilton, Phoebe Meredith"
+      },
+      {
+        "affiliation": "Heidelberg U.",
+        "inspireid": "INSPIRE-00400676",
+        "name": "Han, Xiaoxue"
+      },
+      {
+        "affiliation": "Oxford U.",
+        "name": "Hancock, Thomas Henry"
+      },
+      {
+        "affiliation": "Heidelberg U.",
+        "inspireid": "INSPIRE-00046350",
+        "name": "Hansmann-Menzemer, Stephanie"
+      },
+      {
+        "affiliation": "Oxford U.",
+        "inspireid": "INSPIRE-00088706",
+        "name": "Harnew, Neville"
+      },
+      {
+        "affiliation": "Bristol U.",
+        "inspireid": "INSPIRE-00357202",
+        "name": "Harnew, Samuel"
+      },
+      {
+        "affiliation": "CERN",
+        "name": "Hasse, Christoph"
+      },
+      {
+        "affiliation": "CERN",
+        "inspireid": "INSPIRE-00230526",
+        "name": "Hatch, Mark"
+      },
+      {
+        "affiliation": "Beijing, GUCAS",
+        "inspireid": "INSPIRE-00257559",
+        "name": "He, Jibo"
+      },
+      {
+        "affiliation": "Imperial Coll., London",
+        "name": "Hecker, Malte"
+      },
+      {
+        "affiliation": "Tech. U., Dortmund (main)",
+        "name": "Heinicke, Kevin"
+      },
+      {
+        "affiliation": "Aachen, Tech. Hochsch.",
+        "inspireid": "INSPIRE-00007870",
+        "name": "Heister, Arno"
+      },
+      {
+        "affiliation": "Liverpool U.",
+        "inspireid": "INSPIRE-00014964",
+        "name": "Hennessy, Karol"
+      },
+      {
+        "affiliation": "Clermont-Ferrand U.",
+        "inspireid": "INSPIRE-00257379",
+        "name": "Henrard, Pierre"
+      },
+      {
+        "affiliation": "Valencia U., IFIC",
+        "inspireid": "INSPIRE-00390866",
+        "name": "Henry, Louis"
+      },
+      {
+        "affiliation": "Rostock U.",
+        "inspireid": "INSPIRE-00390793",
+        "name": "He\\ss, Miriam"
+      },
+      {
+        "affiliation": "Rio de Janeiro Federal U.",
+        "inspireid": "INSPIRE-00028041",
+        "name": "Hicheur, Adl\\`ene"
+      },
+      {
+        "affiliation": "Oxford U.",
+        "inspireid": "INSPIRE-00357210",
+        "name": "Hill, Donal"
+      },
+      {
+        "affiliation": "Ecole Polytechnique, Lausanne",
+        "inspireid": "INSPIRE-00257330",
+        "name": "Hopchev, Plamen Hristov"
+      },
+      {
+        "affiliation": "CCNU, Wuhan, Inst. Part. Phys.",
+        "name": "Hu, Wenhua"
+      },
+      {
+        "affiliation": "Beijing, GUCAS",
+        "name": "Huang, Wenqian"
+      },
+      {
+        "affiliation": "Cincinnati U.",
+        "name": "Huard, Zachary"
+      },
+      {
+        "affiliation": "Nikhef, Amsterdam",
+        "inspireid": "INSPIRE-00091582",
+        "name": "Hulsbergen, Wouter"
+      },
+      {
+        "affiliation": "Imperial Coll., London",
+        "inspireid": "INSPIRE-00453346",
+        "name": "Humair, Thibaud"
+      },
+      {
+        "affiliation": "Authors affiliated with an institute formerly covered by a cooperation agreement with CERN.",
+        "inspireid": "INSPIRE-00545541",
+        "name": "Hushchyn, Mikhail"
+      },
+      {
+        "affiliation": "Liverpool U.",
+        "inspireid": "INSPIRE-00091737",
+        "name": "Hutchcroft, David"
+      },
+      {
+        "affiliation": "Tech. U., Dortmund (main)",
+        "name": "Ibis, Philipp"
+      },
+      {
+        "affiliation": "AGH-UST, Krakow",
+        "inspireid": "INSPIRE-00091920",
+        "name": "Idzik, Marek"
+      },
+      {
+        "affiliation": "Birmingham U.",
+        "inspireid": "INSPIRE-00258006",
+        "name": "Ilten, Philip"
+      },
+      {
+        "affiliation": "Authors affiliated with an institute formerly covered by a cooperation agreement with CERN.",
+        "name": "Inyakin, Alexander"
+      },
+      {
+        "affiliation": "CERN",
+        "inspireid": "INSPIRE-00260123",
+        "name": "Jacobsson, Richard"
+      },
+      {
+        "affiliation": "Oxford U.",
+        "inspireid": "INSPIRE-00363060",
+        "name": "Jalocha, Pawel"
+      },
+      {
+        "affiliation": "Nikhef, Amsterdam",
+        "inspireid": "INSPIRE-00258761",
+        "name": "Jans, Eddy"
+      },
+      {
+        "affiliation": "Maryland U., College Park",
+        "inspireid": "INSPIRE-00144300",
+        "name": "Jawahery, Abolhassan"
+      },
+      {
+        "affiliation": "Tsinghua U., Beijing, CHEP",
+        "inspireid": "INSPIRE-00582321",
+        "name": "Jiang, Feng"
+      },
+      {
+        "affiliation": "Oxford U.",
+        "inspireid": "INSPIRE-00042030",
+        "name": "John, Malcolm"
+      },
+      {
+        "affiliation": "CERN",
+        "inspireid": "INSPIRE-00262837",
+        "name": "Johnson, Daniel"
+      },
+      {
+        "affiliation": "Cambridge U.",
+        "inspireid": "INSPIRE-00261047",
+        "name": "Jones, Christopher"
+      },
+      {
+        "affiliation": "CERN",
+        "inspireid": "INSPIRE-00093928",
+        "name": "Joram, Christian"
+      },
+      {
+        "affiliation": "CERN",
+        "inspireid": "INSPIRE-00260147",
+        "name": "Jost, Beat"
+      },
+      {
+        "affiliation": "Oxford U.",
+        "inspireid": "INSPIRE-00400750",
+        "name": "Jurik, Nathan"
+      },
+      {
+        "affiliation": "Kharkov, KIPT",
+        "inspireid": "INSPIRE-00341378",
+        "name": "Kandybei, Sergii"
+      },
+      {
+        "affiliation": "CERN",
+        "inspireid": "INSPIRE-00341385",
+        "name": "Karacson, Matthias"
+      },
+      {
+        "affiliation": "Bristol U.",
+        "inspireid": "INSPIRE-00582332",
+        "name": "Kariuki, James Mwangi"
+      },
+      {
+        "affiliation": "Glasgow U.",
+        "inspireid": "INSPIRE-00453516",
+        "name": "Karodia, Sarah"
+      },
+      {
+        "affiliation": "Authors affiliated with an institute formerly covered by a cooperation agreement with CERN.",
+        "name": "Kazeev, Nikita"
+      },
+      {
+        "affiliation": "Heidelberg U.",
+        "inspireid": "INSPIRE-00522728",
+        "name": "Kecke, Matthieu"
+      },
+      {
+        "affiliation": "Cambridge U.",
+        "name": "Keizer, Floris"
+      },
+      {
+        "affiliation": "Syracuse U.",
+        "inspireid": "INSPIRE-00391054",
+        "name": "Kelsey, Matthew"
+      },
+      {
+        "affiliation": "Cambridge U.",
+        "inspireid": "INSPIRE-00239270",
+        "name": "Kenzie, Matthew"
+      },
+      {
+        "affiliation": "NIKHEF, Amsterdam + Vrije U., Amsterdam",
+        "inspireid": "INSPIRE-00258866",
+        "name": "Ketel, Tjeerd"
+      },
+      {
+        "affiliation": "Authors affiliated with an institute formerly covered by a cooperation agreement with CERN.",
+        "inspireid": "INSPIRE-00545552",
+        "name": "Khairullin, Egor"
+      },
+      {
+        "affiliation": "Heidelberg U.",
+        "inspireid": "INSPIRE-00257475",
+        "name": "Khanji, Basem"
+      },
+      {
+        "affiliation": "Ecole Polytechnique, Lausanne",
+        "inspireid": "INSPIRE-00391108",
+        "name": "Khurewathanakul, Chitsanu"
+      },
+      {
+        "affiliation": "Syracuse U.",
+        "name": "Kim, Kyung Eun"
+      },
+      {
+        "affiliation": "Aachen, Tech. Hochsch.",
+        "inspireid": "INSPIRE-00545568",
+        "name": "Kirn, Thomas"
+      },
+      {
+        "affiliation": "Frascati",
+        "inspireid": "INSPIRE-00391174",
+        "name": "Klaver, Suzanne"
+      },
+      {
+        "affiliation": "NCBJ, Swierk",
+        "inspireid": "INSPIRE-00400854",
+        "name": "Klimaszewski, Konrad"
+      },
+      {
+        "affiliation": "Heidelberg, Max Planck Inst.",
+        "name": "Klimkovich, Tatsiana"
+      },
+      {
+        "affiliation": "Kiev, INR",
+        "inspireid": "INSPIRE-00582346",
+        "name": "Koliiev, Serhii"
+      },
+      {
+        "affiliation": "Heidelberg U.",
+        "inspireid": "INSPIRE-00453628",
+        "name": "Kolpin, Michael"
+      },
+      {
+        "affiliation": "Heidelberg U.",
+        "name": "Kopecna, Renata"
+      },
+      {
+        "affiliation": "Nikhef, Amsterdam",
+        "inspireid": "INSPIRE-00058578",
+        "name": "Koppenburg, Patrick"
+      },
+      {
+        "affiliation": "Authors affiliated with an institute formerly covered by a cooperation agreement with CERN.",
+        "inspireid": "INSPIRE-00259339",
+        "name": "Korolev, Mikhail"
+      },
+      {
+        "affiliation": "Authors affiliated with an institute formerly covered by a cooperation agreement with CERN.",
+        "name": "Kotriakhova, Sofia"
+      },
+      {
+        "affiliation": "Clermont-Ferrand U.",
+        "inspireid": "INSPIRE-00536810",
+        "name": "Kozeiha, Mohamad"
+      },
+      {
+        "affiliation": "Authors affiliated with an institute formerly covered by a cooperation agreement with CERN.",
+        "inspireid": "INSPIRE-00259390",
+        "name": "Kravchuk, Leonid"
+      },
+      {
+        "affiliation": "Warwick U.",
+        "inspireid": "INSPIRE-00041048",
+        "name": "Kreps, Michal"
+      },
+      {
+        "affiliation": "Imperial Coll., London",
+        "name": "Kress, Felix Johannes"
+      },
+      {
+        "affiliation": "Authors affiliated with an institute formerly covered by a cooperation agreement with CERN.",
+        "inspireid": "INSPIRE-00257824",
+        "name": "Krokovny, Pavel"
+      },
+      {
+        "affiliation": "NCBJ, Swierk",
+        "inspireid": "INSPIRE-00437507",
+        "name": "Krzemien, Wojciech"
+      },
+      {
+        "affiliation": "Cracow, INP; AGH-UST, Cracow",
+        "inspireid": "INSPIRE-00256649",
+        "name": "Kucewicz, Wojciech"
+      },
+      {
+        "affiliation": "Cracow, INP",
+        "inspireid": "INSPIRE-00258880",
+        "name": "Kucharczyk, Marcin"
+      },
+      {
+        "affiliation": "Authors affiliated with an institute formerly covered by a cooperation agreement with CERN.",
+        "inspireid": "INSPIRE-00341500",
+        "name": "Kudryavtsev, Vasily"
+      },
+      {
+        "affiliation": "Ecole Polytechnique, Lausanne",
+        "inspireid": "INSPIRE-00536823",
+        "name": "Kuonen, Axel Kevin"
+      },
+      {
+        "affiliation": "Authors affiliated with an institute formerly covered by a cooperation agreement with CERN.; CERN",
+        "inspireid": "INSPIRE-00259275",
+        "name": "Kvaratskheliya, Tengiz"
+      },
+      {
+        "affiliation": "CERN",
+        "inspireid": "INSPIRE-00260180",
+        "name": "Lacarrere, Daniel"
+      },
+      {
+        "affiliation": "Manchester U.",
+        "inspireid": "INSPIRE-00099630",
+        "name": "Lafferty, George"
+      },
+      {
+        "affiliation": "INFN, Cagliari",
+        "inspireid": "INSPIRE-00258150",
+        "name": "Lai, Adriano"
+      },
+      {
+        "affiliation": "Frascati",
+        "inspireid": "INSPIRE-00258442",
+        "name": "Lanfranchi, Gaia"
+      },
+      {
+        "affiliation": "Aachen, Tech. Hochsch.",
+        "inspireid": "INSPIRE-00003200",
+        "name": "Langenbruch, Christoph"
+      },
+      {
+        "affiliation": "Warwick U.",
+        "inspireid": "INSPIRE-00041615",
+        "name": "Latham, Thomas"
+      },
+      {
+        "affiliation": "Birmingham U.",
+        "inspireid": "INSPIRE-00100355",
+        "name": "Lazzeroni, Cristina"
+      },
+      {
+        "affiliation": "Marseille, CPPM",
+        "inspireid": "INSPIRE-00083087",
+        "name": "Le Gac, Renaud"
+      },
+      {
+        "affiliation": "Clermont-Ferrand U.",
+        "inspireid": "INSPIRE-00041022",
+        "name": "Lef\\`evre, Regis"
+      },
+      {
+        "affiliation": "Authors affiliated with an institute formerly covered by a cooperation agreement with CERN.; CERN",
+        "inspireid": "INSPIRE-00100871",
+        "name": "Leflat, Alexander"
+      },
+      {
+        "affiliation": "",
+        "inspireid": "INSPIRE-00144068",
+        "name": "Lefran\\c{c}ois, Jacques"
+      },
+      {
+        "affiliation": "CERN",
+        "inspireid": "INSPIRE-00582375",
+        "name": "Lemaitre, Florian"
+      },
+      {
+        "affiliation": "Marseille, CPPM",
+        "inspireid": "INSPIRE-00101253",
+        "name": "Leroy, Olivier"
+      },
+      {
+        "affiliation": "Cracow, INP",
+        "inspireid": "INSPIRE-00101288",
+        "name": "Lesiak, Tadeusz"
+      },
+      {
+        "affiliation": "Heidelberg U.",
+        "inspireid": "INSPIRE-00391255",
+        "name": "Leverington, Blake"
+      },
+      {
+        "affiliation": "Beijing, GUCAS",
+        "name": "Li, Pei-Rong"
+      },
+      {
+        "affiliation": "Tsinghua U., Beijing, CHEP",
+        "inspireid": "INSPIRE-00582384",
+        "name": "Li, Tenglin"
+      },
+      {
+        "affiliation": "Orsay, LAL",
+        "inspireid": "INSPIRE-00385568",
+        "name": "Li, Yiming"
+      },
+      {
+        "affiliation": "Syracuse U.",
+        "name": "Li, Zhuoming"
+      },
+      {
+        "affiliation": "Syracuse U.",
+        "name": "Liang, Xixin"
+      },
+      {
+        "affiliation": "Authors affiliated with an institute formerly covered by a cooperation agreement with CERN.",
+        "inspireid": "INSPIRE-00400931",
+        "name": "Likhomanenko, Tatiana"
+      },
+      {
+        "affiliation": "CERN",
+        "inspireid": "INSPIRE-00101983",
+        "name": "Lindner, Rolf"
+      },
+      {
+        "affiliation": "Zurich U.",
+        "inspireid": "INSPIRE-00401052",
+        "name": "Lionetto, Federica"
+      },
+      {
+        "affiliation": "Orsay, LAL",
+        "name": "Lisovskyi, Vitalii"
+      },
+      {
+        "affiliation": "Tsinghua U., Beijing, CHEP",
+        "inspireid": "INSPIRE-00536834",
+        "name": "Liu, Xuesong"
+      },
+      {
+        "affiliation": "Warwick U.",
+        "inspireid": "INSPIRE-00536847",
+        "name": "Loh, David"
+      },
+      {
+        "affiliation": "INFN, Cagliari",
+        "name": "Loi, Angelo"
+      },
+      {
+        "affiliation": "Glasgow U.",
+        "inspireid": "INSPIRE-00391330",
+        "name": "Longstaff, Iain"
+      },
+      {
+        "affiliation": "Rio de Janeiro Federal U.",
+        "inspireid": "INSPIRE-00341531",
+        "name": "Lopes, Jose"
+      },
+      {
+        "affiliation": "INFN, Padua; U. Padua (main)",
+        "inspireid": "INSPIRE-00102927",
+        "name": "Lucchesi, Donatella"
+      },
+      {
+        "affiliation": "U. Santiago de Compostela (main)",
+        "inspireid": "INSPIRE-00522703",
+        "name": "Lucio Martinez, Miriam"
+      },
+      {
+        "affiliation": "INFN, Padua",
+        "inspireid": "INSPIRE-00453739",
+        "name": "Lupato, Anna"
+      },
+      {
+        "affiliation": "INFN, Ferrara; Ferrara U.",
+        "inspireid": "INSPIRE-00103142",
+        "name": "Luppi, Eleonora"
+      },
+      {
+        "affiliation": "CERN",
+        "inspireid": "INSPIRE-00391442",
+        "name": "Lupton, Oliver"
+      },
+      {
+        "affiliation": "INFN, Pisa; Pisa, Scuola Normale Superiore",
+        "inspireid": "INSPIRE-00103157",
+        "name": "Lusiani, Alberto"
+      },
+      {
+        "affiliation": "Beijing, GUCAS",
+        "inspireid": "INSPIRE-00385243",
+        "name": "Lyu, Xiao-Rui"
+      },
+      {
+        "affiliation": "Orsay, LAL",
+        "inspireid": "INSPIRE-00103518",
+        "name": "Machefert, Frederic"
+      },
+      {
+        "affiliation": "Bucharest, IFIN-HH",
+        "inspireid": "INSPIRE-00054830",
+        "name": "Maciuc, Florin"
+      },
+      {
+        "affiliation": "Ecole Polytechnique, Lausanne",
+        "name": "Macko, Vladimir"
+      },
+      {
+        "affiliation": "Tech. U., Dortmund (main)",
+        "name": "Mackowiak, Patrick"
+      },
+      {
+        "affiliation": "Bristol U.",
+        "name": "Maddrell-Mander, Samuel"
+      },
+      {
+        "affiliation": "Authors affiliated with an institute formerly covered by a cooperation agreement with CERN.; CERN",
+        "inspireid": "INSPIRE-00259220",
+        "name": "Maev, Oleg"
+      },
+      {
+        "affiliation": "Manchester U.",
+        "inspireid": "INSPIRE-00536855",
+        "name": "Maguire, Kevin"
+      },
+      {
+        "affiliation": "Authors affiliated with an institute formerly covered by a cooperation agreement with CERN.",
+        "name": "Maisuzenko, Dmitrii"
+      },
+      {
+        "affiliation": "AGH-UST, Krakow",
+        "name": "Majewski, Maciej Witold"
+      },
+      {
+        "affiliation": "Oxford U.",
+        "inspireid": "INSPIRE-00040960",
+        "name": "Malde, Sneha"
+      },
+      {
+        "affiliation": "Cracow, INP",
+        "name": "Malecki, Bartosz"
+      },
+      {
+        "affiliation": "Authors affiliated with an institute formerly covered by a cooperation agreement with CERN.",
+        "inspireid": "INSPIRE-00401169",
+        "name": "Malinin, Alexander"
+      },
+      {
+        "affiliation": "Authors affiliated with an institute formerly covered by a cooperation agreement with CERN.",
+        "inspireid": "INSPIRE-00582594",
+        "name": "Maltsev, Timofei"
+      },
+      {
+        "affiliation": "INFN, Cagliari; Cagliari U.",
+        "inspireid": "INSPIRE-00057054",
+        "name": "Manca, Giulia"
+      },
+      {
+        "affiliation": "Marseille, CPPM",
+        "inspireid": "INSPIRE-00042821",
+        "name": "Mancinelli, Giampiero"
+      },
+      {
+        "affiliation": "INFN, Milan; U. Milan (main)",
+        "name": "Marangotto, Daniele"
+      },
+      {
+        "affiliation": "Clermont-Ferrand U.; Mindanao State U., Iligan",
+        "inspireid": "INSPIRE-00391509",
+        "name": "Maratas, Jan Mickelle"
+      },
+      {
+        "affiliation": "Annecy, LAPP",
+        "inspireid": "INSPIRE-00219901",
+        "name": "Marchand, Jean Fran\\c{c}ois"
+      },
+      {
+        "affiliation": "INFN, Bologna",
+        "inspireid": "INSPIRE-00258060",
+        "name": "Marconi, Umberto"
+      },
+      {
+        "affiliation": "U. Barcelona (main)",
+        "inspireid": "INSPIRE-00391574",
+        "name": "Marin Benito, Carla"
+      },
+      {
+        "affiliation": "Ecole Polytechnique, Lausanne",
+        "inspireid": "INSPIRE-00582604",
+        "name": "Marinangeli, Matthieu"
+      },
+      {
+        "affiliation": "Ecole Polytechnique, Lausanne",
+        "inspireid": "INSPIRE-00367766",
+        "name": "Marino, Pietro"
+      },
+      {
+        "affiliation": "Heidelberg U.",
+        "inspireid": "INSPIRE-00145236",
+        "name": "Marks, J\\\"org"
+      },
+      {
+        "affiliation": "INFN, Rome",
+        "inspireid": "INSPIRE-00258664",
+        "name": "Martellotti, Giuseppe"
+      },
+      {
+        "affiliation": "Marseille, CPPM",
+        "inspireid": "INSPIRE-00536869",
+        "name": "Martin, Morgan"
+      },
+      {
+        "affiliation": "Ecole Polytechnique, Lausanne",
+        "inspireid": "INSPIRE-00144085",
+        "name": "Martinelli, Maurizio"
+      },
+      {
+        "affiliation": "U. Santiago de Compostela (main)",
+        "inspireid": "INSPIRE-00259733",
+        "name": "Martinez Santos, Diego"
+      },
+      {
+        "affiliation": "Valencia U., IFIC",
+        "inspireid": "INSPIRE-00105212",
+        "name": "Martinez Vidal, Fernando"
+      },
+      {
+        "affiliation": "Rio de Janeiro, CBPF",
+        "inspireid": "INSPIRE-00271814",
+        "name": "Massafferri, Andr\\'e"
+      },
+      {
+        "affiliation": "CERN",
+        "inspireid": "INSPIRE-00334839",
+        "name": "Matev, Rosen"
+      },
+      {
+        "affiliation": "Warwick U.",
+        "inspireid": "INSPIRE-00522716",
+        "name": "Mathad, Abhijit"
+      },
+      {
+        "affiliation": "CERN",
+        "inspireid": "INSPIRE-00258028",
+        "name": "Mathe, Zoltan"
+      },
+      {
+        "affiliation": "INFN, Milan Bicocca",
+        "inspireid": "INSPIRE-00258531",
+        "name": "Matteuzzi, Clara"
+      },
+      {
+        "affiliation": "Zurich U.",
+        "inspireid": "INSPIRE-00640989",
+        "name": "Mauri, Andrea"
+      },
+      {
+        "affiliation": "Orsay, LAL; Ecole Polytechnique",
+        "inspireid": "INSPIRE-00257487",
+        "name": "Maurice, Emilie"
+      },
+      {
+        "affiliation": "Ecole Polytechnique, Lausanne",
+        "inspireid": "INSPIRE-00453958",
+        "name": "Maurin, Brice"
+      },
+      {
+        "affiliation": "Birmingham U.",
+        "inspireid": "INSPIRE-00259401",
+        "name": "Mazurov, Alexander"
+      },
+      {
+        "affiliation": "Imperial Coll., London; CERN",
+        "inspireid": "INSPIRE-00391673",
+        "name": "McCann, Michael"
+      },
+      {
+        "affiliation": "Manchester U.",
+        "inspireid": "INSPIRE-00391741",
+        "name": "McNab, Andrew"
+      },
+      {
+        "affiliation": "University Coll., Dublin",
+        "inspireid": "INSPIRE-00106463",
+        "name": "McNulty, Ronan"
+      },
+      {
+        "affiliation": "Liverpool U.",
+        "name": "Mead, James Vincent"
+      },
+      {
+        "affiliation": "Cincinnati U.",
+        "inspireid": "INSPIRE-00106491",
+        "name": "Meadows, Brian"
+      },
+      {
+        "affiliation": "Marseille, CPPM",
+        "name": "Meaux, Cedric"
+      },
+      {
+        "affiliation": "Tech. U., Dortmund (main)",
+        "inspireid": "INSPIRE-00391774",
+        "name": "Meier, Frank"
+      },
+      {
+        "affiliation": "Rostock U.",
+        "name": "Meinert, Nis"
+      },
+      {
+        "affiliation": "NCBJ, Swierk",
+        "inspireid": "INSPIRE-00385848",
+        "name": "Melnychuk, Dmytro"
+      },
+      {
+        "affiliation": "Nikhef, Amsterdam",
+        "inspireid": "INSPIRE-00106980",
+        "name": "Merk, Marcel"
+      },
+      {
+        "affiliation": "INFN, Milan; CERN; U. Milan (main)",
+        "inspireid": "INSPIRE-00582614",
+        "name": "Merli, Andrea"
+      },
+      {
+        "affiliation": "INFN, Padua",
+        "inspireid": "INSPIRE-00536870",
+        "name": "Michielin, Emanuele"
+      },
+      {
+        "affiliation": "Colombia, U. Natl.",
+        "inspireid": "INSPIRE-00028258",
+        "name": "Milanes, Diego Alejandro"
+      },
+      {
+        "affiliation": "Warwick U.",
+        "name": "Millard, Edward James"
+      },
+      {
+        "affiliation": "Annecy, LAPP",
+        "inspireid": "INSPIRE-00201357",
+        "name": "Minard, Marie-Noelle"
+      },
+      {
+        "affiliation": "Authors affiliated with an institute formerly covered by a cooperation agreement with CERN.",
+        "name": "Mineev, Oleg"
+      },
+      {
+        "affiliation": "INFN, Ferrara; Ferrara U.",
+        "name": "Minzoni, Luca"
+      },
+      {
+        "affiliation": "Heidelberg U.",
+        "inspireid": "INSPIRE-00522733",
+        "name": "Mitzel, Dominik Stefan"
+      },
+      {
+        "affiliation": "Paris U., VI-VII",
+        "inspireid": "INSPIRE-00582621",
+        "name": "Mogini, Andrea"
+      },
+      {
+        "affiliation": "Rio de Janeiro, CBPF; Zamorano, San Antonio de Oriente",
+        "inspireid": "INSPIRE-00341603",
+        "name": "Molina Rodriguez, Josue"
+      },
+      {
+        "affiliation": "Tech. U., Dortmund (main)",
+        "name": "Momb\\\"acher, Titus"
+      },
+      {
+        "affiliation": "Colombia, U. Natl.",
+        "inspireid": "INSPIRE-00536885",
+        "name": "Monroy, Igancio Alberto"
+      },
+      {
+        "affiliation": "Clermont-Ferrand U.",
+        "inspireid": "INSPIRE-00257390",
+        "name": "Monteil, Stephane"
+      },
+      {
+        "affiliation": "INFN, Padua",
+        "inspireid": "INSPIRE-00108754",
+        "name": "Morandin, Mauro"
+      },
+      {
+        "affiliation": "INFN, Pisa; Pisa, Scuola Normale Superiore",
+        "inspireid": "INSPIRE-00016418",
+        "name": "Morello, Michael Joseph"
+      },
+      {
+        "affiliation": "Authors affiliated with an institute formerly covered by a cooperation agreement with CERN.",
+        "inspireid": "INSPIRE-00582634",
+        "name": "Morgunova, Olga"
+      },
+      {
+        "affiliation": "AGH-UST, Krakow",
+        "inspireid": "INSPIRE-00453992",
+        "name": "Moron, Jakub"
+      },
+      {
+        "affiliation": "Marseille, CPPM",
+        "inspireid": "INSPIRE-00401257",
+        "name": "Morris, Adam Benjamin"
+      },
+      {
+        "affiliation": "Syracuse U.",
+        "inspireid": "INSPIRE-00109283",
+        "name": "Mountain, Raymond"
+      },
+      {
+        "affiliation": "Edinburgh U.",
+        "inspireid": "INSPIRE-00194050",
+        "name": "Muheim, Franz"
+      },
+      {
+        "affiliation": "Nikhef, Amsterdam",
+        "inspireid": "INSPIRE-00518699",
+        "name": "Mulder, Mick"
+      },
+      {
+        "affiliation": "CERN",
+        "name": "M\\\"uller, Dominik"
+      },
+      {
+        "affiliation": "Tech. U., Dortmund (main)",
+        "inspireid": "INSPIRE-00522744",
+        "name": "M\\\"uller, Janine"
+      },
+      {
+        "affiliation": "Zurich U.",
+        "inspireid": "INSPIRE-00185464",
+        "name": "M\\\"uller, Katharina"
+      },
+      {
+        "affiliation": "Tech. U., Dortmund (main)",
+        "inspireid": "INSPIRE-00522759",
+        "name": "M\\\"uller, Vanessa"
+      },
+      {
+        "affiliation": "Bristol U.",
+        "inspireid": "INSPIRE-00260976",
+        "name": "Naik, Paras"
+      },
+      {
+        "affiliation": "Ecole Polytechnique, Lausanne",
+        "inspireid": "INSPIRE-00171856",
+        "name": "Nakada, Tatsuya"
+      },
+      {
+        "affiliation": "Rutherford",
+        "inspireid": "INSPIRE-00110346",
+        "name": "Nandakumar, Raja"
+      },
+      {
+        "affiliation": "Oxford U.",
+        "inspireid": "INSPIRE-00536909",
+        "name": "Nandi, Anita"
+      },
+      {
+        "affiliation": "Rio de Janeiro Federal U.",
+        "inspireid": "INSPIRE-00140157",
+        "name": "Nasteva, Irina"
+      },
+      {
+        "affiliation": "Edinburgh U.",
+        "inspireid": "INSPIRE-00260601",
+        "name": "Needham, Matthew"
+      },
+      {
+        "affiliation": "INFN, Ferrara; Ferrara U.",
+        "name": "Neri, Ilaria"
+      },
+      {
+        "affiliation": "INFN, Milan; CERN; U. Milan (main)",
+        "inspireid": "INSPIRE-00045899",
+        "name": "Neri, Nicola"
+      },
+      {
+        "affiliation": "Heidelberg U.",
+        "inspireid": "INSPIRE-00391914",
+        "name": "Neubert, Sebastian"
+      },
+      {
+        "affiliation": "CERN",
+        "inspireid": "INSPIRE-00260260",
+        "name": "Neufeld, Niko"
+      },
+      {
+        "affiliation": "Heidelberg U.",
+        "inspireid": "INSPIRE-00452189",
+        "name": "Neuner, Max"
+      },
+      {
+        "affiliation": "Authors affiliated with an institute formerly covered by a cooperation agreement with CERN.",
+        "name": "Neustroev, Petr"
+      },
+      {
+        "affiliation": "Ecole Polytechnique, Lausanne",
+        "inspireid": "INSPIRE-00391987",
+        "name": "Nguyen, Thi Dung"
+      },
+      {
+        "affiliation": "Ecole Polytechnique, Lausanne; Hanoi U. of Sci.",
+        "inspireid": "INSPIRE-00341643",
+        "name": "Nguyen-Mau, Chung"
+      },
+      {
+        "affiliation": "Aachen, Tech. Hochsch.",
+        "inspireid": "INSPIRE-00409248",
+        "name": "Nieswand, Simon"
+      },
+      {
+        "affiliation": "Tech. U., Dortmund (main)",
+        "inspireid": "INSPIRE-00392011",
+        "name": "Niet, Ramon"
+      },
+      {
+        "affiliation": "Authors affiliated with an institute formerly covered by a cooperation agreement with CERN.",
+        "inspireid": "INSPIRE-00259364",
+        "name": "Nikitin, Nikolay"
+      },
+      {
+        "affiliation": "Heidelberg U.",
+        "inspireid": "INSPIRE-00341653",
+        "name": "Nikodem, Thomas"
+      },
+      {
+        "affiliation": "Authors affiliated with an institute formerly covered by a cooperation agreement with CERN.",
+        "inspireid": "INSPIRE-00582642",
+        "name": "Nogay, Alla"
+      },
+      {
+        "affiliation": "AGH-UST, Krakow",
+        "inspireid": "INSPIRE-00258945",
+        "name": "Oblakowska-Mucha, Agnieszka"
+      },
+      {
+        "affiliation": "Authors affiliated with an institute formerly covered by a cooperation agreement with CERN.",
+        "inspireid": "INSPIRE-00191751",
+        "name": "Obraztsov, Vladimir"
+      },
+      {
+        "affiliation": "Glasgow U.",
+        "inspireid": "INSPIRE-00341669",
+        "name": "Ogilvy, Stephen"
+      },
+      {
+        "affiliation": "Warwick U.",
+        "inspireid": "INSPIRE-00401396",
+        "name": "O'Hanlon, Daniel Patrick"
+      },
+      {
+        "affiliation": "INFN, Cagliari; Cagliari U.",
+        "inspireid": "INSPIRE-00112910",
+        "name": "Oldeman, Rudolf"
+      },
+      {
+        "affiliation": "U. Groningen, VSI",
+        "inspireid": "INSPIRE-00113159",
+        "name": "Onderwater, Gerco"
+      },
+      {
+        "affiliation": "Cracow, INP",
+        "name": "Ossowska, Anna"
+      },
+      {
+        "affiliation": "Rio de Janeiro Federal U.",
+        "inspireid": "INSPIRE-00218196",
+        "name": "Otalora Goicochea, Juan Martin"
+      },
+      {
+        "affiliation": "Zurich U.",
+        "inspireid": "INSPIRE-00341671",
+        "name": "Owen, Patrick"
+      },
+      {
+        "affiliation": "Valencia U., IFIC",
+        "inspireid": "INSPIRE-00042432",
+        "name": "Oyanguren, Maria Aranzazu"
+      },
+      {
+        "affiliation": "Ecole Polytechnique, Lausanne",
+        "inspireid": "INSPIRE-00237142",
+        "name": "Pais, Preema Rennee"
+      },
+      {
+        "affiliation": "INFN, Bari",
+        "inspireid": "INSPIRE-00114021",
+        "name": "Palano, Antimo"
+      },
+      {
+        "affiliation": "Frascati; CERN",
+        "inspireid": "INSPIRE-00259914",
+        "name": "Palutan, Matteo"
+      },
+      {
+        "affiliation": "Authors affiliated with an institute formerly covered by a cooperation agreement with CERN.",
+        "name": "Panshin, Gennady"
+      },
+      {
+        "affiliation": "Rutherford",
+        "inspireid": "INSPIRE-00261218",
+        "name": "Papanestis, Antonios"
+      },
+      {
+        "affiliation": "Edinburgh U.",
+        "inspireid": "INSPIRE-00043195",
+        "name": "Pappagallo, Marco"
+      },
+      {
+        "affiliation": "INFN, Ferrara; Ferrara U.",
+        "inspireid": "INSPIRE-00401494",
+        "name": "Pappalardo, Luciano"
+      },
+      {
+        "affiliation": "Maryland U., College Park",
+        "inspireid": "INSPIRE-00206947",
+        "name": "Parker, William"
+      },
+      {
+        "affiliation": "Manchester U.",
+        "inspireid": "INSPIRE-00160233",
+        "name": "Parkes, Christopher"
+      },
+      {
+        "affiliation": "INFN, Florence; CERN",
+        "inspireid": "INSPIRE-00114920",
+        "name": "Passaleva, Giovanni"
+      },
+      {
+        "affiliation": "INFN, Bari",
+        "inspireid": "INSPIRE-00268178",
+        "name": "Pastore, Alessandra"
+      },
+      {
+        "affiliation": "Imperial Coll., London",
+        "inspireid": "INSPIRE-00227343",
+        "name": "Patel, Mitesh"
+      },
+      {
+        "affiliation": "INFN, Bologna; Bologna U.",
+        "inspireid": "INSPIRE-00115095",
+        "name": "Patrignani, Claudia"
+      },
+      {
+        "affiliation": "CERN",
+        "inspireid": "INSPIRE-00392044",
+        "name": "Pearce, Alex"
+      },
+      {
+        "affiliation": "Nikhef, Amsterdam",
+        "inspireid": "INSPIRE-00173740",
+        "name": "Pellegrino, Antonio"
+      },
+      {
+        "affiliation": "INFN, Rome",
+        "inspireid": "INSPIRE-00226158",
+        "name": "Penso, Gianni"
+      },
+      {
+        "affiliation": "CERN",
+        "inspireid": "INSPIRE-00296179",
+        "name": "Pepe Altarelli, Monica"
+      },
+      {
+        "affiliation": "CERN",
+        "inspireid": "INSPIRE-00258083",
+        "name": "Perazzini, Stefano"
+      },
+      {
+        "affiliation": "Authors affiliated with an institute formerly covered by a cooperation agreement with CERN.",
+        "name": "Pereima, Dmitrii"
+      },
+      {
+        "affiliation": "Clermont-Ferrand U.",
+        "inspireid": "INSPIRE-00115778",
+        "name": "Perret, Pascal"
+      },
+      {
+        "affiliation": "Ecole Polytechnique, Lausanne",
+        "inspireid": "INSPIRE-00392110",
+        "name": "Pescatore, Luca"
+      },
+      {
+        "affiliation": "Bristol U.",
+        "inspireid": "INSPIRE-00311357",
+        "name": "Petridis, Konstantinos"
+      },
+      {
+        "affiliation": "INFN, Genoa; Genoa U.",
+        "inspireid": "INSPIRE-00116050",
+        "name": "Petrolini, Alessandro"
+      },
+      {
+        "affiliation": "Authors affiliated with an institute formerly covered by a cooperation agreement with CERN.",
+        "inspireid": "INSPIRE-00582654",
+        "name": "Petrov, Aleksandr"
+      },
+      {
+        "affiliation": "INFN, Milan; U. Milan (main)",
+        "inspireid": "INSPIRE-00522770",
+        "name": "Petruzzo, Marco"
+      },
+      {
+        "affiliation": "Annecy, LAPP",
+        "inspireid": "INSPIRE-00257359",
+        "name": "Pietrzyk, Boleslaw"
+      },
+      {
+        "affiliation": "Ecole Polytechnique, Lausanne",
+        "name": "Pietrzyk, Guillaume"
+      },
+      {
+        "affiliation": "Cracow, INP",
+        "inspireid": "INSPIRE-00392248",
+        "name": "Pikies, Malgorzata"
+      },
+      {
+        "affiliation": "INFN, Rome",
+        "inspireid": "INSPIRE-00258670",
+        "name": "Pinci, Davide"
+      },
+      {
+        "affiliation": "CERN",
+        "name": "Pisani, Flavio"
+      },
+      {
+        "affiliation": "INFN, Genoa; Genoa U.",
+        "inspireid": "INSPIRE-00401637",
+        "name": "Pistone, Alessandro"
+      },
+      {
+        "affiliation": "Heidelberg U.",
+        "inspireid": "INSPIRE-00536921",
+        "name": "Piucci, Alessio"
+      },
+      {
+        "affiliation": "Bucharest, IFIN-HH",
+        "inspireid": "INSPIRE-00582660",
+        "name": "Placinta, Vlad-Mihai"
+      },
+      {
+        "affiliation": "Edinburgh U.",
+        "inspireid": "INSPIRE-00144540",
+        "name": "Playfer, Stephen"
+      },
+      {
+        "affiliation": "U. Santiago de Compostela (main)",
+        "inspireid": "INSPIRE-00259765",
+        "name": "Plo Casasus, Maximo"
+      },
+      {
+        "affiliation": "Paris U., VI-VII",
+        "inspireid": "INSPIRE-00041883",
+        "name": "Polci, Francesco"
+      },
+      {
+        "affiliation": "Frascati",
+        "name": "Poli Lener, Marco"
+      },
+      {
+        "affiliation": "Warwick U.",
+        "inspireid": "INSPIRE-00180587",
+        "name": "Poluektov, Anton"
+      },
+      {
+        "affiliation": "Authors affiliated with an institute formerly covered by a cooperation agreement with CERN.",
+        "name": "Polukhina, Natalia"
+      },
+      {
+        "affiliation": "Syracuse U.",
+        "inspireid": "INSPIRE-00392262",
+        "name": "Polyakov, Ivan"
+      },
+      {
+        "affiliation": "Rio de Janeiro Federal U.",
+        "inspireid": "INSPIRE-00117142",
+        "name": "Polycarpo, Erica"
+      },
+      {
+        "affiliation": "Bristol U.",
+        "inspireid": "INSPIRE-00582672",
+        "name": "Pomery, Gabriela Johanna"
+      },
+      {
+        "affiliation": "CERN",
+        "name": "Ponce, Sebastien"
+      },
+      {
+        "affiliation": "Authors affiliated with an institute formerly covered by a cooperation agreement with CERN.",
+        "inspireid": "INSPIRE-00392309",
+        "name": "Popov, Alexander"
+      },
+      {
+        "affiliation": "Heidelberg, Max Planck Inst.; CERN",
+        "inspireid": "INSPIRE-00257709",
+        "name": "Popov, Dmitry"
+      },
+      {
+        "affiliation": "Authors affiliated with an institute formerly covered by a cooperation agreement with CERN.",
+        "inspireid": "INSPIRE-00582684",
+        "name": "Poslavskii, Stanislav"
+      },
+      {
+        "affiliation": "Rio de Janeiro Federal U.",
+        "inspireid": "INSPIRE-00260620",
+        "name": "Potterat, C\\'edric"
+      },
+      {
+        "affiliation": "Bristol U.",
+        "inspireid": "INSPIRE-00401700",
+        "name": "Price, Eugenia"
+      },
+      {
+        "affiliation": "U. Santiago de Compostela (main)",
+        "inspireid": "INSPIRE-00341705",
+        "name": "Prisciandaro, Jessica"
+      },
+      {
+        "affiliation": "Bristol U.",
+        "inspireid": "INSPIRE-00392372",
+        "name": "Prouve, Claire"
+      },
+      {
+        "affiliation": "Kiev, INR",
+        "inspireid": "INSPIRE-00046375",
+        "name": "Pugatch, Valery"
+      },
+      {
+        "affiliation": "Zurich U.",
+        "inspireid": "INSPIRE-00259590",
+        "name": "Puig Navarro, Albert"
+      },
+      {
+        "affiliation": "Oxford U.",
+        "name": "Pullen, Hannah Louise"
+      },
+      {
+        "affiliation": "INFN, Pisa; U. Pisa (main)",
+        "inspireid": "INSPIRE-00118078",
+        "name": "Punzi, Giovanni"
+      },
+      {
+        "affiliation": "Warwick U.",
+        "inspireid": "INSPIRE-00257268",
+        "name": "Qian, Wenbin"
+      },
+      {
+        "affiliation": "Beijing, GUCAS",
+        "name": "Qin, Jia-Jia"
+      },
+      {
+        "affiliation": "Paris U., VI-VII",
+        "inspireid": "INSPIRE-00453676",
+        "name": "Quagliani, Renato"
+      },
+      {
+        "affiliation": "Clermont-Ferrand U.",
+        "name": "Quintana, Boris"
+      },
+      {
+        "affiliation": "AGH-UST, Krakow",
+        "inspireid": "INSPIRE-00392425",
+        "name": "Rachwal, Bartlomiej"
+      },
+      {
+        "affiliation": "Bristol U.",
+        "inspireid": "INSPIRE-00050460",
+        "name": "Rademacker, Jonas"
+      },
+      {
+        "affiliation": "INFN, Pisa",
+        "inspireid": "INSPIRE-00041956",
+        "name": "Rama, Matteo"
+      },
+      {
+        "affiliation": "U. Santiago de Compostela (main)",
+        "inspireid": "INSPIRE-00545589",
+        "name": "Ramos Pernas, Miguel"
+      },
+      {
+        "affiliation": "Rio de Janeiro Federal U.",
+        "inspireid": "INSPIRE-00024740",
+        "name": "Rangel, Murilo"
+      },
+      {
+        "affiliation": "Kharkov, KIPT",
+        "inspireid": "INSPIRE-00260925",
+        "name": "Raniuk, Iurii"
+      },
+      {
+        "affiliation": "Authors affiliated with an institute formerly covered by a cooperation agreement with CERN.",
+        "inspireid": "INSPIRE-00005235",
+        "name": "Ratnikov, Fedor"
+      },
+      {
+        "affiliation": "NIKHEF, Amsterdam + Vrije U., Amsterdam",
+        "inspireid": "INSPIRE-00119187",
+        "name": "Raven, Gerhard"
+      },
+      {
+        "affiliation": "CERN",
+        "name": "Ravonel Salzgeber, Melody"
+      },
+      {
+        "affiliation": "Annecy, LAPP",
+        "name": "Reboud, Meril"
+      },
+      {
+        "affiliation": "Ecole Polytechnique, Lausanne",
+        "inspireid": "INSPIRE-00453784",
+        "name": "Redi, Federico"
+      },
+      {
+        "affiliation": "Tech. U., Dortmund (main)",
+        "inspireid": "INSPIRE-00392459",
+        "name": "Reichert, Stefanie"
+      },
+      {
+        "affiliation": "Valencia U., IFIC",
+        "inspireid": "INSPIRE-00582696",
+        "name": "Remon Alepuz, Clara"
+      },
+      {
+        "affiliation": "Orsay, LAL",
+        "inspireid": "INSPIRE-00545590",
+        "name": "Renaudin, Victor"
+      },
+      {
+        "affiliation": "Rutherford",
+        "inspireid": "INSPIRE-00119926",
+        "name": "Ricciardi, Stefania"
+      },
+      {
+        "affiliation": "Bristol U.",
+        "inspireid": "INSPIRE-00401830",
+        "name": "Richards, Sophie"
+      },
+      {
+        "affiliation": "CERN",
+        "inspireid": "INSPIRE-00401943",
+        "name": "Rihl, Mariana"
+      },
+      {
+        "affiliation": "Liverpool U.",
+        "inspireid": "INSPIRE-00034500",
+        "name": "Rinnert, Kurt"
+      },
+      {
+        "affiliation": "Orsay, LAL",
+        "inspireid": "INSPIRE-00050542",
+        "name": "Robbe, Patrick"
+      },
+      {
+        "affiliation": "Paris U., VI-VII",
+        "name": "Robert, Arnaud"
+      },
+      {
+        "affiliation": "Ecole Polytechnique, Lausanne",
+        "inspireid": "INSPIRE-00392508",
+        "name": "Rodrigues, Ana Barbara"
+      },
+      {
+        "affiliation": "Cincinnati U.",
+        "inspireid": "INSPIRE-00306714",
+        "name": "Rodrigues, Eduardo"
+      },
+      {
+        "affiliation": "Colombia, U. Natl.",
+        "inspireid": "INSPIRE-00120769",
+        "name": "Rodriguez Lopez, Jairo Alexis"
+      },
+      {
+        "affiliation": "Authors affiliated with an institute formerly covered by a cooperation agreement with CERN.",
+        "inspireid": "INSPIRE-00582700",
+        "name": "Rogozhnikov, Alexey"
+      },
+      {
+        "affiliation": "CERN",
+        "inspireid": "INSPIRE-00346259",
+        "name": "Roiser, Stefan"
+      },
+      {
+        "affiliation": "Oxford U.",
+        "inspireid": "INSPIRE-00582716",
+        "name": "Rollings, Alexandra Paige"
+      },
+      {
+        "affiliation": "Authors affiliated with an institute formerly covered by a cooperation agreement with CERN.",
+        "inspireid": "INSPIRE-00259690",
+        "name": "Romanovskiy, Vladimir"
+      },
+      {
+        "affiliation": "U. Santiago de Compostela (main); CERN",
+        "inspireid": "INSPIRE-00357288",
+        "name": "Romero Vidal, Antonio"
+      },
+      {
+        "affiliation": "Frascati",
+        "inspireid": "INSPIRE-00036330",
+        "name": "Rotondo, Marcello"
+      },
+      {
+        "affiliation": "Syracuse U.",
+        "inspireid": "INSPIRE-00176709",
+        "name": "Rudolph, Matthew Scott"
+      },
+      {
+        "affiliation": "CERN",
+        "inspireid": "INSPIRE-00260315",
+        "name": "Ruf, Thomas"
+      },
+      {
+        "affiliation": "Valencia U., IFIC",
+        "inspireid": "INSPIRE-00392538",
+        "name": "Ruiz Valls, Pablo"
+      },
+      {
+        "affiliation": "Valencia U., IFIC",
+        "name": "Ruiz Vidal, Joan"
+      },
+      {
+        "affiliation": "U. Santiago de Compostela (main)",
+        "inspireid": "INSPIRE-00193814",
+        "name": "Saborido Silva, Juan Jose"
+      },
+      {
+        "affiliation": "Authors affiliated with an institute formerly covered by a cooperation agreement with CERN.",
+        "inspireid": "INSPIRE-00207799",
+        "name": "Sagidova, Naylya"
+      },
+      {
+        "affiliation": "INFN, Cagliari; Cagliari U.",
+        "inspireid": "INSPIRE-00258160",
+        "name": "Saitta, Biagio"
+      },
+      {
+        "affiliation": "Rio de Janeiro, Pont. U. Catol.",
+        "inspireid": "INSPIRE-00287090",
+        "name": "Salustino Guimaraes, Valdir"
+      },
+      {
+        "affiliation": "Valencia U., IFIC",
+        "inspireid": "INSPIRE-00454015",
+        "name": "Sanchez Mayordomo, Carlos"
+      },
+      {
+        "affiliation": "U. Santiago de Compostela (main)",
+        "inspireid": "INSPIRE-00357296",
+        "name": "Sanmartin Sedes, Brais"
+      },
+      {
+        "affiliation": "INFN, Rome",
+        "inspireid": "INSPIRE-00258681",
+        "name": "Santacesaria, Roberta"
+      },
+      {
+        "affiliation": "U. Santiago de Compostela (main)",
+        "inspireid": "INSPIRE-00306219",
+        "name": "Santamarina Rios, Cibran"
+      },
+      {
+        "affiliation": "Frascati",
+        "inspireid": "INSPIRE-00536947",
+        "name": "Santimaria, Marco"
+      },
+      {
+        "affiliation": "Rome U., Tor Vergata",
+        "inspireid": "INSPIRE-00038249",
+        "name": "Santovetti, Emanuele"
+      },
+      {
+        "affiliation": "Manchester U.",
+        "name": "Sarpis, Gediminas"
+      },
+      {
+        "affiliation": "Frascati; U. Rome La Sapienza (main)",
+        "inspireid": "INSPIRE-00028229",
+        "name": "Sarti, Alessio"
+      },
+      {
+        "affiliation": "INFN, Rome; Basilicata U., Potenza",
+        "inspireid": "INSPIRE-00258690",
+        "name": "Satriano, Celestina"
+      },
+      {
+        "affiliation": "Rome U., Tor Vergata",
+        "inspireid": "INSPIRE-00258614",
+        "name": "Satta, Alessia"
+      },
+      {
+        "affiliation": "Bristol U.",
+        "inspireid": "INSPIRE-00402066",
+        "name": "Saunders, Daniel Martin"
+      },
+      {
+        "affiliation": "Authors affiliated with an institute formerly covered by a cooperation agreement with CERN.",
+        "inspireid": "INSPIRE-00259293",
+        "name": "Savrina, Darya"
+      },
+      {
+        "affiliation": "Aachen, Tech. Hochsch.",
+        "inspireid": "INSPIRE-00123779",
+        "name": "Schael, Stefan"
+      },
+      {
+        "affiliation": "Tech. U., Dortmund (main)",
+        "inspireid": "INSPIRE-00582732",
+        "name": "Schellenberg, Margarete"
+      },
+      {
+        "affiliation": "Glasgow U.",
+        "inspireid": "INSPIRE-00257856",
+        "name": "Schiller, Manuel"
+      },
+      {
+        "affiliation": "CERN",
+        "inspireid": "INSPIRE-00357303",
+        "name": "Schindler, Heinrich"
+      },
+      {
+        "affiliation": "Heidelberg, Max Planck Inst.",
+        "inspireid": "INSPIRE-00124172",
+        "name": "Schmelling, Michael"
+      },
+      {
+        "affiliation": "Tech. U., Dortmund (main)",
+        "inspireid": "INSPIRE-00522799",
+        "name": "Schmelzer, Timon"
+      },
+      {
+        "affiliation": "CERN",
+        "inspireid": "INSPIRE-00260343",
+        "name": "Schmidt, Burkhard"
+      },
+      {
+        "affiliation": "Ecole Polytechnique, Lausanne",
+        "inspireid": "INSPIRE-00155864",
+        "name": "Schneider, Olivier"
+      },
+      {
+        "affiliation": "CERN",
+        "inspireid": "INSPIRE-00171861",
+        "name": "Schopper, Andreas"
+      },
+      {
+        "affiliation": "Cincinnati U.",
+        "name": "Schreiner, H.F."
+      },
+      {
+        "affiliation": "Ecole Polytechnique, Lausanne",
+        "inspireid": "INSPIRE-00536951",
+        "name": "Schubiger, Maxime"
+      },
+      {
+        "affiliation": "Orsay, LAL",
+        "inspireid": "INSPIRE-00124570",
+        "name": "Schune, Marie Helene"
+      },
+      {
+        "affiliation": "CERN",
+        "inspireid": "INSPIRE-00260360",
+        "name": "Schwemmer, Rainer"
+      },
+      {
+        "affiliation": "Frascati",
+        "inspireid": "INSPIRE-00038235",
+        "name": "Sciascia, Barbara"
+      },
+      {
+        "affiliation": "INFN, Rome; U. Rome La Sapienza (main)",
+        "inspireid": "INSPIRE-00262979",
+        "name": "Sciubba, Adalberto"
+      },
+      {
+        "affiliation": "CERN",
+        "name": "Sciuccati, Augusto"
+      },
+      {
+        "affiliation": "Authors affiliated with an institute formerly covered by a cooperation agreement with CERN.",
+        "inspireid": "INSPIRE-00259305",
+        "name": "Semennikov, Alexander"
+      },
+      {
+        "affiliation": "Paris U., VI-VII",
+        "name": "Sepulveda, Eduardo Enrique"
+      },
+      {
+        "affiliation": "Birmingham U.",
+        "inspireid": "INSPIRE-00184370",
+        "name": "Sergi, Antonino"
+      },
+      {
+        "affiliation": "Zurich U.",
+        "inspireid": "INSPIRE-00258830",
+        "name": "Serra, Nicola"
+      },
+      {
+        "affiliation": "Marseille, CPPM",
+        "inspireid": "INSPIRE-00144713",
+        "name": "Serrano, Justine"
+      },
+      {
+        "affiliation": "INFN, Padua",
+        "inspireid": "INSPIRE-00454148",
+        "name": "Sestini, Lorenzo"
+      },
+      {
+        "affiliation": "CERN",
+        "inspireid": "INSPIRE-00341737",
+        "name": "Seyfert, Paul"
+      },
+      {
+        "affiliation": "Authors affiliated with an institute formerly covered by a cooperation agreement with CERN.",
+        "inspireid": "INSPIRE-00200269",
+        "name": "Shapkin, Mikhail"
+      },
+      {
+        "affiliation": "Authors affiliated with an institute formerly covered by a cooperation agreement with CERN.",
+        "inspireid": "INSPIRE-00005552",
+        "name": "Shcheglov, Yury"
+      },
+      {
+        "affiliation": "Liverpool U.",
+        "inspireid": "INSPIRE-00125751",
+        "name": "Shears, Tara"
+      },
+      {
+        "affiliation": "Authors affiliated with an institute formerly covered by a cooperation agreement with CERN.",
+        "inspireid": "INSPIRE-00072482",
+        "name": "Shekhtman, Lev"
+      },
+      {
+        "affiliation": "Authors affiliated with an institute formerly covered by a cooperation agreement with CERN.",
+        "inspireid": "INSPIRE-00259319",
+        "name": "Shevchenko, Vladimir"
+      },
+      {
+        "affiliation": "INFN, Ferrara; Ferrara U.",
+        "inspireid": "INSPIRE-00536966",
+        "name": "Siddi, Benedetto Gianluca"
+      },
+      {
+        "affiliation": "Zurich U.",
+        "inspireid": "INSPIRE-00341765",
+        "name": "Silva Coutinho, Rafael"
+      },
+      {
+        "affiliation": "Rio de Janeiro Federal U.",
+        "inspireid": "INSPIRE-00536971",
+        "name": "Silva de Oliveira, Luiz Gustavo"
+      },
+      {
+        "affiliation": "INFN, Padua; U. Padua (main)",
+        "inspireid": "INSPIRE-00042241",
+        "name": "Simi, Gabriele"
+      },
+      {
+        "affiliation": "INFN, Bari; Bari U.",
+        "inspireid": "INSPIRE-00408677",
+        "name": "Simone, Saverio"
+      },
+      {
+        "affiliation": "Bristol U.",
+        "inspireid": "INSPIRE-00392618",
+        "name": "Skidmore, Nicola"
+      },
+      {
+        "affiliation": "Syracuse U.",
+        "inspireid": "INSPIRE-00165164",
+        "name": "Skwarnicki, Tomasz"
+      },
+      {
+        "affiliation": "Aachen, Tech. Hochsch.",
+        "inspireid": "INSPIRE-00266880",
+        "name": "Smith, Eluned"
+      },
+      {
+        "affiliation": "Edinburgh U.",
+        "inspireid": "INSPIRE-00536980",
+        "name": "Smith, Iwan Thomas"
+      },
+      {
+        "affiliation": "Cambridge U.",
+        "inspireid": "INSPIRE-00392666",
+        "name": "Smith, Jackson"
+      },
+      {
+        "affiliation": "Imperial Coll., London",
+        "inspireid": "INSPIRE-00342046",
+        "name": "Smith, Mark"
+      },
+      {
+        "affiliation": "Rio de Janeiro, CBPF",
+        "inspireid": "INSPIRE-00582750",
+        "name": "Soares Lavra, Lais"
+      },
+      {
+        "affiliation": "Cincinnati U.",
+        "inspireid": "INSPIRE-00127570",
+        "name": "Sokoloff, Michael"
+      },
+      {
+        "affiliation": "Glasgow U.",
+        "inspireid": "INSPIRE-00160205",
+        "name": "Soler, Paul"
+      },
+      {
+        "affiliation": "Rio de Janeiro Federal U.",
+        "inspireid": "INSPIRE-00257205",
+        "name": "Souza De Paula, Bruno"
+      },
+      {
+        "affiliation": "Tech. U., Dortmund (main)",
+        "inspireid": "INSPIRE-00128007",
+        "name": "Spaan, Bernhard"
+      },
+      {
+        "affiliation": "Authors affiliated with an institute formerly covered by a cooperation agreement with CERN.",
+        "name": "Spiridenkov, Eduard"
+      },
+      {
+        "affiliation": "Glasgow U.",
+        "inspireid": "INSPIRE-00042860",
+        "name": "Spradlin, Patrick"
+      },
+      {
+        "affiliation": "CERN",
+        "inspireid": "INSPIRE-00260412",
+        "name": "Stagni, Federico"
+      },
+      {
+        "affiliation": "Heidelberg U.",
+        "inspireid": "INSPIRE-00402270",
+        "name": "Stahl, Marian"
+      },
+      {
+        "affiliation": "CERN",
+        "inspireid": "INSPIRE-00257861",
+        "name": "Stahl, Sascha"
+      },
+      {
+        "affiliation": "Ecole Polytechnique, Lausanne",
+        "inspireid": "INSPIRE-00582764",
+        "name": "Stefko, Pavol"
+      },
+      {
+        "affiliation": "Imperial Coll., London",
+        "inspireid": "INSPIRE-00537009",
+        "name": "Stefkova, Slavomira"
+      },
+      {
+        "affiliation": "Zurich U.",
+        "inspireid": "INSPIRE-00260853",
+        "name": "Steinkamp, Olaf"
+      },
+      {
+        "affiliation": "Heidelberg U.",
+        "inspireid": "INSPIRE-00582773",
+        "name": "Stemmle, Simon"
+      },
+      {
+        "affiliation": "Authors affiliated with an institute formerly covered by a cooperation agreement with CERN.",
+        "inspireid": "INSPIRE-00010650",
+        "name": "Stenyakin, Oleg"
+      },
+      {
+        "affiliation": "Authors affiliated with an institute formerly covered by a cooperation agreement with CERN.",
+        "name": "Stepanova, Margarita"
+      },
+      {
+        "affiliation": "Tech. U., Dortmund (main)",
+        "inspireid": "INSPIRE-00582780",
+        "name": "Stevens, Holger"
+      },
+      {
+        "affiliation": "Syracuse U.; CERN",
+        "inspireid": "INSPIRE-00160900",
+        "name": "Stone, Sheldon"
+      },
+      {
+        "affiliation": "Zurich U.",
+        "inspireid": "INSPIRE-00004591",
+        "name": "Storaci, Barbara"
+      },
+      {
+        "affiliation": "INFN, Pisa; U. Pisa (main)",
+        "inspireid": "INSPIRE-00003424",
+        "name": "Stracka, Simone"
+      },
+      {
+        "affiliation": "Ecole Polytechnique, Lausanne",
+        "name": "Stramaglia, Maria Elena"
+      },
+      {
+        "affiliation": "Bucharest, IFIN-HH",
+        "inspireid": "INSPIRE-00341791",
+        "name": "Straticiuc, Mihai"
+      },
+      {
+        "affiliation": "Zurich U.",
+        "inspireid": "INSPIRE-00129260",
+        "name": "Straumann, Ulrich"
+      },
+      {
+        "affiliation": "Authors affiliated with an institute formerly covered by a cooperation agreement with CERN.",
+        "name": "Strokov, Sergey"
+      },
+      {
+        "affiliation": "Tsinghua U., Beijing, CHEP",
+        "name": "Sun, Jiayin"
+      },
+      {
+        "affiliation": "Wuhan U.",
+        "inspireid": "INSPIRE-00327085",
+        "name": "Sun, Liang"
+      },
+      {
+        "affiliation": "AGH-UST, Krakow",
+        "inspireid": "INSPIRE-00454405",
+        "name": "Swientek, Krzysztof"
+      },
+      {
+        "affiliation": "NIKHEF, Amsterdam + Vrije U., Amsterdam",
+        "inspireid": "INSPIRE-00392811",
+        "name": "Syropoulos, Vasileios"
+      },
+      {
+        "affiliation": "AGH-UST, Krakow",
+        "inspireid": "INSPIRE-00258964",
+        "name": "Szumlak, Tomasz"
+      },
+      {
+        "affiliation": "Beijing, GUCAS",
+        "name": "Szymanski, Maciej Pawel"
+      },
+      {
+        "affiliation": "Tsinghua U., Beijing, CHEP",
+        "name": "Tang, Zhipeng"
+      },
+      {
+        "affiliation": "Marseille, CPPM",
+        "inspireid": "INSPIRE-00506770",
+        "name": "Tayduganov, Andrey"
+      },
+      {
+        "affiliation": "Tech. U., Dortmund (main)",
+        "inspireid": "INSPIRE-00522805",
+        "name": "Tekampe, Tobias"
+      },
+      {
+        "affiliation": "INFN, Ferrara; Ferrara U.",
+        "inspireid": "INSPIRE-00391939",
+        "name": "Tellarini, Giulia"
+      },
+      {
+        "affiliation": "CERN",
+        "inspireid": "INSPIRE-00131170",
+        "name": "Teubert, Frederic"
+      },
+      {
+        "affiliation": "CERN",
+        "inspireid": "INSPIRE-00260424",
+        "name": "Thomas, Eric"
+      },
+      {
+        "affiliation": "Imperial Coll., London",
+        "inspireid": "INSPIRE-00582792",
+        "name": "Tilley, Matthew James"
+      },
+      {
+        "affiliation": "Clermont-Ferrand U.",
+        "inspireid": "INSPIRE-00131575",
+        "name": "Tisserand, Vincent"
+      },
+      {
+        "affiliation": "Annecy, LAPP",
+        "inspireid": "INSPIRE-00036863",
+        "name": "T'Jampens, Stephane"
+      },
+      {
+        "affiliation": "Ecole Polytechnique, Lausanne",
+        "inspireid": "INSPIRE-00260879",
+        "name": "Tobin, Mark"
+      },
+      {
+        "affiliation": "Cambridge U.",
+        "inspireid": "INSPIRE-00357337",
+        "name": "Tolk, Siim"
+      },
+      {
+        "affiliation": "INFN, Ferrara; Ferrara U.",
+        "inspireid": "INSPIRE-00392023",
+        "name": "Tomassetti, Luca"
+      },
+      {
+        "affiliation": "INFN, Pisa",
+        "inspireid": "INSPIRE-00053184",
+        "name": "Tonelli, Diego"
+      },
+      {
+        "affiliation": "Rio de Janeiro, CBPF",
+        "name": "Tourinho Jadallah Aoude, Rafael"
+      },
+      {
+        "affiliation": "Annecy, LAPP",
+        "inspireid": "INSPIRE-00341842",
+        "name": "Tournefier, Edwige"
+      },
+      {
+        "affiliation": "Glasgow U.",
+        "inspireid": "INSPIRE-00545600",
+        "name": "Traill, Murdo"
+      },
+      {
+        "affiliation": "Ecole Polytechnique, Lausanne",
+        "inspireid": "INSPIRE-00260665",
+        "name": "Tran, Minh T\\^am"
+      },
+      {
+        "affiliation": "Zurich U.",
+        "inspireid": "INSPIRE-00392146",
+        "name": "Tresch, Marco"
+      },
+      {
+        "affiliation": "Cambridge U.",
+        "inspireid": "INSPIRE-00454660",
+        "name": "Trisovic, Ana"
+      },
+      {
+        "affiliation": "Marseille, CPPM",
+        "inspireid": "INSPIRE-00257520",
+        "name": "Tsaregorodtsev, Andrei"
+      },
+      {
+        "affiliation": "Nikhef, Amsterdam",
+        "inspireid": "INSPIRE-00357349",
+        "name": "Tsopelas, Panagiotis"
+      },
+      {
+        "affiliation": "Cambridge U.",
+        "inspireid": "INSPIRE-00582818",
+        "name": "Tully, Alison"
+      },
+      {
+        "affiliation": "Nikhef, Amsterdam; CERN",
+        "inspireid": "INSPIRE-00258853",
+        "name": "Tuning, Niels"
+      },
+      {
+        "affiliation": "NCBJ, Swierk",
+        "inspireid": "INSPIRE-00045795",
+        "name": "Ukleja, Artur"
+      },
+      {
+        "affiliation": "Orsay, LAL",
+        "name": "Usachov, Andrii"
+      },
+      {
+        "affiliation": "Authors affiliated with an institute formerly covered by a cooperation agreement with CERN.",
+        "inspireid": "INSPIRE-00392208",
+        "name": "Ustyuzhanin, Andrey"
+      },
+      {
+        "affiliation": "Heidelberg U.",
+        "inspireid": "INSPIRE-00133105",
+        "name": "Uwer, Ulrich"
+      },
+      {
+        "affiliation": "INFN, Cagliari; Cagliari U.",
+        "inspireid": "INSPIRE-00454790",
+        "name": "Vacca, Claudia"
+      },
+      {
+        "affiliation": "Authors affiliated with an institute formerly covered by a cooperation agreement with CERN.",
+        "name": "Vagner, Alexander"
+      },
+      {
+        "affiliation": "INFN, Bologna; CERN",
+        "inspireid": "INSPIRE-00258091",
+        "name": "Vagnoni, Vincenzo"
+      },
+      {
+        "affiliation": "CERN",
+        "inspireid": "INSPIRE-00343831",
+        "name": "Valassi, Andrea"
+      },
+      {
+        "affiliation": "CERN",
+        "inspireid": "INSPIRE-00582822",
+        "name": "Valat, Sebastien"
+      },
+      {
+        "affiliation": "INFN, Bologna",
+        "inspireid": "INSPIRE-00258103",
+        "name": "Valenti, Giovanni"
+      },
+      {
+        "affiliation": "Nikhef, Amsterdam",
+        "inspireid": "INSPIRE-00032419",
+        "name": "van Beuzekom, Martinus"
+      },
+      {
+        "affiliation": "CERN",
+        "inspireid": "INSPIRE-00260103",
+        "name": "van Herwijnen, Eric"
+      },
+      {
+        "affiliation": "Nikhef, Amsterdam",
+        "inspireid": "INSPIRE-00260865",
+        "name": "van Tilburg, Jeroen"
+      },
+      {
+        "affiliation": "Nikhef, Amsterdam",
+        "inspireid": "INSPIRE-00545618",
+        "name": "van Veghel, Maarten"
+      },
+      {
+        "affiliation": "CERN",
+        "inspireid": "INSPIRE-00259633",
+        "name": "Vazquez Gomez, Ricardo"
+      },
+      {
+        "affiliation": "U. Santiago de Compostela (main)",
+        "inspireid": "INSPIRE-00259816",
+        "name": "Vazquez Regueiro, Pablo"
+      },
+      {
+        "affiliation": "Nikhef, Amsterdam",
+        "inspireid": "INSPIRE-00392390",
+        "name": "V\\'azquez Sierra, Carlos"
+      },
+      {
+        "affiliation": "INFN, Ferrara",
+        "inspireid": "INSPIRE-00258200",
+        "name": "Vecchi, Stefania"
+      },
+      {
+        "affiliation": "Bristol U.",
+        "inspireid": "INSPIRE-00318722",
+        "name": "Velthuis, Jaap"
+      },
+      {
+        "affiliation": "INFN, Florence; U. Urbino (main)",
+        "inspireid": "INSPIRE-00258261",
+        "name": "Veltri, Michele"
+      },
+      {
+        "affiliation": "Oxford U.",
+        "inspireid": "INSPIRE-00357350",
+        "name": "Veneziano, Giovanni"
+      },
+      {
+        "affiliation": "Syracuse U.",
+        "inspireid": "INSPIRE-00582834",
+        "name": "Venkateswaran, Aravindhan"
+      },
+      {
+        "affiliation": "Aachen, Tech. Hochsch.",
+        "name": "Verlage, Tobias Anton"
+      },
+      {
+        "affiliation": "Clermont-Ferrand U.",
+        "inspireid": "INSPIRE-00582843",
+        "name": "Vernet, Maxime"
+      },
+      {
+        "affiliation": "Oxford U.",
+        "inspireid": "INSPIRE-00014030",
+        "name": "Vesterinen, Mika"
+      },
+      {
+        "affiliation": "CERN",
+        "inspireid": "INSPIRE-00454985",
+        "name": "Viana Barbosa, Joao Vitor"
+      },
+      {
+        "affiliation": "Beijing, GUCAS",
+        "inspireid": "INSPIRE-00341866",
+        "name": "Vieira, Daniel"
+      },
+      {
+        "affiliation": "U. Santiago de Compostela (main)",
+        "inspireid": "INSPIRE-00455170",
+        "name": "Vieites Diaz, Maria"
+      },
+      {
+        "affiliation": "Rostock U.",
+        "inspireid": "INSPIRE-00582859",
+        "name": "Viemann, Harald"
+      },
+      {
+        "affiliation": "U. Barcelona (main)",
+        "inspireid": "INSPIRE-00259644",
+        "name": "Vilasis-Cardona, Xavier"
+      },
+      {
+        "affiliation": "Nikhef, Amsterdam",
+        "name": "Vitkovskiy, Arseniy"
+      },
+      {
+        "affiliation": "Cambridge U.",
+        "inspireid": "INSPIRE-00582862",
+        "name": "Vitti, Marcela"
+      },
+      {
+        "affiliation": "Zurich U.",
+        "inspireid": "INSPIRE-00260888",
+        "name": "Vollhardt, Achim"
+      },
+      {
+        "affiliation": "CERN",
+        "inspireid": "INSPIRE-00582871",
+        "name": "Voneki, Balazs"
+      },
+      {
+        "affiliation": "Authors affiliated with an institute formerly covered by a cooperation agreement with CERN.",
+        "inspireid": "INSPIRE-00312898",
+        "name": "Vorobyev, Alexey"
+      },
+      {
+        "affiliation": "Authors affiliated with an institute formerly covered by a cooperation agreement with CERN.",
+        "inspireid": "INSPIRE-00341883",
+        "name": "Vorobyev, Vitaly"
+      },
+      {
+        "affiliation": "Authors affiliated with an institute formerly covered by a cooperation agreement with CERN.",
+        "name": "Voropaev, Nikolai"
+      },
+      {
+        "affiliation": "Aachen, Tech. Hochsch.",
+        "inspireid": "INSPIRE-00000638",
+        "name": "Vo\\ss, Christian"
+      },
+      {
+        "affiliation": "Rostock U.",
+        "inspireid": "INSPIRE-00134615",
+        "name": "Waldi, Roland"
+      },
+      {
+        "affiliation": "INFN, Pisa",
+        "inspireid": "INSPIRE-00134726",
+        "name": "Walsh, John"
+      },
+      {
+        "affiliation": "Syracuse U.",
+        "inspireid": "INSPIRE-00262940",
+        "name": "Wang, Jianchun"
+      },
+      {
+        "affiliation": "Tsinghua U., Beijing, CHEP",
+        "name": "Wang, Mengzhen"
+      },
+      {
+        "affiliation": "CCNU, Wuhan, Inst. Part. Phys.",
+        "name": "Wang, Yilong"
+      },
+      {
+        "affiliation": "Cambridge U.",
+        "inspireid": "INSPIRE-00144738",
+        "name": "Ward, David"
+      },
+      {
+        "affiliation": "Liverpool U.",
+        "inspireid": "INSPIRE-00582888",
+        "name": "Wark, Heather Mckenzie"
+      },
+      {
+        "affiliation": "Birmingham U.",
+        "inspireid": "INSPIRE-00146172",
+        "name": "Watson, Nigel"
+      },
+      {
+        "affiliation": "Imperial Coll., London",
+        "inspireid": "INSPIRE-00135220",
+        "name": "Websdale, David"
+      },
+      {
+        "affiliation": "Zurich U.",
+        "inspireid": "INSPIRE-00522810",
+        "name": "Weiden, Andreas"
+      },
+      {
+        "affiliation": "MIT",
+        "name": "Weisser, Constantin"
+      },
+      {
+        "affiliation": "CERN",
+        "inspireid": "INSPIRE-00261160",
+        "name": "Whitehead, Mark"
+      },
+      {
+        "affiliation": "Warwick U.",
+        "inspireid": "INSPIRE-00341892",
+        "name": "Wicht, Jean"
+      },
+      {
+        "affiliation": "Oxford U.",
+        "inspireid": "INSPIRE-00262885",
+        "name": "Wilkinson, Guy"
+      },
+      {
+        "affiliation": "Syracuse U.",
+        "inspireid": "INSPIRE-00452781",
+        "name": "Wilkinson, Michael K."
+      },
+      {
+        "affiliation": "MIT",
+        "inspireid": "INSPIRE-00342010",
+        "name": "Williams, Mike"
+      },
+      {
+        "affiliation": "Manchester U.",
+        "inspireid": "INSPIRE-00136085",
+        "name": "Williams, Mark Richard James"
+      },
+      {
+        "affiliation": "Birmingham U.",
+        "inspireid": "INSPIRE-00537010",
+        "name": "Williams, Timothy"
+      },
+      {
+        "affiliation": "Rutherford; CERN",
+        "inspireid": "INSPIRE-00136130",
+        "name": "Wilson, Fergus"
+      },
+      {
+        "affiliation": "Maryland U., College Park",
+        "inspireid": "INSPIRE-00392586",
+        "name": "Wimberley, Jack"
+      },
+      {
+        "affiliation": "Orsay, LAL",
+        "name": "Winn, Michael Andreas"
+      },
+      {
+        "affiliation": "Tech. U., Dortmund (main)",
+        "inspireid": "INSPIRE-00257673",
+        "name": "Wishahi, Julian"
+      },
+      {
+        "affiliation": "NCBJ, Swierk",
+        "inspireid": "INSPIRE-00136336",
+        "name": "Wislicki, Wojciech"
+      },
+      {
+        "affiliation": "Cracow, INP",
+        "inspireid": "INSPIRE-00258926",
+        "name": "Witek, Mariusz"
+      },
+      {
+        "affiliation": "Orsay, LAL",
+        "inspireid": "INSPIRE-00136673",
+        "name": "Wormser, Guy"
+      },
+      {
+        "affiliation": "Cambridge U.",
+        "inspireid": "INSPIRE-00261140",
+        "name": "Wotton, Stephen"
+      },
+      {
+        "affiliation": "CERN",
+        "inspireid": "INSPIRE-00260456",
+        "name": "Wyllie, Kenneth"
+      },
+      {
+        "affiliation": "CCNU, Wuhan, Inst. Part. Phys.",
+        "inspireid": "INSPIRE-00025656",
+        "name": "Xie, Yuehong"
+      },
+      {
+        "affiliation": "CCNU, Wuhan, Inst. Part. Phys.",
+        "name": "Xu, Menglin"
+      },
+      {
+        "affiliation": "Beijing, GUCAS",
+        "name": "Xu, Qingnian"
+      },
+      {
+        "affiliation": "Tsinghua U., Beijing, CHEP",
+        "name": "Xu, Zehua"
+      },
+      {
+        "affiliation": "Annecy, LAPP",
+        "inspireid": "INSPIRE-00455305",
+        "name": "Xu, Zhirui"
+      },
+      {
+        "affiliation": "Tsinghua U., Beijing, CHEP",
+        "inspireid": "INSPIRE-00257282",
+        "name": "Yang, Zhenwei"
+      },
+      {
+        "affiliation": "Maryland U., College Park",
+        "name": "Yang, Zishuo"
+      },
+      {
+        "affiliation": "Syracuse U.",
+        "inspireid": "INSPIRE-00582891",
+        "name": "Yao, Yuezhe"
+      },
+      {
+        "affiliation": "CCNU, Wuhan, Inst. Part. Phys.",
+        "inspireid": "INSPIRE-00038031",
+        "name": "Yin, Hang"
+      },
+      {
+        "affiliation": "CCNU, Wuhan, Inst. Part. Phys.; Hunan U.",
+        "inspireid": "INSPIRE-00447456",
+        "name": "Yu, Jiesheng"
+      },
+      {
+        "affiliation": "Syracuse U.",
+        "inspireid": "INSPIRE-00341946",
+        "name": "Yuan, Xuhao"
+      },
+      {
+        "affiliation": "Authors affiliated with an institute formerly covered by a cooperation agreement with CERN.",
+        "inspireid": "INSPIRE-00200283",
+        "name": "Yushchenko, Oleg"
+      },
+      {
+        "affiliation": "Birmingham U.",
+        "inspireid": "INSPIRE-00582900",
+        "name": "Zarebski, Kristian Alexander"
+      },
+      {
+        "affiliation": "Heidelberg, Max Planck Inst.; Authors affiliated with an institute formerly covered by a cooperation agreement with CERN.",
+        "inspireid": "INSPIRE-00357381",
+        "name": "Zavertyaev, Mikhail"
+      },
+      {
+        "affiliation": "Tsinghua U., Beijing, CHEP",
+        "inspireid": "INSPIRE-00043581",
+        "name": "Zhang, Liming"
+      },
+      {
+        "affiliation": "Orsay, LAL",
+        "inspireid": "INSPIRE-00257306",
+        "name": "Zhang, Yanxi"
+      },
+      {
+        "affiliation": "Heidelberg U.",
+        "inspireid": "INSPIRE-00217483",
+        "name": "Zhelezov, Alexey"
+      },
+      {
+        "affiliation": "Beijing, GUCAS",
+        "inspireid": "INSPIRE-00138380",
+        "name": "Zheng, Yangheng"
+      },
+      {
+        "affiliation": "Tsinghua U., Beijing, CHEP",
+        "inspireid": "INSPIRE-00183811",
+        "name": "Zhu, Xianglei"
+      },
+      {
+        "affiliation": "Aachen, Tech. Hochsch.; Authors affiliated with an institute formerly covered by a cooperation agreement with CERN.",
+        "inspireid": "INSPIRE-00170284",
+        "name": "Zhukov, Valery"
+      },
+      {
+        "affiliation": "Edinburgh U.",
+        "name": "Zonneveld, Jennifer Brigitta"
+      },
+      {
+        "affiliation": "INFN, Bologna; Bologna U.",
+        "inspireid": "INSPIRE-00040570",
+        "name": "Zucchelli, Stefano"
+      }
+    ],
+    "collaboration": {
+      "name": "LHCb collaboration"
+    },
+    "collections": [
+      "Author-Lists"
+    ],
+    "date_created": [
+      "2017"
+    ],
+    "date_published": "2026",
+    "experiment": [
+      "LHCb"
+    ],
+    "publisher": "CERN Open Data Portal",
+    "recid": "459",
+    "title": "LHCb author list for the LHCb 2017 open data release",
+    "type": {
+      "primary": "Documentation",
+      "secondary": [
+        "Authors"
+      ]
+    }
+  }
+]


### PR DESCRIPTION
I have converted the 2015-2017 LHCb author lists from December 31 of each year to the expected schema. This relies on querying the inspirehep database to get the inspire ID. 

Currently the queries are only successful if an ORCID is supplied with the author on the author list, in which case the name, inspire ID, and affiliations are gathered from the inspire DB. Otherwise the name and affiliations are extracted directly from the author list. 

Some extra work could be done to make the queries to the inspire DB successful by name in an orcid is not supplied, but this takes a lot of additional effort and can lead to false positives. I am hoping this is "good enough" as it effectively blocks the run 2 metadata release(a PR will be made for this soon).

The record IDs are set to "XYZ" temporarily, but I did confirm that the author lists upload and render properly using the development guide. Once we have firm recids I will need this for the run 2 metadata records to refer to the appropriate author lists. The PR for the run 2 metadata records is here (https://github.com/cernopendata/opendata.cern.ch/pull/3790).

cc @tiborsimko, @pietnogga, @MindaugasSarpis 