### PR TITLE
Add LHCb run2 metadata records

### DIFF
--- a/data/records/LHCb_2015_Beam6500GeV_VeloClosed_MagDown_RealData_Reco15a_Stripping24r2_BHADRONCOMPLETEEVENT_DST.json
+++ b/data/records/LHCb_2015_Beam6500GeV_VeloClosed_MagDown_RealData_Reco15a_Stripping24r2_BHADRONCOMPLETEEVENT_DST.json
@@ -1,0 +1,177 @@
+[{
+  "abstract": {
+    "description": "Data from proton-proton (pp) collisions collected by the LHCb experiment in the year 2015 of Run2 of the LHC."
+  },
+  "accelerator": "CERN-LHC",
+  "collaboration": {
+    "name": "LHCb collaboration",
+    "recid": "456"
+  },
+  "collections": [
+    "LHCb-Collision-Datasets"
+  ],
+  "collision_information": {
+    "energy": "13TeV",
+    "type": "pp"
+  },
+  "date_created": [
+    "2015"
+  ],
+  "date_published": "2026",
+  "date_reprocessed": "2020",
+  "distribution": {
+    "formats": [
+      "DST"
+    ],
+    "number_events": 187939373,
+    "number_files": 5424,
+    "size": 18980101689304
+  },
+  "experiment": [
+    "LHCb"
+  ],
+  "magnet_polarity": "MagDown",
+  "methodology": {
+    "description": "<p> This dataset was created in several production steps. These steps, software used and the configuration is provided below. </p><p> <strong> Prod ID: &nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;</strong> 102354<p> <strong>Prod type:&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp; </strong> Merge<p> <strong> Parent Prod ID:&nbsp;&nbsp;&nbsp;&nbsp; </strong> 102353<p> <strong> Parent Prod type: </strong> DataStripping<p> <strong> Conditions: </strong><p>dddb-20190206-3<p>cond-20191004</strong><p> <strong> List of Trigger Configuration Keys (TCK): </strong> </p> <p><p><strong>TCK &nbsp;&nbsp;&nbsp;&nbsp;&nbsp; Number of Files </strong><p>0x10700a1 &nbsp;&nbsp;&nbsp;&nbsp;&nbsp; 267<p>0x10600a3 &nbsp;&nbsp;&nbsp;&nbsp;&nbsp; 2110<p>0x10600a7 &nbsp;&nbsp;&nbsp;&nbsp;&nbsp; 71<p>0x10600a2 &nbsp;&nbsp;&nbsp;&nbsp;&nbsp; 2607<p>0x10800a2 &nbsp;&nbsp;&nbsp;&nbsp;&nbsp; 366<p>0x10600a6 &nbsp;&nbsp;&nbsp;&nbsp;&nbsp; 3",
+    "steps": [
+      {
+        "configuration_files": [
+          {
+            "title": "DaVinci/DV-Stripping24r2-Stripping.py"
+          },
+          {
+            "title": "DaVinci/DV-RedoCaloPID-Stripping_28_24.py"
+          },
+          {
+            "title": "DaVinci/DataType-2015.py"
+          },
+          {
+            "title": "DaVinci/InputType-RDST.py"
+          },
+          {
+            "title": "Persistency/Compression-ZLIB-1.py"
+          },
+          {
+            "title": "DaVinci/DV-RawEventJuggler-0_3-to-4_3.py"
+          }
+        ],
+        "release": "DaVinci.v44r10p5 AppConfig.v3r393 Det/SQLDDDB.v7r10 TMVAWeights.v1r16",
+        "type": "Stripping24r2"
+      },
+      {
+        "configuration_files": [
+          {
+            "title": "Merging/DV-Stripping-Merging.py"
+          },
+          {
+            "title": "Persistency/Compression-LZMA-4.py"
+          }
+        ],
+        "release": "DaVinci.v44r10p5 AppConfig.v3r393 Det/SQLDDDB.v7r10",
+        "type": "Stripping24r2-Merging"
+      },
+      {
+        "configuration_files": [
+          {
+            "title": "DaVinci/DV-Stripping24r2-Stripping.py"
+          },
+          {
+            "title": "DaVinci/DV-RedoCaloPID-Stripping_28_24.py"
+          },
+          {
+            "title": "DaVinci/DataType-2015.py"
+          },
+          {
+            "title": "DaVinci/InputType-RDST.py"
+          },
+          {
+            "title": "Persistency/Compression-ZLIB-1.py"
+          },
+          {
+            "title": "DaVinci/DV-RawEventJuggler-0_3-to-4_3.py"
+          }
+        ],
+        "release": "DaVinci.v44r10p5 AppConfig.v3r393 Det/SQLDDDB.v7r10 TMVAWeights.v1r16",
+        "type": "Stripping24r2"
+      },
+      {
+        "configuration_files": [
+          {
+            "title": "Merging/DV-Stripping-Merging.py"
+          },
+          {
+            "title": "Persistency/Compression-LZMA-4.py"
+          }
+        ],
+        "release": "DaVinci.v44r10p5 AppConfig.v3r393 Det/SQLDDDB.v7r10",
+        "type": "Stripping24r2-Merging"
+      },
+      {
+        "configuration_files": [
+          {
+            "title": "DaVinci/DV-Stripping24r2-Stripping.py"
+          },
+          {
+            "title": "DaVinci/DV-RedoCaloPID-Stripping_28_24.py"
+          },
+          {
+            "title": "DaVinci/DataType-2015.py"
+          },
+          {
+            "title": "DaVinci/InputType-RDST.py"
+          },
+          {
+            "title": "Persistency/Compression-ZLIB-1.py"
+          },
+          {
+            "title": "DaVinci/DV-RawEventJuggler-0_3-to-4_3.py"
+          }
+        ],
+        "release": "DaVinci.v44r10p5 AppConfig.v3r393 Det/SQLDDDB.v7r10 TMVAWeights.v1r16",
+        "type": "Stripping24r2"
+      },
+      {
+        "configuration_files": [
+          {
+            "title": "Merging/DV-Stripping-Merging.py"
+          },
+          {
+            "title": "Persistency/Compression-LZMA-4.py"
+          }
+        ],
+        "release": "DaVinci.v44r10p5 AppConfig.v3r393 Det/SQLDDDB.v7r10",
+        "type": "Stripping24r2-Merging"
+      }
+    ]
+  },
+  "publisher": "CERN Open Data Portal",
+  "recid": "24625",
+  "run_period": [
+    "2015"
+  ],
+  "stripping": {
+    "stream": "BHADRONCOMPLETEEVENT",
+    "version": "stripping24r2"
+  },
+  "title": "LHCb 2015 Beam6500GeV MagDown BHADRONCOMPLETEEVENT Stream Stripping24r2",
+  "title_additional": "",
+  "type": {
+    "primary": "Dataset",
+    "secondary": [
+      "Collision"
+    ]
+  },
+  "usage": {
+    "description": "<p> The Run 1 and 2 data collected by the LHCb detector is available using the LHCb Ntupling Service, while the Run 1 data is additionally available in .DST and .mDST formats. The data obtained from the LHCb Ntupling Service are ROOT ntuples and do not require custom software to analyze. <p> Links are provided to the LHCb Ntupling Service for exploration of available data and the LHCb Open Data Guide for usage instructions.",
+    "links": [
+      {
+        "description": "LHCb Ntupling Service",
+        "url": "https://opendata-lhcb-ntupling-service.app.cern.ch/"
+      },
+      {
+        "description": "LHCb Open Data Guide",
+        "url": "https://lhcb-opendata-guide.web.cern.ch/"
+      }
+    ]
+  }
+}]

--- a/data/records/LHCb_2015_Beam6500GeV_VeloClosed_MagDown_RealData_Reco15a_Stripping24r2_BHADRON_MDST.json
+++ b/data/records/LHCb_2015_Beam6500GeV_VeloClosed_MagDown_RealData_Reco15a_Stripping24r2_BHADRON_MDST.json
@@ -1,0 +1,177 @@
+[{
+  "abstract": {
+    "description": "Data from proton-proton (pp) collisions collected by the LHCb experiment in the year 2015 of Run2 of the LHC."
+  },
+  "accelerator": "CERN-LHC",
+  "collaboration": {
+    "name": "LHCb collaboration",
+    "recid": "456"
+  },
+  "collections": [
+    "LHCb-Collision-Datasets"
+  ],
+  "collision_information": {
+    "energy": "13TeV",
+    "type": "pp"
+  },
+  "date_created": [
+    "2015"
+  ],
+  "date_published": "2026",
+  "date_reprocessed": "2020",
+  "distribution": {
+    "formats": [
+      "MDST"
+    ],
+    "number_events": 649842770,
+    "number_files": 3041,
+    "size": 9898793831360
+  },
+  "experiment": [
+    "LHCb"
+  ],
+  "magnet_polarity": "MagDown",
+  "methodology": {
+    "description": "<p> This dataset was created in several production steps. These steps, software used and the configuration is provided below. </p><p> <strong> Prod ID: &nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;</strong> 102452<p> <strong>Prod type:&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp; </strong> Merge<p> <strong> Parent Prod ID:&nbsp;&nbsp;&nbsp;&nbsp; </strong> 102353<p> <strong> Parent Prod type: </strong> DataStripping<p> <strong> Conditions: </strong><p>dddb-20190206-3<p>cond-20191004</strong><p> <strong> List of Trigger Configuration Keys (TCK): </strong> </p> <p><p><strong>TCK &nbsp;&nbsp;&nbsp;&nbsp;&nbsp; Number of Files </strong><p>0x10700a1 &nbsp;&nbsp;&nbsp;&nbsp;&nbsp; 160<p>0x10600a7 &nbsp;&nbsp;&nbsp;&nbsp;&nbsp; 41<p>0x10600a6 &nbsp;&nbsp;&nbsp;&nbsp;&nbsp; 2<p>0x10600a3 &nbsp;&nbsp;&nbsp;&nbsp;&nbsp; 1189<p>0x10600a2 &nbsp;&nbsp;&nbsp;&nbsp;&nbsp; 1455<p>0x10800a2 &nbsp;&nbsp;&nbsp;&nbsp;&nbsp; 194",
+    "steps": [
+      {
+        "configuration_files": [
+          {
+            "title": "DaVinci/DV-Stripping24r2-Stripping.py"
+          },
+          {
+            "title": "DaVinci/DV-RedoCaloPID-Stripping_28_24.py"
+          },
+          {
+            "title": "DaVinci/DataType-2015.py"
+          },
+          {
+            "title": "DaVinci/InputType-RDST.py"
+          },
+          {
+            "title": "Persistency/Compression-ZLIB-1.py"
+          },
+          {
+            "title": "DaVinci/DV-RawEventJuggler-0_3-to-4_3.py"
+          }
+        ],
+        "release": "DaVinci.v44r10p5 AppConfig.v3r393 Det/SQLDDDB.v7r10 TMVAWeights.v1r16",
+        "type": "Stripping24r2"
+      },
+      {
+        "configuration_files": [
+          {
+            "title": "Merging/DV-Stripping-Merging.py"
+          },
+          {
+            "title": "Persistency/Compression-LZMA-4.py"
+          }
+        ],
+        "release": "DaVinci.v44r10p5 AppConfig.v3r393 Det/SQLDDDB.v7r10",
+        "type": "Stripping24r2-Merging"
+      },
+      {
+        "configuration_files": [
+          {
+            "title": "DaVinci/DV-Stripping24r2-Stripping.py"
+          },
+          {
+            "title": "DaVinci/DV-RedoCaloPID-Stripping_28_24.py"
+          },
+          {
+            "title": "DaVinci/DataType-2015.py"
+          },
+          {
+            "title": "DaVinci/InputType-RDST.py"
+          },
+          {
+            "title": "Persistency/Compression-ZLIB-1.py"
+          },
+          {
+            "title": "DaVinci/DV-RawEventJuggler-0_3-to-4_3.py"
+          }
+        ],
+        "release": "DaVinci.v44r10p5 AppConfig.v3r393 Det/SQLDDDB.v7r10 TMVAWeights.v1r16",
+        "type": "Stripping24r2"
+      },
+      {
+        "configuration_files": [
+          {
+            "title": "Merging/DV-Stripping-Merging.py"
+          },
+          {
+            "title": "Persistency/Compression-LZMA-4.py"
+          }
+        ],
+        "release": "DaVinci.v44r10p5 AppConfig.v3r393 Det/SQLDDDB.v7r10",
+        "type": "Stripping24r2-Merging"
+      },
+      {
+        "configuration_files": [
+          {
+            "title": "DaVinci/DV-Stripping24r2-Stripping.py"
+          },
+          {
+            "title": "DaVinci/DV-RedoCaloPID-Stripping_28_24.py"
+          },
+          {
+            "title": "DaVinci/DataType-2015.py"
+          },
+          {
+            "title": "DaVinci/InputType-RDST.py"
+          },
+          {
+            "title": "Persistency/Compression-ZLIB-1.py"
+          },
+          {
+            "title": "DaVinci/DV-RawEventJuggler-0_3-to-4_3.py"
+          }
+        ],
+        "release": "DaVinci.v44r10p5 AppConfig.v3r393 Det/SQLDDDB.v7r10 TMVAWeights.v1r16",
+        "type": "Stripping24r2"
+      },
+      {
+        "configuration_files": [
+          {
+            "title": "Merging/DV-Stripping-Merging.py"
+          },
+          {
+            "title": "Persistency/Compression-LZMA-4.py"
+          }
+        ],
+        "release": "DaVinci.v44r10p5 AppConfig.v3r393 Det/SQLDDDB.v7r10",
+        "type": "Stripping24r2-Merging"
+      }
+    ]
+  },
+  "publisher": "CERN Open Data Portal",
+  "recid": "24624",
+  "run_period": [
+    "2015"
+  ],
+  "stripping": {
+    "stream": "BHADRON",
+    "version": "stripping24r2"
+  },
+  "title": "LHCb 2015 Beam6500GeV MagDown BHADRON Stream Stripping24r2",
+  "title_additional": "",
+  "type": {
+    "primary": "Dataset",
+    "secondary": [
+      "Collision"
+    ]
+  },
+  "usage": {
+    "description": "<p> The Run 1 and 2 data collected by the LHCb detector is available using the LHCb Ntupling Service, while the Run 1 data is additionally available in .DST and .mDST formats. The data obtained from the LHCb Ntupling Service are ROOT ntuples and do not require custom software to analyze. <p> Links are provided to the LHCb Ntupling Service for exploration of available data and the LHCb Open Data Guide for usage instructions.",
+    "links": [
+      {
+        "description": "LHCb Ntupling Service",
+        "url": "https://opendata-lhcb-ntupling-service.app.cern.ch/"
+      },
+      {
+        "description": "LHCb Open Data Guide",
+        "url": "https://lhcb-opendata-guide.web.cern.ch/"
+      }
+    ]
+  }
+}]

--- a/data/records/LHCb_2015_Beam6500GeV_VeloClosed_MagDown_RealData_Reco15a_Stripping24r2_CHARMCOMPLETEEVENT_DST.json
+++ b/data/records/LHCb_2015_Beam6500GeV_VeloClosed_MagDown_RealData_Reco15a_Stripping24r2_CHARMCOMPLETEEVENT_DST.json
@@ -1,0 +1,177 @@
+[{
+  "abstract": {
+    "description": "Data from proton-proton (pp) collisions collected by the LHCb experiment in the year 2015 of Run2 of the LHC."
+  },
+  "accelerator": "CERN-LHC",
+  "collaboration": {
+    "name": "LHCb collaboration",
+    "recid": "456"
+  },
+  "collections": [
+    "LHCb-Collision-Datasets"
+  ],
+  "collision_information": {
+    "energy": "13TeV",
+    "type": "pp"
+  },
+  "date_created": [
+    "2015"
+  ],
+  "date_published": "2026",
+  "date_reprocessed": "2020",
+  "distribution": {
+    "formats": [
+      "DST"
+    ],
+    "number_events": 87698560,
+    "number_files": 2606,
+    "size": 7877266679882
+  },
+  "experiment": [
+    "LHCb"
+  ],
+  "magnet_polarity": "MagDown",
+  "methodology": {
+    "description": "<p> This dataset was created in several production steps. These steps, software used and the configuration is provided below. </p><p> <strong> Prod ID: &nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;</strong> 102354<p> <strong>Prod type:&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp; </strong> Merge<p> <strong> Parent Prod ID:&nbsp;&nbsp;&nbsp;&nbsp; </strong> 102353<p> <strong> Parent Prod type: </strong> DataStripping<p> <strong> Conditions: </strong><p>dddb-20190206-3<p>cond-20191004</strong><p> <strong> List of Trigger Configuration Keys (TCK): </strong> </p> <p><p><strong>TCK &nbsp;&nbsp;&nbsp;&nbsp;&nbsp; Number of Files </strong><p>0x10700a1 &nbsp;&nbsp;&nbsp;&nbsp;&nbsp; 147<p>0x10600a7 &nbsp;&nbsp;&nbsp;&nbsp;&nbsp; 40<p>0x10600a3 &nbsp;&nbsp;&nbsp;&nbsp;&nbsp; 1004<p>0x10600a2 &nbsp;&nbsp;&nbsp;&nbsp;&nbsp; 1244<p>0x10800a2 &nbsp;&nbsp;&nbsp;&nbsp;&nbsp; 169<p>0x10600a6 &nbsp;&nbsp;&nbsp;&nbsp;&nbsp; 2",
+    "steps": [
+      {
+        "configuration_files": [
+          {
+            "title": "DaVinci/DV-Stripping24r2-Stripping.py"
+          },
+          {
+            "title": "DaVinci/DV-RedoCaloPID-Stripping_28_24.py"
+          },
+          {
+            "title": "DaVinci/DataType-2015.py"
+          },
+          {
+            "title": "DaVinci/InputType-RDST.py"
+          },
+          {
+            "title": "Persistency/Compression-ZLIB-1.py"
+          },
+          {
+            "title": "DaVinci/DV-RawEventJuggler-0_3-to-4_3.py"
+          }
+        ],
+        "release": "DaVinci.v44r10p5 AppConfig.v3r393 Det/SQLDDDB.v7r10 TMVAWeights.v1r16",
+        "type": "Stripping24r2"
+      },
+      {
+        "configuration_files": [
+          {
+            "title": "Merging/DV-Stripping-Merging.py"
+          },
+          {
+            "title": "Persistency/Compression-LZMA-4.py"
+          }
+        ],
+        "release": "DaVinci.v44r10p5 AppConfig.v3r393 Det/SQLDDDB.v7r10",
+        "type": "Stripping24r2-Merging"
+      },
+      {
+        "configuration_files": [
+          {
+            "title": "DaVinci/DV-Stripping24r2-Stripping.py"
+          },
+          {
+            "title": "DaVinci/DV-RedoCaloPID-Stripping_28_24.py"
+          },
+          {
+            "title": "DaVinci/DataType-2015.py"
+          },
+          {
+            "title": "DaVinci/InputType-RDST.py"
+          },
+          {
+            "title": "Persistency/Compression-ZLIB-1.py"
+          },
+          {
+            "title": "DaVinci/DV-RawEventJuggler-0_3-to-4_3.py"
+          }
+        ],
+        "release": "DaVinci.v44r10p5 AppConfig.v3r393 Det/SQLDDDB.v7r10 TMVAWeights.v1r16",
+        "type": "Stripping24r2"
+      },
+      {
+        "configuration_files": [
+          {
+            "title": "Merging/DV-Stripping-Merging.py"
+          },
+          {
+            "title": "Persistency/Compression-LZMA-4.py"
+          }
+        ],
+        "release": "DaVinci.v44r10p5 AppConfig.v3r393 Det/SQLDDDB.v7r10",
+        "type": "Stripping24r2-Merging"
+      },
+      {
+        "configuration_files": [
+          {
+            "title": "DaVinci/DV-Stripping24r2-Stripping.py"
+          },
+          {
+            "title": "DaVinci/DV-RedoCaloPID-Stripping_28_24.py"
+          },
+          {
+            "title": "DaVinci/DataType-2015.py"
+          },
+          {
+            "title": "DaVinci/InputType-RDST.py"
+          },
+          {
+            "title": "Persistency/Compression-ZLIB-1.py"
+          },
+          {
+            "title": "DaVinci/DV-RawEventJuggler-0_3-to-4_3.py"
+          }
+        ],
+        "release": "DaVinci.v44r10p5 AppConfig.v3r393 Det/SQLDDDB.v7r10 TMVAWeights.v1r16",
+        "type": "Stripping24r2"
+      },
+      {
+        "configuration_files": [
+          {
+            "title": "Merging/DV-Stripping-Merging.py"
+          },
+          {
+            "title": "Persistency/Compression-LZMA-4.py"
+          }
+        ],
+        "release": "DaVinci.v44r10p5 AppConfig.v3r393 Det/SQLDDDB.v7r10",
+        "type": "Stripping24r2-Merging"
+      }
+    ]
+  },
+  "publisher": "CERN Open Data Portal",
+  "recid": "24627",
+  "run_period": [
+    "2015"
+  ],
+  "stripping": {
+    "stream": "CHARMCOMPLETEEVENT",
+    "version": "stripping24r2"
+  },
+  "title": "LHCb 2015 Beam6500GeV MagDown CHARMCOMPLETEEVENT Stream Stripping24r2",
+  "title_additional": "",
+  "type": {
+    "primary": "Dataset",
+    "secondary": [
+      "Collision"
+    ]
+  },
+  "usage": {
+    "description": "<p> The Run 1 and 2 data collected by the LHCb detector is available using the LHCb Ntupling Service, while the Run 1 data is additionally available in .DST and .mDST formats. The data obtained from the LHCb Ntupling Service are ROOT ntuples and do not require custom software to analyze. <p> Links are provided to the LHCb Ntupling Service for exploration of available data and the LHCb Open Data Guide for usage instructions.",
+    "links": [
+      {
+        "description": "LHCb Ntupling Service",
+        "url": "https://opendata-lhcb-ntupling-service.app.cern.ch/"
+      },
+      {
+        "description": "LHCb Open Data Guide",
+        "url": "https://lhcb-opendata-guide.web.cern.ch/"
+      }
+    ]
+  }
+}]

--- a/data/records/LHCb_2015_Beam6500GeV_VeloClosed_MagDown_RealData_Reco15a_Stripping24r2_CHARM_MDST.json
+++ b/data/records/LHCb_2015_Beam6500GeV_VeloClosed_MagDown_RealData_Reco15a_Stripping24r2_CHARM_MDST.json
@@ -1,0 +1,177 @@
+[{
+  "abstract": {
+    "description": "Data from proton-proton (pp) collisions collected by the LHCb experiment in the year 2015 of Run2 of the LHC."
+  },
+  "accelerator": "CERN-LHC",
+  "collaboration": {
+    "name": "LHCb collaboration",
+    "recid": "456"
+  },
+  "collections": [
+    "LHCb-Collision-Datasets"
+  ],
+  "collision_information": {
+    "energy": "13TeV",
+    "type": "pp"
+  },
+  "date_created": [
+    "2015"
+  ],
+  "date_published": "2026",
+  "date_reprocessed": "2020",
+  "distribution": {
+    "formats": [
+      "MDST"
+    ],
+    "number_events": 911343090,
+    "number_files": 3275,
+    "size": 10879329880425
+  },
+  "experiment": [
+    "LHCb"
+  ],
+  "magnet_polarity": "MagDown",
+  "methodology": {
+    "description": "<p> This dataset was created in several production steps. These steps, software used and the configuration is provided below. </p><p> <strong> Prod ID: &nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;</strong> 102452<p> <strong>Prod type:&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp; </strong> Merge<p> <strong> Parent Prod ID:&nbsp;&nbsp;&nbsp;&nbsp; </strong> 102353<p> <strong> Parent Prod type: </strong> DataStripping<p> <strong> Conditions: </strong><p>dddb-20190206-3<p>cond-20191004</strong><p> <strong> List of Trigger Configuration Keys (TCK): </strong> </p> <p><p><strong>TCK &nbsp;&nbsp;&nbsp;&nbsp;&nbsp; Number of Files </strong><p>0x10700a1 &nbsp;&nbsp;&nbsp;&nbsp;&nbsp; 179<p>0x10600a7 &nbsp;&nbsp;&nbsp;&nbsp;&nbsp; 46<p>0x10600a3 &nbsp;&nbsp;&nbsp;&nbsp;&nbsp; 1267<p>0x10600a2 &nbsp;&nbsp;&nbsp;&nbsp;&nbsp; 1563<p>0x10800a2 &nbsp;&nbsp;&nbsp;&nbsp;&nbsp; 218<p>0x10600a6 &nbsp;&nbsp;&nbsp;&nbsp;&nbsp; 2",
+    "steps": [
+      {
+        "configuration_files": [
+          {
+            "title": "DaVinci/DV-Stripping24r2-Stripping.py"
+          },
+          {
+            "title": "DaVinci/DV-RedoCaloPID-Stripping_28_24.py"
+          },
+          {
+            "title": "DaVinci/DataType-2015.py"
+          },
+          {
+            "title": "DaVinci/InputType-RDST.py"
+          },
+          {
+            "title": "Persistency/Compression-ZLIB-1.py"
+          },
+          {
+            "title": "DaVinci/DV-RawEventJuggler-0_3-to-4_3.py"
+          }
+        ],
+        "release": "DaVinci.v44r10p5 AppConfig.v3r393 Det/SQLDDDB.v7r10 TMVAWeights.v1r16",
+        "type": "Stripping24r2"
+      },
+      {
+        "configuration_files": [
+          {
+            "title": "Merging/DV-Stripping-Merging.py"
+          },
+          {
+            "title": "Persistency/Compression-LZMA-4.py"
+          }
+        ],
+        "release": "DaVinci.v44r10p5 AppConfig.v3r393 Det/SQLDDDB.v7r10",
+        "type": "Stripping24r2-Merging"
+      },
+      {
+        "configuration_files": [
+          {
+            "title": "DaVinci/DV-Stripping24r2-Stripping.py"
+          },
+          {
+            "title": "DaVinci/DV-RedoCaloPID-Stripping_28_24.py"
+          },
+          {
+            "title": "DaVinci/DataType-2015.py"
+          },
+          {
+            "title": "DaVinci/InputType-RDST.py"
+          },
+          {
+            "title": "Persistency/Compression-ZLIB-1.py"
+          },
+          {
+            "title": "DaVinci/DV-RawEventJuggler-0_3-to-4_3.py"
+          }
+        ],
+        "release": "DaVinci.v44r10p5 AppConfig.v3r393 Det/SQLDDDB.v7r10 TMVAWeights.v1r16",
+        "type": "Stripping24r2"
+      },
+      {
+        "configuration_files": [
+          {
+            "title": "Merging/DV-Stripping-Merging.py"
+          },
+          {
+            "title": "Persistency/Compression-LZMA-4.py"
+          }
+        ],
+        "release": "DaVinci.v44r10p5 AppConfig.v3r393 Det/SQLDDDB.v7r10",
+        "type": "Stripping24r2-Merging"
+      },
+      {
+        "configuration_files": [
+          {
+            "title": "DaVinci/DV-Stripping24r2-Stripping.py"
+          },
+          {
+            "title": "DaVinci/DV-RedoCaloPID-Stripping_28_24.py"
+          },
+          {
+            "title": "DaVinci/DataType-2015.py"
+          },
+          {
+            "title": "DaVinci/InputType-RDST.py"
+          },
+          {
+            "title": "Persistency/Compression-ZLIB-1.py"
+          },
+          {
+            "title": "DaVinci/DV-RawEventJuggler-0_3-to-4_3.py"
+          }
+        ],
+        "release": "DaVinci.v44r10p5 AppConfig.v3r393 Det/SQLDDDB.v7r10 TMVAWeights.v1r16",
+        "type": "Stripping24r2"
+      },
+      {
+        "configuration_files": [
+          {
+            "title": "Merging/DV-Stripping-Merging.py"
+          },
+          {
+            "title": "Persistency/Compression-LZMA-4.py"
+          }
+        ],
+        "release": "DaVinci.v44r10p5 AppConfig.v3r393 Det/SQLDDDB.v7r10",
+        "type": "Stripping24r2-Merging"
+      }
+    ]
+  },
+  "publisher": "CERN Open Data Portal",
+  "recid": "24626",
+  "run_period": [
+    "2015"
+  ],
+  "stripping": {
+    "stream": "CHARM",
+    "version": "stripping24r2"
+  },
+  "title": "LHCb 2015 Beam6500GeV MagDown CHARM Stream Stripping24r2",
+  "title_additional": "",
+  "type": {
+    "primary": "Dataset",
+    "secondary": [
+      "Collision"
+    ]
+  },
+  "usage": {
+    "description": "<p> The Run 1 and 2 data collected by the LHCb detector is available using the LHCb Ntupling Service, while the Run 1 data is additionally available in .DST and .mDST formats. The data obtained from the LHCb Ntupling Service are ROOT ntuples and do not require custom software to analyze. <p> Links are provided to the LHCb Ntupling Service for exploration of available data and the LHCb Open Data Guide for usage instructions.",
+    "links": [
+      {
+        "description": "LHCb Ntupling Service",
+        "url": "https://opendata-lhcb-ntupling-service.app.cern.ch/"
+      },
+      {
+        "description": "LHCb Open Data Guide",
+        "url": "https://lhcb-opendata-guide.web.cern.ch/"
+      }
+    ]
+  }
+}]

--- a/data/records/LHCb_2015_Beam6500GeV_VeloClosed_MagDown_RealData_Reco15a_Stripping24r2_DIMUON_DST.json
+++ b/data/records/LHCb_2015_Beam6500GeV_VeloClosed_MagDown_RealData_Reco15a_Stripping24r2_DIMUON_DST.json
@@ -1,0 +1,177 @@
+[{
+  "abstract": {
+    "description": "Data from proton-proton (pp) collisions collected by the LHCb experiment in the year 2015 of Run2 of the LHC."
+  },
+  "accelerator": "CERN-LHC",
+  "collaboration": {
+    "name": "LHCb collaboration",
+    "recid": "456"
+  },
+  "collections": [
+    "LHCb-Collision-Datasets"
+  ],
+  "collision_information": {
+    "energy": "13TeV",
+    "type": "pp"
+  },
+  "date_created": [
+    "2015"
+  ],
+  "date_published": "2026",
+  "date_reprocessed": "2020",
+  "distribution": {
+    "formats": [
+      "DST"
+    ],
+    "number_events": 132938710,
+    "number_files": 4171,
+    "size": 14235001092362
+  },
+  "experiment": [
+    "LHCb"
+  ],
+  "magnet_polarity": "MagDown",
+  "methodology": {
+    "description": "<p> This dataset was created in several production steps. These steps, software used and the configuration is provided below. </p><p> <strong> Prod ID: &nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;</strong> 102354<p> <strong>Prod type:&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp; </strong> Merge<p> <strong> Parent Prod ID:&nbsp;&nbsp;&nbsp;&nbsp; </strong> 102353<p> <strong> Parent Prod type: </strong> DataStripping<p> <strong> Conditions: </strong><p>dddb-20190206-3<p>cond-20191004</strong><p> <strong> List of Trigger Configuration Keys (TCK): </strong> </p> <p><p><strong>TCK &nbsp;&nbsp;&nbsp;&nbsp;&nbsp; Number of Files </strong><p>0x10700a1 &nbsp;&nbsp;&nbsp;&nbsp;&nbsp; 196<p>0x10600a7 &nbsp;&nbsp;&nbsp;&nbsp;&nbsp; 44<p>0x10600a3 &nbsp;&nbsp;&nbsp;&nbsp;&nbsp; 1541<p>0x10600a2 &nbsp;&nbsp;&nbsp;&nbsp;&nbsp; 2103<p>0x10800a2 &nbsp;&nbsp;&nbsp;&nbsp;&nbsp; 285<p>0x10600a6 &nbsp;&nbsp;&nbsp;&nbsp;&nbsp; 2",
+    "steps": [
+      {
+        "configuration_files": [
+          {
+            "title": "DaVinci/DV-Stripping24r2-Stripping.py"
+          },
+          {
+            "title": "DaVinci/DV-RedoCaloPID-Stripping_28_24.py"
+          },
+          {
+            "title": "DaVinci/DataType-2015.py"
+          },
+          {
+            "title": "DaVinci/InputType-RDST.py"
+          },
+          {
+            "title": "Persistency/Compression-ZLIB-1.py"
+          },
+          {
+            "title": "DaVinci/DV-RawEventJuggler-0_3-to-4_3.py"
+          }
+        ],
+        "release": "DaVinci.v44r10p5 AppConfig.v3r393 Det/SQLDDDB.v7r10 TMVAWeights.v1r16",
+        "type": "Stripping24r2"
+      },
+      {
+        "configuration_files": [
+          {
+            "title": "Merging/DV-Stripping-Merging.py"
+          },
+          {
+            "title": "Persistency/Compression-LZMA-4.py"
+          }
+        ],
+        "release": "DaVinci.v44r10p5 AppConfig.v3r393 Det/SQLDDDB.v7r10",
+        "type": "Stripping24r2-Merging"
+      },
+      {
+        "configuration_files": [
+          {
+            "title": "DaVinci/DV-Stripping24r2-Stripping.py"
+          },
+          {
+            "title": "DaVinci/DV-RedoCaloPID-Stripping_28_24.py"
+          },
+          {
+            "title": "DaVinci/DataType-2015.py"
+          },
+          {
+            "title": "DaVinci/InputType-RDST.py"
+          },
+          {
+            "title": "Persistency/Compression-ZLIB-1.py"
+          },
+          {
+            "title": "DaVinci/DV-RawEventJuggler-0_3-to-4_3.py"
+          }
+        ],
+        "release": "DaVinci.v44r10p5 AppConfig.v3r393 Det/SQLDDDB.v7r10 TMVAWeights.v1r16",
+        "type": "Stripping24r2"
+      },
+      {
+        "configuration_files": [
+          {
+            "title": "Merging/DV-Stripping-Merging.py"
+          },
+          {
+            "title": "Persistency/Compression-LZMA-4.py"
+          }
+        ],
+        "release": "DaVinci.v44r10p5 AppConfig.v3r393 Det/SQLDDDB.v7r10",
+        "type": "Stripping24r2-Merging"
+      },
+      {
+        "configuration_files": [
+          {
+            "title": "DaVinci/DV-Stripping24r2-Stripping.py"
+          },
+          {
+            "title": "DaVinci/DV-RedoCaloPID-Stripping_28_24.py"
+          },
+          {
+            "title": "DaVinci/DataType-2015.py"
+          },
+          {
+            "title": "DaVinci/InputType-RDST.py"
+          },
+          {
+            "title": "Persistency/Compression-ZLIB-1.py"
+          },
+          {
+            "title": "DaVinci/DV-RawEventJuggler-0_3-to-4_3.py"
+          }
+        ],
+        "release": "DaVinci.v44r10p5 AppConfig.v3r393 Det/SQLDDDB.v7r10 TMVAWeights.v1r16",
+        "type": "Stripping24r2"
+      },
+      {
+        "configuration_files": [
+          {
+            "title": "Merging/DV-Stripping-Merging.py"
+          },
+          {
+            "title": "Persistency/Compression-LZMA-4.py"
+          }
+        ],
+        "release": "DaVinci.v44r10p5 AppConfig.v3r393 Det/SQLDDDB.v7r10",
+        "type": "Stripping24r2-Merging"
+      }
+    ]
+  },
+  "publisher": "CERN Open Data Portal",
+  "recid": "24628",
+  "run_period": [
+    "2015"
+  ],
+  "stripping": {
+    "stream": "DIMUON",
+    "version": "stripping24r2"
+  },
+  "title": "LHCb 2015 Beam6500GeV MagDown DIMUON Stream Stripping24r2",
+  "title_additional": "",
+  "type": {
+    "primary": "Dataset",
+    "secondary": [
+      "Collision"
+    ]
+  },
+  "usage": {
+    "description": "<p> The Run 1 and 2 data collected by the LHCb detector is available using the LHCb Ntupling Service, while the Run 1 data is additionally available in .DST and .mDST formats. The data obtained from the LHCb Ntupling Service are ROOT ntuples and do not require custom software to analyze. <p> Links are provided to the LHCb Ntupling Service for exploration of available data and the LHCb Open Data Guide for usage instructions.",
+    "links": [
+      {
+        "description": "LHCb Ntupling Service",
+        "url": "https://opendata-lhcb-ntupling-service.app.cern.ch/"
+      },
+      {
+        "description": "LHCb Open Data Guide",
+        "url": "https://lhcb-opendata-guide.web.cern.ch/"
+      }
+    ]
+  }
+}]

--- a/data/records/LHCb_2015_Beam6500GeV_VeloClosed_MagDown_RealData_Reco15a_Stripping24r2_EW_DST.json
+++ b/data/records/LHCb_2015_Beam6500GeV_VeloClosed_MagDown_RealData_Reco15a_Stripping24r2_EW_DST.json
@@ -1,0 +1,177 @@
+[{
+  "abstract": {
+    "description": "Data from proton-proton (pp) collisions collected by the LHCb experiment in the year 2015 of Run2 of the LHC."
+  },
+  "accelerator": "CERN-LHC",
+  "collaboration": {
+    "name": "LHCb collaboration",
+    "recid": "456"
+  },
+  "collections": [
+    "LHCb-Collision-Datasets"
+  ],
+  "collision_information": {
+    "energy": "13TeV",
+    "type": "pp"
+  },
+  "date_created": [
+    "2015"
+  ],
+  "date_published": "2026",
+  "date_reprocessed": "2020",
+  "distribution": {
+    "formats": [
+      "DST"
+    ],
+    "number_events": 62902753,
+    "number_files": 2216,
+    "size": 6158195035962
+  },
+  "experiment": [
+    "LHCb"
+  ],
+  "magnet_polarity": "MagDown",
+  "methodology": {
+    "description": "<p> This dataset was created in several production steps. These steps, software used and the configuration is provided below. </p><p> <strong> Prod ID: &nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;</strong> 102354<p> <strong>Prod type:&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp; </strong> Merge<p> <strong> Parent Prod ID:&nbsp;&nbsp;&nbsp;&nbsp; </strong> 102353<p> <strong> Parent Prod type: </strong> DataStripping<p> <strong> Conditions: </strong><p>dddb-20190206-3<p>cond-20191004</strong><p> <strong> List of Trigger Configuration Keys (TCK): </strong> </p> <p><p><strong>TCK &nbsp;&nbsp;&nbsp;&nbsp;&nbsp; Number of Files </strong><p>0x10600a7 &nbsp;&nbsp;&nbsp;&nbsp;&nbsp; 40<p>0x10700a1 &nbsp;&nbsp;&nbsp;&nbsp;&nbsp; 121<p>0x10600a3 &nbsp;&nbsp;&nbsp;&nbsp;&nbsp; 821<p>0x10600a2 &nbsp;&nbsp;&nbsp;&nbsp;&nbsp; 1094<p>0x10800a2 &nbsp;&nbsp;&nbsp;&nbsp;&nbsp; 138<p>0x10600a6 &nbsp;&nbsp;&nbsp;&nbsp;&nbsp; 2",
+    "steps": [
+      {
+        "configuration_files": [
+          {
+            "title": "DaVinci/DV-Stripping24r2-Stripping.py"
+          },
+          {
+            "title": "DaVinci/DV-RedoCaloPID-Stripping_28_24.py"
+          },
+          {
+            "title": "DaVinci/DataType-2015.py"
+          },
+          {
+            "title": "DaVinci/InputType-RDST.py"
+          },
+          {
+            "title": "Persistency/Compression-ZLIB-1.py"
+          },
+          {
+            "title": "DaVinci/DV-RawEventJuggler-0_3-to-4_3.py"
+          }
+        ],
+        "release": "DaVinci.v44r10p5 AppConfig.v3r393 Det/SQLDDDB.v7r10 TMVAWeights.v1r16",
+        "type": "Stripping24r2"
+      },
+      {
+        "configuration_files": [
+          {
+            "title": "Merging/DV-Stripping-Merging.py"
+          },
+          {
+            "title": "Persistency/Compression-LZMA-4.py"
+          }
+        ],
+        "release": "DaVinci.v44r10p5 AppConfig.v3r393 Det/SQLDDDB.v7r10",
+        "type": "Stripping24r2-Merging"
+      },
+      {
+        "configuration_files": [
+          {
+            "title": "DaVinci/DV-Stripping24r2-Stripping.py"
+          },
+          {
+            "title": "DaVinci/DV-RedoCaloPID-Stripping_28_24.py"
+          },
+          {
+            "title": "DaVinci/DataType-2015.py"
+          },
+          {
+            "title": "DaVinci/InputType-RDST.py"
+          },
+          {
+            "title": "Persistency/Compression-ZLIB-1.py"
+          },
+          {
+            "title": "DaVinci/DV-RawEventJuggler-0_3-to-4_3.py"
+          }
+        ],
+        "release": "DaVinci.v44r10p5 AppConfig.v3r393 Det/SQLDDDB.v7r10 TMVAWeights.v1r16",
+        "type": "Stripping24r2"
+      },
+      {
+        "configuration_files": [
+          {
+            "title": "Merging/DV-Stripping-Merging.py"
+          },
+          {
+            "title": "Persistency/Compression-LZMA-4.py"
+          }
+        ],
+        "release": "DaVinci.v44r10p5 AppConfig.v3r393 Det/SQLDDDB.v7r10",
+        "type": "Stripping24r2-Merging"
+      },
+      {
+        "configuration_files": [
+          {
+            "title": "DaVinci/DV-Stripping24r2-Stripping.py"
+          },
+          {
+            "title": "DaVinci/DV-RedoCaloPID-Stripping_28_24.py"
+          },
+          {
+            "title": "DaVinci/DataType-2015.py"
+          },
+          {
+            "title": "DaVinci/InputType-RDST.py"
+          },
+          {
+            "title": "Persistency/Compression-ZLIB-1.py"
+          },
+          {
+            "title": "DaVinci/DV-RawEventJuggler-0_3-to-4_3.py"
+          }
+        ],
+        "release": "DaVinci.v44r10p5 AppConfig.v3r393 Det/SQLDDDB.v7r10 TMVAWeights.v1r16",
+        "type": "Stripping24r2"
+      },
+      {
+        "configuration_files": [
+          {
+            "title": "Merging/DV-Stripping-Merging.py"
+          },
+          {
+            "title": "Persistency/Compression-LZMA-4.py"
+          }
+        ],
+        "release": "DaVinci.v44r10p5 AppConfig.v3r393 Det/SQLDDDB.v7r10",
+        "type": "Stripping24r2-Merging"
+      }
+    ]
+  },
+  "publisher": "CERN Open Data Portal",
+  "recid": "24620",
+  "run_period": [
+    "2015"
+  ],
+  "stripping": {
+    "stream": "EW",
+    "version": "stripping24r2"
+  },
+  "title": "LHCb 2015 Beam6500GeV MagDown EW Stream Stripping24r2",
+  "title_additional": "",
+  "type": {
+    "primary": "Dataset",
+    "secondary": [
+      "Collision"
+    ]
+  },
+  "usage": {
+    "description": "<p> The Run 1 and 2 data collected by the LHCb detector is available using the LHCb Ntupling Service, while the Run 1 data is additionally available in .DST and .mDST formats. The data obtained from the LHCb Ntupling Service are ROOT ntuples and do not require custom software to analyze. <p> Links are provided to the LHCb Ntupling Service for exploration of available data and the LHCb Open Data Guide for usage instructions.",
+    "links": [
+      {
+        "description": "LHCb Ntupling Service",
+        "url": "https://opendata-lhcb-ntupling-service.app.cern.ch/"
+      },
+      {
+        "description": "LHCb Open Data Guide",
+        "url": "https://lhcb-opendata-guide.web.cern.ch/"
+      }
+    ]
+  }
+}]

--- a/data/records/LHCb_2015_Beam6500GeV_VeloClosed_MagDown_RealData_Reco15a_Stripping24r2_LEPTONIC_MDST.json
+++ b/data/records/LHCb_2015_Beam6500GeV_VeloClosed_MagDown_RealData_Reco15a_Stripping24r2_LEPTONIC_MDST.json
@@ -1,0 +1,177 @@
+[{
+  "abstract": {
+    "description": "Data from proton-proton (pp) collisions collected by the LHCb experiment in the year 2015 of Run2 of the LHC."
+  },
+  "accelerator": "CERN-LHC",
+  "collaboration": {
+    "name": "LHCb collaboration",
+    "recid": "456"
+  },
+  "collections": [
+    "LHCb-Collision-Datasets"
+  ],
+  "collision_information": {
+    "energy": "13TeV",
+    "type": "pp"
+  },
+  "date_created": [
+    "2015"
+  ],
+  "date_published": "2026",
+  "date_reprocessed": "2020",
+  "distribution": {
+    "formats": [
+      "MDST"
+    ],
+    "number_events": 986801170,
+    "number_files": 3450,
+    "size": 11913531361937
+  },
+  "experiment": [
+    "LHCb"
+  ],
+  "magnet_polarity": "MagDown",
+  "methodology": {
+    "description": "<p> This dataset was created in several production steps. These steps, software used and the configuration is provided below. </p><p> <strong> Prod ID: &nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;</strong> 102354<p> <strong>Prod type:&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp; </strong> Merge<p> <strong> Parent Prod ID:&nbsp;&nbsp;&nbsp;&nbsp; </strong> 102353<p> <strong> Parent Prod type: </strong> DataStripping<p> <strong> Conditions: </strong><p>dddb-20190206-3<p>cond-20191004</strong><p> <strong> List of Trigger Configuration Keys (TCK): </strong> </p> <p><p><strong>TCK &nbsp;&nbsp;&nbsp;&nbsp;&nbsp; Number of Files </strong><p>0x10600a3 &nbsp;&nbsp;&nbsp;&nbsp;&nbsp; 1304<p>0x10600a7 &nbsp;&nbsp;&nbsp;&nbsp;&nbsp; 43<p>0x10700a1 &nbsp;&nbsp;&nbsp;&nbsp;&nbsp; 177<p>0x10600a2 &nbsp;&nbsp;&nbsp;&nbsp;&nbsp; 1694<p>0x10800a2 &nbsp;&nbsp;&nbsp;&nbsp;&nbsp; 230<p>0x10600a6 &nbsp;&nbsp;&nbsp;&nbsp;&nbsp; 2",
+    "steps": [
+      {
+        "configuration_files": [
+          {
+            "title": "DaVinci/DV-Stripping24r2-Stripping.py"
+          },
+          {
+            "title": "DaVinci/DV-RedoCaloPID-Stripping_28_24.py"
+          },
+          {
+            "title": "DaVinci/DataType-2015.py"
+          },
+          {
+            "title": "DaVinci/InputType-RDST.py"
+          },
+          {
+            "title": "Persistency/Compression-ZLIB-1.py"
+          },
+          {
+            "title": "DaVinci/DV-RawEventJuggler-0_3-to-4_3.py"
+          }
+        ],
+        "release": "DaVinci.v44r10p5 AppConfig.v3r393 Det/SQLDDDB.v7r10 TMVAWeights.v1r16",
+        "type": "Stripping24r2"
+      },
+      {
+        "configuration_files": [
+          {
+            "title": "Merging/DV-Stripping-Merging.py"
+          },
+          {
+            "title": "Persistency/Compression-LZMA-4.py"
+          }
+        ],
+        "release": "DaVinci.v44r10p5 AppConfig.v3r393 Det/SQLDDDB.v7r10",
+        "type": "Stripping24r2-Merging"
+      },
+      {
+        "configuration_files": [
+          {
+            "title": "DaVinci/DV-Stripping24r2-Stripping.py"
+          },
+          {
+            "title": "DaVinci/DV-RedoCaloPID-Stripping_28_24.py"
+          },
+          {
+            "title": "DaVinci/DataType-2015.py"
+          },
+          {
+            "title": "DaVinci/InputType-RDST.py"
+          },
+          {
+            "title": "Persistency/Compression-ZLIB-1.py"
+          },
+          {
+            "title": "DaVinci/DV-RawEventJuggler-0_3-to-4_3.py"
+          }
+        ],
+        "release": "DaVinci.v44r10p5 AppConfig.v3r393 Det/SQLDDDB.v7r10 TMVAWeights.v1r16",
+        "type": "Stripping24r2"
+      },
+      {
+        "configuration_files": [
+          {
+            "title": "Merging/DV-Stripping-Merging.py"
+          },
+          {
+            "title": "Persistency/Compression-LZMA-4.py"
+          }
+        ],
+        "release": "DaVinci.v44r10p5 AppConfig.v3r393 Det/SQLDDDB.v7r10",
+        "type": "Stripping24r2-Merging"
+      },
+      {
+        "configuration_files": [
+          {
+            "title": "DaVinci/DV-Stripping24r2-Stripping.py"
+          },
+          {
+            "title": "DaVinci/DV-RedoCaloPID-Stripping_28_24.py"
+          },
+          {
+            "title": "DaVinci/DataType-2015.py"
+          },
+          {
+            "title": "DaVinci/InputType-RDST.py"
+          },
+          {
+            "title": "Persistency/Compression-ZLIB-1.py"
+          },
+          {
+            "title": "DaVinci/DV-RawEventJuggler-0_3-to-4_3.py"
+          }
+        ],
+        "release": "DaVinci.v44r10p5 AppConfig.v3r393 Det/SQLDDDB.v7r10 TMVAWeights.v1r16",
+        "type": "Stripping24r2"
+      },
+      {
+        "configuration_files": [
+          {
+            "title": "Merging/DV-Stripping-Merging.py"
+          },
+          {
+            "title": "Persistency/Compression-LZMA-4.py"
+          }
+        ],
+        "release": "DaVinci.v44r10p5 AppConfig.v3r393 Det/SQLDDDB.v7r10",
+        "type": "Stripping24r2-Merging"
+      }
+    ]
+  },
+  "publisher": "CERN Open Data Portal",
+  "recid": "24621",
+  "run_period": [
+    "2015"
+  ],
+  "stripping": {
+    "stream": "LEPTONIC",
+    "version": "stripping24r2"
+  },
+  "title": "LHCb 2015 Beam6500GeV MagDown LEPTONIC Stream Stripping24r2",
+  "title_additional": "",
+  "type": {
+    "primary": "Dataset",
+    "secondary": [
+      "Collision"
+    ]
+  },
+  "usage": {
+    "description": "<p> The Run 1 and 2 data collected by the LHCb detector is available using the LHCb Ntupling Service, while the Run 1 data is additionally available in .DST and .mDST formats. The data obtained from the LHCb Ntupling Service are ROOT ntuples and do not require custom software to analyze. <p> Links are provided to the LHCb Ntupling Service for exploration of available data and the LHCb Open Data Guide for usage instructions.",
+    "links": [
+      {
+        "description": "LHCb Ntupling Service",
+        "url": "https://opendata-lhcb-ntupling-service.app.cern.ch/"
+      },
+      {
+        "description": "LHCb Open Data Guide",
+        "url": "https://lhcb-opendata-guide.web.cern.ch/"
+      }
+    ]
+  }
+}]

--- a/data/records/LHCb_2015_Beam6500GeV_VeloClosed_MagDown_RealData_Reco15a_Stripping24r2_SEMILEPTONIC_DST.json
+++ b/data/records/LHCb_2015_Beam6500GeV_VeloClosed_MagDown_RealData_Reco15a_Stripping24r2_SEMILEPTONIC_DST.json
@@ -1,0 +1,177 @@
+[{
+  "abstract": {
+    "description": "Data from proton-proton (pp) collisions collected by the LHCb experiment in the year 2015 of Run2 of the LHC."
+  },
+  "accelerator": "CERN-LHC",
+  "collaboration": {
+    "name": "LHCb collaboration",
+    "recid": "456"
+  },
+  "collections": [
+    "LHCb-Collision-Datasets"
+  ],
+  "collision_information": {
+    "energy": "13TeV",
+    "type": "pp"
+  },
+  "date_created": [
+    "2015"
+  ],
+  "date_published": "2026",
+  "date_reprocessed": "2020",
+  "distribution": {
+    "formats": [
+      "DST"
+    ],
+    "number_events": 169436889,
+    "number_files": 4373,
+    "size": 14679878889059
+  },
+  "experiment": [
+    "LHCb"
+  ],
+  "magnet_polarity": "MagDown",
+  "methodology": {
+    "description": "<p> This dataset was created in several production steps. These steps, software used and the configuration is provided below. </p><p> <strong> Prod ID: &nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;</strong> 102354<p> <strong>Prod type:&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp; </strong> Merge<p> <strong> Parent Prod ID:&nbsp;&nbsp;&nbsp;&nbsp; </strong> 102353<p> <strong> Parent Prod type: </strong> DataStripping<p> <strong> Conditions: </strong><p>dddb-20190206-3<p>cond-20191004</strong><p> <strong> List of Trigger Configuration Keys (TCK): </strong> </p> <p><p><strong>TCK &nbsp;&nbsp;&nbsp;&nbsp;&nbsp; Number of Files </strong><p>0x10700a1 &nbsp;&nbsp;&nbsp;&nbsp;&nbsp; 219<p>0x10600a7 &nbsp;&nbsp;&nbsp;&nbsp;&nbsp; 53<p>0x10600a3 &nbsp;&nbsp;&nbsp;&nbsp;&nbsp; 1685<p>0x10600a6 &nbsp;&nbsp;&nbsp;&nbsp;&nbsp; 2<p>0x10600a2 &nbsp;&nbsp;&nbsp;&nbsp;&nbsp; 2125<p>0x10800a2 &nbsp;&nbsp;&nbsp;&nbsp;&nbsp; 289",
+    "steps": [
+      {
+        "configuration_files": [
+          {
+            "title": "DaVinci/DV-Stripping24r2-Stripping.py"
+          },
+          {
+            "title": "DaVinci/DV-RedoCaloPID-Stripping_28_24.py"
+          },
+          {
+            "title": "DaVinci/DataType-2015.py"
+          },
+          {
+            "title": "DaVinci/InputType-RDST.py"
+          },
+          {
+            "title": "Persistency/Compression-ZLIB-1.py"
+          },
+          {
+            "title": "DaVinci/DV-RawEventJuggler-0_3-to-4_3.py"
+          }
+        ],
+        "release": "DaVinci.v44r10p5 AppConfig.v3r393 Det/SQLDDDB.v7r10 TMVAWeights.v1r16",
+        "type": "Stripping24r2"
+      },
+      {
+        "configuration_files": [
+          {
+            "title": "Merging/DV-Stripping-Merging.py"
+          },
+          {
+            "title": "Persistency/Compression-LZMA-4.py"
+          }
+        ],
+        "release": "DaVinci.v44r10p5 AppConfig.v3r393 Det/SQLDDDB.v7r10",
+        "type": "Stripping24r2-Merging"
+      },
+      {
+        "configuration_files": [
+          {
+            "title": "DaVinci/DV-Stripping24r2-Stripping.py"
+          },
+          {
+            "title": "DaVinci/DV-RedoCaloPID-Stripping_28_24.py"
+          },
+          {
+            "title": "DaVinci/DataType-2015.py"
+          },
+          {
+            "title": "DaVinci/InputType-RDST.py"
+          },
+          {
+            "title": "Persistency/Compression-ZLIB-1.py"
+          },
+          {
+            "title": "DaVinci/DV-RawEventJuggler-0_3-to-4_3.py"
+          }
+        ],
+        "release": "DaVinci.v44r10p5 AppConfig.v3r393 Det/SQLDDDB.v7r10 TMVAWeights.v1r16",
+        "type": "Stripping24r2"
+      },
+      {
+        "configuration_files": [
+          {
+            "title": "Merging/DV-Stripping-Merging.py"
+          },
+          {
+            "title": "Persistency/Compression-LZMA-4.py"
+          }
+        ],
+        "release": "DaVinci.v44r10p5 AppConfig.v3r393 Det/SQLDDDB.v7r10",
+        "type": "Stripping24r2-Merging"
+      },
+      {
+        "configuration_files": [
+          {
+            "title": "DaVinci/DV-Stripping24r2-Stripping.py"
+          },
+          {
+            "title": "DaVinci/DV-RedoCaloPID-Stripping_28_24.py"
+          },
+          {
+            "title": "DaVinci/DataType-2015.py"
+          },
+          {
+            "title": "DaVinci/InputType-RDST.py"
+          },
+          {
+            "title": "Persistency/Compression-ZLIB-1.py"
+          },
+          {
+            "title": "DaVinci/DV-RawEventJuggler-0_3-to-4_3.py"
+          }
+        ],
+        "release": "DaVinci.v44r10p5 AppConfig.v3r393 Det/SQLDDDB.v7r10 TMVAWeights.v1r16",
+        "type": "Stripping24r2"
+      },
+      {
+        "configuration_files": [
+          {
+            "title": "Merging/DV-Stripping-Merging.py"
+          },
+          {
+            "title": "Persistency/Compression-LZMA-4.py"
+          }
+        ],
+        "release": "DaVinci.v44r10p5 AppConfig.v3r393 Det/SQLDDDB.v7r10",
+        "type": "Stripping24r2-Merging"
+      }
+    ]
+  },
+  "publisher": "CERN Open Data Portal",
+  "recid": "24629",
+  "run_period": [
+    "2015"
+  ],
+  "stripping": {
+    "stream": "SEMILEPTONIC",
+    "version": "stripping24r2"
+  },
+  "title": "LHCb 2015 Beam6500GeV MagDown SEMILEPTONIC Stream Stripping24r2",
+  "title_additional": "",
+  "type": {
+    "primary": "Dataset",
+    "secondary": [
+      "Collision"
+    ]
+  },
+  "usage": {
+    "description": "<p> The Run 1 and 2 data collected by the LHCb detector is available using the LHCb Ntupling Service, while the Run 1 data is additionally available in .DST and .mDST formats. The data obtained from the LHCb Ntupling Service are ROOT ntuples and do not require custom software to analyze. <p> Links are provided to the LHCb Ntupling Service for exploration of available data and the LHCb Open Data Guide for usage instructions.",
+    "links": [
+      {
+        "description": "LHCb Ntupling Service",
+        "url": "https://opendata-lhcb-ntupling-service.app.cern.ch/"
+      },
+      {
+        "description": "LHCb Open Data Guide",
+        "url": "https://lhcb-opendata-guide.web.cern.ch/"
+      }
+    ]
+  }
+}]

--- a/data/records/LHCb_2015_Beam6500GeV_VeloClosed_MagUp_RealData_Reco15a_Stripping24r2_BHADRONCOMPLETEEVENT_DST.json
+++ b/data/records/LHCb_2015_Beam6500GeV_VeloClosed_MagUp_RealData_Reco15a_Stripping24r2_BHADRONCOMPLETEEVENT_DST.json
@@ -1,0 +1,105 @@
+[{
+  "abstract": {
+    "description": "Data from proton-proton (pp) collisions collected by the LHCb experiment in the year 2015 of Run2 of the LHC."
+  },
+  "accelerator": "CERN-LHC",
+  "collaboration": {
+    "name": "LHCb collaboration",
+    "recid": "456"
+  },
+  "collections": [
+    "LHCb-Collision-Datasets"
+  ],
+  "collision_information": {
+    "energy": "13TeV",
+    "type": "pp"
+  },
+  "date_created": [
+    "2015"
+  ],
+  "date_published": "2026",
+  "date_reprocessed": "2020",
+  "distribution": {
+    "formats": [
+      "DST"
+    ],
+    "number_events": 127805997,
+    "number_files": 3632,
+    "size": 13136268088280
+  },
+  "experiment": [
+    "LHCb"
+  ],
+  "magnet_polarity": "MagUp",
+  "methodology": {
+    "description": "<p> This dataset was created in several production steps. These steps, software used and the configuration is provided below. </p><p> <strong> Prod ID: &nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;</strong> 102356<p> <strong>Prod type:&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp; </strong> Merge<p> <strong> Parent Prod ID:&nbsp;&nbsp;&nbsp;&nbsp; </strong> 102355<p> <strong> Parent Prod type: </strong> DataStripping<p> <strong> Conditions: </strong><p>dddb-20190206-3<p>cond-20191004</strong><p> <strong> List of Trigger Configuration Keys (TCK): </strong> </p> <p><p><strong>TCK &nbsp;&nbsp;&nbsp;&nbsp;&nbsp; Number of Files </strong><p>0x10800a2 &nbsp;&nbsp;&nbsp;&nbsp;&nbsp; 1476<p>0x11400a8 &nbsp;&nbsp;&nbsp;&nbsp;&nbsp; 2156",
+    "steps": [
+      {
+        "configuration_files": [
+          {
+            "title": "DaVinci/DV-Stripping24r2-Stripping.py"
+          },
+          {
+            "title": "DaVinci/DV-RedoCaloPID-Stripping_28_24.py"
+          },
+          {
+            "title": "DaVinci/DataType-2015.py"
+          },
+          {
+            "title": "DaVinci/InputType-RDST.py"
+          },
+          {
+            "title": "Persistency/Compression-ZLIB-1.py"
+          },
+          {
+            "title": "DaVinci/DV-RawEventJuggler-0_3-to-4_3.py"
+          }
+        ],
+        "release": "DaVinci.v44r10p5 AppConfig.v3r393 Det/SQLDDDB.v7r10 TMVAWeights.v1r16",
+        "type": "Stripping24r2"
+      },
+      {
+        "configuration_files": [
+          {
+            "title": "Merging/DV-Stripping-Merging.py"
+          },
+          {
+            "title": "Persistency/Compression-LZMA-4.py"
+          }
+        ],
+        "release": "DaVinci.v44r10p5 AppConfig.v3r393 Det/SQLDDDB.v7r10",
+        "type": "Stripping24r2-Merging"
+      }
+    ]
+  },
+  "publisher": "CERN Open Data Portal",
+  "recid": "24635",
+  "run_period": [
+    "2015"
+  ],
+  "stripping": {
+    "stream": "BHADRONCOMPLETEEVENT",
+    "version": "stripping24r2"
+  },
+  "title": "LHCb 2015 Beam6500GeV MagUp BHADRONCOMPLETEEVENT Stream Stripping24r2",
+  "title_additional": "",
+  "type": {
+    "primary": "Dataset",
+    "secondary": [
+      "Collision"
+    ]
+  },
+  "usage": {
+    "description": "<p> The Run 1 and 2 data collected by the LHCb detector is available using the LHCb Ntupling Service, while the Run 1 data is additionally available in .DST and .mDST formats. The data obtained from the LHCb Ntupling Service are ROOT ntuples and do not require custom software to analyze. <p> Links are provided to the LHCb Ntupling Service for exploration of available data and the LHCb Open Data Guide for usage instructions.",
+    "links": [
+      {
+        "description": "LHCb Ntupling Service",
+        "url": "https://opendata-lhcb-ntupling-service.app.cern.ch/"
+      },
+      {
+        "description": "LHCb Open Data Guide",
+        "url": "https://lhcb-opendata-guide.web.cern.ch/"
+      }
+    ]
+  }
+}]

--- a/data/records/LHCb_2015_Beam6500GeV_VeloClosed_MagUp_RealData_Reco15a_Stripping24r2_BHADRON_MDST.json
+++ b/data/records/LHCb_2015_Beam6500GeV_VeloClosed_MagUp_RealData_Reco15a_Stripping24r2_BHADRON_MDST.json
@@ -1,0 +1,105 @@
+[{
+  "abstract": {
+    "description": "Data from proton-proton (pp) collisions collected by the LHCb experiment in the year 2015 of Run2 of the LHC."
+  },
+  "accelerator": "CERN-LHC",
+  "collaboration": {
+    "name": "LHCb collaboration",
+    "recid": "456"
+  },
+  "collections": [
+    "LHCb-Collision-Datasets"
+  ],
+  "collision_information": {
+    "energy": "13TeV",
+    "type": "pp"
+  },
+  "date_created": [
+    "2015"
+  ],
+  "date_published": "2026",
+  "date_reprocessed": "2020",
+  "distribution": {
+    "formats": [
+      "MDST"
+    ],
+    "number_events": 439677899,
+    "number_files": 1907,
+    "size": 6680388105946
+  },
+  "experiment": [
+    "LHCb"
+  ],
+  "magnet_polarity": "MagUp",
+  "methodology": {
+    "description": "<p> This dataset was created in several production steps. These steps, software used and the configuration is provided below. </p><p> <strong> Prod ID: &nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;</strong> 102356<p> <strong>Prod type:&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp; </strong> Merge<p> <strong> Parent Prod ID:&nbsp;&nbsp;&nbsp;&nbsp; </strong> 102355<p> <strong> Parent Prod type: </strong> DataStripping<p> <strong> Conditions: </strong><p>dddb-20190206-3<p>cond-20191004</strong><p> <strong> List of Trigger Configuration Keys (TCK): </strong> </p> <p><p><strong>TCK &nbsp;&nbsp;&nbsp;&nbsp;&nbsp; Number of Files </strong><p>0x10800a2 &nbsp;&nbsp;&nbsp;&nbsp;&nbsp; 770<p>0x11400a8 &nbsp;&nbsp;&nbsp;&nbsp;&nbsp; 1137",
+    "steps": [
+      {
+        "configuration_files": [
+          {
+            "title": "DaVinci/DV-Stripping24r2-Stripping.py"
+          },
+          {
+            "title": "DaVinci/DV-RedoCaloPID-Stripping_28_24.py"
+          },
+          {
+            "title": "DaVinci/DataType-2015.py"
+          },
+          {
+            "title": "DaVinci/InputType-RDST.py"
+          },
+          {
+            "title": "Persistency/Compression-ZLIB-1.py"
+          },
+          {
+            "title": "DaVinci/DV-RawEventJuggler-0_3-to-4_3.py"
+          }
+        ],
+        "release": "DaVinci.v44r10p5 AppConfig.v3r393 Det/SQLDDDB.v7r10 TMVAWeights.v1r16",
+        "type": "Stripping24r2"
+      },
+      {
+        "configuration_files": [
+          {
+            "title": "Merging/DV-Stripping-Merging.py"
+          },
+          {
+            "title": "Persistency/Compression-LZMA-4.py"
+          }
+        ],
+        "release": "DaVinci.v44r10p5 AppConfig.v3r393 Det/SQLDDDB.v7r10",
+        "type": "Stripping24r2-Merging"
+      }
+    ]
+  },
+  "publisher": "CERN Open Data Portal",
+  "recid": "24634",
+  "run_period": [
+    "2015"
+  ],
+  "stripping": {
+    "stream": "BHADRON",
+    "version": "stripping24r2"
+  },
+  "title": "LHCb 2015 Beam6500GeV MagUp BHADRON Stream Stripping24r2",
+  "title_additional": "",
+  "type": {
+    "primary": "Dataset",
+    "secondary": [
+      "Collision"
+    ]
+  },
+  "usage": {
+    "description": "<p> The Run 1 and 2 data collected by the LHCb detector is available using the LHCb Ntupling Service, while the Run 1 data is additionally available in .DST and .mDST formats. The data obtained from the LHCb Ntupling Service are ROOT ntuples and do not require custom software to analyze. <p> Links are provided to the LHCb Ntupling Service for exploration of available data and the LHCb Open Data Guide for usage instructions.",
+    "links": [
+      {
+        "description": "LHCb Ntupling Service",
+        "url": "https://opendata-lhcb-ntupling-service.app.cern.ch/"
+      },
+      {
+        "description": "LHCb Open Data Guide",
+        "url": "https://lhcb-opendata-guide.web.cern.ch/"
+      }
+    ]
+  }
+}]

--- a/data/records/LHCb_2015_Beam6500GeV_VeloClosed_MagUp_RealData_Reco15a_Stripping24r2_CHARMCOMPLETEEVENT_DST.json
+++ b/data/records/LHCb_2015_Beam6500GeV_VeloClosed_MagUp_RealData_Reco15a_Stripping24r2_CHARMCOMPLETEEVENT_DST.json
@@ -1,0 +1,105 @@
+[{
+  "abstract": {
+    "description": "Data from proton-proton (pp) collisions collected by the LHCb experiment in the year 2015 of Run2 of the LHC."
+  },
+  "accelerator": "CERN-LHC",
+  "collaboration": {
+    "name": "LHCb collaboration",
+    "recid": "456"
+  },
+  "collections": [
+    "LHCb-Collision-Datasets"
+  ],
+  "collision_information": {
+    "energy": "13TeV",
+    "type": "pp"
+  },
+  "date_created": [
+    "2015"
+  ],
+  "date_published": "2026",
+  "date_reprocessed": "2020",
+  "distribution": {
+    "formats": [
+      "DST"
+    ],
+    "number_events": 59844737,
+    "number_files": 1638,
+    "size": 5456069820799
+  },
+  "experiment": [
+    "LHCb"
+  ],
+  "magnet_polarity": "MagUp",
+  "methodology": {
+    "description": "<p> This dataset was created in several production steps. These steps, software used and the configuration is provided below. </p><p> <strong> Prod ID: &nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;</strong> 102356<p> <strong>Prod type:&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp; </strong> Merge<p> <strong> Parent Prod ID:&nbsp;&nbsp;&nbsp;&nbsp; </strong> 102355<p> <strong> Parent Prod type: </strong> DataStripping<p> <strong> Conditions: </strong><p>dddb-20190206-3<p>cond-20191004</strong><p> <strong> List of Trigger Configuration Keys (TCK): </strong> </p> <p><p><strong>TCK &nbsp;&nbsp;&nbsp;&nbsp;&nbsp; Number of Files </strong><p>0x10800a2 &nbsp;&nbsp;&nbsp;&nbsp;&nbsp; 665<p>0x11400a8 &nbsp;&nbsp;&nbsp;&nbsp;&nbsp; 973",
+    "steps": [
+      {
+        "configuration_files": [
+          {
+            "title": "DaVinci/DV-Stripping24r2-Stripping.py"
+          },
+          {
+            "title": "DaVinci/DV-RedoCaloPID-Stripping_28_24.py"
+          },
+          {
+            "title": "DaVinci/DataType-2015.py"
+          },
+          {
+            "title": "DaVinci/InputType-RDST.py"
+          },
+          {
+            "title": "Persistency/Compression-ZLIB-1.py"
+          },
+          {
+            "title": "DaVinci/DV-RawEventJuggler-0_3-to-4_3.py"
+          }
+        ],
+        "release": "DaVinci.v44r10p5 AppConfig.v3r393 Det/SQLDDDB.v7r10 TMVAWeights.v1r16",
+        "type": "Stripping24r2"
+      },
+      {
+        "configuration_files": [
+          {
+            "title": "Merging/DV-Stripping-Merging.py"
+          },
+          {
+            "title": "Persistency/Compression-LZMA-4.py"
+          }
+        ],
+        "release": "DaVinci.v44r10p5 AppConfig.v3r393 Det/SQLDDDB.v7r10",
+        "type": "Stripping24r2-Merging"
+      }
+    ]
+  },
+  "publisher": "CERN Open Data Portal",
+  "recid": "24637",
+  "run_period": [
+    "2015"
+  ],
+  "stripping": {
+    "stream": "CHARMCOMPLETEEVENT",
+    "version": "stripping24r2"
+  },
+  "title": "LHCb 2015 Beam6500GeV MagUp CHARMCOMPLETEEVENT Stream Stripping24r2",
+  "title_additional": "",
+  "type": {
+    "primary": "Dataset",
+    "secondary": [
+      "Collision"
+    ]
+  },
+  "usage": {
+    "description": "<p> The Run 1 and 2 data collected by the LHCb detector is available using the LHCb Ntupling Service, while the Run 1 data is additionally available in .DST and .mDST formats. The data obtained from the LHCb Ntupling Service are ROOT ntuples and do not require custom software to analyze. <p> Links are provided to the LHCb Ntupling Service for exploration of available data and the LHCb Open Data Guide for usage instructions.",
+    "links": [
+      {
+        "description": "LHCb Ntupling Service",
+        "url": "https://opendata-lhcb-ntupling-service.app.cern.ch/"
+      },
+      {
+        "description": "LHCb Open Data Guide",
+        "url": "https://lhcb-opendata-guide.web.cern.ch/"
+      }
+    ]
+  }
+}]

--- a/data/records/LHCb_2015_Beam6500GeV_VeloClosed_MagUp_RealData_Reco15a_Stripping24r2_CHARM_MDST.json
+++ b/data/records/LHCb_2015_Beam6500GeV_VeloClosed_MagUp_RealData_Reco15a_Stripping24r2_CHARM_MDST.json
@@ -1,0 +1,105 @@
+[{
+  "abstract": {
+    "description": "Data from proton-proton (pp) collisions collected by the LHCb experiment in the year 2015 of Run2 of the LHC."
+  },
+  "accelerator": "CERN-LHC",
+  "collaboration": {
+    "name": "LHCb collaboration",
+    "recid": "456"
+  },
+  "collections": [
+    "LHCb-Collision-Datasets"
+  ],
+  "collision_information": {
+    "energy": "13TeV",
+    "type": "pp"
+  },
+  "date_created": [
+    "2015"
+  ],
+  "date_published": "2026",
+  "date_reprocessed": "2020",
+  "distribution": {
+    "formats": [
+      "MDST"
+    ],
+    "number_events": 642004894,
+    "number_files": 2159,
+    "size": 7717453028271
+  },
+  "experiment": [
+    "LHCb"
+  ],
+  "magnet_polarity": "MagUp",
+  "methodology": {
+    "description": "<p> This dataset was created in several production steps. These steps, software used and the configuration is provided below. </p><p> <strong> Prod ID: &nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;</strong> 102356<p> <strong>Prod type:&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp; </strong> Merge<p> <strong> Parent Prod ID:&nbsp;&nbsp;&nbsp;&nbsp; </strong> 102355<p> <strong> Parent Prod type: </strong> DataStripping<p> <strong> Conditions: </strong><p>dddb-20190206-3<p>cond-20191004</strong><p> <strong> List of Trigger Configuration Keys (TCK): </strong> </p> <p><p><strong>TCK &nbsp;&nbsp;&nbsp;&nbsp;&nbsp; Number of Files </strong><p>0x10800a2 &nbsp;&nbsp;&nbsp;&nbsp;&nbsp; 872<p>0x11400a8 &nbsp;&nbsp;&nbsp;&nbsp;&nbsp; 1287",
+    "steps": [
+      {
+        "configuration_files": [
+          {
+            "title": "DaVinci/DV-Stripping24r2-Stripping.py"
+          },
+          {
+            "title": "DaVinci/DV-RedoCaloPID-Stripping_28_24.py"
+          },
+          {
+            "title": "DaVinci/DataType-2015.py"
+          },
+          {
+            "title": "DaVinci/InputType-RDST.py"
+          },
+          {
+            "title": "Persistency/Compression-ZLIB-1.py"
+          },
+          {
+            "title": "DaVinci/DV-RawEventJuggler-0_3-to-4_3.py"
+          }
+        ],
+        "release": "DaVinci.v44r10p5 AppConfig.v3r393 Det/SQLDDDB.v7r10 TMVAWeights.v1r16",
+        "type": "Stripping24r2"
+      },
+      {
+        "configuration_files": [
+          {
+            "title": "Merging/DV-Stripping-Merging.py"
+          },
+          {
+            "title": "Persistency/Compression-LZMA-4.py"
+          }
+        ],
+        "release": "DaVinci.v44r10p5 AppConfig.v3r393 Det/SQLDDDB.v7r10",
+        "type": "Stripping24r2-Merging"
+      }
+    ]
+  },
+  "publisher": "CERN Open Data Portal",
+  "recid": "24636",
+  "run_period": [
+    "2015"
+  ],
+  "stripping": {
+    "stream": "CHARM",
+    "version": "stripping24r2"
+  },
+  "title": "LHCb 2015 Beam6500GeV MagUp CHARM Stream Stripping24r2",
+  "title_additional": "",
+  "type": {
+    "primary": "Dataset",
+    "secondary": [
+      "Collision"
+    ]
+  },
+  "usage": {
+    "description": "<p> The Run 1 and 2 data collected by the LHCb detector is available using the LHCb Ntupling Service, while the Run 1 data is additionally available in .DST and .mDST formats. The data obtained from the LHCb Ntupling Service are ROOT ntuples and do not require custom software to analyze. <p> Links are provided to the LHCb Ntupling Service for exploration of available data and the LHCb Open Data Guide for usage instructions.",
+    "links": [
+      {
+        "description": "LHCb Ntupling Service",
+        "url": "https://opendata-lhcb-ntupling-service.app.cern.ch/"
+      },
+      {
+        "description": "LHCb Open Data Guide",
+        "url": "https://lhcb-opendata-guide.web.cern.ch/"
+      }
+    ]
+  }
+}]

--- a/data/records/LHCb_2015_Beam6500GeV_VeloClosed_MagUp_RealData_Reco15a_Stripping24r2_DIMUON_DST.json
+++ b/data/records/LHCb_2015_Beam6500GeV_VeloClosed_MagUp_RealData_Reco15a_Stripping24r2_DIMUON_DST.json
@@ -1,0 +1,105 @@
+[{
+  "abstract": {
+    "description": "Data from proton-proton (pp) collisions collected by the LHCb experiment in the year 2015 of Run2 of the LHC."
+  },
+  "accelerator": "CERN-LHC",
+  "collaboration": {
+    "name": "LHCb collaboration",
+    "recid": "456"
+  },
+  "collections": [
+    "LHCb-Collision-Datasets"
+  ],
+  "collision_information": {
+    "energy": "13TeV",
+    "type": "pp"
+  },
+  "date_created": [
+    "2015"
+  ],
+  "date_published": "2026",
+  "date_reprocessed": "2020",
+  "distribution": {
+    "formats": [
+      "DST"
+    ],
+    "number_events": 96773326,
+    "number_files": 2870,
+    "size": 10279854337625
+  },
+  "experiment": [
+    "LHCb"
+  ],
+  "magnet_polarity": "MagUp",
+  "methodology": {
+    "description": "<p> This dataset was created in several production steps. These steps, software used and the configuration is provided below. </p><p> <strong> Prod ID: &nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;</strong> 102356<p> <strong>Prod type:&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp; </strong> Merge<p> <strong> Parent Prod ID:&nbsp;&nbsp;&nbsp;&nbsp; </strong> 102355<p> <strong> Parent Prod type: </strong> DataStripping<p> <strong> Conditions: </strong><p>dddb-20190206-3<p>cond-20191004</strong><p> <strong> List of Trigger Configuration Keys (TCK): </strong> </p> <p><p><strong>TCK &nbsp;&nbsp;&nbsp;&nbsp;&nbsp; Number of Files </strong><p>0x10800a2 &nbsp;&nbsp;&nbsp;&nbsp;&nbsp; 1117<p>0x11400a8 &nbsp;&nbsp;&nbsp;&nbsp;&nbsp; 1753",
+    "steps": [
+      {
+        "configuration_files": [
+          {
+            "title": "DaVinci/DV-Stripping24r2-Stripping.py"
+          },
+          {
+            "title": "DaVinci/DV-RedoCaloPID-Stripping_28_24.py"
+          },
+          {
+            "title": "DaVinci/DataType-2015.py"
+          },
+          {
+            "title": "DaVinci/InputType-RDST.py"
+          },
+          {
+            "title": "Persistency/Compression-ZLIB-1.py"
+          },
+          {
+            "title": "DaVinci/DV-RawEventJuggler-0_3-to-4_3.py"
+          }
+        ],
+        "release": "DaVinci.v44r10p5 AppConfig.v3r393 Det/SQLDDDB.v7r10 TMVAWeights.v1r16",
+        "type": "Stripping24r2"
+      },
+      {
+        "configuration_files": [
+          {
+            "title": "Merging/DV-Stripping-Merging.py"
+          },
+          {
+            "title": "Persistency/Compression-LZMA-4.py"
+          }
+        ],
+        "release": "DaVinci.v44r10p5 AppConfig.v3r393 Det/SQLDDDB.v7r10",
+        "type": "Stripping24r2-Merging"
+      }
+    ]
+  },
+  "publisher": "CERN Open Data Portal",
+  "recid": "24638",
+  "run_period": [
+    "2015"
+  ],
+  "stripping": {
+    "stream": "DIMUON",
+    "version": "stripping24r2"
+  },
+  "title": "LHCb 2015 Beam6500GeV MagUp DIMUON Stream Stripping24r2",
+  "title_additional": "",
+  "type": {
+    "primary": "Dataset",
+    "secondary": [
+      "Collision"
+    ]
+  },
+  "usage": {
+    "description": "<p> The Run 1 and 2 data collected by the LHCb detector is available using the LHCb Ntupling Service, while the Run 1 data is additionally available in .DST and .mDST formats. The data obtained from the LHCb Ntupling Service are ROOT ntuples and do not require custom software to analyze. <p> Links are provided to the LHCb Ntupling Service for exploration of available data and the LHCb Open Data Guide for usage instructions.",
+    "links": [
+      {
+        "description": "LHCb Ntupling Service",
+        "url": "https://opendata-lhcb-ntupling-service.app.cern.ch/"
+      },
+      {
+        "description": "LHCb Open Data Guide",
+        "url": "https://lhcb-opendata-guide.web.cern.ch/"
+      }
+    ]
+  }
+}]

--- a/data/records/LHCb_2015_Beam6500GeV_VeloClosed_MagUp_RealData_Reco15a_Stripping24r2_EW_DST.json
+++ b/data/records/LHCb_2015_Beam6500GeV_VeloClosed_MagUp_RealData_Reco15a_Stripping24r2_EW_DST.json
@@ -1,0 +1,105 @@
+[{
+  "abstract": {
+    "description": "Data from proton-proton (pp) collisions collected by the LHCb experiment in the year 2015 of Run2 of the LHC."
+  },
+  "accelerator": "CERN-LHC",
+  "collaboration": {
+    "name": "LHCb collaboration",
+    "recid": "456"
+  },
+  "collections": [
+    "LHCb-Collision-Datasets"
+  ],
+  "collision_information": {
+    "energy": "13TeV",
+    "type": "pp"
+  },
+  "date_created": [
+    "2015"
+  ],
+  "date_published": "2026",
+  "date_reprocessed": "2020",
+  "distribution": {
+    "formats": [
+      "DST"
+    ],
+    "number_events": 45600826,
+    "number_files": 1398,
+    "size": 4498008649421
+  },
+  "experiment": [
+    "LHCb"
+  ],
+  "magnet_polarity": "MagUp",
+  "methodology": {
+    "description": "<p> This dataset was created in several production steps. These steps, software used and the configuration is provided below. </p><p> <strong> Prod ID: &nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;</strong> 102356<p> <strong>Prod type:&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp; </strong> Merge<p> <strong> Parent Prod ID:&nbsp;&nbsp;&nbsp;&nbsp; </strong> 102355<p> <strong> Parent Prod type: </strong> DataStripping<p> <strong> Conditions: </strong><p>dddb-20190206-3<p>cond-20191004</strong><p> <strong> List of Trigger Configuration Keys (TCK): </strong> </p> <p><p><strong>TCK &nbsp;&nbsp;&nbsp;&nbsp;&nbsp; Number of Files </strong><p>0x10800a2 &nbsp;&nbsp;&nbsp;&nbsp;&nbsp; 547<p>0x11400a8 &nbsp;&nbsp;&nbsp;&nbsp;&nbsp; 851",
+    "steps": [
+      {
+        "configuration_files": [
+          {
+            "title": "DaVinci/DV-Stripping24r2-Stripping.py"
+          },
+          {
+            "title": "DaVinci/DV-RedoCaloPID-Stripping_28_24.py"
+          },
+          {
+            "title": "DaVinci/DataType-2015.py"
+          },
+          {
+            "title": "DaVinci/InputType-RDST.py"
+          },
+          {
+            "title": "Persistency/Compression-ZLIB-1.py"
+          },
+          {
+            "title": "DaVinci/DV-RawEventJuggler-0_3-to-4_3.py"
+          }
+        ],
+        "release": "DaVinci.v44r10p5 AppConfig.v3r393 Det/SQLDDDB.v7r10 TMVAWeights.v1r16",
+        "type": "Stripping24r2"
+      },
+      {
+        "configuration_files": [
+          {
+            "title": "Merging/DV-Stripping-Merging.py"
+          },
+          {
+            "title": "Persistency/Compression-LZMA-4.py"
+          }
+        ],
+        "release": "DaVinci.v44r10p5 AppConfig.v3r393 Det/SQLDDDB.v7r10",
+        "type": "Stripping24r2-Merging"
+      }
+    ]
+  },
+  "publisher": "CERN Open Data Portal",
+  "recid": "24630",
+  "run_period": [
+    "2015"
+  ],
+  "stripping": {
+    "stream": "EW",
+    "version": "stripping24r2"
+  },
+  "title": "LHCb 2015 Beam6500GeV MagUp EW Stream Stripping24r2",
+  "title_additional": "",
+  "type": {
+    "primary": "Dataset",
+    "secondary": [
+      "Collision"
+    ]
+  },
+  "usage": {
+    "description": "<p> The Run 1 and 2 data collected by the LHCb detector is available using the LHCb Ntupling Service, while the Run 1 data is additionally available in .DST and .mDST formats. The data obtained from the LHCb Ntupling Service are ROOT ntuples and do not require custom software to analyze. <p> Links are provided to the LHCb Ntupling Service for exploration of available data and the LHCb Open Data Guide for usage instructions.",
+    "links": [
+      {
+        "description": "LHCb Ntupling Service",
+        "url": "https://opendata-lhcb-ntupling-service.app.cern.ch/"
+      },
+      {
+        "description": "LHCb Open Data Guide",
+        "url": "https://lhcb-opendata-guide.web.cern.ch/"
+      }
+    ]
+  }
+}]

--- a/data/records/LHCb_2015_Beam6500GeV_VeloClosed_MagUp_RealData_Reco15a_Stripping24r2_LEPTONIC_MDST.json
+++ b/data/records/LHCb_2015_Beam6500GeV_VeloClosed_MagUp_RealData_Reco15a_Stripping24r2_LEPTONIC_MDST.json
@@ -1,0 +1,105 @@
+[{
+  "abstract": {
+    "description": "Data from proton-proton (pp) collisions collected by the LHCb experiment in the year 2015 of Run2 of the LHC."
+  },
+  "accelerator": "CERN-LHC",
+  "collaboration": {
+    "name": "LHCb collaboration",
+    "recid": "456"
+  },
+  "collections": [
+    "LHCb-Collision-Datasets"
+  ],
+  "collision_information": {
+    "energy": "13TeV",
+    "type": "pp"
+  },
+  "date_created": [
+    "2015"
+  ],
+  "date_published": "2026",
+  "date_reprocessed": "2020",
+  "distribution": {
+    "formats": [
+      "MDST"
+    ],
+    "number_events": 696486376,
+    "number_files": 2307,
+    "size": 8454733885922
+  },
+  "experiment": [
+    "LHCb"
+  ],
+  "magnet_polarity": "MagUp",
+  "methodology": {
+    "description": "<p> This dataset was created in several production steps. These steps, software used and the configuration is provided below. </p><p> <strong> Prod ID: &nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;</strong> 102356<p> <strong>Prod type:&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp; </strong> Merge<p> <strong> Parent Prod ID:&nbsp;&nbsp;&nbsp;&nbsp; </strong> 102355<p> <strong> Parent Prod type: </strong> DataStripping<p> <strong> Conditions: </strong><p>dddb-20190206-3<p>cond-20191004</strong><p> <strong> List of Trigger Configuration Keys (TCK): </strong> </p> <p><p><strong>TCK &nbsp;&nbsp;&nbsp;&nbsp;&nbsp; Number of Files </strong><p>0x10800a2 &nbsp;&nbsp;&nbsp;&nbsp;&nbsp; 913<p>0x11400a8 &nbsp;&nbsp;&nbsp;&nbsp;&nbsp; 1394",
+    "steps": [
+      {
+        "configuration_files": [
+          {
+            "title": "DaVinci/DV-Stripping24r2-Stripping.py"
+          },
+          {
+            "title": "DaVinci/DV-RedoCaloPID-Stripping_28_24.py"
+          },
+          {
+            "title": "DaVinci/DataType-2015.py"
+          },
+          {
+            "title": "DaVinci/InputType-RDST.py"
+          },
+          {
+            "title": "Persistency/Compression-ZLIB-1.py"
+          },
+          {
+            "title": "DaVinci/DV-RawEventJuggler-0_3-to-4_3.py"
+          }
+        ],
+        "release": "DaVinci.v44r10p5 AppConfig.v3r393 Det/SQLDDDB.v7r10 TMVAWeights.v1r16",
+        "type": "Stripping24r2"
+      },
+      {
+        "configuration_files": [
+          {
+            "title": "Merging/DV-Stripping-Merging.py"
+          },
+          {
+            "title": "Persistency/Compression-LZMA-4.py"
+          }
+        ],
+        "release": "DaVinci.v44r10p5 AppConfig.v3r393 Det/SQLDDDB.v7r10",
+        "type": "Stripping24r2-Merging"
+      }
+    ]
+  },
+  "publisher": "CERN Open Data Portal",
+  "recid": "24631",
+  "run_period": [
+    "2015"
+  ],
+  "stripping": {
+    "stream": "LEPTONIC",
+    "version": "stripping24r2"
+  },
+  "title": "LHCb 2015 Beam6500GeV MagUp LEPTONIC Stream Stripping24r2",
+  "title_additional": "",
+  "type": {
+    "primary": "Dataset",
+    "secondary": [
+      "Collision"
+    ]
+  },
+  "usage": {
+    "description": "<p> The Run 1 and 2 data collected by the LHCb detector is available using the LHCb Ntupling Service, while the Run 1 data is additionally available in .DST and .mDST formats. The data obtained from the LHCb Ntupling Service are ROOT ntuples and do not require custom software to analyze. <p> Links are provided to the LHCb Ntupling Service for exploration of available data and the LHCb Open Data Guide for usage instructions.",
+    "links": [
+      {
+        "description": "LHCb Ntupling Service",
+        "url": "https://opendata-lhcb-ntupling-service.app.cern.ch/"
+      },
+      {
+        "description": "LHCb Open Data Guide",
+        "url": "https://lhcb-opendata-guide.web.cern.ch/"
+      }
+    ]
+  }
+}]

--- a/data/records/LHCb_2015_Beam6500GeV_VeloClosed_MagUp_RealData_Reco15a_Stripping24r2_SEMILEPTONIC_DST.json
+++ b/data/records/LHCb_2015_Beam6500GeV_VeloClosed_MagUp_RealData_Reco15a_Stripping24r2_SEMILEPTONIC_DST.json
@@ -1,0 +1,105 @@
+[{
+  "abstract": {
+    "description": "Data from proton-proton (pp) collisions collected by the LHCb experiment in the year 2015 of Run2 of the LHC."
+  },
+  "accelerator": "CERN-LHC",
+  "collaboration": {
+    "name": "LHCb collaboration",
+    "recid": "456"
+  },
+  "collections": [
+    "LHCb-Collision-Datasets"
+  ],
+  "collision_information": {
+    "energy": "13TeV",
+    "type": "pp"
+  },
+  "date_created": [
+    "2015"
+  ],
+  "date_published": "2026",
+  "date_reprocessed": "2020",
+  "distribution": {
+    "formats": [
+      "DST"
+    ],
+    "number_events": 117710274,
+    "number_files": 2930,
+    "size": 10274478942024
+  },
+  "experiment": [
+    "LHCb"
+  ],
+  "magnet_polarity": "MagUp",
+  "methodology": {
+    "description": "<p> This dataset was created in several production steps. These steps, software used and the configuration is provided below. </p><p> <strong> Prod ID: &nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;</strong> 102356<p> <strong>Prod type:&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp; </strong> Merge<p> <strong> Parent Prod ID:&nbsp;&nbsp;&nbsp;&nbsp; </strong> 102355<p> <strong> Parent Prod type: </strong> DataStripping<p> <strong> Conditions: </strong><p>dddb-20190206-3<p>cond-20191004</strong><p> <strong> List of Trigger Configuration Keys (TCK): </strong> </p> <p><p><strong>TCK &nbsp;&nbsp;&nbsp;&nbsp;&nbsp; Number of Files </strong><p>0x10800a2 &nbsp;&nbsp;&nbsp;&nbsp;&nbsp; 1177<p>0x11400a8 &nbsp;&nbsp;&nbsp;&nbsp;&nbsp; 1753",
+    "steps": [
+      {
+        "configuration_files": [
+          {
+            "title": "DaVinci/DV-Stripping24r2-Stripping.py"
+          },
+          {
+            "title": "DaVinci/DV-RedoCaloPID-Stripping_28_24.py"
+          },
+          {
+            "title": "DaVinci/DataType-2015.py"
+          },
+          {
+            "title": "DaVinci/InputType-RDST.py"
+          },
+          {
+            "title": "Persistency/Compression-ZLIB-1.py"
+          },
+          {
+            "title": "DaVinci/DV-RawEventJuggler-0_3-to-4_3.py"
+          }
+        ],
+        "release": "DaVinci.v44r10p5 AppConfig.v3r393 Det/SQLDDDB.v7r10 TMVAWeights.v1r16",
+        "type": "Stripping24r2"
+      },
+      {
+        "configuration_files": [
+          {
+            "title": "Merging/DV-Stripping-Merging.py"
+          },
+          {
+            "title": "Persistency/Compression-LZMA-4.py"
+          }
+        ],
+        "release": "DaVinci.v44r10p5 AppConfig.v3r393 Det/SQLDDDB.v7r10",
+        "type": "Stripping24r2-Merging"
+      }
+    ]
+  },
+  "publisher": "CERN Open Data Portal",
+  "recid": "24639",
+  "run_period": [
+    "2015"
+  ],
+  "stripping": {
+    "stream": "SEMILEPTONIC",
+    "version": "stripping24r2"
+  },
+  "title": "LHCb 2015 Beam6500GeV MagUp SEMILEPTONIC Stream Stripping24r2",
+  "title_additional": "",
+  "type": {
+    "primary": "Dataset",
+    "secondary": [
+      "Collision"
+    ]
+  },
+  "usage": {
+    "description": "<p> The Run 1 and 2 data collected by the LHCb detector is available using the LHCb Ntupling Service, while the Run 1 data is additionally available in .DST and .mDST formats. The data obtained from the LHCb Ntupling Service are ROOT ntuples and do not require custom software to analyze. <p> Links are provided to the LHCb Ntupling Service for exploration of available data and the LHCb Open Data Guide for usage instructions.",
+    "links": [
+      {
+        "description": "LHCb Ntupling Service",
+        "url": "https://opendata-lhcb-ntupling-service.app.cern.ch/"
+      },
+      {
+        "description": "LHCb Open Data Guide",
+        "url": "https://lhcb-opendata-guide.web.cern.ch/"
+      }
+    ]
+  }
+}]

--- a/data/records/LHCb_2016_Beam6500GeV_VeloClosed_MagDown_RealData_Reco16_Stripping28r2_BHADRONCOMPLETEEVENT_DST.json
+++ b/data/records/LHCb_2016_Beam6500GeV_VeloClosed_MagDown_RealData_Reco16_Stripping28r2_BHADRONCOMPLETEEVENT_DST.json
@@ -1,0 +1,213 @@
+[{
+  "abstract": {
+    "description": "Data from proton-proton (pp) collisions collected by the LHCb experiment in the year 2016 of Run2 of the LHC."
+  },
+  "accelerator": "CERN-LHC",
+  "collaboration": {
+    "name": "LHCb collaboration",
+    "recid": "456"
+  },
+  "collections": [
+    "LHCb-Collision-Datasets"
+  ],
+  "collision_information": {
+    "energy": "13TeV",
+    "type": "pp"
+  },
+  "date_created": [
+    "2016"
+  ],
+  "date_published": "2026",
+  "date_reprocessed": "2020",
+  "distribution": {
+    "formats": [
+      "DST"
+    ],
+    "number_events": 1094709920,
+    "number_files": 28220,
+    "size": 105320868036806
+  },
+  "experiment": [
+    "LHCb"
+  ],
+  "magnet_polarity": "MagDown",
+  "methodology": {
+    "description": "<p> This dataset was created in several production steps. These steps, software used and the configuration is provided below. </p><p> <strong> Prod ID: &nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;</strong> 102837<p> <strong>Prod type:&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp; </strong> Merge<p> <strong> Parent Prod ID:&nbsp;&nbsp;&nbsp;&nbsp; </strong> 102836<p> <strong> Parent Prod type: </strong> DataStripping<p> <strong> Conditions: </strong><p>dddb-20190206-3<p>cond-20191004-1</strong><p> <strong> List of Trigger Configuration Keys (TCK): </strong> </p> <p><p><strong>TCK &nbsp;&nbsp;&nbsp;&nbsp;&nbsp; Number of Files </strong><p>0x1138160f &nbsp;&nbsp;&nbsp;&nbsp;&nbsp; 19664<p>0x11381609 &nbsp;&nbsp;&nbsp;&nbsp;&nbsp; 254<p>0x11371609 &nbsp;&nbsp;&nbsp;&nbsp;&nbsp; 1941<p>0x1137160e &nbsp;&nbsp;&nbsp;&nbsp;&nbsp; 696<p>0x1138160e &nbsp;&nbsp;&nbsp;&nbsp;&nbsp; 1077<p>0x11291600 &nbsp;&nbsp;&nbsp;&nbsp;&nbsp; 257<p>0x11291603 &nbsp;&nbsp;&nbsp;&nbsp;&nbsp; 988<p>0x11291604 &nbsp;&nbsp;&nbsp;&nbsp;&nbsp; 826<p>0x11291605 &nbsp;&nbsp;&nbsp;&nbsp;&nbsp; 2517",
+    "steps": [
+      {
+        "configuration_files": [
+          {
+            "title": "DaVinci/DV-Stripping28r2-Stripping.py"
+          },
+          {
+            "title": "DaVinci/DV-RedoCaloPID-Stripping_28_24.py"
+          },
+          {
+            "title": "DaVinci/DataType-2016.py"
+          },
+          {
+            "title": "DaVinci/InputType-RDST.py"
+          },
+          {
+            "title": "Persistency/Compression-ZLIB-1.py"
+          },
+          {
+            "title": "DaVinci/DV-RawEventJuggler-0_3-to-4_3.py"
+          }
+        ],
+        "release": "DaVinci.v44r10p5 AppConfig.v3r393 Det/SQLDDDB.v7r10 TMVAWeights.v1r16",
+        "type": "Stripping28r2"
+      },
+      {
+        "configuration_files": [
+          {
+            "title": "Merging/DV-Stripping-Merging.py"
+          },
+          {
+            "title": "Persistency/Compression-LZMA-4.py"
+          }
+        ],
+        "release": "DaVinci.v44r10p5 AppConfig.v3r393 Det/SQLDDDB.v7r10",
+        "type": "Stripping28r2-Merging"
+      },
+      {
+        "configuration_files": [
+          {
+            "title": "DaVinci/DV-Stripping28r2-Stripping.py"
+          },
+          {
+            "title": "DaVinci/DV-RedoCaloPID-Stripping_28_24.py"
+          },
+          {
+            "title": "DaVinci/DataType-2016.py"
+          },
+          {
+            "title": "DaVinci/InputType-RDST.py"
+          },
+          {
+            "title": "Persistency/Compression-ZLIB-1.py"
+          },
+          {
+            "title": "DaVinci/DV-RawEventJuggler-0_3-to-4_3.py"
+          }
+        ],
+        "release": "DaVinci.v44r10p5 AppConfig.v3r393 Det/SQLDDDB.v7r10 TMVAWeights.v1r16",
+        "type": "Stripping28r2"
+      },
+      {
+        "configuration_files": [
+          {
+            "title": "Merging/DV-Stripping-Merging.py"
+          },
+          {
+            "title": "Persistency/Compression-LZMA-4.py"
+          }
+        ],
+        "release": "DaVinci.v44r10p5 AppConfig.v3r393 Det/SQLDDDB.v7r10",
+        "type": "Stripping28r2-Merging"
+      },
+      {
+        "configuration_files": [
+          {
+            "title": "DaVinci/DV-Stripping28r2-Stripping.py"
+          },
+          {
+            "title": "DaVinci/DV-RedoCaloPID-Stripping_28_24.py"
+          },
+          {
+            "title": "DaVinci/DataType-2016.py"
+          },
+          {
+            "title": "DaVinci/InputType-RDST.py"
+          },
+          {
+            "title": "Persistency/Compression-ZLIB-1.py"
+          },
+          {
+            "title": "DaVinci/DV-RawEventJuggler-0_3-to-4_3.py"
+          }
+        ],
+        "release": "DaVinci.v44r10p5 AppConfig.v3r393 Det/SQLDDDB.v7r10 TMVAWeights.v1r16",
+        "type": "Stripping28r2"
+      },
+      {
+        "configuration_files": [
+          {
+            "title": "Merging/DV-Stripping-Merging.py"
+          },
+          {
+            "title": "Persistency/Compression-LZMA-4.py"
+          }
+        ],
+        "release": "DaVinci.v44r10p5 AppConfig.v3r393 Det/SQLDDDB.v7r10",
+        "type": "Stripping28r2-Merging"
+      },
+      {
+        "configuration_files": [
+          {
+            "title": "DaVinci/DV-Stripping28r2-Stripping.py"
+          },
+          {
+            "title": "DaVinci/DV-RedoCaloPID-Stripping_28_24.py"
+          },
+          {
+            "title": "DaVinci/DataType-2016.py"
+          },
+          {
+            "title": "DaVinci/InputType-RDST.py"
+          },
+          {
+            "title": "Persistency/Compression-ZLIB-1.py"
+          },
+          {
+            "title": "DaVinci/DV-RawEventJuggler-0_3-to-4_3.py"
+          }
+        ],
+        "release": "DaVinci.v44r10p5 AppConfig.v3r393 Det/SQLDDDB.v7r10 TMVAWeights.v1r16",
+        "type": "Stripping28r2"
+      },
+      {
+        "configuration_files": [
+          {
+            "title": "Merging/DV-Stripping-Merging.py"
+          },
+          {
+            "title": "Persistency/Compression-LZMA-4.py"
+          }
+        ],
+        "release": "DaVinci.v44r10p5 AppConfig.v3r393 Det/SQLDDDB.v7r10",
+        "type": "Stripping28r2-Merging"
+      }
+    ]
+  },
+  "publisher": "CERN Open Data Portal",
+  "recid": "24645",
+  "run_period": [
+    "2016"
+  ],
+  "stripping": {
+    "stream": "BHADRONCOMPLETEEVENT",
+    "version": "stripping28r2"
+  },
+  "title": "LHCb 2016 Beam6500GeV MagDown BHADRONCOMPLETEEVENT Stream Stripping28r2",
+  "title_additional": "",
+  "type": {
+    "primary": "Dataset",
+    "secondary": [
+      "Collision"
+    ]
+  },
+  "usage": {
+    "description": "<p> The Run 1 and 2 data collected by the LHCb detector is available using the LHCb Ntupling Service, while the Run 1 data is additionally available in .DST and .mDST formats. The data obtained from the LHCb Ntupling Service are ROOT ntuples and do not require custom software to analyze. <p> Links are provided to the LHCb Ntupling Service for exploration of available data and the LHCb Open Data Guide for usage instructions.",
+    "links": [
+      {
+        "description": "LHCb Ntupling Service",
+        "url": "https://opendata-lhcb-ntupling-service.app.cern.ch/"
+      },
+      {
+        "description": "LHCb Open Data Guide",
+        "url": "https://lhcb-opendata-guide.web.cern.ch/"
+      }
+    ]
+  }
+}]

--- a/data/records/LHCb_2016_Beam6500GeV_VeloClosed_MagDown_RealData_Reco16_Stripping28r2_BHADRON_MDST.json
+++ b/data/records/LHCb_2016_Beam6500GeV_VeloClosed_MagDown_RealData_Reco16_Stripping28r2_BHADRON_MDST.json
@@ -1,0 +1,213 @@
+[{
+  "abstract": {
+    "description": "Data from proton-proton (pp) collisions collected by the LHCb experiment in the year 2016 of Run2 of the LHC."
+  },
+  "accelerator": "CERN-LHC",
+  "collaboration": {
+    "name": "LHCb collaboration",
+    "recid": "456"
+  },
+  "collections": [
+    "LHCb-Collision-Datasets"
+  ],
+  "collision_information": {
+    "energy": "13TeV",
+    "type": "pp"
+  },
+  "date_created": [
+    "2016"
+  ],
+  "date_published": "2026",
+  "date_reprocessed": "2020",
+  "distribution": {
+    "formats": [
+      "MDST"
+    ],
+    "number_events": 3424483169,
+    "number_files": 14505,
+    "size": 52554368031751
+  },
+  "experiment": [
+    "LHCb"
+  ],
+  "magnet_polarity": "MagDown",
+  "methodology": {
+    "description": "<p> This dataset was created in several production steps. These steps, software used and the configuration is provided below. </p><p> <strong> Prod ID: &nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;</strong> 103804<p> <strong>Prod type:&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp; </strong> Merge<p> <strong> Parent Prod ID:&nbsp;&nbsp;&nbsp;&nbsp; </strong> 102836<p> <strong> Parent Prod type: </strong> DataStripping<p> <strong> Conditions: </strong><p>dddb-20190206-3<p>cond-20191004-1</strong><p> <strong> List of Trigger Configuration Keys (TCK): </strong> </p> <p><p><strong>TCK &nbsp;&nbsp;&nbsp;&nbsp;&nbsp; Number of Files </strong><p>0x1138160f &nbsp;&nbsp;&nbsp;&nbsp;&nbsp; 9647<p>0x11381609 &nbsp;&nbsp;&nbsp;&nbsp;&nbsp; 126<p>0x11371609 &nbsp;&nbsp;&nbsp;&nbsp;&nbsp; 997<p>0x1137160e &nbsp;&nbsp;&nbsp;&nbsp;&nbsp; 362<p>0x1138160e &nbsp;&nbsp;&nbsp;&nbsp;&nbsp; 529<p>0x11291600 &nbsp;&nbsp;&nbsp;&nbsp;&nbsp; 223<p>0x11291603 &nbsp;&nbsp;&nbsp;&nbsp;&nbsp; 699<p>0x11291604 &nbsp;&nbsp;&nbsp;&nbsp;&nbsp; 471<p>0x11291605 &nbsp;&nbsp;&nbsp;&nbsp;&nbsp; 1451",
+    "steps": [
+      {
+        "configuration_files": [
+          {
+            "title": "DaVinci/DV-Stripping28r2-Stripping.py"
+          },
+          {
+            "title": "DaVinci/DV-RedoCaloPID-Stripping_28_24.py"
+          },
+          {
+            "title": "DaVinci/DataType-2016.py"
+          },
+          {
+            "title": "DaVinci/InputType-RDST.py"
+          },
+          {
+            "title": "Persistency/Compression-ZLIB-1.py"
+          },
+          {
+            "title": "DaVinci/DV-RawEventJuggler-0_3-to-4_3.py"
+          }
+        ],
+        "release": "DaVinci.v44r10p5 AppConfig.v3r393 Det/SQLDDDB.v7r10 TMVAWeights.v1r16",
+        "type": "Stripping28r2"
+      },
+      {
+        "configuration_files": [
+          {
+            "title": "Merging/DV-Stripping-Merging.py"
+          },
+          {
+            "title": "Persistency/Compression-LZMA-4.py"
+          }
+        ],
+        "release": "DaVinci.v44r10p5 AppConfig.v3r393 Det/SQLDDDB.v7r10",
+        "type": "Stripping28r2-Merging"
+      },
+      {
+        "configuration_files": [
+          {
+            "title": "DaVinci/DV-Stripping28r2-Stripping.py"
+          },
+          {
+            "title": "DaVinci/DV-RedoCaloPID-Stripping_28_24.py"
+          },
+          {
+            "title": "DaVinci/DataType-2016.py"
+          },
+          {
+            "title": "DaVinci/InputType-RDST.py"
+          },
+          {
+            "title": "Persistency/Compression-ZLIB-1.py"
+          },
+          {
+            "title": "DaVinci/DV-RawEventJuggler-0_3-to-4_3.py"
+          }
+        ],
+        "release": "DaVinci.v44r10p5 AppConfig.v3r393 Det/SQLDDDB.v7r10 TMVAWeights.v1r16",
+        "type": "Stripping28r2"
+      },
+      {
+        "configuration_files": [
+          {
+            "title": "Merging/DV-Stripping-Merging.py"
+          },
+          {
+            "title": "Persistency/Compression-LZMA-4.py"
+          }
+        ],
+        "release": "DaVinci.v44r10p5 AppConfig.v3r393 Det/SQLDDDB.v7r10",
+        "type": "Stripping28r2-Merging"
+      },
+      {
+        "configuration_files": [
+          {
+            "title": "DaVinci/DV-Stripping28r2-Stripping.py"
+          },
+          {
+            "title": "DaVinci/DV-RedoCaloPID-Stripping_28_24.py"
+          },
+          {
+            "title": "DaVinci/DataType-2016.py"
+          },
+          {
+            "title": "DaVinci/InputType-RDST.py"
+          },
+          {
+            "title": "Persistency/Compression-ZLIB-1.py"
+          },
+          {
+            "title": "DaVinci/DV-RawEventJuggler-0_3-to-4_3.py"
+          }
+        ],
+        "release": "DaVinci.v44r10p5 AppConfig.v3r393 Det/SQLDDDB.v7r10 TMVAWeights.v1r16",
+        "type": "Stripping28r2"
+      },
+      {
+        "configuration_files": [
+          {
+            "title": "Merging/DV-Stripping-Merging.py"
+          },
+          {
+            "title": "Persistency/Compression-LZMA-4.py"
+          }
+        ],
+        "release": "DaVinci.v44r10p5 AppConfig.v3r393 Det/SQLDDDB.v7r10",
+        "type": "Stripping28r2-Merging"
+      },
+      {
+        "configuration_files": [
+          {
+            "title": "DaVinci/DV-Stripping28r2-Stripping.py"
+          },
+          {
+            "title": "DaVinci/DV-RedoCaloPID-Stripping_28_24.py"
+          },
+          {
+            "title": "DaVinci/DataType-2016.py"
+          },
+          {
+            "title": "DaVinci/InputType-RDST.py"
+          },
+          {
+            "title": "Persistency/Compression-ZLIB-1.py"
+          },
+          {
+            "title": "DaVinci/DV-RawEventJuggler-0_3-to-4_3.py"
+          }
+        ],
+        "release": "DaVinci.v44r10p5 AppConfig.v3r393 Det/SQLDDDB.v7r10 TMVAWeights.v1r16",
+        "type": "Stripping28r2"
+      },
+      {
+        "configuration_files": [
+          {
+            "title": "Merging/DV-Stripping-Merging.py"
+          },
+          {
+            "title": "Persistency/Compression-LZMA-4.py"
+          }
+        ],
+        "release": "DaVinci.v44r10p5 AppConfig.v3r393 Det/SQLDDDB.v7r10",
+        "type": "Stripping28r2-Merging"
+      }
+    ]
+  },
+  "publisher": "CERN Open Data Portal",
+  "recid": "24644",
+  "run_period": [
+    "2016"
+  ],
+  "stripping": {
+    "stream": "BHADRON",
+    "version": "stripping28r2"
+  },
+  "title": "LHCb 2016 Beam6500GeV MagDown BHADRON Stream Stripping28r2",
+  "title_additional": "",
+  "type": {
+    "primary": "Dataset",
+    "secondary": [
+      "Collision"
+    ]
+  },
+  "usage": {
+    "description": "<p> The Run 1 and 2 data collected by the LHCb detector is available using the LHCb Ntupling Service, while the Run 1 data is additionally available in .DST and .mDST formats. The data obtained from the LHCb Ntupling Service are ROOT ntuples and do not require custom software to analyze. <p> Links are provided to the LHCb Ntupling Service for exploration of available data and the LHCb Open Data Guide for usage instructions.",
+    "links": [
+      {
+        "description": "LHCb Ntupling Service",
+        "url": "https://opendata-lhcb-ntupling-service.app.cern.ch/"
+      },
+      {
+        "description": "LHCb Open Data Guide",
+        "url": "https://lhcb-opendata-guide.web.cern.ch/"
+      }
+    ]
+  }
+}]

--- a/data/records/LHCb_2016_Beam6500GeV_VeloClosed_MagDown_RealData_Reco16_Stripping28r2_CHARMCOMPLETEEVENT_DST.json
+++ b/data/records/LHCb_2016_Beam6500GeV_VeloClosed_MagDown_RealData_Reco16_Stripping28r2_CHARMCOMPLETEEVENT_DST.json
@@ -1,0 +1,213 @@
+[{
+  "abstract": {
+    "description": "Data from proton-proton (pp) collisions collected by the LHCb experiment in the year 2016 of Run2 of the LHC."
+  },
+  "accelerator": "CERN-LHC",
+  "collaboration": {
+    "name": "LHCb collaboration",
+    "recid": "456"
+  },
+  "collections": [
+    "LHCb-Collision-Datasets"
+  ],
+  "collision_information": {
+    "energy": "13TeV",
+    "type": "pp"
+  },
+  "date_created": [
+    "2016"
+  ],
+  "date_published": "2026",
+  "date_reprocessed": "2020",
+  "distribution": {
+    "formats": [
+      "DST"
+    ],
+    "number_events": 424974076,
+    "number_files": 10266,
+    "size": 35097093202161
+  },
+  "experiment": [
+    "LHCb"
+  ],
+  "magnet_polarity": "MagDown",
+  "methodology": {
+    "description": "<p> This dataset was created in several production steps. These steps, software used and the configuration is provided below. </p><p> <strong> Prod ID: &nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;</strong> 103400<p> <strong>Prod type:&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp; </strong> Merge<p> <strong> Parent Prod ID:&nbsp;&nbsp;&nbsp;&nbsp; </strong> 102836<p> <strong> Parent Prod type: </strong> DataStripping<p> <strong> Conditions: </strong><p>dddb-20190206-3<p>cond-20191004-1</strong><p> <strong> List of Trigger Configuration Keys (TCK): </strong> </p> <p><p><strong>TCK &nbsp;&nbsp;&nbsp;&nbsp;&nbsp; Number of Files </strong><p>0x1138160f &nbsp;&nbsp;&nbsp;&nbsp;&nbsp; 6813<p>0x11381609 &nbsp;&nbsp;&nbsp;&nbsp;&nbsp; 95<p>0x11371609 &nbsp;&nbsp;&nbsp;&nbsp;&nbsp; 681<p>0x1137160e &nbsp;&nbsp;&nbsp;&nbsp;&nbsp; 237<p>0x1138160e &nbsp;&nbsp;&nbsp;&nbsp;&nbsp; 374<p>0x11291600 &nbsp;&nbsp;&nbsp;&nbsp;&nbsp; 184<p>0x11291603 &nbsp;&nbsp;&nbsp;&nbsp;&nbsp; 504<p>0x11291604 &nbsp;&nbsp;&nbsp;&nbsp;&nbsp; 334<p>0x11291605 &nbsp;&nbsp;&nbsp;&nbsp;&nbsp; 1044",
+    "steps": [
+      {
+        "configuration_files": [
+          {
+            "title": "DaVinci/DV-Stripping28r2-Stripping.py"
+          },
+          {
+            "title": "DaVinci/DV-RedoCaloPID-Stripping_28_24.py"
+          },
+          {
+            "title": "DaVinci/DataType-2016.py"
+          },
+          {
+            "title": "DaVinci/InputType-RDST.py"
+          },
+          {
+            "title": "Persistency/Compression-ZLIB-1.py"
+          },
+          {
+            "title": "DaVinci/DV-RawEventJuggler-0_3-to-4_3.py"
+          }
+        ],
+        "release": "DaVinci.v44r10p5 AppConfig.v3r393 Det/SQLDDDB.v7r10 TMVAWeights.v1r16",
+        "type": "Stripping28r2"
+      },
+      {
+        "configuration_files": [
+          {
+            "title": "Merging/DV-Stripping-Merging.py"
+          },
+          {
+            "title": "Persistency/Compression-LZMA-4.py"
+          }
+        ],
+        "release": "DaVinci.v44r10p5 AppConfig.v3r393 Det/SQLDDDB.v7r10",
+        "type": "Stripping28r2-Merging"
+      },
+      {
+        "configuration_files": [
+          {
+            "title": "DaVinci/DV-Stripping28r2-Stripping.py"
+          },
+          {
+            "title": "DaVinci/DV-RedoCaloPID-Stripping_28_24.py"
+          },
+          {
+            "title": "DaVinci/DataType-2016.py"
+          },
+          {
+            "title": "DaVinci/InputType-RDST.py"
+          },
+          {
+            "title": "Persistency/Compression-ZLIB-1.py"
+          },
+          {
+            "title": "DaVinci/DV-RawEventJuggler-0_3-to-4_3.py"
+          }
+        ],
+        "release": "DaVinci.v44r10p5 AppConfig.v3r393 Det/SQLDDDB.v7r10 TMVAWeights.v1r16",
+        "type": "Stripping28r2"
+      },
+      {
+        "configuration_files": [
+          {
+            "title": "Merging/DV-Stripping-Merging.py"
+          },
+          {
+            "title": "Persistency/Compression-LZMA-4.py"
+          }
+        ],
+        "release": "DaVinci.v44r10p5 AppConfig.v3r393 Det/SQLDDDB.v7r10",
+        "type": "Stripping28r2-Merging"
+      },
+      {
+        "configuration_files": [
+          {
+            "title": "DaVinci/DV-Stripping28r2-Stripping.py"
+          },
+          {
+            "title": "DaVinci/DV-RedoCaloPID-Stripping_28_24.py"
+          },
+          {
+            "title": "DaVinci/DataType-2016.py"
+          },
+          {
+            "title": "DaVinci/InputType-RDST.py"
+          },
+          {
+            "title": "Persistency/Compression-ZLIB-1.py"
+          },
+          {
+            "title": "DaVinci/DV-RawEventJuggler-0_3-to-4_3.py"
+          }
+        ],
+        "release": "DaVinci.v44r10p5 AppConfig.v3r393 Det/SQLDDDB.v7r10 TMVAWeights.v1r16",
+        "type": "Stripping28r2"
+      },
+      {
+        "configuration_files": [
+          {
+            "title": "Merging/DV-Stripping-Merging.py"
+          },
+          {
+            "title": "Persistency/Compression-LZMA-4.py"
+          }
+        ],
+        "release": "DaVinci.v44r10p5 AppConfig.v3r393 Det/SQLDDDB.v7r10",
+        "type": "Stripping28r2-Merging"
+      },
+      {
+        "configuration_files": [
+          {
+            "title": "DaVinci/DV-Stripping28r2-Stripping.py"
+          },
+          {
+            "title": "DaVinci/DV-RedoCaloPID-Stripping_28_24.py"
+          },
+          {
+            "title": "DaVinci/DataType-2016.py"
+          },
+          {
+            "title": "DaVinci/InputType-RDST.py"
+          },
+          {
+            "title": "Persistency/Compression-ZLIB-1.py"
+          },
+          {
+            "title": "DaVinci/DV-RawEventJuggler-0_3-to-4_3.py"
+          }
+        ],
+        "release": "DaVinci.v44r10p5 AppConfig.v3r393 Det/SQLDDDB.v7r10 TMVAWeights.v1r16",
+        "type": "Stripping28r2"
+      },
+      {
+        "configuration_files": [
+          {
+            "title": "Merging/DV-Stripping-Merging.py"
+          },
+          {
+            "title": "Persistency/Compression-LZMA-4.py"
+          }
+        ],
+        "release": "DaVinci.v44r10p5 AppConfig.v3r393 Det/SQLDDDB.v7r10",
+        "type": "Stripping28r2-Merging"
+      }
+    ]
+  },
+  "publisher": "CERN Open Data Portal",
+  "recid": "24647",
+  "run_period": [
+    "2016"
+  ],
+  "stripping": {
+    "stream": "CHARMCOMPLETEEVENT",
+    "version": "stripping28r2"
+  },
+  "title": "LHCb 2016 Beam6500GeV MagDown CHARMCOMPLETEEVENT Stream Stripping28r2",
+  "title_additional": "",
+  "type": {
+    "primary": "Dataset",
+    "secondary": [
+      "Collision"
+    ]
+  },
+  "usage": {
+    "description": "<p> The Run 1 and 2 data collected by the LHCb detector is available using the LHCb Ntupling Service, while the Run 1 data is additionally available in .DST and .mDST formats. The data obtained from the LHCb Ntupling Service are ROOT ntuples and do not require custom software to analyze. <p> Links are provided to the LHCb Ntupling Service for exploration of available data and the LHCb Open Data Guide for usage instructions.",
+    "links": [
+      {
+        "description": "LHCb Ntupling Service",
+        "url": "https://opendata-lhcb-ntupling-service.app.cern.ch/"
+      },
+      {
+        "description": "LHCb Open Data Guide",
+        "url": "https://lhcb-opendata-guide.web.cern.ch/"
+      }
+    ]
+  }
+}]

--- a/data/records/LHCb_2016_Beam6500GeV_VeloClosed_MagDown_RealData_Reco16_Stripping28r2_CHARM_MDST.json
+++ b/data/records/LHCb_2016_Beam6500GeV_VeloClosed_MagDown_RealData_Reco16_Stripping28r2_CHARM_MDST.json
@@ -1,0 +1,213 @@
+[{
+  "abstract": {
+    "description": "Data from proton-proton (pp) collisions collected by the LHCb experiment in the year 2016 of Run2 of the LHC."
+  },
+  "accelerator": "CERN-LHC",
+  "collaboration": {
+    "name": "LHCb collaboration",
+    "recid": "456"
+  },
+  "collections": [
+    "LHCb-Collision-Datasets"
+  ],
+  "collision_information": {
+    "energy": "13TeV",
+    "type": "pp"
+  },
+  "date_created": [
+    "2016"
+  ],
+  "date_published": "2026",
+  "date_reprocessed": "2020",
+  "distribution": {
+    "formats": [
+      "MDST"
+    ],
+    "number_events": 4125167413,
+    "number_files": 13095,
+    "size": 47193583776356
+  },
+  "experiment": [
+    "LHCb"
+  ],
+  "magnet_polarity": "MagDown",
+  "methodology": {
+    "description": "<p> This dataset was created in several production steps. These steps, software used and the configuration is provided below. </p><p> <strong> Prod ID: &nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;</strong> 103804<p> <strong>Prod type:&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp; </strong> Merge<p> <strong> Parent Prod ID:&nbsp;&nbsp;&nbsp;&nbsp; </strong> 102836<p> <strong> Parent Prod type: </strong> DataStripping<p> <strong> Conditions: </strong><p>dddb-20190206-3<p>cond-20191004-1</strong><p> <strong> List of Trigger Configuration Keys (TCK): </strong> </p> <p><p><strong>TCK &nbsp;&nbsp;&nbsp;&nbsp;&nbsp; Number of Files </strong><p>0x1138160f &nbsp;&nbsp;&nbsp;&nbsp;&nbsp; 8639<p>0x11381609 &nbsp;&nbsp;&nbsp;&nbsp;&nbsp; 117<p>0x11371609 &nbsp;&nbsp;&nbsp;&nbsp;&nbsp; 874<p>0x1137160e &nbsp;&nbsp;&nbsp;&nbsp;&nbsp; 309<p>0x1138160e &nbsp;&nbsp;&nbsp;&nbsp;&nbsp; 479<p>0x11291600 &nbsp;&nbsp;&nbsp;&nbsp;&nbsp; 219<p>0x11291603 &nbsp;&nbsp;&nbsp;&nbsp;&nbsp; 667<p>0x11291604 &nbsp;&nbsp;&nbsp;&nbsp;&nbsp; 445<p>0x11291605 &nbsp;&nbsp;&nbsp;&nbsp;&nbsp; 1346",
+    "steps": [
+      {
+        "configuration_files": [
+          {
+            "title": "DaVinci/DV-Stripping28r2-Stripping.py"
+          },
+          {
+            "title": "DaVinci/DV-RedoCaloPID-Stripping_28_24.py"
+          },
+          {
+            "title": "DaVinci/DataType-2016.py"
+          },
+          {
+            "title": "DaVinci/InputType-RDST.py"
+          },
+          {
+            "title": "Persistency/Compression-ZLIB-1.py"
+          },
+          {
+            "title": "DaVinci/DV-RawEventJuggler-0_3-to-4_3.py"
+          }
+        ],
+        "release": "DaVinci.v44r10p5 AppConfig.v3r393 Det/SQLDDDB.v7r10 TMVAWeights.v1r16",
+        "type": "Stripping28r2"
+      },
+      {
+        "configuration_files": [
+          {
+            "title": "Merging/DV-Stripping-Merging.py"
+          },
+          {
+            "title": "Persistency/Compression-LZMA-4.py"
+          }
+        ],
+        "release": "DaVinci.v44r10p5 AppConfig.v3r393 Det/SQLDDDB.v7r10",
+        "type": "Stripping28r2-Merging"
+      },
+      {
+        "configuration_files": [
+          {
+            "title": "DaVinci/DV-Stripping28r2-Stripping.py"
+          },
+          {
+            "title": "DaVinci/DV-RedoCaloPID-Stripping_28_24.py"
+          },
+          {
+            "title": "DaVinci/DataType-2016.py"
+          },
+          {
+            "title": "DaVinci/InputType-RDST.py"
+          },
+          {
+            "title": "Persistency/Compression-ZLIB-1.py"
+          },
+          {
+            "title": "DaVinci/DV-RawEventJuggler-0_3-to-4_3.py"
+          }
+        ],
+        "release": "DaVinci.v44r10p5 AppConfig.v3r393 Det/SQLDDDB.v7r10 TMVAWeights.v1r16",
+        "type": "Stripping28r2"
+      },
+      {
+        "configuration_files": [
+          {
+            "title": "Merging/DV-Stripping-Merging.py"
+          },
+          {
+            "title": "Persistency/Compression-LZMA-4.py"
+          }
+        ],
+        "release": "DaVinci.v44r10p5 AppConfig.v3r393 Det/SQLDDDB.v7r10",
+        "type": "Stripping28r2-Merging"
+      },
+      {
+        "configuration_files": [
+          {
+            "title": "DaVinci/DV-Stripping28r2-Stripping.py"
+          },
+          {
+            "title": "DaVinci/DV-RedoCaloPID-Stripping_28_24.py"
+          },
+          {
+            "title": "DaVinci/DataType-2016.py"
+          },
+          {
+            "title": "DaVinci/InputType-RDST.py"
+          },
+          {
+            "title": "Persistency/Compression-ZLIB-1.py"
+          },
+          {
+            "title": "DaVinci/DV-RawEventJuggler-0_3-to-4_3.py"
+          }
+        ],
+        "release": "DaVinci.v44r10p5 AppConfig.v3r393 Det/SQLDDDB.v7r10 TMVAWeights.v1r16",
+        "type": "Stripping28r2"
+      },
+      {
+        "configuration_files": [
+          {
+            "title": "Merging/DV-Stripping-Merging.py"
+          },
+          {
+            "title": "Persistency/Compression-LZMA-4.py"
+          }
+        ],
+        "release": "DaVinci.v44r10p5 AppConfig.v3r393 Det/SQLDDDB.v7r10",
+        "type": "Stripping28r2-Merging"
+      },
+      {
+        "configuration_files": [
+          {
+            "title": "DaVinci/DV-Stripping28r2-Stripping.py"
+          },
+          {
+            "title": "DaVinci/DV-RedoCaloPID-Stripping_28_24.py"
+          },
+          {
+            "title": "DaVinci/DataType-2016.py"
+          },
+          {
+            "title": "DaVinci/InputType-RDST.py"
+          },
+          {
+            "title": "Persistency/Compression-ZLIB-1.py"
+          },
+          {
+            "title": "DaVinci/DV-RawEventJuggler-0_3-to-4_3.py"
+          }
+        ],
+        "release": "DaVinci.v44r10p5 AppConfig.v3r393 Det/SQLDDDB.v7r10 TMVAWeights.v1r16",
+        "type": "Stripping28r2"
+      },
+      {
+        "configuration_files": [
+          {
+            "title": "Merging/DV-Stripping-Merging.py"
+          },
+          {
+            "title": "Persistency/Compression-LZMA-4.py"
+          }
+        ],
+        "release": "DaVinci.v44r10p5 AppConfig.v3r393 Det/SQLDDDB.v7r10",
+        "type": "Stripping28r2-Merging"
+      }
+    ]
+  },
+  "publisher": "CERN Open Data Portal",
+  "recid": "24646",
+  "run_period": [
+    "2016"
+  ],
+  "stripping": {
+    "stream": "CHARM",
+    "version": "stripping28r2"
+  },
+  "title": "LHCb 2016 Beam6500GeV MagDown CHARM Stream Stripping28r2",
+  "title_additional": "",
+  "type": {
+    "primary": "Dataset",
+    "secondary": [
+      "Collision"
+    ]
+  },
+  "usage": {
+    "description": "<p> The Run 1 and 2 data collected by the LHCb detector is available using the LHCb Ntupling Service, while the Run 1 data is additionally available in .DST and .mDST formats. The data obtained from the LHCb Ntupling Service are ROOT ntuples and do not require custom software to analyze. <p> Links are provided to the LHCb Ntupling Service for exploration of available data and the LHCb Open Data Guide for usage instructions.",
+    "links": [
+      {
+        "description": "LHCb Ntupling Service",
+        "url": "https://opendata-lhcb-ntupling-service.app.cern.ch/"
+      },
+      {
+        "description": "LHCb Open Data Guide",
+        "url": "https://lhcb-opendata-guide.web.cern.ch/"
+      }
+    ]
+  }
+}]

--- a/data/records/LHCb_2016_Beam6500GeV_VeloClosed_MagDown_RealData_Reco16_Stripping28r2_DIMUON_DST.json
+++ b/data/records/LHCb_2016_Beam6500GeV_VeloClosed_MagDown_RealData_Reco16_Stripping28r2_DIMUON_DST.json
@@ -1,0 +1,213 @@
+[{
+  "abstract": {
+    "description": "Data from proton-proton (pp) collisions collected by the LHCb experiment in the year 2016 of Run2 of the LHC."
+  },
+  "accelerator": "CERN-LHC",
+  "collaboration": {
+    "name": "LHCb collaboration",
+    "recid": "456"
+  },
+  "collections": [
+    "LHCb-Collision-Datasets"
+  ],
+  "collision_information": {
+    "energy": "13TeV",
+    "type": "pp"
+  },
+  "date_created": [
+    "2016"
+  ],
+  "date_published": "2026",
+  "date_reprocessed": "2020",
+  "distribution": {
+    "formats": [
+      "DST"
+    ],
+    "number_events": 562295732,
+    "number_files": 15394,
+    "size": 55693262100281
+  },
+  "experiment": [
+    "LHCb"
+  ],
+  "magnet_polarity": "MagDown",
+  "methodology": {
+    "description": "<p> This dataset was created in several production steps. These steps, software used and the configuration is provided below. </p><p> <strong> Prod ID: &nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;</strong> 103804<p> <strong>Prod type:&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp; </strong> Merge<p> <strong> Parent Prod ID:&nbsp;&nbsp;&nbsp;&nbsp; </strong> 102836<p> <strong> Parent Prod type: </strong> DataStripping<p> <strong> Conditions: </strong><p>dddb-20190206-3<p>cond-20191004-1</strong><p> <strong> List of Trigger Configuration Keys (TCK): </strong> </p> <p><p><strong>TCK &nbsp;&nbsp;&nbsp;&nbsp;&nbsp; Number of Files </strong><p>0x11381609 &nbsp;&nbsp;&nbsp;&nbsp;&nbsp; 130<p>0x1138160f &nbsp;&nbsp;&nbsp;&nbsp;&nbsp; 9894<p>0x11371609 &nbsp;&nbsp;&nbsp;&nbsp;&nbsp; 1109<p>0x1137160e &nbsp;&nbsp;&nbsp;&nbsp;&nbsp; 407<p>0x1138160e &nbsp;&nbsp;&nbsp;&nbsp;&nbsp; 563<p>0x11291600 &nbsp;&nbsp;&nbsp;&nbsp;&nbsp; 222<p>0x11291603 &nbsp;&nbsp;&nbsp;&nbsp;&nbsp; 773<p>0x11291604 &nbsp;&nbsp;&nbsp;&nbsp;&nbsp; 555<p>0x11291605 &nbsp;&nbsp;&nbsp;&nbsp;&nbsp; 1741",
+    "steps": [
+      {
+        "configuration_files": [
+          {
+            "title": "DaVinci/DV-Stripping28r2-Stripping.py"
+          },
+          {
+            "title": "DaVinci/DV-RedoCaloPID-Stripping_28_24.py"
+          },
+          {
+            "title": "DaVinci/DataType-2016.py"
+          },
+          {
+            "title": "DaVinci/InputType-RDST.py"
+          },
+          {
+            "title": "Persistency/Compression-ZLIB-1.py"
+          },
+          {
+            "title": "DaVinci/DV-RawEventJuggler-0_3-to-4_3.py"
+          }
+        ],
+        "release": "DaVinci.v44r10p5 AppConfig.v3r393 Det/SQLDDDB.v7r10 TMVAWeights.v1r16",
+        "type": "Stripping28r2"
+      },
+      {
+        "configuration_files": [
+          {
+            "title": "Merging/DV-Stripping-Merging.py"
+          },
+          {
+            "title": "Persistency/Compression-LZMA-4.py"
+          }
+        ],
+        "release": "DaVinci.v44r10p5 AppConfig.v3r393 Det/SQLDDDB.v7r10",
+        "type": "Stripping28r2-Merging"
+      },
+      {
+        "configuration_files": [
+          {
+            "title": "DaVinci/DV-Stripping28r2-Stripping.py"
+          },
+          {
+            "title": "DaVinci/DV-RedoCaloPID-Stripping_28_24.py"
+          },
+          {
+            "title": "DaVinci/DataType-2016.py"
+          },
+          {
+            "title": "DaVinci/InputType-RDST.py"
+          },
+          {
+            "title": "Persistency/Compression-ZLIB-1.py"
+          },
+          {
+            "title": "DaVinci/DV-RawEventJuggler-0_3-to-4_3.py"
+          }
+        ],
+        "release": "DaVinci.v44r10p5 AppConfig.v3r393 Det/SQLDDDB.v7r10 TMVAWeights.v1r16",
+        "type": "Stripping28r2"
+      },
+      {
+        "configuration_files": [
+          {
+            "title": "Merging/DV-Stripping-Merging.py"
+          },
+          {
+            "title": "Persistency/Compression-LZMA-4.py"
+          }
+        ],
+        "release": "DaVinci.v44r10p5 AppConfig.v3r393 Det/SQLDDDB.v7r10",
+        "type": "Stripping28r2-Merging"
+      },
+      {
+        "configuration_files": [
+          {
+            "title": "DaVinci/DV-Stripping28r2-Stripping.py"
+          },
+          {
+            "title": "DaVinci/DV-RedoCaloPID-Stripping_28_24.py"
+          },
+          {
+            "title": "DaVinci/DataType-2016.py"
+          },
+          {
+            "title": "DaVinci/InputType-RDST.py"
+          },
+          {
+            "title": "Persistency/Compression-ZLIB-1.py"
+          },
+          {
+            "title": "DaVinci/DV-RawEventJuggler-0_3-to-4_3.py"
+          }
+        ],
+        "release": "DaVinci.v44r10p5 AppConfig.v3r393 Det/SQLDDDB.v7r10 TMVAWeights.v1r16",
+        "type": "Stripping28r2"
+      },
+      {
+        "configuration_files": [
+          {
+            "title": "Merging/DV-Stripping-Merging.py"
+          },
+          {
+            "title": "Persistency/Compression-LZMA-4.py"
+          }
+        ],
+        "release": "DaVinci.v44r10p5 AppConfig.v3r393 Det/SQLDDDB.v7r10",
+        "type": "Stripping28r2-Merging"
+      },
+      {
+        "configuration_files": [
+          {
+            "title": "DaVinci/DV-Stripping28r2-Stripping.py"
+          },
+          {
+            "title": "DaVinci/DV-RedoCaloPID-Stripping_28_24.py"
+          },
+          {
+            "title": "DaVinci/DataType-2016.py"
+          },
+          {
+            "title": "DaVinci/InputType-RDST.py"
+          },
+          {
+            "title": "Persistency/Compression-ZLIB-1.py"
+          },
+          {
+            "title": "DaVinci/DV-RawEventJuggler-0_3-to-4_3.py"
+          }
+        ],
+        "release": "DaVinci.v44r10p5 AppConfig.v3r393 Det/SQLDDDB.v7r10 TMVAWeights.v1r16",
+        "type": "Stripping28r2"
+      },
+      {
+        "configuration_files": [
+          {
+            "title": "Merging/DV-Stripping-Merging.py"
+          },
+          {
+            "title": "Persistency/Compression-LZMA-4.py"
+          }
+        ],
+        "release": "DaVinci.v44r10p5 AppConfig.v3r393 Det/SQLDDDB.v7r10",
+        "type": "Stripping28r2-Merging"
+      }
+    ]
+  },
+  "publisher": "CERN Open Data Portal",
+  "recid": "24648",
+  "run_period": [
+    "2016"
+  ],
+  "stripping": {
+    "stream": "DIMUON",
+    "version": "stripping28r2"
+  },
+  "title": "LHCb 2016 Beam6500GeV MagDown DIMUON Stream Stripping28r2",
+  "title_additional": "",
+  "type": {
+    "primary": "Dataset",
+    "secondary": [
+      "Collision"
+    ]
+  },
+  "usage": {
+    "description": "<p> The Run 1 and 2 data collected by the LHCb detector is available using the LHCb Ntupling Service, while the Run 1 data is additionally available in .DST and .mDST formats. The data obtained from the LHCb Ntupling Service are ROOT ntuples and do not require custom software to analyze. <p> Links are provided to the LHCb Ntupling Service for exploration of available data and the LHCb Open Data Guide for usage instructions.",
+    "links": [
+      {
+        "description": "LHCb Ntupling Service",
+        "url": "https://opendata-lhcb-ntupling-service.app.cern.ch/"
+      },
+      {
+        "description": "LHCb Open Data Guide",
+        "url": "https://lhcb-opendata-guide.web.cern.ch/"
+      }
+    ]
+  }
+}]

--- a/data/records/LHCb_2016_Beam6500GeV_VeloClosed_MagDown_RealData_Reco16_Stripping28r2_EW_DST.json
+++ b/data/records/LHCb_2016_Beam6500GeV_VeloClosed_MagDown_RealData_Reco16_Stripping28r2_EW_DST.json
@@ -1,0 +1,213 @@
+[{
+  "abstract": {
+    "description": "Data from proton-proton (pp) collisions collected by the LHCb experiment in the year 2016 of Run2 of the LHC."
+  },
+  "accelerator": "CERN-LHC",
+  "collaboration": {
+    "name": "LHCb collaboration",
+    "recid": "456"
+  },
+  "collections": [
+    "LHCb-Collision-Datasets"
+  ],
+  "collision_information": {
+    "energy": "13TeV",
+    "type": "pp"
+  },
+  "date_created": [
+    "2016"
+  ],
+  "date_published": "2026",
+  "date_reprocessed": "2020",
+  "distribution": {
+    "formats": [
+      "DST"
+    ],
+    "number_events": 316925010,
+    "number_files": 8362,
+    "size": 28083222750872
+  },
+  "experiment": [
+    "LHCb"
+  ],
+  "magnet_polarity": "MagDown",
+  "methodology": {
+    "description": "<p> This dataset was created in several production steps. These steps, software used and the configuration is provided below. </p><p> <strong> Prod ID: &nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;</strong> 103398<p> <strong>Prod type:&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp; </strong> Merge<p> <strong> Parent Prod ID:&nbsp;&nbsp;&nbsp;&nbsp; </strong> 102836<p> <strong> Parent Prod type: </strong> DataStripping<p> <strong> Conditions: </strong><p>dddb-20190206-3<p>cond-20191004-1</strong><p> <strong> List of Trigger Configuration Keys (TCK): </strong> </p> <p><p><strong>TCK &nbsp;&nbsp;&nbsp;&nbsp;&nbsp; Number of Files </strong><p>0x1138160f &nbsp;&nbsp;&nbsp;&nbsp;&nbsp; 5325<p>0x11381609 &nbsp;&nbsp;&nbsp;&nbsp;&nbsp; 72<p>0x11371609 &nbsp;&nbsp;&nbsp;&nbsp;&nbsp; 581<p>0x1137160e &nbsp;&nbsp;&nbsp;&nbsp;&nbsp; 210<p>0x1138160e &nbsp;&nbsp;&nbsp;&nbsp;&nbsp; 292<p>0x11291600 &nbsp;&nbsp;&nbsp;&nbsp;&nbsp; 199<p>0x11291603 &nbsp;&nbsp;&nbsp;&nbsp;&nbsp; 444<p>0x11291604 &nbsp;&nbsp;&nbsp;&nbsp;&nbsp; 299<p>0x11291605 &nbsp;&nbsp;&nbsp;&nbsp;&nbsp; 940",
+    "steps": [
+      {
+        "configuration_files": [
+          {
+            "title": "DaVinci/DV-Stripping28r2-Stripping.py"
+          },
+          {
+            "title": "DaVinci/DV-RedoCaloPID-Stripping_28_24.py"
+          },
+          {
+            "title": "DaVinci/DataType-2016.py"
+          },
+          {
+            "title": "DaVinci/InputType-RDST.py"
+          },
+          {
+            "title": "Persistency/Compression-ZLIB-1.py"
+          },
+          {
+            "title": "DaVinci/DV-RawEventJuggler-0_3-to-4_3.py"
+          }
+        ],
+        "release": "DaVinci.v44r10p5 AppConfig.v3r393 Det/SQLDDDB.v7r10 TMVAWeights.v1r16",
+        "type": "Stripping28r2"
+      },
+      {
+        "configuration_files": [
+          {
+            "title": "Merging/DV-Stripping-Merging.py"
+          },
+          {
+            "title": "Persistency/Compression-LZMA-4.py"
+          }
+        ],
+        "release": "DaVinci.v44r10p5 AppConfig.v3r393 Det/SQLDDDB.v7r10",
+        "type": "Stripping28r2-Merging"
+      },
+      {
+        "configuration_files": [
+          {
+            "title": "DaVinci/DV-Stripping28r2-Stripping.py"
+          },
+          {
+            "title": "DaVinci/DV-RedoCaloPID-Stripping_28_24.py"
+          },
+          {
+            "title": "DaVinci/DataType-2016.py"
+          },
+          {
+            "title": "DaVinci/InputType-RDST.py"
+          },
+          {
+            "title": "Persistency/Compression-ZLIB-1.py"
+          },
+          {
+            "title": "DaVinci/DV-RawEventJuggler-0_3-to-4_3.py"
+          }
+        ],
+        "release": "DaVinci.v44r10p5 AppConfig.v3r393 Det/SQLDDDB.v7r10 TMVAWeights.v1r16",
+        "type": "Stripping28r2"
+      },
+      {
+        "configuration_files": [
+          {
+            "title": "Merging/DV-Stripping-Merging.py"
+          },
+          {
+            "title": "Persistency/Compression-LZMA-4.py"
+          }
+        ],
+        "release": "DaVinci.v44r10p5 AppConfig.v3r393 Det/SQLDDDB.v7r10",
+        "type": "Stripping28r2-Merging"
+      },
+      {
+        "configuration_files": [
+          {
+            "title": "DaVinci/DV-Stripping28r2-Stripping.py"
+          },
+          {
+            "title": "DaVinci/DV-RedoCaloPID-Stripping_28_24.py"
+          },
+          {
+            "title": "DaVinci/DataType-2016.py"
+          },
+          {
+            "title": "DaVinci/InputType-RDST.py"
+          },
+          {
+            "title": "Persistency/Compression-ZLIB-1.py"
+          },
+          {
+            "title": "DaVinci/DV-RawEventJuggler-0_3-to-4_3.py"
+          }
+        ],
+        "release": "DaVinci.v44r10p5 AppConfig.v3r393 Det/SQLDDDB.v7r10 TMVAWeights.v1r16",
+        "type": "Stripping28r2"
+      },
+      {
+        "configuration_files": [
+          {
+            "title": "Merging/DV-Stripping-Merging.py"
+          },
+          {
+            "title": "Persistency/Compression-LZMA-4.py"
+          }
+        ],
+        "release": "DaVinci.v44r10p5 AppConfig.v3r393 Det/SQLDDDB.v7r10",
+        "type": "Stripping28r2-Merging"
+      },
+      {
+        "configuration_files": [
+          {
+            "title": "DaVinci/DV-Stripping28r2-Stripping.py"
+          },
+          {
+            "title": "DaVinci/DV-RedoCaloPID-Stripping_28_24.py"
+          },
+          {
+            "title": "DaVinci/DataType-2016.py"
+          },
+          {
+            "title": "DaVinci/InputType-RDST.py"
+          },
+          {
+            "title": "Persistency/Compression-ZLIB-1.py"
+          },
+          {
+            "title": "DaVinci/DV-RawEventJuggler-0_3-to-4_3.py"
+          }
+        ],
+        "release": "DaVinci.v44r10p5 AppConfig.v3r393 Det/SQLDDDB.v7r10 TMVAWeights.v1r16",
+        "type": "Stripping28r2"
+      },
+      {
+        "configuration_files": [
+          {
+            "title": "Merging/DV-Stripping-Merging.py"
+          },
+          {
+            "title": "Persistency/Compression-LZMA-4.py"
+          }
+        ],
+        "release": "DaVinci.v44r10p5 AppConfig.v3r393 Det/SQLDDDB.v7r10",
+        "type": "Stripping28r2-Merging"
+      }
+    ]
+  },
+  "publisher": "CERN Open Data Portal",
+  "recid": "24640",
+  "run_period": [
+    "2016"
+  ],
+  "stripping": {
+    "stream": "EW",
+    "version": "stripping28r2"
+  },
+  "title": "LHCb 2016 Beam6500GeV MagDown EW Stream Stripping28r2",
+  "title_additional": "",
+  "type": {
+    "primary": "Dataset",
+    "secondary": [
+      "Collision"
+    ]
+  },
+  "usage": {
+    "description": "<p> The Run 1 and 2 data collected by the LHCb detector is available using the LHCb Ntupling Service, while the Run 1 data is additionally available in .DST and .mDST formats. The data obtained from the LHCb Ntupling Service are ROOT ntuples and do not require custom software to analyze. <p> Links are provided to the LHCb Ntupling Service for exploration of available data and the LHCb Open Data Guide for usage instructions.",
+    "links": [
+      {
+        "description": "LHCb Ntupling Service",
+        "url": "https://opendata-lhcb-ntupling-service.app.cern.ch/"
+      },
+      {
+        "description": "LHCb Open Data Guide",
+        "url": "https://lhcb-opendata-guide.web.cern.ch/"
+      }
+    ]
+  }
+}]

--- a/data/records/LHCb_2016_Beam6500GeV_VeloClosed_MagDown_RealData_Reco16_Stripping28r2_LEPTONIC_MDST.json
+++ b/data/records/LHCb_2016_Beam6500GeV_VeloClosed_MagDown_RealData_Reco16_Stripping28r2_LEPTONIC_MDST.json
@@ -1,0 +1,213 @@
+[{
+  "abstract": {
+    "description": "Data from proton-proton (pp) collisions collected by the LHCb experiment in the year 2016 of Run2 of the LHC."
+  },
+  "accelerator": "CERN-LHC",
+  "collaboration": {
+    "name": "LHCb collaboration",
+    "recid": "456"
+  },
+  "collections": [
+    "LHCb-Collision-Datasets"
+  ],
+  "collision_information": {
+    "energy": "13TeV",
+    "type": "pp"
+  },
+  "date_created": [
+    "2016"
+  ],
+  "date_published": "2026",
+  "date_reprocessed": "2020",
+  "distribution": {
+    "formats": [
+      "MDST"
+    ],
+    "number_events": 4470532221,
+    "number_files": 14916,
+    "size": 55681501071452
+  },
+  "experiment": [
+    "LHCb"
+  ],
+  "magnet_polarity": "MagDown",
+  "methodology": {
+    "description": "<p> This dataset was created in several production steps. These steps, software used and the configuration is provided below. </p><p> <strong> Prod ID: &nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;</strong> 103398<p> <strong>Prod type:&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp; </strong> Merge<p> <strong> Parent Prod ID:&nbsp;&nbsp;&nbsp;&nbsp; </strong> 102836<p> <strong> Parent Prod type: </strong> DataStripping<p> <strong> Conditions: </strong><p>dddb-20190206-3<p>cond-20191004-1</strong><p> <strong> List of Trigger Configuration Keys (TCK): </strong> </p> <p><p><strong>TCK &nbsp;&nbsp;&nbsp;&nbsp;&nbsp; Number of Files </strong><p>0x1138160f &nbsp;&nbsp;&nbsp;&nbsp;&nbsp; 9789<p>0x11381609 &nbsp;&nbsp;&nbsp;&nbsp;&nbsp; 130<p>0x11371609 &nbsp;&nbsp;&nbsp;&nbsp;&nbsp; 1014<p>0x1137160e &nbsp;&nbsp;&nbsp;&nbsp;&nbsp; 364<p>0x1138160e &nbsp;&nbsp;&nbsp;&nbsp;&nbsp; 530<p>0x11291600 &nbsp;&nbsp;&nbsp;&nbsp;&nbsp; 230<p>0x11291603 &nbsp;&nbsp;&nbsp;&nbsp;&nbsp; 734<p>0x11291604 &nbsp;&nbsp;&nbsp;&nbsp;&nbsp; 521<p>0x11291605 &nbsp;&nbsp;&nbsp;&nbsp;&nbsp; 1604",
+    "steps": [
+      {
+        "configuration_files": [
+          {
+            "title": "DaVinci/DV-Stripping28r2-Stripping.py"
+          },
+          {
+            "title": "DaVinci/DV-RedoCaloPID-Stripping_28_24.py"
+          },
+          {
+            "title": "DaVinci/DataType-2016.py"
+          },
+          {
+            "title": "DaVinci/InputType-RDST.py"
+          },
+          {
+            "title": "Persistency/Compression-ZLIB-1.py"
+          },
+          {
+            "title": "DaVinci/DV-RawEventJuggler-0_3-to-4_3.py"
+          }
+        ],
+        "release": "DaVinci.v44r10p5 AppConfig.v3r393 Det/SQLDDDB.v7r10 TMVAWeights.v1r16",
+        "type": "Stripping28r2"
+      },
+      {
+        "configuration_files": [
+          {
+            "title": "Merging/DV-Stripping-Merging.py"
+          },
+          {
+            "title": "Persistency/Compression-LZMA-4.py"
+          }
+        ],
+        "release": "DaVinci.v44r10p5 AppConfig.v3r393 Det/SQLDDDB.v7r10",
+        "type": "Stripping28r2-Merging"
+      },
+      {
+        "configuration_files": [
+          {
+            "title": "DaVinci/DV-Stripping28r2-Stripping.py"
+          },
+          {
+            "title": "DaVinci/DV-RedoCaloPID-Stripping_28_24.py"
+          },
+          {
+            "title": "DaVinci/DataType-2016.py"
+          },
+          {
+            "title": "DaVinci/InputType-RDST.py"
+          },
+          {
+            "title": "Persistency/Compression-ZLIB-1.py"
+          },
+          {
+            "title": "DaVinci/DV-RawEventJuggler-0_3-to-4_3.py"
+          }
+        ],
+        "release": "DaVinci.v44r10p5 AppConfig.v3r393 Det/SQLDDDB.v7r10 TMVAWeights.v1r16",
+        "type": "Stripping28r2"
+      },
+      {
+        "configuration_files": [
+          {
+            "title": "Merging/DV-Stripping-Merging.py"
+          },
+          {
+            "title": "Persistency/Compression-LZMA-4.py"
+          }
+        ],
+        "release": "DaVinci.v44r10p5 AppConfig.v3r393 Det/SQLDDDB.v7r10",
+        "type": "Stripping28r2-Merging"
+      },
+      {
+        "configuration_files": [
+          {
+            "title": "DaVinci/DV-Stripping28r2-Stripping.py"
+          },
+          {
+            "title": "DaVinci/DV-RedoCaloPID-Stripping_28_24.py"
+          },
+          {
+            "title": "DaVinci/DataType-2016.py"
+          },
+          {
+            "title": "DaVinci/InputType-RDST.py"
+          },
+          {
+            "title": "Persistency/Compression-ZLIB-1.py"
+          },
+          {
+            "title": "DaVinci/DV-RawEventJuggler-0_3-to-4_3.py"
+          }
+        ],
+        "release": "DaVinci.v44r10p5 AppConfig.v3r393 Det/SQLDDDB.v7r10 TMVAWeights.v1r16",
+        "type": "Stripping28r2"
+      },
+      {
+        "configuration_files": [
+          {
+            "title": "Merging/DV-Stripping-Merging.py"
+          },
+          {
+            "title": "Persistency/Compression-LZMA-4.py"
+          }
+        ],
+        "release": "DaVinci.v44r10p5 AppConfig.v3r393 Det/SQLDDDB.v7r10",
+        "type": "Stripping28r2-Merging"
+      },
+      {
+        "configuration_files": [
+          {
+            "title": "DaVinci/DV-Stripping28r2-Stripping.py"
+          },
+          {
+            "title": "DaVinci/DV-RedoCaloPID-Stripping_28_24.py"
+          },
+          {
+            "title": "DaVinci/DataType-2016.py"
+          },
+          {
+            "title": "DaVinci/InputType-RDST.py"
+          },
+          {
+            "title": "Persistency/Compression-ZLIB-1.py"
+          },
+          {
+            "title": "DaVinci/DV-RawEventJuggler-0_3-to-4_3.py"
+          }
+        ],
+        "release": "DaVinci.v44r10p5 AppConfig.v3r393 Det/SQLDDDB.v7r10 TMVAWeights.v1r16",
+        "type": "Stripping28r2"
+      },
+      {
+        "configuration_files": [
+          {
+            "title": "Merging/DV-Stripping-Merging.py"
+          },
+          {
+            "title": "Persistency/Compression-LZMA-4.py"
+          }
+        ],
+        "release": "DaVinci.v44r10p5 AppConfig.v3r393 Det/SQLDDDB.v7r10",
+        "type": "Stripping28r2-Merging"
+      }
+    ]
+  },
+  "publisher": "CERN Open Data Portal",
+  "recid": "24641",
+  "run_period": [
+    "2016"
+  ],
+  "stripping": {
+    "stream": "LEPTONIC",
+    "version": "stripping28r2"
+  },
+  "title": "LHCb 2016 Beam6500GeV MagDown LEPTONIC Stream Stripping28r2",
+  "title_additional": "",
+  "type": {
+    "primary": "Dataset",
+    "secondary": [
+      "Collision"
+    ]
+  },
+  "usage": {
+    "description": "<p> The Run 1 and 2 data collected by the LHCb detector is available using the LHCb Ntupling Service, while the Run 1 data is additionally available in .DST and .mDST formats. The data obtained from the LHCb Ntupling Service are ROOT ntuples and do not require custom software to analyze. <p> Links are provided to the LHCb Ntupling Service for exploration of available data and the LHCb Open Data Guide for usage instructions.",
+    "links": [
+      {
+        "description": "LHCb Ntupling Service",
+        "url": "https://opendata-lhcb-ntupling-service.app.cern.ch/"
+      },
+      {
+        "description": "LHCb Open Data Guide",
+        "url": "https://lhcb-opendata-guide.web.cern.ch/"
+      }
+    ]
+  }
+}]

--- a/data/records/LHCb_2016_Beam6500GeV_VeloClosed_MagDown_RealData_Reco16_Stripping28r2_LOWMULT_DST.json
+++ b/data/records/LHCb_2016_Beam6500GeV_VeloClosed_MagDown_RealData_Reco16_Stripping28r2_LOWMULT_DST.json
@@ -1,0 +1,213 @@
+[{
+  "abstract": {
+    "description": "Data from proton-proton (pp) collisions collected by the LHCb experiment in the year 2016 of Run2 of the LHC."
+  },
+  "accelerator": "CERN-LHC",
+  "collaboration": {
+    "name": "LHCb collaboration",
+    "recid": "456"
+  },
+  "collections": [
+    "LHCb-Collision-Datasets"
+  ],
+  "collision_information": {
+    "energy": "13TeV",
+    "type": "pp"
+  },
+  "date_created": [
+    "2016"
+  ],
+  "date_published": "2026",
+  "date_reprocessed": "2020",
+  "distribution": {
+    "formats": [
+      "DST"
+    ],
+    "number_events": 2516314778,
+    "number_files": 7136,
+    "size": 21749851195905
+  },
+  "experiment": [
+    "LHCb"
+  ],
+  "magnet_polarity": "MagDown",
+  "methodology": {
+    "description": "<p> This dataset was created in several production steps. These steps, software used and the configuration is provided below. </p><p> <strong> Prod ID: &nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;</strong> 103398<p> <strong>Prod type:&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp; </strong> Merge<p> <strong> Parent Prod ID:&nbsp;&nbsp;&nbsp;&nbsp; </strong> 102836<p> <strong> Parent Prod type: </strong> DataStripping<p> <strong> Conditions: </strong><p>dddb-20190206-3<p>cond-20191004-1</strong><p> <strong> List of Trigger Configuration Keys (TCK): </strong> </p> <p><p><strong>TCK &nbsp;&nbsp;&nbsp;&nbsp;&nbsp; Number of Files </strong><p>0x11381609 &nbsp;&nbsp;&nbsp;&nbsp;&nbsp; 59<p>0x1138160f &nbsp;&nbsp;&nbsp;&nbsp;&nbsp; 4058<p>0x11371609 &nbsp;&nbsp;&nbsp;&nbsp;&nbsp; 472<p>0x1137160e &nbsp;&nbsp;&nbsp;&nbsp;&nbsp; 163<p>0x1138160e &nbsp;&nbsp;&nbsp;&nbsp;&nbsp; 211<p>0x11291600 &nbsp;&nbsp;&nbsp;&nbsp;&nbsp; 275<p>0x11291603 &nbsp;&nbsp;&nbsp;&nbsp;&nbsp; 625<p>0x11291604 &nbsp;&nbsp;&nbsp;&nbsp;&nbsp; 310<p>0x11291605 &nbsp;&nbsp;&nbsp;&nbsp;&nbsp; 963",
+    "steps": [
+      {
+        "configuration_files": [
+          {
+            "title": "DaVinci/DV-Stripping28r2-Stripping.py"
+          },
+          {
+            "title": "DaVinci/DV-RedoCaloPID-Stripping_28_24.py"
+          },
+          {
+            "title": "DaVinci/DataType-2016.py"
+          },
+          {
+            "title": "DaVinci/InputType-RDST.py"
+          },
+          {
+            "title": "Persistency/Compression-ZLIB-1.py"
+          },
+          {
+            "title": "DaVinci/DV-RawEventJuggler-0_3-to-4_3.py"
+          }
+        ],
+        "release": "DaVinci.v44r10p5 AppConfig.v3r393 Det/SQLDDDB.v7r10 TMVAWeights.v1r16",
+        "type": "Stripping28r2"
+      },
+      {
+        "configuration_files": [
+          {
+            "title": "Merging/DV-Stripping-Merging.py"
+          },
+          {
+            "title": "Persistency/Compression-LZMA-4.py"
+          }
+        ],
+        "release": "DaVinci.v44r10p5 AppConfig.v3r393 Det/SQLDDDB.v7r10",
+        "type": "Stripping28r2-Merging"
+      },
+      {
+        "configuration_files": [
+          {
+            "title": "DaVinci/DV-Stripping28r2-Stripping.py"
+          },
+          {
+            "title": "DaVinci/DV-RedoCaloPID-Stripping_28_24.py"
+          },
+          {
+            "title": "DaVinci/DataType-2016.py"
+          },
+          {
+            "title": "DaVinci/InputType-RDST.py"
+          },
+          {
+            "title": "Persistency/Compression-ZLIB-1.py"
+          },
+          {
+            "title": "DaVinci/DV-RawEventJuggler-0_3-to-4_3.py"
+          }
+        ],
+        "release": "DaVinci.v44r10p5 AppConfig.v3r393 Det/SQLDDDB.v7r10 TMVAWeights.v1r16",
+        "type": "Stripping28r2"
+      },
+      {
+        "configuration_files": [
+          {
+            "title": "Merging/DV-Stripping-Merging.py"
+          },
+          {
+            "title": "Persistency/Compression-LZMA-4.py"
+          }
+        ],
+        "release": "DaVinci.v44r10p5 AppConfig.v3r393 Det/SQLDDDB.v7r10",
+        "type": "Stripping28r2-Merging"
+      },
+      {
+        "configuration_files": [
+          {
+            "title": "DaVinci/DV-Stripping28r2-Stripping.py"
+          },
+          {
+            "title": "DaVinci/DV-RedoCaloPID-Stripping_28_24.py"
+          },
+          {
+            "title": "DaVinci/DataType-2016.py"
+          },
+          {
+            "title": "DaVinci/InputType-RDST.py"
+          },
+          {
+            "title": "Persistency/Compression-ZLIB-1.py"
+          },
+          {
+            "title": "DaVinci/DV-RawEventJuggler-0_3-to-4_3.py"
+          }
+        ],
+        "release": "DaVinci.v44r10p5 AppConfig.v3r393 Det/SQLDDDB.v7r10 TMVAWeights.v1r16",
+        "type": "Stripping28r2"
+      },
+      {
+        "configuration_files": [
+          {
+            "title": "Merging/DV-Stripping-Merging.py"
+          },
+          {
+            "title": "Persistency/Compression-LZMA-4.py"
+          }
+        ],
+        "release": "DaVinci.v44r10p5 AppConfig.v3r393 Det/SQLDDDB.v7r10",
+        "type": "Stripping28r2-Merging"
+      },
+      {
+        "configuration_files": [
+          {
+            "title": "DaVinci/DV-Stripping28r2-Stripping.py"
+          },
+          {
+            "title": "DaVinci/DV-RedoCaloPID-Stripping_28_24.py"
+          },
+          {
+            "title": "DaVinci/DataType-2016.py"
+          },
+          {
+            "title": "DaVinci/InputType-RDST.py"
+          },
+          {
+            "title": "Persistency/Compression-ZLIB-1.py"
+          },
+          {
+            "title": "DaVinci/DV-RawEventJuggler-0_3-to-4_3.py"
+          }
+        ],
+        "release": "DaVinci.v44r10p5 AppConfig.v3r393 Det/SQLDDDB.v7r10 TMVAWeights.v1r16",
+        "type": "Stripping28r2"
+      },
+      {
+        "configuration_files": [
+          {
+            "title": "Merging/DV-Stripping-Merging.py"
+          },
+          {
+            "title": "Persistency/Compression-LZMA-4.py"
+          }
+        ],
+        "release": "DaVinci.v44r10p5 AppConfig.v3r393 Det/SQLDDDB.v7r10",
+        "type": "Stripping28r2-Merging"
+      }
+    ]
+  },
+  "publisher": "CERN Open Data Portal",
+  "recid": "24642",
+  "run_period": [
+    "2016"
+  ],
+  "stripping": {
+    "stream": "LOWMULT",
+    "version": "stripping28r2"
+  },
+  "title": "LHCb 2016 Beam6500GeV MagDown LOWMULT Stream Stripping28r2",
+  "title_additional": "",
+  "type": {
+    "primary": "Dataset",
+    "secondary": [
+      "Collision"
+    ]
+  },
+  "usage": {
+    "description": "<p> The Run 1 and 2 data collected by the LHCb detector is available using the LHCb Ntupling Service, while the Run 1 data is additionally available in .DST and .mDST formats. The data obtained from the LHCb Ntupling Service are ROOT ntuples and do not require custom software to analyze. <p> Links are provided to the LHCb Ntupling Service for exploration of available data and the LHCb Open Data Guide for usage instructions.",
+    "links": [
+      {
+        "description": "LHCb Ntupling Service",
+        "url": "https://opendata-lhcb-ntupling-service.app.cern.ch/"
+      },
+      {
+        "description": "LHCb Open Data Guide",
+        "url": "https://lhcb-opendata-guide.web.cern.ch/"
+      }
+    ]
+  }
+}]

--- a/data/records/LHCb_2016_Beam6500GeV_VeloClosed_MagDown_RealData_Reco16_Stripping28r2_SEMILEPTONIC_DST.json
+++ b/data/records/LHCb_2016_Beam6500GeV_VeloClosed_MagDown_RealData_Reco16_Stripping28r2_SEMILEPTONIC_DST.json
@@ -1,0 +1,213 @@
+[{
+  "abstract": {
+    "description": "Data from proton-proton (pp) collisions collected by the LHCb experiment in the year 2016 of Run2 of the LHC."
+  },
+  "accelerator": "CERN-LHC",
+  "collaboration": {
+    "name": "LHCb collaboration",
+    "recid": "456"
+  },
+  "collections": [
+    "LHCb-Collision-Datasets"
+  ],
+  "collision_information": {
+    "energy": "13TeV",
+    "type": "pp"
+  },
+  "date_created": [
+    "2016"
+  ],
+  "date_published": "2026",
+  "date_reprocessed": "2020",
+  "distribution": {
+    "formats": [
+      "DST"
+    ],
+    "number_events": 999373140,
+    "number_files": 21186,
+    "size": 76120678069552
+  },
+  "experiment": [
+    "LHCb"
+  ],
+  "magnet_polarity": "MagDown",
+  "methodology": {
+    "description": "<p> This dataset was created in several production steps. These steps, software used and the configuration is provided below. </p><p> <strong> Prod ID: &nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;</strong> 102837<p> <strong>Prod type:&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp; </strong> Merge<p> <strong> Parent Prod ID:&nbsp;&nbsp;&nbsp;&nbsp; </strong> 102836<p> <strong> Parent Prod type: </strong> DataStripping<p> <strong> Conditions: </strong><p>dddb-20190206-3<p>cond-20191004-1</strong><p> <strong> List of Trigger Configuration Keys (TCK): </strong> </p> <p><p><strong>TCK &nbsp;&nbsp;&nbsp;&nbsp;&nbsp; Number of Files </strong><p>0x1138160f &nbsp;&nbsp;&nbsp;&nbsp;&nbsp; 14049<p>0x11381609 &nbsp;&nbsp;&nbsp;&nbsp;&nbsp; 187<p>0x11371609 &nbsp;&nbsp;&nbsp;&nbsp;&nbsp; 1557<p>0x1137160e &nbsp;&nbsp;&nbsp;&nbsp;&nbsp; 557<p>0x1138160e &nbsp;&nbsp;&nbsp;&nbsp;&nbsp; 783<p>0x11291600 &nbsp;&nbsp;&nbsp;&nbsp;&nbsp; 259<p>0x11291603 &nbsp;&nbsp;&nbsp;&nbsp;&nbsp; 999<p>0x11291604 &nbsp;&nbsp;&nbsp;&nbsp;&nbsp; 692<p>0x11291605 &nbsp;&nbsp;&nbsp;&nbsp;&nbsp; 2103",
+    "steps": [
+      {
+        "configuration_files": [
+          {
+            "title": "DaVinci/DV-Stripping28r2-Stripping.py"
+          },
+          {
+            "title": "DaVinci/DV-RedoCaloPID-Stripping_28_24.py"
+          },
+          {
+            "title": "DaVinci/DataType-2016.py"
+          },
+          {
+            "title": "DaVinci/InputType-RDST.py"
+          },
+          {
+            "title": "Persistency/Compression-ZLIB-1.py"
+          },
+          {
+            "title": "DaVinci/DV-RawEventJuggler-0_3-to-4_3.py"
+          }
+        ],
+        "release": "DaVinci.v44r10p5 AppConfig.v3r393 Det/SQLDDDB.v7r10 TMVAWeights.v1r16",
+        "type": "Stripping28r2"
+      },
+      {
+        "configuration_files": [
+          {
+            "title": "Merging/DV-Stripping-Merging.py"
+          },
+          {
+            "title": "Persistency/Compression-LZMA-4.py"
+          }
+        ],
+        "release": "DaVinci.v44r10p5 AppConfig.v3r393 Det/SQLDDDB.v7r10",
+        "type": "Stripping28r2-Merging"
+      },
+      {
+        "configuration_files": [
+          {
+            "title": "DaVinci/DV-Stripping28r2-Stripping.py"
+          },
+          {
+            "title": "DaVinci/DV-RedoCaloPID-Stripping_28_24.py"
+          },
+          {
+            "title": "DaVinci/DataType-2016.py"
+          },
+          {
+            "title": "DaVinci/InputType-RDST.py"
+          },
+          {
+            "title": "Persistency/Compression-ZLIB-1.py"
+          },
+          {
+            "title": "DaVinci/DV-RawEventJuggler-0_3-to-4_3.py"
+          }
+        ],
+        "release": "DaVinci.v44r10p5 AppConfig.v3r393 Det/SQLDDDB.v7r10 TMVAWeights.v1r16",
+        "type": "Stripping28r2"
+      },
+      {
+        "configuration_files": [
+          {
+            "title": "Merging/DV-Stripping-Merging.py"
+          },
+          {
+            "title": "Persistency/Compression-LZMA-4.py"
+          }
+        ],
+        "release": "DaVinci.v44r10p5 AppConfig.v3r393 Det/SQLDDDB.v7r10",
+        "type": "Stripping28r2-Merging"
+      },
+      {
+        "configuration_files": [
+          {
+            "title": "DaVinci/DV-Stripping28r2-Stripping.py"
+          },
+          {
+            "title": "DaVinci/DV-RedoCaloPID-Stripping_28_24.py"
+          },
+          {
+            "title": "DaVinci/DataType-2016.py"
+          },
+          {
+            "title": "DaVinci/InputType-RDST.py"
+          },
+          {
+            "title": "Persistency/Compression-ZLIB-1.py"
+          },
+          {
+            "title": "DaVinci/DV-RawEventJuggler-0_3-to-4_3.py"
+          }
+        ],
+        "release": "DaVinci.v44r10p5 AppConfig.v3r393 Det/SQLDDDB.v7r10 TMVAWeights.v1r16",
+        "type": "Stripping28r2"
+      },
+      {
+        "configuration_files": [
+          {
+            "title": "Merging/DV-Stripping-Merging.py"
+          },
+          {
+            "title": "Persistency/Compression-LZMA-4.py"
+          }
+        ],
+        "release": "DaVinci.v44r10p5 AppConfig.v3r393 Det/SQLDDDB.v7r10",
+        "type": "Stripping28r2-Merging"
+      },
+      {
+        "configuration_files": [
+          {
+            "title": "DaVinci/DV-Stripping28r2-Stripping.py"
+          },
+          {
+            "title": "DaVinci/DV-RedoCaloPID-Stripping_28_24.py"
+          },
+          {
+            "title": "DaVinci/DataType-2016.py"
+          },
+          {
+            "title": "DaVinci/InputType-RDST.py"
+          },
+          {
+            "title": "Persistency/Compression-ZLIB-1.py"
+          },
+          {
+            "title": "DaVinci/DV-RawEventJuggler-0_3-to-4_3.py"
+          }
+        ],
+        "release": "DaVinci.v44r10p5 AppConfig.v3r393 Det/SQLDDDB.v7r10 TMVAWeights.v1r16",
+        "type": "Stripping28r2"
+      },
+      {
+        "configuration_files": [
+          {
+            "title": "Merging/DV-Stripping-Merging.py"
+          },
+          {
+            "title": "Persistency/Compression-LZMA-4.py"
+          }
+        ],
+        "release": "DaVinci.v44r10p5 AppConfig.v3r393 Det/SQLDDDB.v7r10",
+        "type": "Stripping28r2-Merging"
+      }
+    ]
+  },
+  "publisher": "CERN Open Data Portal",
+  "recid": "24649",
+  "run_period": [
+    "2016"
+  ],
+  "stripping": {
+    "stream": "SEMILEPTONIC",
+    "version": "stripping28r2"
+  },
+  "title": "LHCb 2016 Beam6500GeV MagDown SEMILEPTONIC Stream Stripping28r2",
+  "title_additional": "",
+  "type": {
+    "primary": "Dataset",
+    "secondary": [
+      "Collision"
+    ]
+  },
+  "usage": {
+    "description": "<p> The Run 1 and 2 data collected by the LHCb detector is available using the LHCb Ntupling Service, while the Run 1 data is additionally available in .DST and .mDST formats. The data obtained from the LHCb Ntupling Service are ROOT ntuples and do not require custom software to analyze. <p> Links are provided to the LHCb Ntupling Service for exploration of available data and the LHCb Open Data Guide for usage instructions.",
+    "links": [
+      {
+        "description": "LHCb Ntupling Service",
+        "url": "https://opendata-lhcb-ntupling-service.app.cern.ch/"
+      },
+      {
+        "description": "LHCb Open Data Guide",
+        "url": "https://lhcb-opendata-guide.web.cern.ch/"
+      }
+    ]
+  }
+}]

--- a/data/records/LHCb_2016_Beam6500GeV_VeloClosed_MagDown_RealData_Reco16_Stripping28r2p1_BHADRONCOMPLETEEVENT_DST.json
+++ b/data/records/LHCb_2016_Beam6500GeV_VeloClosed_MagDown_RealData_Reco16_Stripping28r2p1_BHADRONCOMPLETEEVENT_DST.json
@@ -1,0 +1,213 @@
+[{
+  "abstract": {
+    "description": "Data from proton-proton (pp) collisions collected by the LHCb experiment in the year 2016 of Run2 of the LHC."
+  },
+  "accelerator": "CERN-LHC",
+  "collaboration": {
+    "name": "LHCb collaboration",
+    "recid": "456"
+  },
+  "collections": [
+    "LHCb-Collision-Datasets"
+  ],
+  "collision_information": {
+    "energy": "13TeV",
+    "type": "pp"
+  },
+  "date_created": [
+    "2016"
+  ],
+  "date_published": "2026",
+  "date_reprocessed": "2021",
+  "distribution": {
+    "formats": [
+      "DST"
+    ],
+    "number_events": 431787678,
+    "number_files": 13109,
+    "size": 47826395582461
+  },
+  "experiment": [
+    "LHCb"
+  ],
+  "magnet_polarity": "MagDown",
+  "methodology": {
+    "description": "<p> This dataset was created in several production steps. These steps, software used and the configuration is provided below. </p><p> <strong> Prod ID: &nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;</strong> 152415<p> <strong>Prod type:&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp; </strong> Merge<p> <strong> Parent Prod ID:&nbsp;&nbsp;&nbsp;&nbsp; </strong> 151978<p> <strong> Parent Prod type: </strong> DataStripping<p> <strong> Conditions: </strong><p>dddb-20210528-6<p>cond-20191004-1</strong><p> <strong> List of Trigger Configuration Keys (TCK): </strong> </p> <p><p><strong>TCK &nbsp;&nbsp;&nbsp;&nbsp;&nbsp; Number of Files </strong><p>0x1138160f &nbsp;&nbsp;&nbsp;&nbsp;&nbsp; 8729<p>0x11371609 &nbsp;&nbsp;&nbsp;&nbsp;&nbsp; 898<p>0x1137160e &nbsp;&nbsp;&nbsp;&nbsp;&nbsp; 315<p>0x1138160e &nbsp;&nbsp;&nbsp;&nbsp;&nbsp; 479<p>0x11381609 &nbsp;&nbsp;&nbsp;&nbsp;&nbsp; 116<p>0x11291600 &nbsp;&nbsp;&nbsp;&nbsp;&nbsp; 176<p>0x11291603 &nbsp;&nbsp;&nbsp;&nbsp;&nbsp; 636<p>0x11291604 &nbsp;&nbsp;&nbsp;&nbsp;&nbsp; 436<p>0x11291605 &nbsp;&nbsp;&nbsp;&nbsp;&nbsp; 1324",
+    "steps": [
+      {
+        "configuration_files": [
+          {
+            "title": "DaVinci/DV-Stripping28r2p1-Stripping.py"
+          },
+          {
+            "title": "DaVinci/DataType-2016.py"
+          },
+          {
+            "title": "DaVinci/InputType-RDST.py"
+          },
+          {
+            "title": "DaVinci/DV-RawEventJuggler-0_3-to-4_3.py"
+          },
+          {
+            "title": "Persistency/Compression-ZLIB-1.py"
+          },
+          {
+            "title": "DaVinci/DV-RedoCaloPID-Stripping_28_24.py"
+          }
+        ],
+        "release": "DaVinci.v44r11p4 AppConfig.v3r407 Det/SQLDDDB.v7r10 TMVAWeights.v1r17",
+        "type": "Stripping28r2p1"
+      },
+      {
+        "configuration_files": [
+          {
+            "title": "Merging/DV-Stripping-Merging.py"
+          },
+          {
+            "title": "Persistency/Compression-LZMA-4.py"
+          }
+        ],
+        "release": "DaVinci.v44r11p4 AppConfig.v3r407 Det/SQLDDDB.v7r10",
+        "type": "Stripping28r2p1-Merging"
+      },
+      {
+        "configuration_files": [
+          {
+            "title": "DaVinci/DV-Stripping28r2p1-Stripping.py"
+          },
+          {
+            "title": "DaVinci/DataType-2016.py"
+          },
+          {
+            "title": "DaVinci/InputType-RDST.py"
+          },
+          {
+            "title": "DaVinci/DV-RawEventJuggler-0_3-to-4_3.py"
+          },
+          {
+            "title": "Persistency/Compression-ZLIB-1.py"
+          },
+          {
+            "title": "DaVinci/DV-RedoCaloPID-Stripping_28_24.py"
+          }
+        ],
+        "release": "DaVinci.v44r11p4 AppConfig.v3r407 Det/SQLDDDB.v7r10 TMVAWeights.v1r17",
+        "type": "Stripping28r2p1"
+      },
+      {
+        "configuration_files": [
+          {
+            "title": "Merging/DV-Stripping-Merging.py"
+          },
+          {
+            "title": "Persistency/Compression-LZMA-4.py"
+          }
+        ],
+        "release": "DaVinci.v44r11p4 AppConfig.v3r407 Det/SQLDDDB.v7r10",
+        "type": "Stripping28r2p1-Merging"
+      },
+      {
+        "configuration_files": [
+          {
+            "title": "DaVinci/DV-Stripping28r2p1-Stripping.py"
+          },
+          {
+            "title": "DaVinci/DataType-2016.py"
+          },
+          {
+            "title": "DaVinci/InputType-RDST.py"
+          },
+          {
+            "title": "DaVinci/DV-RawEventJuggler-0_3-to-4_3.py"
+          },
+          {
+            "title": "Persistency/Compression-ZLIB-1.py"
+          },
+          {
+            "title": "DaVinci/DV-RedoCaloPID-Stripping_28_24.py"
+          }
+        ],
+        "release": "DaVinci.v44r11p4 AppConfig.v3r407 Det/SQLDDDB.v7r10 TMVAWeights.v1r17",
+        "type": "Stripping28r2p1"
+      },
+      {
+        "configuration_files": [
+          {
+            "title": "Merging/DV-Stripping-Merging.py"
+          },
+          {
+            "title": "Persistency/Compression-LZMA-4.py"
+          }
+        ],
+        "release": "DaVinci.v44r11p4 AppConfig.v3r407 Det/SQLDDDB.v7r10",
+        "type": "Stripping28r2p1-Merging"
+      },
+      {
+        "configuration_files": [
+          {
+            "title": "DaVinci/DV-Stripping28r2p1-Stripping.py"
+          },
+          {
+            "title": "DaVinci/DataType-2016.py"
+          },
+          {
+            "title": "DaVinci/InputType-RDST.py"
+          },
+          {
+            "title": "DaVinci/DV-RawEventJuggler-0_3-to-4_3.py"
+          },
+          {
+            "title": "Persistency/Compression-ZLIB-1.py"
+          },
+          {
+            "title": "DaVinci/DV-RedoCaloPID-Stripping_28_24.py"
+          }
+        ],
+        "release": "DaVinci.v44r11p4 AppConfig.v3r407 Det/SQLDDDB.v7r10 TMVAWeights.v1r17",
+        "type": "Stripping28r2p1"
+      },
+      {
+        "configuration_files": [
+          {
+            "title": "Merging/DV-Stripping-Merging.py"
+          },
+          {
+            "title": "Persistency/Compression-LZMA-4.py"
+          }
+        ],
+        "release": "DaVinci.v44r11p4 AppConfig.v3r407 Det/SQLDDDB.v7r10",
+        "type": "Stripping28r2p1-Merging"
+      }
+    ]
+  },
+  "publisher": "CERN Open Data Portal",
+  "recid": "24665",
+  "run_period": [
+    "2016"
+  ],
+  "stripping": {
+    "stream": "BHADRONCOMPLETEEVENT",
+    "version": "stripping28r2p1"
+  },
+  "title": "LHCb 2016 Beam6500GeV MagDown BHADRONCOMPLETEEVENT Stream Stripping28r2p1",
+  "title_additional": "",
+  "type": {
+    "primary": "Dataset",
+    "secondary": [
+      "Collision"
+    ]
+  },
+  "usage": {
+    "description": "<p> The Run 1 and 2 data collected by the LHCb detector is available using the LHCb Ntupling Service, while the Run 1 data is additionally available in .DST and .mDST formats. The data obtained from the LHCb Ntupling Service are ROOT ntuples and do not require custom software to analyze. <p> Links are provided to the LHCb Ntupling Service for exploration of available data and the LHCb Open Data Guide for usage instructions.",
+    "links": [
+      {
+        "description": "LHCb Ntupling Service",
+        "url": "https://opendata-lhcb-ntupling-service.app.cern.ch/"
+      },
+      {
+        "description": "LHCb Open Data Guide",
+        "url": "https://lhcb-opendata-guide.web.cern.ch/"
+      }
+    ]
+  }
+}]

--- a/data/records/LHCb_2016_Beam6500GeV_VeloClosed_MagDown_RealData_Reco16_Stripping28r2p1_BHADRON_MDST.json
+++ b/data/records/LHCb_2016_Beam6500GeV_VeloClosed_MagDown_RealData_Reco16_Stripping28r2p1_BHADRON_MDST.json
@@ -1,0 +1,213 @@
+[{
+  "abstract": {
+    "description": "Data from proton-proton (pp) collisions collected by the LHCb experiment in the year 2016 of Run2 of the LHC."
+  },
+  "accelerator": "CERN-LHC",
+  "collaboration": {
+    "name": "LHCb collaboration",
+    "recid": "456"
+  },
+  "collections": [
+    "LHCb-Collision-Datasets"
+  ],
+  "collision_information": {
+    "energy": "13TeV",
+    "type": "pp"
+  },
+  "date_created": [
+    "2016"
+  ],
+  "date_published": "2026",
+  "date_reprocessed": "2021",
+  "distribution": {
+    "formats": [
+      "MDST"
+    ],
+    "number_events": 826455236,
+    "number_files": 5593,
+    "size": 15804283993826
+  },
+  "experiment": [
+    "LHCb"
+  ],
+  "magnet_polarity": "MagDown",
+  "methodology": {
+    "description": "<p> This dataset was created in several production steps. These steps, software used and the configuration is provided below. </p><p> <strong> Prod ID: &nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;</strong> 153032<p> <strong>Prod type:&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp; </strong> Merge<p> <strong> Parent Prod ID:&nbsp;&nbsp;&nbsp;&nbsp; </strong> 151978<p> <strong> Parent Prod type: </strong> DataStripping<p> <strong> Conditions: </strong><p>dddb-20210528-6<p>cond-20191004-1</strong><p> <strong> List of Trigger Configuration Keys (TCK): </strong> </p> <p><p><strong>TCK &nbsp;&nbsp;&nbsp;&nbsp;&nbsp; Number of Files </strong><p>0x1138160f &nbsp;&nbsp;&nbsp;&nbsp;&nbsp; 3564<p>0x11371609 &nbsp;&nbsp;&nbsp;&nbsp;&nbsp; 383<p>0x1137160e &nbsp;&nbsp;&nbsp;&nbsp;&nbsp; 125<p>0x1138160e &nbsp;&nbsp;&nbsp;&nbsp;&nbsp; 192<p>0x11381609 &nbsp;&nbsp;&nbsp;&nbsp;&nbsp; 52<p>0x11291600 &nbsp;&nbsp;&nbsp;&nbsp;&nbsp; 138<p>0x11291603 &nbsp;&nbsp;&nbsp;&nbsp;&nbsp; 320<p>0x11291604 &nbsp;&nbsp;&nbsp;&nbsp;&nbsp; 192<p>0x11291605 &nbsp;&nbsp;&nbsp;&nbsp;&nbsp; 627",
+    "steps": [
+      {
+        "configuration_files": [
+          {
+            "title": "DaVinci/DV-Stripping28r2p1-Stripping.py"
+          },
+          {
+            "title": "DaVinci/DataType-2016.py"
+          },
+          {
+            "title": "DaVinci/InputType-RDST.py"
+          },
+          {
+            "title": "DaVinci/DV-RawEventJuggler-0_3-to-4_3.py"
+          },
+          {
+            "title": "Persistency/Compression-ZLIB-1.py"
+          },
+          {
+            "title": "DaVinci/DV-RedoCaloPID-Stripping_28_24.py"
+          }
+        ],
+        "release": "DaVinci.v44r11p4 AppConfig.v3r407 Det/SQLDDDB.v7r10 TMVAWeights.v1r17",
+        "type": "Stripping28r2p1"
+      },
+      {
+        "configuration_files": [
+          {
+            "title": "Merging/DV-Stripping-Merging.py"
+          },
+          {
+            "title": "Persistency/Compression-LZMA-4.py"
+          }
+        ],
+        "release": "DaVinci.v44r11p4 AppConfig.v3r407 Det/SQLDDDB.v7r10",
+        "type": "Stripping28r2p1-Merging"
+      },
+      {
+        "configuration_files": [
+          {
+            "title": "DaVinci/DV-Stripping28r2p1-Stripping.py"
+          },
+          {
+            "title": "DaVinci/DataType-2016.py"
+          },
+          {
+            "title": "DaVinci/InputType-RDST.py"
+          },
+          {
+            "title": "DaVinci/DV-RawEventJuggler-0_3-to-4_3.py"
+          },
+          {
+            "title": "Persistency/Compression-ZLIB-1.py"
+          },
+          {
+            "title": "DaVinci/DV-RedoCaloPID-Stripping_28_24.py"
+          }
+        ],
+        "release": "DaVinci.v44r11p4 AppConfig.v3r407 Det/SQLDDDB.v7r10 TMVAWeights.v1r17",
+        "type": "Stripping28r2p1"
+      },
+      {
+        "configuration_files": [
+          {
+            "title": "Merging/DV-Stripping-Merging.py"
+          },
+          {
+            "title": "Persistency/Compression-LZMA-4.py"
+          }
+        ],
+        "release": "DaVinci.v44r11p4 AppConfig.v3r407 Det/SQLDDDB.v7r10",
+        "type": "Stripping28r2p1-Merging"
+      },
+      {
+        "configuration_files": [
+          {
+            "title": "DaVinci/DV-Stripping28r2p1-Stripping.py"
+          },
+          {
+            "title": "DaVinci/DataType-2016.py"
+          },
+          {
+            "title": "DaVinci/InputType-RDST.py"
+          },
+          {
+            "title": "DaVinci/DV-RawEventJuggler-0_3-to-4_3.py"
+          },
+          {
+            "title": "Persistency/Compression-ZLIB-1.py"
+          },
+          {
+            "title": "DaVinci/DV-RedoCaloPID-Stripping_28_24.py"
+          }
+        ],
+        "release": "DaVinci.v44r11p4 AppConfig.v3r407 Det/SQLDDDB.v7r10 TMVAWeights.v1r17",
+        "type": "Stripping28r2p1"
+      },
+      {
+        "configuration_files": [
+          {
+            "title": "Merging/DV-Stripping-Merging.py"
+          },
+          {
+            "title": "Persistency/Compression-LZMA-4.py"
+          }
+        ],
+        "release": "DaVinci.v44r11p4 AppConfig.v3r407 Det/SQLDDDB.v7r10",
+        "type": "Stripping28r2p1-Merging"
+      },
+      {
+        "configuration_files": [
+          {
+            "title": "DaVinci/DV-Stripping28r2p1-Stripping.py"
+          },
+          {
+            "title": "DaVinci/DataType-2016.py"
+          },
+          {
+            "title": "DaVinci/InputType-RDST.py"
+          },
+          {
+            "title": "DaVinci/DV-RawEventJuggler-0_3-to-4_3.py"
+          },
+          {
+            "title": "Persistency/Compression-ZLIB-1.py"
+          },
+          {
+            "title": "DaVinci/DV-RedoCaloPID-Stripping_28_24.py"
+          }
+        ],
+        "release": "DaVinci.v44r11p4 AppConfig.v3r407 Det/SQLDDDB.v7r10 TMVAWeights.v1r17",
+        "type": "Stripping28r2p1"
+      },
+      {
+        "configuration_files": [
+          {
+            "title": "Merging/DV-Stripping-Merging.py"
+          },
+          {
+            "title": "Persistency/Compression-LZMA-4.py"
+          }
+        ],
+        "release": "DaVinci.v44r11p4 AppConfig.v3r407 Det/SQLDDDB.v7r10",
+        "type": "Stripping28r2p1-Merging"
+      }
+    ]
+  },
+  "publisher": "CERN Open Data Portal",
+  "recid": "24664",
+  "run_period": [
+    "2016"
+  ],
+  "stripping": {
+    "stream": "BHADRON",
+    "version": "stripping28r2p1"
+  },
+  "title": "LHCb 2016 Beam6500GeV MagDown BHADRON Stream Stripping28r2p1",
+  "title_additional": "",
+  "type": {
+    "primary": "Dataset",
+    "secondary": [
+      "Collision"
+    ]
+  },
+  "usage": {
+    "description": "<p> The Run 1 and 2 data collected by the LHCb detector is available using the LHCb Ntupling Service, while the Run 1 data is additionally available in .DST and .mDST formats. The data obtained from the LHCb Ntupling Service are ROOT ntuples and do not require custom software to analyze. <p> Links are provided to the LHCb Ntupling Service for exploration of available data and the LHCb Open Data Guide for usage instructions.",
+    "links": [
+      {
+        "description": "LHCb Ntupling Service",
+        "url": "https://opendata-lhcb-ntupling-service.app.cern.ch/"
+      },
+      {
+        "description": "LHCb Open Data Guide",
+        "url": "https://lhcb-opendata-guide.web.cern.ch/"
+      }
+    ]
+  }
+}]

--- a/data/records/LHCb_2016_Beam6500GeV_VeloClosed_MagDown_RealData_Reco16_Stripping28r2p1_CHARMCOMPLETEEVENT_DST.json
+++ b/data/records/LHCb_2016_Beam6500GeV_VeloClosed_MagDown_RealData_Reco16_Stripping28r2p1_CHARMCOMPLETEEVENT_DST.json
@@ -1,0 +1,213 @@
+[{
+  "abstract": {
+    "description": "Data from proton-proton (pp) collisions collected by the LHCb experiment in the year 2016 of Run2 of the LHC."
+  },
+  "accelerator": "CERN-LHC",
+  "collaboration": {
+    "name": "LHCb collaboration",
+    "recid": "456"
+  },
+  "collections": [
+    "LHCb-Collision-Datasets"
+  ],
+  "collision_information": {
+    "energy": "13TeV",
+    "type": "pp"
+  },
+  "date_created": [
+    "2016"
+  ],
+  "date_published": "2026",
+  "date_reprocessed": "2021",
+  "distribution": {
+    "formats": [
+      "DST"
+    ],
+    "number_events": 275515070,
+    "number_files": 8212,
+    "size": 27296821236329
+  },
+  "experiment": [
+    "LHCb"
+  ],
+  "magnet_polarity": "MagDown",
+  "methodology": {
+    "description": "<p> This dataset was created in several production steps. These steps, software used and the configuration is provided below. </p><p> <strong> Prod ID: &nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;</strong> 152688<p> <strong>Prod type:&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp; </strong> Merge<p> <strong> Parent Prod ID:&nbsp;&nbsp;&nbsp;&nbsp; </strong> 151978<p> <strong> Parent Prod type: </strong> DataStripping<p> <strong> Conditions: </strong><p>dddb-20210528-6<p>cond-20191004-1</strong><p> <strong> List of Trigger Configuration Keys (TCK): </strong> </p> <p><p><strong>TCK &nbsp;&nbsp;&nbsp;&nbsp;&nbsp; Number of Files </strong><p>0x1138160f &nbsp;&nbsp;&nbsp;&nbsp;&nbsp; 5412<p>0x11371609 &nbsp;&nbsp;&nbsp;&nbsp;&nbsp; 549<p>0x1137160e &nbsp;&nbsp;&nbsp;&nbsp;&nbsp; 195<p>0x1138160e &nbsp;&nbsp;&nbsp;&nbsp;&nbsp; 295<p>0x11381609 &nbsp;&nbsp;&nbsp;&nbsp;&nbsp; 75<p>0x11291600 &nbsp;&nbsp;&nbsp;&nbsp;&nbsp; 143<p>0x11291603 &nbsp;&nbsp;&nbsp;&nbsp;&nbsp; 407<p>0x11291604 &nbsp;&nbsp;&nbsp;&nbsp;&nbsp; 272<p>0x11291605 &nbsp;&nbsp;&nbsp;&nbsp;&nbsp; 864",
+    "steps": [
+      {
+        "configuration_files": [
+          {
+            "title": "DaVinci/DV-Stripping28r2p1-Stripping.py"
+          },
+          {
+            "title": "DaVinci/DataType-2016.py"
+          },
+          {
+            "title": "DaVinci/InputType-RDST.py"
+          },
+          {
+            "title": "DaVinci/DV-RawEventJuggler-0_3-to-4_3.py"
+          },
+          {
+            "title": "Persistency/Compression-ZLIB-1.py"
+          },
+          {
+            "title": "DaVinci/DV-RedoCaloPID-Stripping_28_24.py"
+          }
+        ],
+        "release": "DaVinci.v44r11p4 AppConfig.v3r407 Det/SQLDDDB.v7r10 TMVAWeights.v1r17",
+        "type": "Stripping28r2p1"
+      },
+      {
+        "configuration_files": [
+          {
+            "title": "Merging/DV-Stripping-Merging.py"
+          },
+          {
+            "title": "Persistency/Compression-LZMA-4.py"
+          }
+        ],
+        "release": "DaVinci.v44r11p4 AppConfig.v3r407 Det/SQLDDDB.v7r10",
+        "type": "Stripping28r2p1-Merging"
+      },
+      {
+        "configuration_files": [
+          {
+            "title": "DaVinci/DV-Stripping28r2p1-Stripping.py"
+          },
+          {
+            "title": "DaVinci/DataType-2016.py"
+          },
+          {
+            "title": "DaVinci/InputType-RDST.py"
+          },
+          {
+            "title": "DaVinci/DV-RawEventJuggler-0_3-to-4_3.py"
+          },
+          {
+            "title": "Persistency/Compression-ZLIB-1.py"
+          },
+          {
+            "title": "DaVinci/DV-RedoCaloPID-Stripping_28_24.py"
+          }
+        ],
+        "release": "DaVinci.v44r11p4 AppConfig.v3r407 Det/SQLDDDB.v7r10 TMVAWeights.v1r17",
+        "type": "Stripping28r2p1"
+      },
+      {
+        "configuration_files": [
+          {
+            "title": "Merging/DV-Stripping-Merging.py"
+          },
+          {
+            "title": "Persistency/Compression-LZMA-4.py"
+          }
+        ],
+        "release": "DaVinci.v44r11p4 AppConfig.v3r407 Det/SQLDDDB.v7r10",
+        "type": "Stripping28r2p1-Merging"
+      },
+      {
+        "configuration_files": [
+          {
+            "title": "DaVinci/DV-Stripping28r2p1-Stripping.py"
+          },
+          {
+            "title": "DaVinci/DataType-2016.py"
+          },
+          {
+            "title": "DaVinci/InputType-RDST.py"
+          },
+          {
+            "title": "DaVinci/DV-RawEventJuggler-0_3-to-4_3.py"
+          },
+          {
+            "title": "Persistency/Compression-ZLIB-1.py"
+          },
+          {
+            "title": "DaVinci/DV-RedoCaloPID-Stripping_28_24.py"
+          }
+        ],
+        "release": "DaVinci.v44r11p4 AppConfig.v3r407 Det/SQLDDDB.v7r10 TMVAWeights.v1r17",
+        "type": "Stripping28r2p1"
+      },
+      {
+        "configuration_files": [
+          {
+            "title": "Merging/DV-Stripping-Merging.py"
+          },
+          {
+            "title": "Persistency/Compression-LZMA-4.py"
+          }
+        ],
+        "release": "DaVinci.v44r11p4 AppConfig.v3r407 Det/SQLDDDB.v7r10",
+        "type": "Stripping28r2p1-Merging"
+      },
+      {
+        "configuration_files": [
+          {
+            "title": "DaVinci/DV-Stripping28r2p1-Stripping.py"
+          },
+          {
+            "title": "DaVinci/DataType-2016.py"
+          },
+          {
+            "title": "DaVinci/InputType-RDST.py"
+          },
+          {
+            "title": "DaVinci/DV-RawEventJuggler-0_3-to-4_3.py"
+          },
+          {
+            "title": "Persistency/Compression-ZLIB-1.py"
+          },
+          {
+            "title": "DaVinci/DV-RedoCaloPID-Stripping_28_24.py"
+          }
+        ],
+        "release": "DaVinci.v44r11p4 AppConfig.v3r407 Det/SQLDDDB.v7r10 TMVAWeights.v1r17",
+        "type": "Stripping28r2p1"
+      },
+      {
+        "configuration_files": [
+          {
+            "title": "Merging/DV-Stripping-Merging.py"
+          },
+          {
+            "title": "Persistency/Compression-LZMA-4.py"
+          }
+        ],
+        "release": "DaVinci.v44r11p4 AppConfig.v3r407 Det/SQLDDDB.v7r10",
+        "type": "Stripping28r2p1-Merging"
+      }
+    ]
+  },
+  "publisher": "CERN Open Data Portal",
+  "recid": "24667",
+  "run_period": [
+    "2016"
+  ],
+  "stripping": {
+    "stream": "CHARMCOMPLETEEVENT",
+    "version": "stripping28r2p1"
+  },
+  "title": "LHCb 2016 Beam6500GeV MagDown CHARMCOMPLETEEVENT Stream Stripping28r2p1",
+  "title_additional": "",
+  "type": {
+    "primary": "Dataset",
+    "secondary": [
+      "Collision"
+    ]
+  },
+  "usage": {
+    "description": "<p> The Run 1 and 2 data collected by the LHCb detector is available using the LHCb Ntupling Service, while the Run 1 data is additionally available in .DST and .mDST formats. The data obtained from the LHCb Ntupling Service are ROOT ntuples and do not require custom software to analyze. <p> Links are provided to the LHCb Ntupling Service for exploration of available data and the LHCb Open Data Guide for usage instructions.",
+    "links": [
+      {
+        "description": "LHCb Ntupling Service",
+        "url": "https://opendata-lhcb-ntupling-service.app.cern.ch/"
+      },
+      {
+        "description": "LHCb Open Data Guide",
+        "url": "https://lhcb-opendata-guide.web.cern.ch/"
+      }
+    ]
+  }
+}]

--- a/data/records/LHCb_2016_Beam6500GeV_VeloClosed_MagDown_RealData_Reco16_Stripping28r2p1_CHARM_MDST.json
+++ b/data/records/LHCb_2016_Beam6500GeV_VeloClosed_MagDown_RealData_Reco16_Stripping28r2p1_CHARM_MDST.json
@@ -1,0 +1,213 @@
+[{
+  "abstract": {
+    "description": "Data from proton-proton (pp) collisions collected by the LHCb experiment in the year 2016 of Run2 of the LHC."
+  },
+  "accelerator": "CERN-LHC",
+  "collaboration": {
+    "name": "LHCb collaboration",
+    "recid": "456"
+  },
+  "collections": [
+    "LHCb-Collision-Datasets"
+  ],
+  "collision_information": {
+    "energy": "13TeV",
+    "type": "pp"
+  },
+  "date_created": [
+    "2016"
+  ],
+  "date_published": "2026",
+  "date_reprocessed": "2021",
+  "distribution": {
+    "formats": [
+      "MDST"
+    ],
+    "number_events": 1170223542,
+    "number_files": 6005,
+    "size": 20321007106014
+  },
+  "experiment": [
+    "LHCb"
+  ],
+  "magnet_polarity": "MagDown",
+  "methodology": {
+    "description": "<p> This dataset was created in several production steps. These steps, software used and the configuration is provided below. </p><p> <strong> Prod ID: &nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;</strong> 151979<p> <strong>Prod type:&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp; </strong> Merge<p> <strong> Parent Prod ID:&nbsp;&nbsp;&nbsp;&nbsp; </strong> 151978<p> <strong> Parent Prod type: </strong> DataStripping<p> <strong> Conditions: </strong><p>dddb-20210528-6<p>cond-20191004-1</strong><p> <strong> List of Trigger Configuration Keys (TCK): </strong> </p> <p><p><strong>TCK &nbsp;&nbsp;&nbsp;&nbsp;&nbsp; Number of Files </strong><p>0x1138160f &nbsp;&nbsp;&nbsp;&nbsp;&nbsp; 3940<p>0x11371609 &nbsp;&nbsp;&nbsp;&nbsp;&nbsp; 384<p>0x1137160e &nbsp;&nbsp;&nbsp;&nbsp;&nbsp; 133<p>0x1138160e &nbsp;&nbsp;&nbsp;&nbsp;&nbsp; 210<p>0x11381609 &nbsp;&nbsp;&nbsp;&nbsp;&nbsp; 57<p>0x11291600 &nbsp;&nbsp;&nbsp;&nbsp;&nbsp; 136<p>0x11291603 &nbsp;&nbsp;&nbsp;&nbsp;&nbsp; 320<p>0x11291604 &nbsp;&nbsp;&nbsp;&nbsp;&nbsp; 193<p>0x11291605 &nbsp;&nbsp;&nbsp;&nbsp;&nbsp; 632",
+    "steps": [
+      {
+        "configuration_files": [
+          {
+            "title": "DaVinci/DV-Stripping28r2p1-Stripping.py"
+          },
+          {
+            "title": "DaVinci/DataType-2016.py"
+          },
+          {
+            "title": "DaVinci/InputType-RDST.py"
+          },
+          {
+            "title": "DaVinci/DV-RawEventJuggler-0_3-to-4_3.py"
+          },
+          {
+            "title": "Persistency/Compression-ZLIB-1.py"
+          },
+          {
+            "title": "DaVinci/DV-RedoCaloPID-Stripping_28_24.py"
+          }
+        ],
+        "release": "DaVinci.v44r11p4 AppConfig.v3r407 Det/SQLDDDB.v7r10 TMVAWeights.v1r17",
+        "type": "Stripping28r2p1"
+      },
+      {
+        "configuration_files": [
+          {
+            "title": "Merging/DV-Stripping-Merging.py"
+          },
+          {
+            "title": "Persistency/Compression-LZMA-4.py"
+          }
+        ],
+        "release": "DaVinci.v44r11p4 AppConfig.v3r407 Det/SQLDDDB.v7r10",
+        "type": "Stripping28r2p1-Merging"
+      },
+      {
+        "configuration_files": [
+          {
+            "title": "DaVinci/DV-Stripping28r2p1-Stripping.py"
+          },
+          {
+            "title": "DaVinci/DataType-2016.py"
+          },
+          {
+            "title": "DaVinci/InputType-RDST.py"
+          },
+          {
+            "title": "DaVinci/DV-RawEventJuggler-0_3-to-4_3.py"
+          },
+          {
+            "title": "Persistency/Compression-ZLIB-1.py"
+          },
+          {
+            "title": "DaVinci/DV-RedoCaloPID-Stripping_28_24.py"
+          }
+        ],
+        "release": "DaVinci.v44r11p4 AppConfig.v3r407 Det/SQLDDDB.v7r10 TMVAWeights.v1r17",
+        "type": "Stripping28r2p1"
+      },
+      {
+        "configuration_files": [
+          {
+            "title": "Merging/DV-Stripping-Merging.py"
+          },
+          {
+            "title": "Persistency/Compression-LZMA-4.py"
+          }
+        ],
+        "release": "DaVinci.v44r11p4 AppConfig.v3r407 Det/SQLDDDB.v7r10",
+        "type": "Stripping28r2p1-Merging"
+      },
+      {
+        "configuration_files": [
+          {
+            "title": "DaVinci/DV-Stripping28r2p1-Stripping.py"
+          },
+          {
+            "title": "DaVinci/DataType-2016.py"
+          },
+          {
+            "title": "DaVinci/InputType-RDST.py"
+          },
+          {
+            "title": "DaVinci/DV-RawEventJuggler-0_3-to-4_3.py"
+          },
+          {
+            "title": "Persistency/Compression-ZLIB-1.py"
+          },
+          {
+            "title": "DaVinci/DV-RedoCaloPID-Stripping_28_24.py"
+          }
+        ],
+        "release": "DaVinci.v44r11p4 AppConfig.v3r407 Det/SQLDDDB.v7r10 TMVAWeights.v1r17",
+        "type": "Stripping28r2p1"
+      },
+      {
+        "configuration_files": [
+          {
+            "title": "Merging/DV-Stripping-Merging.py"
+          },
+          {
+            "title": "Persistency/Compression-LZMA-4.py"
+          }
+        ],
+        "release": "DaVinci.v44r11p4 AppConfig.v3r407 Det/SQLDDDB.v7r10",
+        "type": "Stripping28r2p1-Merging"
+      },
+      {
+        "configuration_files": [
+          {
+            "title": "DaVinci/DV-Stripping28r2p1-Stripping.py"
+          },
+          {
+            "title": "DaVinci/DataType-2016.py"
+          },
+          {
+            "title": "DaVinci/InputType-RDST.py"
+          },
+          {
+            "title": "DaVinci/DV-RawEventJuggler-0_3-to-4_3.py"
+          },
+          {
+            "title": "Persistency/Compression-ZLIB-1.py"
+          },
+          {
+            "title": "DaVinci/DV-RedoCaloPID-Stripping_28_24.py"
+          }
+        ],
+        "release": "DaVinci.v44r11p4 AppConfig.v3r407 Det/SQLDDDB.v7r10 TMVAWeights.v1r17",
+        "type": "Stripping28r2p1"
+      },
+      {
+        "configuration_files": [
+          {
+            "title": "Merging/DV-Stripping-Merging.py"
+          },
+          {
+            "title": "Persistency/Compression-LZMA-4.py"
+          }
+        ],
+        "release": "DaVinci.v44r11p4 AppConfig.v3r407 Det/SQLDDDB.v7r10",
+        "type": "Stripping28r2p1-Merging"
+      }
+    ]
+  },
+  "publisher": "CERN Open Data Portal",
+  "recid": "24666",
+  "run_period": [
+    "2016"
+  ],
+  "stripping": {
+    "stream": "CHARM",
+    "version": "stripping28r2p1"
+  },
+  "title": "LHCb 2016 Beam6500GeV MagDown CHARM Stream Stripping28r2p1",
+  "title_additional": "",
+  "type": {
+    "primary": "Dataset",
+    "secondary": [
+      "Collision"
+    ]
+  },
+  "usage": {
+    "description": "<p> The Run 1 and 2 data collected by the LHCb detector is available using the LHCb Ntupling Service, while the Run 1 data is additionally available in .DST and .mDST formats. The data obtained from the LHCb Ntupling Service are ROOT ntuples and do not require custom software to analyze. <p> Links are provided to the LHCb Ntupling Service for exploration of available data and the LHCb Open Data Guide for usage instructions.",
+    "links": [
+      {
+        "description": "LHCb Ntupling Service",
+        "url": "https://opendata-lhcb-ntupling-service.app.cern.ch/"
+      },
+      {
+        "description": "LHCb Open Data Guide",
+        "url": "https://lhcb-opendata-guide.web.cern.ch/"
+      }
+    ]
+  }
+}]

--- a/data/records/LHCb_2016_Beam6500GeV_VeloClosed_MagDown_RealData_Reco16_Stripping28r2p1_DIMUON_DST.json
+++ b/data/records/LHCb_2016_Beam6500GeV_VeloClosed_MagDown_RealData_Reco16_Stripping28r2p1_DIMUON_DST.json
@@ -1,0 +1,213 @@
+[{
+  "abstract": {
+    "description": "Data from proton-proton (pp) collisions collected by the LHCb experiment in the year 2016 of Run2 of the LHC."
+  },
+  "accelerator": "CERN-LHC",
+  "collaboration": {
+    "name": "LHCb collaboration",
+    "recid": "456"
+  },
+  "collections": [
+    "LHCb-Collision-Datasets"
+  ],
+  "collision_information": {
+    "energy": "13TeV",
+    "type": "pp"
+  },
+  "date_created": [
+    "2016"
+  ],
+  "date_published": "2026",
+  "date_reprocessed": "2021",
+  "distribution": {
+    "formats": [
+      "DST"
+    ],
+    "number_events": 302891253,
+    "number_files": 9222,
+    "size": 32437549112852
+  },
+  "experiment": [
+    "LHCb"
+  ],
+  "magnet_polarity": "MagDown",
+  "methodology": {
+    "description": "<p> This dataset was created in several production steps. These steps, software used and the configuration is provided below. </p><p> <strong> Prod ID: &nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;</strong> 151979<p> <strong>Prod type:&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp; </strong> Merge<p> <strong> Parent Prod ID:&nbsp;&nbsp;&nbsp;&nbsp; </strong> 151978<p> <strong> Parent Prod type: </strong> DataStripping<p> <strong> Conditions: </strong><p>dddb-20210528-6<p>cond-20191004-1</strong><p> <strong> List of Trigger Configuration Keys (TCK): </strong> </p> <p><p><strong>TCK &nbsp;&nbsp;&nbsp;&nbsp;&nbsp; Number of Files </strong><p>0x1138160f &nbsp;&nbsp;&nbsp;&nbsp;&nbsp; 5970<p>0x11371609 &nbsp;&nbsp;&nbsp;&nbsp;&nbsp; 668<p>0x1137160e &nbsp;&nbsp;&nbsp;&nbsp;&nbsp; 236<p>0x1138160e &nbsp;&nbsp;&nbsp;&nbsp;&nbsp; 325<p>0x11381609 &nbsp;&nbsp;&nbsp;&nbsp;&nbsp; 81<p>0x11291600 &nbsp;&nbsp;&nbsp;&nbsp;&nbsp; 150<p>0x11291603 &nbsp;&nbsp;&nbsp;&nbsp;&nbsp; 477<p>0x11291604 &nbsp;&nbsp;&nbsp;&nbsp;&nbsp; 320<p>0x11291605 &nbsp;&nbsp;&nbsp;&nbsp;&nbsp; 995",
+    "steps": [
+      {
+        "configuration_files": [
+          {
+            "title": "DaVinci/DV-Stripping28r2p1-Stripping.py"
+          },
+          {
+            "title": "DaVinci/DataType-2016.py"
+          },
+          {
+            "title": "DaVinci/InputType-RDST.py"
+          },
+          {
+            "title": "DaVinci/DV-RawEventJuggler-0_3-to-4_3.py"
+          },
+          {
+            "title": "Persistency/Compression-ZLIB-1.py"
+          },
+          {
+            "title": "DaVinci/DV-RedoCaloPID-Stripping_28_24.py"
+          }
+        ],
+        "release": "DaVinci.v44r11p4 AppConfig.v3r407 Det/SQLDDDB.v7r10 TMVAWeights.v1r17",
+        "type": "Stripping28r2p1"
+      },
+      {
+        "configuration_files": [
+          {
+            "title": "Merging/DV-Stripping-Merging.py"
+          },
+          {
+            "title": "Persistency/Compression-LZMA-4.py"
+          }
+        ],
+        "release": "DaVinci.v44r11p4 AppConfig.v3r407 Det/SQLDDDB.v7r10",
+        "type": "Stripping28r2p1-Merging"
+      },
+      {
+        "configuration_files": [
+          {
+            "title": "DaVinci/DV-Stripping28r2p1-Stripping.py"
+          },
+          {
+            "title": "DaVinci/DataType-2016.py"
+          },
+          {
+            "title": "DaVinci/InputType-RDST.py"
+          },
+          {
+            "title": "DaVinci/DV-RawEventJuggler-0_3-to-4_3.py"
+          },
+          {
+            "title": "Persistency/Compression-ZLIB-1.py"
+          },
+          {
+            "title": "DaVinci/DV-RedoCaloPID-Stripping_28_24.py"
+          }
+        ],
+        "release": "DaVinci.v44r11p4 AppConfig.v3r407 Det/SQLDDDB.v7r10 TMVAWeights.v1r17",
+        "type": "Stripping28r2p1"
+      },
+      {
+        "configuration_files": [
+          {
+            "title": "Merging/DV-Stripping-Merging.py"
+          },
+          {
+            "title": "Persistency/Compression-LZMA-4.py"
+          }
+        ],
+        "release": "DaVinci.v44r11p4 AppConfig.v3r407 Det/SQLDDDB.v7r10",
+        "type": "Stripping28r2p1-Merging"
+      },
+      {
+        "configuration_files": [
+          {
+            "title": "DaVinci/DV-Stripping28r2p1-Stripping.py"
+          },
+          {
+            "title": "DaVinci/DataType-2016.py"
+          },
+          {
+            "title": "DaVinci/InputType-RDST.py"
+          },
+          {
+            "title": "DaVinci/DV-RawEventJuggler-0_3-to-4_3.py"
+          },
+          {
+            "title": "Persistency/Compression-ZLIB-1.py"
+          },
+          {
+            "title": "DaVinci/DV-RedoCaloPID-Stripping_28_24.py"
+          }
+        ],
+        "release": "DaVinci.v44r11p4 AppConfig.v3r407 Det/SQLDDDB.v7r10 TMVAWeights.v1r17",
+        "type": "Stripping28r2p1"
+      },
+      {
+        "configuration_files": [
+          {
+            "title": "Merging/DV-Stripping-Merging.py"
+          },
+          {
+            "title": "Persistency/Compression-LZMA-4.py"
+          }
+        ],
+        "release": "DaVinci.v44r11p4 AppConfig.v3r407 Det/SQLDDDB.v7r10",
+        "type": "Stripping28r2p1-Merging"
+      },
+      {
+        "configuration_files": [
+          {
+            "title": "DaVinci/DV-Stripping28r2p1-Stripping.py"
+          },
+          {
+            "title": "DaVinci/DataType-2016.py"
+          },
+          {
+            "title": "DaVinci/InputType-RDST.py"
+          },
+          {
+            "title": "DaVinci/DV-RawEventJuggler-0_3-to-4_3.py"
+          },
+          {
+            "title": "Persistency/Compression-ZLIB-1.py"
+          },
+          {
+            "title": "DaVinci/DV-RedoCaloPID-Stripping_28_24.py"
+          }
+        ],
+        "release": "DaVinci.v44r11p4 AppConfig.v3r407 Det/SQLDDDB.v7r10 TMVAWeights.v1r17",
+        "type": "Stripping28r2p1"
+      },
+      {
+        "configuration_files": [
+          {
+            "title": "Merging/DV-Stripping-Merging.py"
+          },
+          {
+            "title": "Persistency/Compression-LZMA-4.py"
+          }
+        ],
+        "release": "DaVinci.v44r11p4 AppConfig.v3r407 Det/SQLDDDB.v7r10",
+        "type": "Stripping28r2p1-Merging"
+      }
+    ]
+  },
+  "publisher": "CERN Open Data Portal",
+  "recid": "24668",
+  "run_period": [
+    "2016"
+  ],
+  "stripping": {
+    "stream": "DIMUON",
+    "version": "stripping28r2p1"
+  },
+  "title": "LHCb 2016 Beam6500GeV MagDown DIMUON Stream Stripping28r2p1",
+  "title_additional": "",
+  "type": {
+    "primary": "Dataset",
+    "secondary": [
+      "Collision"
+    ]
+  },
+  "usage": {
+    "description": "<p> The Run 1 and 2 data collected by the LHCb detector is available using the LHCb Ntupling Service, while the Run 1 data is additionally available in .DST and .mDST formats. The data obtained from the LHCb Ntupling Service are ROOT ntuples and do not require custom software to analyze. <p> Links are provided to the LHCb Ntupling Service for exploration of available data and the LHCb Open Data Guide for usage instructions.",
+    "links": [
+      {
+        "description": "LHCb Ntupling Service",
+        "url": "https://opendata-lhcb-ntupling-service.app.cern.ch/"
+      },
+      {
+        "description": "LHCb Open Data Guide",
+        "url": "https://lhcb-opendata-guide.web.cern.ch/"
+      }
+    ]
+  }
+}]

--- a/data/records/LHCb_2016_Beam6500GeV_VeloClosed_MagDown_RealData_Reco16_Stripping28r2p1_LEPTONIC_MDST.json
+++ b/data/records/LHCb_2016_Beam6500GeV_VeloClosed_MagDown_RealData_Reco16_Stripping28r2p1_LEPTONIC_MDST.json
@@ -1,0 +1,213 @@
+[{
+  "abstract": {
+    "description": "Data from proton-proton (pp) collisions collected by the LHCb experiment in the year 2016 of Run2 of the LHC."
+  },
+  "accelerator": "CERN-LHC",
+  "collaboration": {
+    "name": "LHCb collaboration",
+    "recid": "456"
+  },
+  "collections": [
+    "LHCb-Collision-Datasets"
+  ],
+  "collision_information": {
+    "energy": "13TeV",
+    "type": "pp"
+  },
+  "date_created": [
+    "2016"
+  ],
+  "date_published": "2026",
+  "date_reprocessed": "2021",
+  "distribution": {
+    "formats": [
+      "MDST"
+    ],
+    "number_events": 2184941426,
+    "number_files": 15416,
+    "size": 63166434993347
+  },
+  "experiment": [
+    "LHCb"
+  ],
+  "magnet_polarity": "MagDown",
+  "methodology": {
+    "description": "<p> This dataset was created in several production steps. These steps, software used and the configuration is provided below. </p><p> <strong> Prod ID: &nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;</strong> 153032<p> <strong>Prod type:&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp; </strong> Merge<p> <strong> Parent Prod ID:&nbsp;&nbsp;&nbsp;&nbsp; </strong> 151978<p> <strong> Parent Prod type: </strong> DataStripping<p> <strong> Conditions: </strong><p>dddb-20210528-6<p>cond-20191004-1</strong><p> <strong> List of Trigger Configuration Keys (TCK): </strong> </p> <p><p><strong>TCK &nbsp;&nbsp;&nbsp;&nbsp;&nbsp; Number of Files </strong><p>0x1138160f &nbsp;&nbsp;&nbsp;&nbsp;&nbsp; 10097<p>0x11371609 &nbsp;&nbsp;&nbsp;&nbsp;&nbsp; 1071<p>0x1137160e &nbsp;&nbsp;&nbsp;&nbsp;&nbsp; 385<p>0x1138160e &nbsp;&nbsp;&nbsp;&nbsp;&nbsp; 567<p>0x11381609 &nbsp;&nbsp;&nbsp;&nbsp;&nbsp; 130<p>0x11291600 &nbsp;&nbsp;&nbsp;&nbsp;&nbsp; 195<p>0x11291603 &nbsp;&nbsp;&nbsp;&nbsp;&nbsp; 765<p>0x11291604 &nbsp;&nbsp;&nbsp;&nbsp;&nbsp; 542<p>0x11291605 &nbsp;&nbsp;&nbsp;&nbsp;&nbsp; 1664",
+    "steps": [
+      {
+        "configuration_files": [
+          {
+            "title": "DaVinci/DV-Stripping28r2p1-Stripping.py"
+          },
+          {
+            "title": "DaVinci/DataType-2016.py"
+          },
+          {
+            "title": "DaVinci/InputType-RDST.py"
+          },
+          {
+            "title": "DaVinci/DV-RawEventJuggler-0_3-to-4_3.py"
+          },
+          {
+            "title": "Persistency/Compression-ZLIB-1.py"
+          },
+          {
+            "title": "DaVinci/DV-RedoCaloPID-Stripping_28_24.py"
+          }
+        ],
+        "release": "DaVinci.v44r11p4 AppConfig.v3r407 Det/SQLDDDB.v7r10 TMVAWeights.v1r17",
+        "type": "Stripping28r2p1"
+      },
+      {
+        "configuration_files": [
+          {
+            "title": "Merging/DV-Stripping-Merging.py"
+          },
+          {
+            "title": "Persistency/Compression-LZMA-4.py"
+          }
+        ],
+        "release": "DaVinci.v44r11p4 AppConfig.v3r407 Det/SQLDDDB.v7r10",
+        "type": "Stripping28r2p1-Merging"
+      },
+      {
+        "configuration_files": [
+          {
+            "title": "DaVinci/DV-Stripping28r2p1-Stripping.py"
+          },
+          {
+            "title": "DaVinci/DataType-2016.py"
+          },
+          {
+            "title": "DaVinci/InputType-RDST.py"
+          },
+          {
+            "title": "DaVinci/DV-RawEventJuggler-0_3-to-4_3.py"
+          },
+          {
+            "title": "Persistency/Compression-ZLIB-1.py"
+          },
+          {
+            "title": "DaVinci/DV-RedoCaloPID-Stripping_28_24.py"
+          }
+        ],
+        "release": "DaVinci.v44r11p4 AppConfig.v3r407 Det/SQLDDDB.v7r10 TMVAWeights.v1r17",
+        "type": "Stripping28r2p1"
+      },
+      {
+        "configuration_files": [
+          {
+            "title": "Merging/DV-Stripping-Merging.py"
+          },
+          {
+            "title": "Persistency/Compression-LZMA-4.py"
+          }
+        ],
+        "release": "DaVinci.v44r11p4 AppConfig.v3r407 Det/SQLDDDB.v7r10",
+        "type": "Stripping28r2p1-Merging"
+      },
+      {
+        "configuration_files": [
+          {
+            "title": "DaVinci/DV-Stripping28r2p1-Stripping.py"
+          },
+          {
+            "title": "DaVinci/DataType-2016.py"
+          },
+          {
+            "title": "DaVinci/InputType-RDST.py"
+          },
+          {
+            "title": "DaVinci/DV-RawEventJuggler-0_3-to-4_3.py"
+          },
+          {
+            "title": "Persistency/Compression-ZLIB-1.py"
+          },
+          {
+            "title": "DaVinci/DV-RedoCaloPID-Stripping_28_24.py"
+          }
+        ],
+        "release": "DaVinci.v44r11p4 AppConfig.v3r407 Det/SQLDDDB.v7r10 TMVAWeights.v1r17",
+        "type": "Stripping28r2p1"
+      },
+      {
+        "configuration_files": [
+          {
+            "title": "Merging/DV-Stripping-Merging.py"
+          },
+          {
+            "title": "Persistency/Compression-LZMA-4.py"
+          }
+        ],
+        "release": "DaVinci.v44r11p4 AppConfig.v3r407 Det/SQLDDDB.v7r10",
+        "type": "Stripping28r2p1-Merging"
+      },
+      {
+        "configuration_files": [
+          {
+            "title": "DaVinci/DV-Stripping28r2p1-Stripping.py"
+          },
+          {
+            "title": "DaVinci/DataType-2016.py"
+          },
+          {
+            "title": "DaVinci/InputType-RDST.py"
+          },
+          {
+            "title": "DaVinci/DV-RawEventJuggler-0_3-to-4_3.py"
+          },
+          {
+            "title": "Persistency/Compression-ZLIB-1.py"
+          },
+          {
+            "title": "DaVinci/DV-RedoCaloPID-Stripping_28_24.py"
+          }
+        ],
+        "release": "DaVinci.v44r11p4 AppConfig.v3r407 Det/SQLDDDB.v7r10 TMVAWeights.v1r17",
+        "type": "Stripping28r2p1"
+      },
+      {
+        "configuration_files": [
+          {
+            "title": "Merging/DV-Stripping-Merging.py"
+          },
+          {
+            "title": "Persistency/Compression-LZMA-4.py"
+          }
+        ],
+        "release": "DaVinci.v44r11p4 AppConfig.v3r407 Det/SQLDDDB.v7r10",
+        "type": "Stripping28r2p1-Merging"
+      }
+    ]
+  },
+  "publisher": "CERN Open Data Portal",
+  "recid": "24661",
+  "run_period": [
+    "2016"
+  ],
+  "stripping": {
+    "stream": "LEPTONIC",
+    "version": "stripping28r2p1"
+  },
+  "title": "LHCb 2016 Beam6500GeV MagDown LEPTONIC Stream Stripping28r2p1",
+  "title_additional": "",
+  "type": {
+    "primary": "Dataset",
+    "secondary": [
+      "Collision"
+    ]
+  },
+  "usage": {
+    "description": "<p> The Run 1 and 2 data collected by the LHCb detector is available using the LHCb Ntupling Service, while the Run 1 data is additionally available in .DST and .mDST formats. The data obtained from the LHCb Ntupling Service are ROOT ntuples and do not require custom software to analyze. <p> Links are provided to the LHCb Ntupling Service for exploration of available data and the LHCb Open Data Guide for usage instructions.",
+    "links": [
+      {
+        "description": "LHCb Ntupling Service",
+        "url": "https://opendata-lhcb-ntupling-service.app.cern.ch/"
+      },
+      {
+        "description": "LHCb Open Data Guide",
+        "url": "https://lhcb-opendata-guide.web.cern.ch/"
+      }
+    ]
+  }
+}]

--- a/data/records/LHCb_2016_Beam6500GeV_VeloClosed_MagDown_RealData_Reco16_Stripping28r2p1_SEMILEPTONIC_DST.json
+++ b/data/records/LHCb_2016_Beam6500GeV_VeloClosed_MagDown_RealData_Reco16_Stripping28r2p1_SEMILEPTONIC_DST.json
@@ -1,0 +1,213 @@
+[{
+  "abstract": {
+    "description": "Data from proton-proton (pp) collisions collected by the LHCb experiment in the year 2016 of Run2 of the LHC."
+  },
+  "accelerator": "CERN-LHC",
+  "collaboration": {
+    "name": "LHCb collaboration",
+    "recid": "456"
+  },
+  "collections": [
+    "LHCb-Collision-Datasets"
+  ],
+  "collision_information": {
+    "energy": "13TeV",
+    "type": "pp"
+  },
+  "date_created": [
+    "2016"
+  ],
+  "date_published": "2026",
+  "date_reprocessed": "2021",
+  "distribution": {
+    "formats": [
+      "DST"
+    ],
+    "number_events": 104239820,
+    "number_files": 5594,
+    "size": 10257762714018
+  },
+  "experiment": [
+    "LHCb"
+  ],
+  "magnet_polarity": "MagDown",
+  "methodology": {
+    "description": "<p> This dataset was created in several production steps. These steps, software used and the configuration is provided below. </p><p> <strong> Prod ID: &nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;</strong> 153032<p> <strong>Prod type:&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp; </strong> Merge<p> <strong> Parent Prod ID:&nbsp;&nbsp;&nbsp;&nbsp; </strong> 151978<p> <strong> Parent Prod type: </strong> DataStripping<p> <strong> Conditions: </strong><p>dddb-20210528-6<p>cond-20191004-1</strong><p> <strong> List of Trigger Configuration Keys (TCK): </strong> </p> <p><p><strong>TCK &nbsp;&nbsp;&nbsp;&nbsp;&nbsp; Number of Files </strong><p>0x1138160f &nbsp;&nbsp;&nbsp;&nbsp;&nbsp; 3565<p>0x11371609 &nbsp;&nbsp;&nbsp;&nbsp;&nbsp; 383<p>0x1137160e &nbsp;&nbsp;&nbsp;&nbsp;&nbsp; 125<p>0x1138160e &nbsp;&nbsp;&nbsp;&nbsp;&nbsp; 192<p>0x11381609 &nbsp;&nbsp;&nbsp;&nbsp;&nbsp; 52<p>0x11291600 &nbsp;&nbsp;&nbsp;&nbsp;&nbsp; 139<p>0x11291603 &nbsp;&nbsp;&nbsp;&nbsp;&nbsp; 320<p>0x11291604 &nbsp;&nbsp;&nbsp;&nbsp;&nbsp; 192<p>0x11291605 &nbsp;&nbsp;&nbsp;&nbsp;&nbsp; 626",
+    "steps": [
+      {
+        "configuration_files": [
+          {
+            "title": "DaVinci/DV-Stripping28r2p1-Stripping.py"
+          },
+          {
+            "title": "DaVinci/DataType-2016.py"
+          },
+          {
+            "title": "DaVinci/InputType-RDST.py"
+          },
+          {
+            "title": "DaVinci/DV-RawEventJuggler-0_3-to-4_3.py"
+          },
+          {
+            "title": "Persistency/Compression-ZLIB-1.py"
+          },
+          {
+            "title": "DaVinci/DV-RedoCaloPID-Stripping_28_24.py"
+          }
+        ],
+        "release": "DaVinci.v44r11p4 AppConfig.v3r407 Det/SQLDDDB.v7r10 TMVAWeights.v1r17",
+        "type": "Stripping28r2p1"
+      },
+      {
+        "configuration_files": [
+          {
+            "title": "Merging/DV-Stripping-Merging.py"
+          },
+          {
+            "title": "Persistency/Compression-LZMA-4.py"
+          }
+        ],
+        "release": "DaVinci.v44r11p4 AppConfig.v3r407 Det/SQLDDDB.v7r10",
+        "type": "Stripping28r2p1-Merging"
+      },
+      {
+        "configuration_files": [
+          {
+            "title": "DaVinci/DV-Stripping28r2p1-Stripping.py"
+          },
+          {
+            "title": "DaVinci/DataType-2016.py"
+          },
+          {
+            "title": "DaVinci/InputType-RDST.py"
+          },
+          {
+            "title": "DaVinci/DV-RawEventJuggler-0_3-to-4_3.py"
+          },
+          {
+            "title": "Persistency/Compression-ZLIB-1.py"
+          },
+          {
+            "title": "DaVinci/DV-RedoCaloPID-Stripping_28_24.py"
+          }
+        ],
+        "release": "DaVinci.v44r11p4 AppConfig.v3r407 Det/SQLDDDB.v7r10 TMVAWeights.v1r17",
+        "type": "Stripping28r2p1"
+      },
+      {
+        "configuration_files": [
+          {
+            "title": "Merging/DV-Stripping-Merging.py"
+          },
+          {
+            "title": "Persistency/Compression-LZMA-4.py"
+          }
+        ],
+        "release": "DaVinci.v44r11p4 AppConfig.v3r407 Det/SQLDDDB.v7r10",
+        "type": "Stripping28r2p1-Merging"
+      },
+      {
+        "configuration_files": [
+          {
+            "title": "DaVinci/DV-Stripping28r2p1-Stripping.py"
+          },
+          {
+            "title": "DaVinci/DataType-2016.py"
+          },
+          {
+            "title": "DaVinci/InputType-RDST.py"
+          },
+          {
+            "title": "DaVinci/DV-RawEventJuggler-0_3-to-4_3.py"
+          },
+          {
+            "title": "Persistency/Compression-ZLIB-1.py"
+          },
+          {
+            "title": "DaVinci/DV-RedoCaloPID-Stripping_28_24.py"
+          }
+        ],
+        "release": "DaVinci.v44r11p4 AppConfig.v3r407 Det/SQLDDDB.v7r10 TMVAWeights.v1r17",
+        "type": "Stripping28r2p1"
+      },
+      {
+        "configuration_files": [
+          {
+            "title": "Merging/DV-Stripping-Merging.py"
+          },
+          {
+            "title": "Persistency/Compression-LZMA-4.py"
+          }
+        ],
+        "release": "DaVinci.v44r11p4 AppConfig.v3r407 Det/SQLDDDB.v7r10",
+        "type": "Stripping28r2p1-Merging"
+      },
+      {
+        "configuration_files": [
+          {
+            "title": "DaVinci/DV-Stripping28r2p1-Stripping.py"
+          },
+          {
+            "title": "DaVinci/DataType-2016.py"
+          },
+          {
+            "title": "DaVinci/InputType-RDST.py"
+          },
+          {
+            "title": "DaVinci/DV-RawEventJuggler-0_3-to-4_3.py"
+          },
+          {
+            "title": "Persistency/Compression-ZLIB-1.py"
+          },
+          {
+            "title": "DaVinci/DV-RedoCaloPID-Stripping_28_24.py"
+          }
+        ],
+        "release": "DaVinci.v44r11p4 AppConfig.v3r407 Det/SQLDDDB.v7r10 TMVAWeights.v1r17",
+        "type": "Stripping28r2p1"
+      },
+      {
+        "configuration_files": [
+          {
+            "title": "Merging/DV-Stripping-Merging.py"
+          },
+          {
+            "title": "Persistency/Compression-LZMA-4.py"
+          }
+        ],
+        "release": "DaVinci.v44r11p4 AppConfig.v3r407 Det/SQLDDDB.v7r10",
+        "type": "Stripping28r2p1-Merging"
+      }
+    ]
+  },
+  "publisher": "CERN Open Data Portal",
+  "recid": "24669",
+  "run_period": [
+    "2016"
+  ],
+  "stripping": {
+    "stream": "SEMILEPTONIC",
+    "version": "stripping28r2p1"
+  },
+  "title": "LHCb 2016 Beam6500GeV MagDown SEMILEPTONIC Stream Stripping28r2p1",
+  "title_additional": "",
+  "type": {
+    "primary": "Dataset",
+    "secondary": [
+      "Collision"
+    ]
+  },
+  "usage": {
+    "description": "<p> The Run 1 and 2 data collected by the LHCb detector is available using the LHCb Ntupling Service, while the Run 1 data is additionally available in .DST and .mDST formats. The data obtained from the LHCb Ntupling Service are ROOT ntuples and do not require custom software to analyze. <p> Links are provided to the LHCb Ntupling Service for exploration of available data and the LHCb Open Data Guide for usage instructions.",
+    "links": [
+      {
+        "description": "LHCb Ntupling Service",
+        "url": "https://opendata-lhcb-ntupling-service.app.cern.ch/"
+      },
+      {
+        "description": "LHCb Open Data Guide",
+        "url": "https://lhcb-opendata-guide.web.cern.ch/"
+      }
+    ]
+  }
+}]

--- a/data/records/LHCb_2016_Beam6500GeV_VeloClosed_MagDown_RealData_Reco16_Stripping28r2p2_BHADRONCOMPLETEEVENT_DST.json
+++ b/data/records/LHCb_2016_Beam6500GeV_VeloClosed_MagDown_RealData_Reco16_Stripping28r2p2_BHADRONCOMPLETEEVENT_DST.json
@@ -1,0 +1,249 @@
+[{
+  "abstract": {
+    "description": "Data from proton-proton (pp) collisions collected by the LHCb experiment in the year 2016 of Run2 of the LHC."
+  },
+  "accelerator": "CERN-LHC",
+  "collaboration": {
+    "name": "LHCb collaboration",
+    "recid": "456"
+  },
+  "collections": [
+    "LHCb-Collision-Datasets"
+  ],
+  "collision_information": {
+    "energy": "13TeV",
+    "type": "pp"
+  },
+  "date_created": [
+    "2016"
+  ],
+  "date_published": "2026",
+  "date_reprocessed": "2024",
+  "distribution": {
+    "formats": [
+      "DST"
+    ],
+    "number_events": 507244141,
+    "number_files": 16264,
+    "size": 60120915043674
+  },
+  "experiment": [
+    "LHCb"
+  ],
+  "magnet_polarity": "MagDown",
+  "methodology": {
+    "description": "<p> This dataset was created in several production steps. These steps, software used and the configuration is provided below. </p><p> <strong> Prod ID: &nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;</strong> 205789<p> <strong>Prod type:&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp; </strong> Merge<p> <strong> Parent Prod ID:&nbsp;&nbsp;&nbsp;&nbsp; </strong> 205601<p> <strong> Parent Prod type: </strong> DataStripping<p> <strong> Conditions: </strong><p>dddb-20220927-2016<p>cond-20191004-1</strong><p> <strong> List of Trigger Configuration Keys (TCK): </strong> </p> <p><p><strong>TCK &nbsp;&nbsp;&nbsp;&nbsp;&nbsp; Number of Files </strong><p>0x11291605 &nbsp;&nbsp;&nbsp;&nbsp;&nbsp; 1690<p>0x1138160f &nbsp;&nbsp;&nbsp;&nbsp;&nbsp; 10788<p>0x11291604 &nbsp;&nbsp;&nbsp;&nbsp;&nbsp; 545<p>0x11291600 &nbsp;&nbsp;&nbsp;&nbsp;&nbsp; 236<p>0x11291603 &nbsp;&nbsp;&nbsp;&nbsp;&nbsp; 811<p>0x1138160e &nbsp;&nbsp;&nbsp;&nbsp;&nbsp; 598<p>0x11371609 &nbsp;&nbsp;&nbsp;&nbsp;&nbsp; 1073<p>0x1137160e &nbsp;&nbsp;&nbsp;&nbsp;&nbsp; 381<p>0x11381609 &nbsp;&nbsp;&nbsp;&nbsp;&nbsp; 142",
+    "steps": [
+      {
+        "configuration_files": [
+          {
+            "title": "DaVinci/DV-Stripping28r2p2-Stripping.py"
+          },
+          {
+            "title": "DaVinci/DataType-2016.py"
+          },
+          {
+            "title": "DaVinci/InputType-RDST.py"
+          },
+          {
+            "title": "DaVinci/DV-RawEventJuggler-0_3-to-4_3.py"
+          },
+          {
+            "title": "Persistency/Compression-ZLIB-1.py"
+          },
+          {
+            "title": "DaVinci/DV-RedoCaloPID-Stripping_28_24.py"
+          }
+        ],
+        "release": "DaVinci.v44r11p6 AppConfig.v3r421 Det/SQLDDDB.v7r12 TMVAWeights.v1r18",
+        "type": "Stripping28r2p2_md"
+      },
+      {
+        "configuration_files": [
+          {
+            "title": "Merging/DV-Stripping-Merging.py"
+          },
+          {
+            "title": "Persistency/Compression-LZMA-4.py"
+          }
+        ],
+        "release": "DaVinci.v44r11p6 AppConfig.v3r421 Det/SQLDDDB.v7r12 TMVAWeights.v1r18",
+        "type": "Merge_Stripping28r2p2_md"
+      },
+      {
+        "configuration_files": [
+          {
+            "title": "DaVinci/DV-Stripping28r2p2-Stripping.py"
+          },
+          {
+            "title": "DaVinci/DataType-2016.py"
+          },
+          {
+            "title": "DaVinci/InputType-RDST.py"
+          },
+          {
+            "title": "DaVinci/DV-RawEventJuggler-0_3-to-4_3.py"
+          },
+          {
+            "title": "Persistency/Compression-ZLIB-1.py"
+          },
+          {
+            "title": "DaVinci/DV-RedoCaloPID-Stripping_28_24.py"
+          }
+        ],
+        "release": "DaVinci.v44r11p6 AppConfig.v3r421 Det/SQLDDDB.v7r12 TMVAWeights.v1r18",
+        "type": "Stripping28r2p2_md"
+      },
+      {
+        "configuration_files": [
+          {
+            "title": "Merging/DV-Stripping-Merging.py"
+          },
+          {
+            "title": "Persistency/Compression-LZMA-4.py"
+          }
+        ],
+        "release": "DaVinci.v44r11p6 AppConfig.v3r421 Det/SQLDDDB.v7r12 TMVAWeights.v1r18",
+        "type": "Merge_Stripping28r2p2_md"
+      },
+      {
+        "configuration_files": [
+          {
+            "title": "DaVinci/DV-Stripping28r2p2-Stripping.py"
+          },
+          {
+            "title": "DaVinci/DataType-2016.py"
+          },
+          {
+            "title": "DaVinci/InputType-RDST.py"
+          },
+          {
+            "title": "DaVinci/DV-RawEventJuggler-0_3-to-4_3.py"
+          },
+          {
+            "title": "Persistency/Compression-ZLIB-1.py"
+          },
+          {
+            "title": "DaVinci/DV-RedoCaloPID-Stripping_28_24.py"
+          }
+        ],
+        "release": "DaVinci.v44r11p6 AppConfig.v3r421 Det/SQLDDDB.v7r12 TMVAWeights.v1r18",
+        "type": "Stripping28r2p2_md"
+      },
+      {
+        "configuration_files": [
+          {
+            "title": "Merging/DV-Stripping-Merging.py"
+          },
+          {
+            "title": "Persistency/Compression-LZMA-4.py"
+          }
+        ],
+        "release": "DaVinci.v44r11p6 AppConfig.v3r421 Det/SQLDDDB.v7r12 TMVAWeights.v1r18",
+        "type": "Merge_Stripping28r2p2_md"
+      },
+      {
+        "configuration_files": [
+          {
+            "title": "DaVinci/DV-Stripping28r2p2-Stripping.py"
+          },
+          {
+            "title": "DaVinci/DataType-2016.py"
+          },
+          {
+            "title": "DaVinci/InputType-RDST.py"
+          },
+          {
+            "title": "DaVinci/DV-RawEventJuggler-0_3-to-4_3.py"
+          },
+          {
+            "title": "Persistency/Compression-ZLIB-1.py"
+          },
+          {
+            "title": "DaVinci/DV-RedoCaloPID-Stripping_28_24.py"
+          }
+        ],
+        "release": "DaVinci.v44r11p6 AppConfig.v3r421 Det/SQLDDDB.v7r12 TMVAWeights.v1r18",
+        "type": "Stripping28r2p2_md"
+      },
+      {
+        "configuration_files": [
+          {
+            "title": "Merging/DV-Stripping-Merging.py"
+          },
+          {
+            "title": "Persistency/Compression-LZMA-4.py"
+          }
+        ],
+        "release": "DaVinci.v44r11p6 AppConfig.v3r421 Det/SQLDDDB.v7r12 TMVAWeights.v1r18",
+        "type": "Merge_Stripping28r2p2_md"
+      },
+      {
+        "configuration_files": [
+          {
+            "title": "DaVinci/DV-Stripping28r2p2-Stripping.py"
+          },
+          {
+            "title": "DaVinci/DataType-2016.py"
+          },
+          {
+            "title": "DaVinci/InputType-RDST.py"
+          },
+          {
+            "title": "DaVinci/DV-RawEventJuggler-0_3-to-4_3.py"
+          },
+          {
+            "title": "Persistency/Compression-ZLIB-1.py"
+          },
+          {
+            "title": "DaVinci/DV-RedoCaloPID-Stripping_28_24.py"
+          }
+        ],
+        "release": "DaVinci.v44r11p6 AppConfig.v3r421 Det/SQLDDDB.v7r12 TMVAWeights.v1r18",
+        "type": "Stripping28r2p2_md"
+      },
+      {
+        "configuration_files": [
+          {
+            "title": "Merging/DV-Stripping-Merging.py"
+          },
+          {
+            "title": "Persistency/Compression-LZMA-4.py"
+          }
+        ],
+        "release": "DaVinci.v44r11p6 AppConfig.v3r421 Det/SQLDDDB.v7r12 TMVAWeights.v1r18",
+        "type": "Merge_Stripping28r2p2_md"
+      }
+    ]
+  },
+  "publisher": "CERN Open Data Portal",
+  "recid": "24685",
+  "run_period": [
+    "2016"
+  ],
+  "stripping": {
+    "stream": "BHADRONCOMPLETEEVENT",
+    "version": "stripping28r2p2"
+  },
+  "title": "LHCb 2016 Beam6500GeV MagDown BHADRONCOMPLETEEVENT Stream Stripping28r2p2",
+  "title_additional": "",
+  "type": {
+    "primary": "Dataset",
+    "secondary": [
+      "Collision"
+    ]
+  },
+  "usage": {
+    "description": "<p> The Run 1 and 2 data collected by the LHCb detector is available using the LHCb Ntupling Service, while the Run 1 data is additionally available in .DST and .mDST formats. The data obtained from the LHCb Ntupling Service are ROOT ntuples and do not require custom software to analyze. <p> Links are provided to the LHCb Ntupling Service for exploration of available data and the LHCb Open Data Guide for usage instructions.",
+    "links": [
+      {
+        "description": "LHCb Ntupling Service",
+        "url": "https://opendata-lhcb-ntupling-service.app.cern.ch/"
+      },
+      {
+        "description": "LHCb Open Data Guide",
+        "url": "https://lhcb-opendata-guide.web.cern.ch/"
+      }
+    ]
+  }
+}]

--- a/data/records/LHCb_2016_Beam6500GeV_VeloClosed_MagDown_RealData_Reco16_Stripping28r2p2_BHADRON_MDST.json
+++ b/data/records/LHCb_2016_Beam6500GeV_VeloClosed_MagDown_RealData_Reco16_Stripping28r2p2_BHADRON_MDST.json
@@ -1,0 +1,177 @@
+[{
+  "abstract": {
+    "description": "Data from proton-proton (pp) collisions collected by the LHCb experiment in the year 2016 of Run2 of the LHC."
+  },
+  "accelerator": "CERN-LHC",
+  "collaboration": {
+    "name": "LHCb collaboration",
+    "recid": "456"
+  },
+  "collections": [
+    "LHCb-Collision-Datasets"
+  ],
+  "collision_information": {
+    "energy": "13TeV",
+    "type": "pp"
+  },
+  "date_created": [
+    "2016"
+  ],
+  "date_published": "2026",
+  "date_reprocessed": "2024",
+  "distribution": {
+    "formats": [
+      "MDST"
+    ],
+    "number_events": 2103910109,
+    "number_files": 12334,
+    "size": 42266405361177
+  },
+  "experiment": [
+    "LHCb"
+  ],
+  "magnet_polarity": "MagDown",
+  "methodology": {
+    "description": "<p> This dataset was created in several production steps. These steps, software used and the configuration is provided below. </p><p> <strong> Prod ID: &nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;</strong> 212878<p> <strong>Prod type:&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp; </strong> Merge<p> <strong> Parent Prod ID:&nbsp;&nbsp;&nbsp;&nbsp; </strong> 205601<p> <strong> Parent Prod type: </strong> DataStripping<p> <strong> Conditions: </strong><p>dddb-20220927-2016<p>cond-20191004-1</strong><p> <strong> List of Trigger Configuration Keys (TCK): </strong> </p> <p><p><strong>TCK &nbsp;&nbsp;&nbsp;&nbsp;&nbsp; Number of Files </strong><p>0x11291604 &nbsp;&nbsp;&nbsp;&nbsp;&nbsp; 385<p>0x1138160f &nbsp;&nbsp;&nbsp;&nbsp;&nbsp; 8246<p>0x11291603 &nbsp;&nbsp;&nbsp;&nbsp;&nbsp; 608<p>0x11291605 &nbsp;&nbsp;&nbsp;&nbsp;&nbsp; 1203<p>0x11291600 &nbsp;&nbsp;&nbsp;&nbsp;&nbsp; 209<p>0x1138160e &nbsp;&nbsp;&nbsp;&nbsp;&nbsp; 445<p>0x11371609 &nbsp;&nbsp;&nbsp;&nbsp;&nbsp; 833<p>0x1137160e &nbsp;&nbsp;&nbsp;&nbsp;&nbsp; 297<p>0x11381609 &nbsp;&nbsp;&nbsp;&nbsp;&nbsp; 108",
+    "steps": [
+      {
+        "configuration_files": [
+          {
+            "title": "DaVinci/DV-Stripping28r2p2-Stripping.py"
+          },
+          {
+            "title": "DaVinci/DataType-2016.py"
+          },
+          {
+            "title": "DaVinci/InputType-RDST.py"
+          },
+          {
+            "title": "DaVinci/DV-RawEventJuggler-0_3-to-4_3.py"
+          },
+          {
+            "title": "Persistency/Compression-ZLIB-1.py"
+          },
+          {
+            "title": "DaVinci/DV-RedoCaloPID-Stripping_28_24.py"
+          }
+        ],
+        "release": "DaVinci.v44r11p6 AppConfig.v3r421 Det/SQLDDDB.v7r12 TMVAWeights.v1r18",
+        "type": "Stripping28r2p2_md"
+      },
+      {
+        "configuration_files": [
+          {
+            "title": "Merging/DV-Stripping-Merging.py"
+          },
+          {
+            "title": "Persistency/Compression-LZMA-4.py"
+          }
+        ],
+        "release": "DaVinci.v44r11p6 AppConfig.v3r421 Det/SQLDDDB.v7r12 TMVAWeights.v1r18",
+        "type": "Merge_Stripping28r2p2_md"
+      },
+      {
+        "configuration_files": [
+          {
+            "title": "DaVinci/DV-Stripping28r2p2-Stripping.py"
+          },
+          {
+            "title": "DaVinci/DataType-2016.py"
+          },
+          {
+            "title": "DaVinci/InputType-RDST.py"
+          },
+          {
+            "title": "DaVinci/DV-RawEventJuggler-0_3-to-4_3.py"
+          },
+          {
+            "title": "Persistency/Compression-ZLIB-1.py"
+          },
+          {
+            "title": "DaVinci/DV-RedoCaloPID-Stripping_28_24.py"
+          }
+        ],
+        "release": "DaVinci.v44r11p6 AppConfig.v3r421 Det/SQLDDDB.v7r12 TMVAWeights.v1r18",
+        "type": "Stripping28r2p2_md"
+      },
+      {
+        "configuration_files": [
+          {
+            "title": "Merging/DV-Stripping-Merging.py"
+          },
+          {
+            "title": "Persistency/Compression-LZMA-4.py"
+          }
+        ],
+        "release": "DaVinci.v44r11p6 AppConfig.v3r421 Det/SQLDDDB.v7r12 TMVAWeights.v1r18",
+        "type": "Merge_Stripping28r2p2_md"
+      },
+      {
+        "configuration_files": [
+          {
+            "title": "DaVinci/DV-Stripping28r2p2-Stripping.py"
+          },
+          {
+            "title": "DaVinci/DataType-2016.py"
+          },
+          {
+            "title": "DaVinci/InputType-RDST.py"
+          },
+          {
+            "title": "DaVinci/DV-RawEventJuggler-0_3-to-4_3.py"
+          },
+          {
+            "title": "Persistency/Compression-ZLIB-1.py"
+          },
+          {
+            "title": "DaVinci/DV-RedoCaloPID-Stripping_28_24.py"
+          }
+        ],
+        "release": "DaVinci.v44r11p6 AppConfig.v3r421 Det/SQLDDDB.v7r12 TMVAWeights.v1r18",
+        "type": "Stripping28r2p2_md"
+      },
+      {
+        "configuration_files": [
+          {
+            "title": "Merging/DV-Stripping-Merging.py"
+          },
+          {
+            "title": "Persistency/Compression-LZMA-4.py"
+          }
+        ],
+        "release": "DaVinci.v44r11p6 AppConfig.v3r421 Det/SQLDDDB.v7r12 TMVAWeights.v1r18",
+        "type": "Merge_Stripping28r2p2_md"
+      }
+    ]
+  },
+  "publisher": "CERN Open Data Portal",
+  "recid": "24684",
+  "run_period": [
+    "2016"
+  ],
+  "stripping": {
+    "stream": "BHADRON",
+    "version": "stripping28r2p2"
+  },
+  "title": "LHCb 2016 Beam6500GeV MagDown BHADRON Stream Stripping28r2p2",
+  "title_additional": "",
+  "type": {
+    "primary": "Dataset",
+    "secondary": [
+      "Collision"
+    ]
+  },
+  "usage": {
+    "description": "<p> The Run 1 and 2 data collected by the LHCb detector is available using the LHCb Ntupling Service, while the Run 1 data is additionally available in .DST and .mDST formats. The data obtained from the LHCb Ntupling Service are ROOT ntuples and do not require custom software to analyze. <p> Links are provided to the LHCb Ntupling Service for exploration of available data and the LHCb Open Data Guide for usage instructions.",
+    "links": [
+      {
+        "description": "LHCb Ntupling Service",
+        "url": "https://opendata-lhcb-ntupling-service.app.cern.ch/"
+      },
+      {
+        "description": "LHCb Open Data Guide",
+        "url": "https://lhcb-opendata-guide.web.cern.ch/"
+      }
+    ]
+  }
+}]

--- a/data/records/LHCb_2016_Beam6500GeV_VeloClosed_MagDown_RealData_Reco16_Stripping28r2p2_CHARMCOMPLETEEVENT_DST.json
+++ b/data/records/LHCb_2016_Beam6500GeV_VeloClosed_MagDown_RealData_Reco16_Stripping28r2p2_CHARMCOMPLETEEVENT_DST.json
@@ -1,0 +1,177 @@
+[{
+  "abstract": {
+    "description": "Data from proton-proton (pp) collisions collected by the LHCb experiment in the year 2016 of Run2 of the LHC."
+  },
+  "accelerator": "CERN-LHC",
+  "collaboration": {
+    "name": "LHCb collaboration",
+    "recid": "456"
+  },
+  "collections": [
+    "LHCb-Collision-Datasets"
+  ],
+  "collision_information": {
+    "energy": "13TeV",
+    "type": "pp"
+  },
+  "date_created": [
+    "2016"
+  ],
+  "date_published": "2026",
+  "date_reprocessed": "2024",
+  "distribution": {
+    "formats": [
+      "DST"
+    ],
+    "number_events": 147270739,
+    "number_files": 5828,
+    "size": 12578885925972
+  },
+  "experiment": [
+    "LHCb"
+  ],
+  "magnet_polarity": "MagDown",
+  "methodology": {
+    "description": "<p> This dataset was created in several production steps. These steps, software used and the configuration is provided below. </p><p> <strong> Prod ID: &nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;</strong> 212878<p> <strong>Prod type:&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp; </strong> Merge<p> <strong> Parent Prod ID:&nbsp;&nbsp;&nbsp;&nbsp; </strong> 205601<p> <strong> Parent Prod type: </strong> DataStripping<p> <strong> Conditions: </strong><p>dddb-20220927-2016<p>cond-20191004-1</strong><p> <strong> List of Trigger Configuration Keys (TCK): </strong> </p> <p><p><strong>TCK &nbsp;&nbsp;&nbsp;&nbsp;&nbsp; Number of Files </strong><p>0x11291604 &nbsp;&nbsp;&nbsp;&nbsp;&nbsp; 194<p>0x1138160f &nbsp;&nbsp;&nbsp;&nbsp;&nbsp; 3684<p>0x11291605 &nbsp;&nbsp;&nbsp;&nbsp;&nbsp; 666<p>0x11291603 &nbsp;&nbsp;&nbsp;&nbsp;&nbsp; 335<p>0x11291600 &nbsp;&nbsp;&nbsp;&nbsp;&nbsp; 174<p>0x11371609 &nbsp;&nbsp;&nbsp;&nbsp;&nbsp; 387<p>0x1137160e &nbsp;&nbsp;&nbsp;&nbsp;&nbsp; 128<p>0x1138160e &nbsp;&nbsp;&nbsp;&nbsp;&nbsp; 204<p>0x11381609 &nbsp;&nbsp;&nbsp;&nbsp;&nbsp; 56",
+    "steps": [
+      {
+        "configuration_files": [
+          {
+            "title": "DaVinci/DV-Stripping28r2p2-Stripping.py"
+          },
+          {
+            "title": "DaVinci/DataType-2016.py"
+          },
+          {
+            "title": "DaVinci/InputType-RDST.py"
+          },
+          {
+            "title": "DaVinci/DV-RawEventJuggler-0_3-to-4_3.py"
+          },
+          {
+            "title": "Persistency/Compression-ZLIB-1.py"
+          },
+          {
+            "title": "DaVinci/DV-RedoCaloPID-Stripping_28_24.py"
+          }
+        ],
+        "release": "DaVinci.v44r11p6 AppConfig.v3r421 Det/SQLDDDB.v7r12 TMVAWeights.v1r18",
+        "type": "Stripping28r2p2_md"
+      },
+      {
+        "configuration_files": [
+          {
+            "title": "Merging/DV-Stripping-Merging.py"
+          },
+          {
+            "title": "Persistency/Compression-LZMA-4.py"
+          }
+        ],
+        "release": "DaVinci.v44r11p6 AppConfig.v3r421 Det/SQLDDDB.v7r12 TMVAWeights.v1r18",
+        "type": "Merge_Stripping28r2p2_md"
+      },
+      {
+        "configuration_files": [
+          {
+            "title": "DaVinci/DV-Stripping28r2p2-Stripping.py"
+          },
+          {
+            "title": "DaVinci/DataType-2016.py"
+          },
+          {
+            "title": "DaVinci/InputType-RDST.py"
+          },
+          {
+            "title": "DaVinci/DV-RawEventJuggler-0_3-to-4_3.py"
+          },
+          {
+            "title": "Persistency/Compression-ZLIB-1.py"
+          },
+          {
+            "title": "DaVinci/DV-RedoCaloPID-Stripping_28_24.py"
+          }
+        ],
+        "release": "DaVinci.v44r11p6 AppConfig.v3r421 Det/SQLDDDB.v7r12 TMVAWeights.v1r18",
+        "type": "Stripping28r2p2_md"
+      },
+      {
+        "configuration_files": [
+          {
+            "title": "Merging/DV-Stripping-Merging.py"
+          },
+          {
+            "title": "Persistency/Compression-LZMA-4.py"
+          }
+        ],
+        "release": "DaVinci.v44r11p6 AppConfig.v3r421 Det/SQLDDDB.v7r12 TMVAWeights.v1r18",
+        "type": "Merge_Stripping28r2p2_md"
+      },
+      {
+        "configuration_files": [
+          {
+            "title": "DaVinci/DV-Stripping28r2p2-Stripping.py"
+          },
+          {
+            "title": "DaVinci/DataType-2016.py"
+          },
+          {
+            "title": "DaVinci/InputType-RDST.py"
+          },
+          {
+            "title": "DaVinci/DV-RawEventJuggler-0_3-to-4_3.py"
+          },
+          {
+            "title": "Persistency/Compression-ZLIB-1.py"
+          },
+          {
+            "title": "DaVinci/DV-RedoCaloPID-Stripping_28_24.py"
+          }
+        ],
+        "release": "DaVinci.v44r11p6 AppConfig.v3r421 Det/SQLDDDB.v7r12 TMVAWeights.v1r18",
+        "type": "Stripping28r2p2_md"
+      },
+      {
+        "configuration_files": [
+          {
+            "title": "Merging/DV-Stripping-Merging.py"
+          },
+          {
+            "title": "Persistency/Compression-LZMA-4.py"
+          }
+        ],
+        "release": "DaVinci.v44r11p6 AppConfig.v3r421 Det/SQLDDDB.v7r12 TMVAWeights.v1r18",
+        "type": "Merge_Stripping28r2p2_md"
+      }
+    ]
+  },
+  "publisher": "CERN Open Data Portal",
+  "recid": "24687",
+  "run_period": [
+    "2016"
+  ],
+  "stripping": {
+    "stream": "CHARMCOMPLETEEVENT",
+    "version": "stripping28r2p2"
+  },
+  "title": "LHCb 2016 Beam6500GeV MagDown CHARMCOMPLETEEVENT Stream Stripping28r2p2",
+  "title_additional": "",
+  "type": {
+    "primary": "Dataset",
+    "secondary": [
+      "Collision"
+    ]
+  },
+  "usage": {
+    "description": "<p> The Run 1 and 2 data collected by the LHCb detector is available using the LHCb Ntupling Service, while the Run 1 data is additionally available in .DST and .mDST formats. The data obtained from the LHCb Ntupling Service are ROOT ntuples and do not require custom software to analyze. <p> Links are provided to the LHCb Ntupling Service for exploration of available data and the LHCb Open Data Guide for usage instructions.",
+    "links": [
+      {
+        "description": "LHCb Ntupling Service",
+        "url": "https://opendata-lhcb-ntupling-service.app.cern.ch/"
+      },
+      {
+        "description": "LHCb Open Data Guide",
+        "url": "https://lhcb-opendata-guide.web.cern.ch/"
+      }
+    ]
+  }
+}]

--- a/data/records/LHCb_2016_Beam6500GeV_VeloClosed_MagDown_RealData_Reco16_Stripping28r2p2_CHARM_MDST.json
+++ b/data/records/LHCb_2016_Beam6500GeV_VeloClosed_MagDown_RealData_Reco16_Stripping28r2p2_CHARM_MDST.json
@@ -1,0 +1,177 @@
+[{
+  "abstract": {
+    "description": "Data from proton-proton (pp) collisions collected by the LHCb experiment in the year 2016 of Run2 of the LHC."
+  },
+  "accelerator": "CERN-LHC",
+  "collaboration": {
+    "name": "LHCb collaboration",
+    "recid": "456"
+  },
+  "collections": [
+    "LHCb-Collision-Datasets"
+  ],
+  "collision_information": {
+    "energy": "13TeV",
+    "type": "pp"
+  },
+  "date_created": [
+    "2016"
+  ],
+  "date_published": "2026",
+  "date_reprocessed": "2024",
+  "distribution": {
+    "formats": [
+      "MDST"
+    ],
+    "number_events": 2208939726,
+    "number_files": 8472,
+    "size": 28409882628092
+  },
+  "experiment": [
+    "LHCb"
+  ],
+  "magnet_polarity": "MagDown",
+  "methodology": {
+    "description": "<p> This dataset was created in several production steps. These steps, software used and the configuration is provided below. </p><p> <strong> Prod ID: &nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;</strong> 212878<p> <strong>Prod type:&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp; </strong> Merge<p> <strong> Parent Prod ID:&nbsp;&nbsp;&nbsp;&nbsp; </strong> 205601<p> <strong> Parent Prod type: </strong> DataStripping<p> <strong> Conditions: </strong><p>dddb-20220927-2016<p>cond-20191004-1</strong><p> <strong> List of Trigger Configuration Keys (TCK): </strong> </p> <p><p><strong>TCK &nbsp;&nbsp;&nbsp;&nbsp;&nbsp; Number of Files </strong><p>0x1138160f &nbsp;&nbsp;&nbsp;&nbsp;&nbsp; 5551<p>0x11371609 &nbsp;&nbsp;&nbsp;&nbsp;&nbsp; 553<p>0x11291600 &nbsp;&nbsp;&nbsp;&nbsp;&nbsp; 181<p>0x11291603 &nbsp;&nbsp;&nbsp;&nbsp;&nbsp; 440<p>0x11291605 &nbsp;&nbsp;&nbsp;&nbsp;&nbsp; 893<p>0x11291604 &nbsp;&nbsp;&nbsp;&nbsp;&nbsp; 276<p>0x1138160e &nbsp;&nbsp;&nbsp;&nbsp;&nbsp; 306<p>0x1137160e &nbsp;&nbsp;&nbsp;&nbsp;&nbsp; 193<p>0x11381609 &nbsp;&nbsp;&nbsp;&nbsp;&nbsp; 79",
+    "steps": [
+      {
+        "configuration_files": [
+          {
+            "title": "DaVinci/DV-Stripping28r2p2-Stripping.py"
+          },
+          {
+            "title": "DaVinci/DataType-2016.py"
+          },
+          {
+            "title": "DaVinci/InputType-RDST.py"
+          },
+          {
+            "title": "DaVinci/DV-RawEventJuggler-0_3-to-4_3.py"
+          },
+          {
+            "title": "Persistency/Compression-ZLIB-1.py"
+          },
+          {
+            "title": "DaVinci/DV-RedoCaloPID-Stripping_28_24.py"
+          }
+        ],
+        "release": "DaVinci.v44r11p6 AppConfig.v3r421 Det/SQLDDDB.v7r12 TMVAWeights.v1r18",
+        "type": "Stripping28r2p2_md"
+      },
+      {
+        "configuration_files": [
+          {
+            "title": "Merging/DV-Stripping-Merging.py"
+          },
+          {
+            "title": "Persistency/Compression-LZMA-4.py"
+          }
+        ],
+        "release": "DaVinci.v44r11p6 AppConfig.v3r421 Det/SQLDDDB.v7r12 TMVAWeights.v1r18",
+        "type": "Merge_Stripping28r2p2_md"
+      },
+      {
+        "configuration_files": [
+          {
+            "title": "DaVinci/DV-Stripping28r2p2-Stripping.py"
+          },
+          {
+            "title": "DaVinci/DataType-2016.py"
+          },
+          {
+            "title": "DaVinci/InputType-RDST.py"
+          },
+          {
+            "title": "DaVinci/DV-RawEventJuggler-0_3-to-4_3.py"
+          },
+          {
+            "title": "Persistency/Compression-ZLIB-1.py"
+          },
+          {
+            "title": "DaVinci/DV-RedoCaloPID-Stripping_28_24.py"
+          }
+        ],
+        "release": "DaVinci.v44r11p6 AppConfig.v3r421 Det/SQLDDDB.v7r12 TMVAWeights.v1r18",
+        "type": "Stripping28r2p2_md"
+      },
+      {
+        "configuration_files": [
+          {
+            "title": "Merging/DV-Stripping-Merging.py"
+          },
+          {
+            "title": "Persistency/Compression-LZMA-4.py"
+          }
+        ],
+        "release": "DaVinci.v44r11p6 AppConfig.v3r421 Det/SQLDDDB.v7r12 TMVAWeights.v1r18",
+        "type": "Merge_Stripping28r2p2_md"
+      },
+      {
+        "configuration_files": [
+          {
+            "title": "DaVinci/DV-Stripping28r2p2-Stripping.py"
+          },
+          {
+            "title": "DaVinci/DataType-2016.py"
+          },
+          {
+            "title": "DaVinci/InputType-RDST.py"
+          },
+          {
+            "title": "DaVinci/DV-RawEventJuggler-0_3-to-4_3.py"
+          },
+          {
+            "title": "Persistency/Compression-ZLIB-1.py"
+          },
+          {
+            "title": "DaVinci/DV-RedoCaloPID-Stripping_28_24.py"
+          }
+        ],
+        "release": "DaVinci.v44r11p6 AppConfig.v3r421 Det/SQLDDDB.v7r12 TMVAWeights.v1r18",
+        "type": "Stripping28r2p2_md"
+      },
+      {
+        "configuration_files": [
+          {
+            "title": "Merging/DV-Stripping-Merging.py"
+          },
+          {
+            "title": "Persistency/Compression-LZMA-4.py"
+          }
+        ],
+        "release": "DaVinci.v44r11p6 AppConfig.v3r421 Det/SQLDDDB.v7r12 TMVAWeights.v1r18",
+        "type": "Merge_Stripping28r2p2_md"
+      }
+    ]
+  },
+  "publisher": "CERN Open Data Portal",
+  "recid": "24686",
+  "run_period": [
+    "2016"
+  ],
+  "stripping": {
+    "stream": "CHARM",
+    "version": "stripping28r2p2"
+  },
+  "title": "LHCb 2016 Beam6500GeV MagDown CHARM Stream Stripping28r2p2",
+  "title_additional": "",
+  "type": {
+    "primary": "Dataset",
+    "secondary": [
+      "Collision"
+    ]
+  },
+  "usage": {
+    "description": "<p> The Run 1 and 2 data collected by the LHCb detector is available using the LHCb Ntupling Service, while the Run 1 data is additionally available in .DST and .mDST formats. The data obtained from the LHCb Ntupling Service are ROOT ntuples and do not require custom software to analyze. <p> Links are provided to the LHCb Ntupling Service for exploration of available data and the LHCb Open Data Guide for usage instructions.",
+    "links": [
+      {
+        "description": "LHCb Ntupling Service",
+        "url": "https://opendata-lhcb-ntupling-service.app.cern.ch/"
+      },
+      {
+        "description": "LHCb Open Data Guide",
+        "url": "https://lhcb-opendata-guide.web.cern.ch/"
+      }
+    ]
+  }
+}]

--- a/data/records/LHCb_2016_Beam6500GeV_VeloClosed_MagDown_RealData_Reco16_Stripping28r2p2_DIMUON_DST.json
+++ b/data/records/LHCb_2016_Beam6500GeV_VeloClosed_MagDown_RealData_Reco16_Stripping28r2p2_DIMUON_DST.json
@@ -1,0 +1,177 @@
+[{
+  "abstract": {
+    "description": "Data from proton-proton (pp) collisions collected by the LHCb experiment in the year 2016 of Run2 of the LHC."
+  },
+  "accelerator": "CERN-LHC",
+  "collaboration": {
+    "name": "LHCb collaboration",
+    "recid": "456"
+  },
+  "collections": [
+    "LHCb-Collision-Datasets"
+  ],
+  "collision_information": {
+    "energy": "13TeV",
+    "type": "pp"
+  },
+  "date_created": [
+    "2016"
+  ],
+  "date_published": "2026",
+  "date_reprocessed": "2024",
+  "distribution": {
+    "formats": [
+      "DST"
+    ],
+    "number_events": 105990750,
+    "number_files": 5818,
+    "size": 13688274289847
+  },
+  "experiment": [
+    "LHCb"
+  ],
+  "magnet_polarity": "MagDown",
+  "methodology": {
+    "description": "<p> This dataset was created in several production steps. These steps, software used and the configuration is provided below. </p><p> <strong> Prod ID: &nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;</strong> 212878<p> <strong>Prod type:&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp; </strong> Merge<p> <strong> Parent Prod ID:&nbsp;&nbsp;&nbsp;&nbsp; </strong> 205601<p> <strong> Parent Prod type: </strong> DataStripping<p> <strong> Conditions: </strong><p>dddb-20220927-2016<p>cond-20191004-1</strong><p> <strong> List of Trigger Configuration Keys (TCK): </strong> </p> <p><p><strong>TCK &nbsp;&nbsp;&nbsp;&nbsp;&nbsp; Number of Files </strong><p>0x1137160e &nbsp;&nbsp;&nbsp;&nbsp;&nbsp; 128<p>0x11371609 &nbsp;&nbsp;&nbsp;&nbsp;&nbsp; 389<p>0x1138160f &nbsp;&nbsp;&nbsp;&nbsp;&nbsp; 3675<p>0x11291603 &nbsp;&nbsp;&nbsp;&nbsp;&nbsp; 336<p>0x11291604 &nbsp;&nbsp;&nbsp;&nbsp;&nbsp; 193<p>0x11291605 &nbsp;&nbsp;&nbsp;&nbsp;&nbsp; 665<p>0x11291600 &nbsp;&nbsp;&nbsp;&nbsp;&nbsp; 172<p>0x1138160e &nbsp;&nbsp;&nbsp;&nbsp;&nbsp; 204<p>0x11381609 &nbsp;&nbsp;&nbsp;&nbsp;&nbsp; 56",
+    "steps": [
+      {
+        "configuration_files": [
+          {
+            "title": "DaVinci/DV-Stripping28r2p2-Stripping.py"
+          },
+          {
+            "title": "DaVinci/DataType-2016.py"
+          },
+          {
+            "title": "DaVinci/InputType-RDST.py"
+          },
+          {
+            "title": "DaVinci/DV-RawEventJuggler-0_3-to-4_3.py"
+          },
+          {
+            "title": "Persistency/Compression-ZLIB-1.py"
+          },
+          {
+            "title": "DaVinci/DV-RedoCaloPID-Stripping_28_24.py"
+          }
+        ],
+        "release": "DaVinci.v44r11p6 AppConfig.v3r421 Det/SQLDDDB.v7r12 TMVAWeights.v1r18",
+        "type": "Stripping28r2p2_md"
+      },
+      {
+        "configuration_files": [
+          {
+            "title": "Merging/DV-Stripping-Merging.py"
+          },
+          {
+            "title": "Persistency/Compression-LZMA-4.py"
+          }
+        ],
+        "release": "DaVinci.v44r11p6 AppConfig.v3r421 Det/SQLDDDB.v7r12 TMVAWeights.v1r18",
+        "type": "Merge_Stripping28r2p2_md"
+      },
+      {
+        "configuration_files": [
+          {
+            "title": "DaVinci/DV-Stripping28r2p2-Stripping.py"
+          },
+          {
+            "title": "DaVinci/DataType-2016.py"
+          },
+          {
+            "title": "DaVinci/InputType-RDST.py"
+          },
+          {
+            "title": "DaVinci/DV-RawEventJuggler-0_3-to-4_3.py"
+          },
+          {
+            "title": "Persistency/Compression-ZLIB-1.py"
+          },
+          {
+            "title": "DaVinci/DV-RedoCaloPID-Stripping_28_24.py"
+          }
+        ],
+        "release": "DaVinci.v44r11p6 AppConfig.v3r421 Det/SQLDDDB.v7r12 TMVAWeights.v1r18",
+        "type": "Stripping28r2p2_md"
+      },
+      {
+        "configuration_files": [
+          {
+            "title": "Merging/DV-Stripping-Merging.py"
+          },
+          {
+            "title": "Persistency/Compression-LZMA-4.py"
+          }
+        ],
+        "release": "DaVinci.v44r11p6 AppConfig.v3r421 Det/SQLDDDB.v7r12 TMVAWeights.v1r18",
+        "type": "Merge_Stripping28r2p2_md"
+      },
+      {
+        "configuration_files": [
+          {
+            "title": "DaVinci/DV-Stripping28r2p2-Stripping.py"
+          },
+          {
+            "title": "DaVinci/DataType-2016.py"
+          },
+          {
+            "title": "DaVinci/InputType-RDST.py"
+          },
+          {
+            "title": "DaVinci/DV-RawEventJuggler-0_3-to-4_3.py"
+          },
+          {
+            "title": "Persistency/Compression-ZLIB-1.py"
+          },
+          {
+            "title": "DaVinci/DV-RedoCaloPID-Stripping_28_24.py"
+          }
+        ],
+        "release": "DaVinci.v44r11p6 AppConfig.v3r421 Det/SQLDDDB.v7r12 TMVAWeights.v1r18",
+        "type": "Stripping28r2p2_md"
+      },
+      {
+        "configuration_files": [
+          {
+            "title": "Merging/DV-Stripping-Merging.py"
+          },
+          {
+            "title": "Persistency/Compression-LZMA-4.py"
+          }
+        ],
+        "release": "DaVinci.v44r11p6 AppConfig.v3r421 Det/SQLDDDB.v7r12 TMVAWeights.v1r18",
+        "type": "Merge_Stripping28r2p2_md"
+      }
+    ]
+  },
+  "publisher": "CERN Open Data Portal",
+  "recid": "24688",
+  "run_period": [
+    "2016"
+  ],
+  "stripping": {
+    "stream": "DIMUON",
+    "version": "stripping28r2p2"
+  },
+  "title": "LHCb 2016 Beam6500GeV MagDown DIMUON Stream Stripping28r2p2",
+  "title_additional": "",
+  "type": {
+    "primary": "Dataset",
+    "secondary": [
+      "Collision"
+    ]
+  },
+  "usage": {
+    "description": "<p> The Run 1 and 2 data collected by the LHCb detector is available using the LHCb Ntupling Service, while the Run 1 data is additionally available in .DST and .mDST formats. The data obtained from the LHCb Ntupling Service are ROOT ntuples and do not require custom software to analyze. <p> Links are provided to the LHCb Ntupling Service for exploration of available data and the LHCb Open Data Guide for usage instructions.",
+    "links": [
+      {
+        "description": "LHCb Ntupling Service",
+        "url": "https://opendata-lhcb-ntupling-service.app.cern.ch/"
+      },
+      {
+        "description": "LHCb Open Data Guide",
+        "url": "https://lhcb-opendata-guide.web.cern.ch/"
+      }
+    ]
+  }
+}]

--- a/data/records/LHCb_2016_Beam6500GeV_VeloClosed_MagDown_RealData_Reco16_Stripping28r2p2_EW_DST.json
+++ b/data/records/LHCb_2016_Beam6500GeV_VeloClosed_MagDown_RealData_Reco16_Stripping28r2p2_EW_DST.json
@@ -1,0 +1,177 @@
+[{
+  "abstract": {
+    "description": "Data from proton-proton (pp) collisions collected by the LHCb experiment in the year 2016 of Run2 of the LHC."
+  },
+  "accelerator": "CERN-LHC",
+  "collaboration": {
+    "name": "LHCb collaboration",
+    "recid": "456"
+  },
+  "collections": [
+    "LHCb-Collision-Datasets"
+  ],
+  "collision_information": {
+    "energy": "13TeV",
+    "type": "pp"
+  },
+  "date_created": [
+    "2016"
+  ],
+  "date_published": "2026",
+  "date_reprocessed": "2024",
+  "distribution": {
+    "formats": [
+      "DST"
+    ],
+    "number_events": 60688583,
+    "number_files": 5832,
+    "size": 3881892297974
+  },
+  "experiment": [
+    "LHCb"
+  ],
+  "magnet_polarity": "MagDown",
+  "methodology": {
+    "description": "<p> This dataset was created in several production steps. These steps, software used and the configuration is provided below. </p><p> <strong> Prod ID: &nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;</strong> 212878<p> <strong>Prod type:&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp; </strong> Merge<p> <strong> Parent Prod ID:&nbsp;&nbsp;&nbsp;&nbsp; </strong> 205601<p> <strong> Parent Prod type: </strong> DataStripping<p> <strong> Conditions: </strong><p>dddb-20220927-2016<p>cond-20191004-1</strong><p> <strong> List of Trigger Configuration Keys (TCK): </strong> </p> <p><p><strong>TCK &nbsp;&nbsp;&nbsp;&nbsp;&nbsp; Number of Files </strong><p>0x1138160f &nbsp;&nbsp;&nbsp;&nbsp;&nbsp; 3685<p>0x11371609 &nbsp;&nbsp;&nbsp;&nbsp;&nbsp; 387<p>0x11291604 &nbsp;&nbsp;&nbsp;&nbsp;&nbsp; 194<p>0x11291605 &nbsp;&nbsp;&nbsp;&nbsp;&nbsp; 666<p>0x11291603 &nbsp;&nbsp;&nbsp;&nbsp;&nbsp; 340<p>0x11291600 &nbsp;&nbsp;&nbsp;&nbsp;&nbsp; 172<p>0x1137160e &nbsp;&nbsp;&nbsp;&nbsp;&nbsp; 128<p>0x1138160e &nbsp;&nbsp;&nbsp;&nbsp;&nbsp; 204<p>0x11381609 &nbsp;&nbsp;&nbsp;&nbsp;&nbsp; 56",
+    "steps": [
+      {
+        "configuration_files": [
+          {
+            "title": "DaVinci/DV-Stripping28r2p2-Stripping.py"
+          },
+          {
+            "title": "DaVinci/DataType-2016.py"
+          },
+          {
+            "title": "DaVinci/InputType-RDST.py"
+          },
+          {
+            "title": "DaVinci/DV-RawEventJuggler-0_3-to-4_3.py"
+          },
+          {
+            "title": "Persistency/Compression-ZLIB-1.py"
+          },
+          {
+            "title": "DaVinci/DV-RedoCaloPID-Stripping_28_24.py"
+          }
+        ],
+        "release": "DaVinci.v44r11p6 AppConfig.v3r421 Det/SQLDDDB.v7r12 TMVAWeights.v1r18",
+        "type": "Stripping28r2p2_md"
+      },
+      {
+        "configuration_files": [
+          {
+            "title": "Merging/DV-Stripping-Merging.py"
+          },
+          {
+            "title": "Persistency/Compression-LZMA-4.py"
+          }
+        ],
+        "release": "DaVinci.v44r11p6 AppConfig.v3r421 Det/SQLDDDB.v7r12 TMVAWeights.v1r18",
+        "type": "Merge_Stripping28r2p2_md"
+      },
+      {
+        "configuration_files": [
+          {
+            "title": "DaVinci/DV-Stripping28r2p2-Stripping.py"
+          },
+          {
+            "title": "DaVinci/DataType-2016.py"
+          },
+          {
+            "title": "DaVinci/InputType-RDST.py"
+          },
+          {
+            "title": "DaVinci/DV-RawEventJuggler-0_3-to-4_3.py"
+          },
+          {
+            "title": "Persistency/Compression-ZLIB-1.py"
+          },
+          {
+            "title": "DaVinci/DV-RedoCaloPID-Stripping_28_24.py"
+          }
+        ],
+        "release": "DaVinci.v44r11p6 AppConfig.v3r421 Det/SQLDDDB.v7r12 TMVAWeights.v1r18",
+        "type": "Stripping28r2p2_md"
+      },
+      {
+        "configuration_files": [
+          {
+            "title": "Merging/DV-Stripping-Merging.py"
+          },
+          {
+            "title": "Persistency/Compression-LZMA-4.py"
+          }
+        ],
+        "release": "DaVinci.v44r11p6 AppConfig.v3r421 Det/SQLDDDB.v7r12 TMVAWeights.v1r18",
+        "type": "Merge_Stripping28r2p2_md"
+      },
+      {
+        "configuration_files": [
+          {
+            "title": "DaVinci/DV-Stripping28r2p2-Stripping.py"
+          },
+          {
+            "title": "DaVinci/DataType-2016.py"
+          },
+          {
+            "title": "DaVinci/InputType-RDST.py"
+          },
+          {
+            "title": "DaVinci/DV-RawEventJuggler-0_3-to-4_3.py"
+          },
+          {
+            "title": "Persistency/Compression-ZLIB-1.py"
+          },
+          {
+            "title": "DaVinci/DV-RedoCaloPID-Stripping_28_24.py"
+          }
+        ],
+        "release": "DaVinci.v44r11p6 AppConfig.v3r421 Det/SQLDDDB.v7r12 TMVAWeights.v1r18",
+        "type": "Stripping28r2p2_md"
+      },
+      {
+        "configuration_files": [
+          {
+            "title": "Merging/DV-Stripping-Merging.py"
+          },
+          {
+            "title": "Persistency/Compression-LZMA-4.py"
+          }
+        ],
+        "release": "DaVinci.v44r11p6 AppConfig.v3r421 Det/SQLDDDB.v7r12 TMVAWeights.v1r18",
+        "type": "Merge_Stripping28r2p2_md"
+      }
+    ]
+  },
+  "publisher": "CERN Open Data Portal",
+  "recid": "24680",
+  "run_period": [
+    "2016"
+  ],
+  "stripping": {
+    "stream": "EW",
+    "version": "stripping28r2p2"
+  },
+  "title": "LHCb 2016 Beam6500GeV MagDown EW Stream Stripping28r2p2",
+  "title_additional": "",
+  "type": {
+    "primary": "Dataset",
+    "secondary": [
+      "Collision"
+    ]
+  },
+  "usage": {
+    "description": "<p> The Run 1 and 2 data collected by the LHCb detector is available using the LHCb Ntupling Service, while the Run 1 data is additionally available in .DST and .mDST formats. The data obtained from the LHCb Ntupling Service are ROOT ntuples and do not require custom software to analyze. <p> Links are provided to the LHCb Ntupling Service for exploration of available data and the LHCb Open Data Guide for usage instructions.",
+    "links": [
+      {
+        "description": "LHCb Ntupling Service",
+        "url": "https://opendata-lhcb-ntupling-service.app.cern.ch/"
+      },
+      {
+        "description": "LHCb Open Data Guide",
+        "url": "https://lhcb-opendata-guide.web.cern.ch/"
+      }
+    ]
+  }
+}]

--- a/data/records/LHCb_2016_Beam6500GeV_VeloClosed_MagDown_RealData_Reco16_Stripping28r2p2_LEPTONIC_MDST.json
+++ b/data/records/LHCb_2016_Beam6500GeV_VeloClosed_MagDown_RealData_Reco16_Stripping28r2p2_LEPTONIC_MDST.json
@@ -1,0 +1,177 @@
+[{
+  "abstract": {
+    "description": "Data from proton-proton (pp) collisions collected by the LHCb experiment in the year 2016 of Run2 of the LHC."
+  },
+  "accelerator": "CERN-LHC",
+  "collaboration": {
+    "name": "LHCb collaboration",
+    "recid": "456"
+  },
+  "collections": [
+    "LHCb-Collision-Datasets"
+  ],
+  "collision_information": {
+    "energy": "13TeV",
+    "type": "pp"
+  },
+  "date_created": [
+    "2016"
+  ],
+  "date_published": "2026",
+  "date_reprocessed": "2024",
+  "distribution": {
+    "formats": [
+      "MDST"
+    ],
+    "number_events": 2078916032,
+    "number_files": 13347,
+    "size": 51560174096326
+  },
+  "experiment": [
+    "LHCb"
+  ],
+  "magnet_polarity": "MagDown",
+  "methodology": {
+    "description": "<p> This dataset was created in several production steps. These steps, software used and the configuration is provided below. </p><p> <strong> Prod ID: &nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;</strong> 212878<p> <strong>Prod type:&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp; </strong> Merge<p> <strong> Parent Prod ID:&nbsp;&nbsp;&nbsp;&nbsp; </strong> 205601<p> <strong> Parent Prod type: </strong> DataStripping<p> <strong> Conditions: </strong><p>dddb-20220927-2016<p>cond-20191004-1</strong><p> <strong> List of Trigger Configuration Keys (TCK): </strong> </p> <p><p><strong>TCK &nbsp;&nbsp;&nbsp;&nbsp;&nbsp; Number of Files </strong><p>0x1138160f &nbsp;&nbsp;&nbsp;&nbsp;&nbsp; 8720<p>0x11371609 &nbsp;&nbsp;&nbsp;&nbsp;&nbsp; 905<p>0x11291603 &nbsp;&nbsp;&nbsp;&nbsp;&nbsp; 675<p>0x11291600 &nbsp;&nbsp;&nbsp;&nbsp;&nbsp; 216<p>0x11291605 &nbsp;&nbsp;&nbsp;&nbsp;&nbsp; 1444<p>0x11291604 &nbsp;&nbsp;&nbsp;&nbsp;&nbsp; 461<p>0x1138160e &nbsp;&nbsp;&nbsp;&nbsp;&nbsp; 487<p>0x1137160e &nbsp;&nbsp;&nbsp;&nbsp;&nbsp; 322<p>0x11381609 &nbsp;&nbsp;&nbsp;&nbsp;&nbsp; 117",
+    "steps": [
+      {
+        "configuration_files": [
+          {
+            "title": "DaVinci/DV-Stripping28r2p2-Stripping.py"
+          },
+          {
+            "title": "DaVinci/DataType-2016.py"
+          },
+          {
+            "title": "DaVinci/InputType-RDST.py"
+          },
+          {
+            "title": "DaVinci/DV-RawEventJuggler-0_3-to-4_3.py"
+          },
+          {
+            "title": "Persistency/Compression-ZLIB-1.py"
+          },
+          {
+            "title": "DaVinci/DV-RedoCaloPID-Stripping_28_24.py"
+          }
+        ],
+        "release": "DaVinci.v44r11p6 AppConfig.v3r421 Det/SQLDDDB.v7r12 TMVAWeights.v1r18",
+        "type": "Stripping28r2p2_md"
+      },
+      {
+        "configuration_files": [
+          {
+            "title": "Merging/DV-Stripping-Merging.py"
+          },
+          {
+            "title": "Persistency/Compression-LZMA-4.py"
+          }
+        ],
+        "release": "DaVinci.v44r11p6 AppConfig.v3r421 Det/SQLDDDB.v7r12 TMVAWeights.v1r18",
+        "type": "Merge_Stripping28r2p2_md"
+      },
+      {
+        "configuration_files": [
+          {
+            "title": "DaVinci/DV-Stripping28r2p2-Stripping.py"
+          },
+          {
+            "title": "DaVinci/DataType-2016.py"
+          },
+          {
+            "title": "DaVinci/InputType-RDST.py"
+          },
+          {
+            "title": "DaVinci/DV-RawEventJuggler-0_3-to-4_3.py"
+          },
+          {
+            "title": "Persistency/Compression-ZLIB-1.py"
+          },
+          {
+            "title": "DaVinci/DV-RedoCaloPID-Stripping_28_24.py"
+          }
+        ],
+        "release": "DaVinci.v44r11p6 AppConfig.v3r421 Det/SQLDDDB.v7r12 TMVAWeights.v1r18",
+        "type": "Stripping28r2p2_md"
+      },
+      {
+        "configuration_files": [
+          {
+            "title": "Merging/DV-Stripping-Merging.py"
+          },
+          {
+            "title": "Persistency/Compression-LZMA-4.py"
+          }
+        ],
+        "release": "DaVinci.v44r11p6 AppConfig.v3r421 Det/SQLDDDB.v7r12 TMVAWeights.v1r18",
+        "type": "Merge_Stripping28r2p2_md"
+      },
+      {
+        "configuration_files": [
+          {
+            "title": "DaVinci/DV-Stripping28r2p2-Stripping.py"
+          },
+          {
+            "title": "DaVinci/DataType-2016.py"
+          },
+          {
+            "title": "DaVinci/InputType-RDST.py"
+          },
+          {
+            "title": "DaVinci/DV-RawEventJuggler-0_3-to-4_3.py"
+          },
+          {
+            "title": "Persistency/Compression-ZLIB-1.py"
+          },
+          {
+            "title": "DaVinci/DV-RedoCaloPID-Stripping_28_24.py"
+          }
+        ],
+        "release": "DaVinci.v44r11p6 AppConfig.v3r421 Det/SQLDDDB.v7r12 TMVAWeights.v1r18",
+        "type": "Stripping28r2p2_md"
+      },
+      {
+        "configuration_files": [
+          {
+            "title": "Merging/DV-Stripping-Merging.py"
+          },
+          {
+            "title": "Persistency/Compression-LZMA-4.py"
+          }
+        ],
+        "release": "DaVinci.v44r11p6 AppConfig.v3r421 Det/SQLDDDB.v7r12 TMVAWeights.v1r18",
+        "type": "Merge_Stripping28r2p2_md"
+      }
+    ]
+  },
+  "publisher": "CERN Open Data Portal",
+  "recid": "24681",
+  "run_period": [
+    "2016"
+  ],
+  "stripping": {
+    "stream": "LEPTONIC",
+    "version": "stripping28r2p2"
+  },
+  "title": "LHCb 2016 Beam6500GeV MagDown LEPTONIC Stream Stripping28r2p2",
+  "title_additional": "",
+  "type": {
+    "primary": "Dataset",
+    "secondary": [
+      "Collision"
+    ]
+  },
+  "usage": {
+    "description": "<p> The Run 1 and 2 data collected by the LHCb detector is available using the LHCb Ntupling Service, while the Run 1 data is additionally available in .DST and .mDST formats. The data obtained from the LHCb Ntupling Service are ROOT ntuples and do not require custom software to analyze. <p> Links are provided to the LHCb Ntupling Service for exploration of available data and the LHCb Open Data Guide for usage instructions.",
+    "links": [
+      {
+        "description": "LHCb Ntupling Service",
+        "url": "https://opendata-lhcb-ntupling-service.app.cern.ch/"
+      },
+      {
+        "description": "LHCb Open Data Guide",
+        "url": "https://lhcb-opendata-guide.web.cern.ch/"
+      }
+    ]
+  }
+}]

--- a/data/records/LHCb_2016_Beam6500GeV_VeloClosed_MagDown_RealData_Reco16_Stripping28r2p2_SEMILEPTONIC_DST.json
+++ b/data/records/LHCb_2016_Beam6500GeV_VeloClosed_MagDown_RealData_Reco16_Stripping28r2p2_SEMILEPTONIC_DST.json
@@ -1,0 +1,249 @@
+[{
+  "abstract": {
+    "description": "Data from proton-proton (pp) collisions collected by the LHCb experiment in the year 2016 of Run2 of the LHC."
+  },
+  "accelerator": "CERN-LHC",
+  "collaboration": {
+    "name": "LHCb collaboration",
+    "recid": "456"
+  },
+  "collections": [
+    "LHCb-Collision-Datasets"
+  ],
+  "collision_information": {
+    "energy": "13TeV",
+    "type": "pp"
+  },
+  "date_created": [
+    "2016"
+  ],
+  "date_published": "2026",
+  "date_reprocessed": "2024",
+  "distribution": {
+    "formats": [
+      "DST"
+    ],
+    "number_events": 546617037,
+    "number_files": 11453,
+    "size": 38413932820786
+  },
+  "experiment": [
+    "LHCb"
+  ],
+  "magnet_polarity": "MagDown",
+  "methodology": {
+    "description": "<p> This dataset was created in several production steps. These steps, software used and the configuration is provided below. </p><p> <strong> Prod ID: &nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;</strong> 205602<p> <strong>Prod type:&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp; </strong> Merge<p> <strong> Parent Prod ID:&nbsp;&nbsp;&nbsp;&nbsp; </strong> 205601<p> <strong> Parent Prod type: </strong> DataStripping<p> <strong> Conditions: </strong><p>dddb-20220927-2016<p>cond-20191004-1</strong><p> <strong> List of Trigger Configuration Keys (TCK): </strong> </p> <p><p><strong>TCK &nbsp;&nbsp;&nbsp;&nbsp;&nbsp; Number of Files </strong><p>0x1138160f &nbsp;&nbsp;&nbsp;&nbsp;&nbsp; 7597<p>0x11291600 &nbsp;&nbsp;&nbsp;&nbsp;&nbsp; 198<p>0x11291603 &nbsp;&nbsp;&nbsp;&nbsp;&nbsp; 562<p>0x11291605 &nbsp;&nbsp;&nbsp;&nbsp;&nbsp; 1122<p>0x11291604 &nbsp;&nbsp;&nbsp;&nbsp;&nbsp; 361<p>0x1137160e &nbsp;&nbsp;&nbsp;&nbsp;&nbsp; 287<p>0x11371609 &nbsp;&nbsp;&nbsp;&nbsp;&nbsp; 808<p>0x1138160e &nbsp;&nbsp;&nbsp;&nbsp;&nbsp; 412<p>0x11381609 &nbsp;&nbsp;&nbsp;&nbsp;&nbsp; 106",
+    "steps": [
+      {
+        "configuration_files": [
+          {
+            "title": "DaVinci/DV-Stripping28r2p2-Stripping.py"
+          },
+          {
+            "title": "DaVinci/DataType-2016.py"
+          },
+          {
+            "title": "DaVinci/InputType-RDST.py"
+          },
+          {
+            "title": "DaVinci/DV-RawEventJuggler-0_3-to-4_3.py"
+          },
+          {
+            "title": "Persistency/Compression-ZLIB-1.py"
+          },
+          {
+            "title": "DaVinci/DV-RedoCaloPID-Stripping_28_24.py"
+          }
+        ],
+        "release": "DaVinci.v44r11p6 AppConfig.v3r421 Det/SQLDDDB.v7r12 TMVAWeights.v1r18",
+        "type": "Stripping28r2p2_md"
+      },
+      {
+        "configuration_files": [
+          {
+            "title": "Merging/DV-Stripping-Merging.py"
+          },
+          {
+            "title": "Persistency/Compression-LZMA-4.py"
+          }
+        ],
+        "release": "DaVinci.v44r11p6 AppConfig.v3r421 Det/SQLDDDB.v7r12 TMVAWeights.v1r18",
+        "type": "Merge_Stripping28r2p2_md"
+      },
+      {
+        "configuration_files": [
+          {
+            "title": "DaVinci/DV-Stripping28r2p2-Stripping.py"
+          },
+          {
+            "title": "DaVinci/DataType-2016.py"
+          },
+          {
+            "title": "DaVinci/InputType-RDST.py"
+          },
+          {
+            "title": "DaVinci/DV-RawEventJuggler-0_3-to-4_3.py"
+          },
+          {
+            "title": "Persistency/Compression-ZLIB-1.py"
+          },
+          {
+            "title": "DaVinci/DV-RedoCaloPID-Stripping_28_24.py"
+          }
+        ],
+        "release": "DaVinci.v44r11p6 AppConfig.v3r421 Det/SQLDDDB.v7r12 TMVAWeights.v1r18",
+        "type": "Stripping28r2p2_md"
+      },
+      {
+        "configuration_files": [
+          {
+            "title": "Merging/DV-Stripping-Merging.py"
+          },
+          {
+            "title": "Persistency/Compression-LZMA-4.py"
+          }
+        ],
+        "release": "DaVinci.v44r11p6 AppConfig.v3r421 Det/SQLDDDB.v7r12 TMVAWeights.v1r18",
+        "type": "Merge_Stripping28r2p2_md"
+      },
+      {
+        "configuration_files": [
+          {
+            "title": "DaVinci/DV-Stripping28r2p2-Stripping.py"
+          },
+          {
+            "title": "DaVinci/DataType-2016.py"
+          },
+          {
+            "title": "DaVinci/InputType-RDST.py"
+          },
+          {
+            "title": "DaVinci/DV-RawEventJuggler-0_3-to-4_3.py"
+          },
+          {
+            "title": "Persistency/Compression-ZLIB-1.py"
+          },
+          {
+            "title": "DaVinci/DV-RedoCaloPID-Stripping_28_24.py"
+          }
+        ],
+        "release": "DaVinci.v44r11p6 AppConfig.v3r421 Det/SQLDDDB.v7r12 TMVAWeights.v1r18",
+        "type": "Stripping28r2p2_md"
+      },
+      {
+        "configuration_files": [
+          {
+            "title": "Merging/DV-Stripping-Merging.py"
+          },
+          {
+            "title": "Persistency/Compression-LZMA-4.py"
+          }
+        ],
+        "release": "DaVinci.v44r11p6 AppConfig.v3r421 Det/SQLDDDB.v7r12 TMVAWeights.v1r18",
+        "type": "Merge_Stripping28r2p2_md"
+      },
+      {
+        "configuration_files": [
+          {
+            "title": "DaVinci/DV-Stripping28r2p2-Stripping.py"
+          },
+          {
+            "title": "DaVinci/DataType-2016.py"
+          },
+          {
+            "title": "DaVinci/InputType-RDST.py"
+          },
+          {
+            "title": "DaVinci/DV-RawEventJuggler-0_3-to-4_3.py"
+          },
+          {
+            "title": "Persistency/Compression-ZLIB-1.py"
+          },
+          {
+            "title": "DaVinci/DV-RedoCaloPID-Stripping_28_24.py"
+          }
+        ],
+        "release": "DaVinci.v44r11p6 AppConfig.v3r421 Det/SQLDDDB.v7r12 TMVAWeights.v1r18",
+        "type": "Stripping28r2p2_md"
+      },
+      {
+        "configuration_files": [
+          {
+            "title": "Merging/DV-Stripping-Merging.py"
+          },
+          {
+            "title": "Persistency/Compression-LZMA-4.py"
+          }
+        ],
+        "release": "DaVinci.v44r11p6 AppConfig.v3r421 Det/SQLDDDB.v7r12 TMVAWeights.v1r18",
+        "type": "Merge_Stripping28r2p2_md"
+      },
+      {
+        "configuration_files": [
+          {
+            "title": "DaVinci/DV-Stripping28r2p2-Stripping.py"
+          },
+          {
+            "title": "DaVinci/DataType-2016.py"
+          },
+          {
+            "title": "DaVinci/InputType-RDST.py"
+          },
+          {
+            "title": "DaVinci/DV-RawEventJuggler-0_3-to-4_3.py"
+          },
+          {
+            "title": "Persistency/Compression-ZLIB-1.py"
+          },
+          {
+            "title": "DaVinci/DV-RedoCaloPID-Stripping_28_24.py"
+          }
+        ],
+        "release": "DaVinci.v44r11p6 AppConfig.v3r421 Det/SQLDDDB.v7r12 TMVAWeights.v1r18",
+        "type": "Stripping28r2p2_md"
+      },
+      {
+        "configuration_files": [
+          {
+            "title": "Merging/DV-Stripping-Merging.py"
+          },
+          {
+            "title": "Persistency/Compression-LZMA-4.py"
+          }
+        ],
+        "release": "DaVinci.v44r11p6 AppConfig.v3r421 Det/SQLDDDB.v7r12 TMVAWeights.v1r18",
+        "type": "Merge_Stripping28r2p2_md"
+      }
+    ]
+  },
+  "publisher": "CERN Open Data Portal",
+  "recid": "24689",
+  "run_period": [
+    "2016"
+  ],
+  "stripping": {
+    "stream": "SEMILEPTONIC",
+    "version": "stripping28r2p2"
+  },
+  "title": "LHCb 2016 Beam6500GeV MagDown SEMILEPTONIC Stream Stripping28r2p2",
+  "title_additional": "",
+  "type": {
+    "primary": "Dataset",
+    "secondary": [
+      "Collision"
+    ]
+  },
+  "usage": {
+    "description": "<p> The Run 1 and 2 data collected by the LHCb detector is available using the LHCb Ntupling Service, while the Run 1 data is additionally available in .DST and .mDST formats. The data obtained from the LHCb Ntupling Service are ROOT ntuples and do not require custom software to analyze. <p> Links are provided to the LHCb Ntupling Service for exploration of available data and the LHCb Open Data Guide for usage instructions.",
+    "links": [
+      {
+        "description": "LHCb Ntupling Service",
+        "url": "https://opendata-lhcb-ntupling-service.app.cern.ch/"
+      },
+      {
+        "description": "LHCb Open Data Guide",
+        "url": "https://lhcb-opendata-guide.web.cern.ch/"
+      }
+    ]
+  }
+}]

--- a/data/records/LHCb_2016_Beam6500GeV_VeloClosed_MagUp_RealData_Reco16_Stripping28r2_BHADRONCOMPLETEEVENT_DST.json
+++ b/data/records/LHCb_2016_Beam6500GeV_VeloClosed_MagUp_RealData_Reco16_Stripping28r2_BHADRONCOMPLETEEVENT_DST.json
@@ -1,0 +1,213 @@
+[{
+  "abstract": {
+    "description": "Data from proton-proton (pp) collisions collected by the LHCb experiment in the year 2016 of Run2 of the LHC."
+  },
+  "accelerator": "CERN-LHC",
+  "collaboration": {
+    "name": "LHCb collaboration",
+    "recid": "456"
+  },
+  "collections": [
+    "LHCb-Collision-Datasets"
+  ],
+  "collision_information": {
+    "energy": "13TeV",
+    "type": "pp"
+  },
+  "date_created": [
+    "2016"
+  ],
+  "date_published": "2026",
+  "date_reprocessed": "2020",
+  "distribution": {
+    "formats": [
+      "DST"
+    ],
+    "number_events": 1004055423,
+    "number_files": 25927,
+    "size": 96393631234052
+  },
+  "experiment": [
+    "LHCb"
+  ],
+  "magnet_polarity": "MagUp",
+  "methodology": {
+    "description": "<p> This dataset was created in several production steps. These steps, software used and the configuration is provided below. </p><p> <strong> Prod ID: &nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;</strong> 102982<p> <strong>Prod type:&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp; </strong> Merge<p> <strong> Parent Prod ID:&nbsp;&nbsp;&nbsp;&nbsp; </strong> 102838<p> <strong> Parent Prod type: </strong> DataStripping<p> <strong> Conditions: </strong><p>dddb-20190206-3<p>cond-20191004-1</strong><p> <strong> List of Trigger Configuration Keys (TCK): </strong> </p> <p><p><strong>TCK &nbsp;&nbsp;&nbsp;&nbsp;&nbsp; Number of Files </strong><p>0x11361609 &nbsp;&nbsp;&nbsp;&nbsp;&nbsp; 12524<p>0x11321609 &nbsp;&nbsp;&nbsp;&nbsp;&nbsp; 4119<p>0x11341609 &nbsp;&nbsp;&nbsp;&nbsp;&nbsp; 4080<p>0x11381611 &nbsp;&nbsp;&nbsp;&nbsp;&nbsp; 1513<p>0x11381612 &nbsp;&nbsp;&nbsp;&nbsp;&nbsp; 2977<p>0x11351609 &nbsp;&nbsp;&nbsp;&nbsp;&nbsp; 714",
+    "steps": [
+      {
+        "configuration_files": [
+          {
+            "title": "DaVinci/DV-Stripping28r2-Stripping.py"
+          },
+          {
+            "title": "DaVinci/DV-RedoCaloPID-Stripping_28_24.py"
+          },
+          {
+            "title": "DaVinci/DataType-2016.py"
+          },
+          {
+            "title": "DaVinci/InputType-RDST.py"
+          },
+          {
+            "title": "Persistency/Compression-ZLIB-1.py"
+          },
+          {
+            "title": "DaVinci/DV-RawEventJuggler-0_3-to-4_3.py"
+          }
+        ],
+        "release": "DaVinci.v44r10p5 AppConfig.v3r393 Det/SQLDDDB.v7r10 TMVAWeights.v1r16",
+        "type": "Stripping28r2"
+      },
+      {
+        "configuration_files": [
+          {
+            "title": "Merging/DV-Stripping-Merging.py"
+          },
+          {
+            "title": "Persistency/Compression-LZMA-4.py"
+          }
+        ],
+        "release": "DaVinci.v44r10p5 AppConfig.v3r393 Det/SQLDDDB.v7r10",
+        "type": "Stripping28r2-Merging"
+      },
+      {
+        "configuration_files": [
+          {
+            "title": "DaVinci/DV-Stripping28r2-Stripping.py"
+          },
+          {
+            "title": "DaVinci/DV-RedoCaloPID-Stripping_28_24.py"
+          },
+          {
+            "title": "DaVinci/DataType-2016.py"
+          },
+          {
+            "title": "DaVinci/InputType-RDST.py"
+          },
+          {
+            "title": "Persistency/Compression-ZLIB-1.py"
+          },
+          {
+            "title": "DaVinci/DV-RawEventJuggler-0_3-to-4_3.py"
+          }
+        ],
+        "release": "DaVinci.v44r10p5 AppConfig.v3r393 Det/SQLDDDB.v7r10 TMVAWeights.v1r16",
+        "type": "Stripping28r2"
+      },
+      {
+        "configuration_files": [
+          {
+            "title": "Merging/DV-Stripping-Merging.py"
+          },
+          {
+            "title": "Persistency/Compression-LZMA-4.py"
+          }
+        ],
+        "release": "DaVinci.v44r10p5 AppConfig.v3r393 Det/SQLDDDB.v7r10",
+        "type": "Stripping28r2-Merging"
+      },
+      {
+        "configuration_files": [
+          {
+            "title": "DaVinci/DV-Stripping28r2-Stripping.py"
+          },
+          {
+            "title": "DaVinci/DV-RedoCaloPID-Stripping_28_24.py"
+          },
+          {
+            "title": "DaVinci/DataType-2016.py"
+          },
+          {
+            "title": "DaVinci/InputType-RDST.py"
+          },
+          {
+            "title": "Persistency/Compression-ZLIB-1.py"
+          },
+          {
+            "title": "DaVinci/DV-RawEventJuggler-0_3-to-4_3.py"
+          }
+        ],
+        "release": "DaVinci.v44r10p5 AppConfig.v3r393 Det/SQLDDDB.v7r10 TMVAWeights.v1r16",
+        "type": "Stripping28r2"
+      },
+      {
+        "configuration_files": [
+          {
+            "title": "Merging/DV-Stripping-Merging.py"
+          },
+          {
+            "title": "Persistency/Compression-LZMA-4.py"
+          }
+        ],
+        "release": "DaVinci.v44r10p5 AppConfig.v3r393 Det/SQLDDDB.v7r10",
+        "type": "Stripping28r2-Merging"
+      },
+      {
+        "configuration_files": [
+          {
+            "title": "DaVinci/DV-Stripping28r2-Stripping.py"
+          },
+          {
+            "title": "DaVinci/DV-RedoCaloPID-Stripping_28_24.py"
+          },
+          {
+            "title": "DaVinci/DataType-2016.py"
+          },
+          {
+            "title": "DaVinci/InputType-RDST.py"
+          },
+          {
+            "title": "Persistency/Compression-ZLIB-1.py"
+          },
+          {
+            "title": "DaVinci/DV-RawEventJuggler-0_3-to-4_3.py"
+          }
+        ],
+        "release": "DaVinci.v44r10p5 AppConfig.v3r393 Det/SQLDDDB.v7r10 TMVAWeights.v1r16",
+        "type": "Stripping28r2"
+      },
+      {
+        "configuration_files": [
+          {
+            "title": "Merging/DV-Stripping-Merging.py"
+          },
+          {
+            "title": "Persistency/Compression-LZMA-4.py"
+          }
+        ],
+        "release": "DaVinci.v44r10p5 AppConfig.v3r393 Det/SQLDDDB.v7r10",
+        "type": "Stripping28r2-Merging"
+      }
+    ]
+  },
+  "publisher": "CERN Open Data Portal",
+  "recid": "24655",
+  "run_period": [
+    "2016"
+  ],
+  "stripping": {
+    "stream": "BHADRONCOMPLETEEVENT",
+    "version": "stripping28r2"
+  },
+  "title": "LHCb 2016 Beam6500GeV MagUp BHADRONCOMPLETEEVENT Stream Stripping28r2",
+  "title_additional": "",
+  "type": {
+    "primary": "Dataset",
+    "secondary": [
+      "Collision"
+    ]
+  },
+  "usage": {
+    "description": "<p> The Run 1 and 2 data collected by the LHCb detector is available using the LHCb Ntupling Service, while the Run 1 data is additionally available in .DST and .mDST formats. The data obtained from the LHCb Ntupling Service are ROOT ntuples and do not require custom software to analyze. <p> Links are provided to the LHCb Ntupling Service for exploration of available data and the LHCb Open Data Guide for usage instructions.",
+    "links": [
+      {
+        "description": "LHCb Ntupling Service",
+        "url": "https://opendata-lhcb-ntupling-service.app.cern.ch/"
+      },
+      {
+        "description": "LHCb Open Data Guide",
+        "url": "https://lhcb-opendata-guide.web.cern.ch/"
+      }
+    ]
+  }
+}]

--- a/data/records/LHCb_2016_Beam6500GeV_VeloClosed_MagUp_RealData_Reco16_Stripping28r2_BHADRON_MDST.json
+++ b/data/records/LHCb_2016_Beam6500GeV_VeloClosed_MagUp_RealData_Reco16_Stripping28r2_BHADRON_MDST.json
@@ -1,0 +1,213 @@
+[{
+  "abstract": {
+    "description": "Data from proton-proton (pp) collisions collected by the LHCb experiment in the year 2016 of Run2 of the LHC."
+  },
+  "accelerator": "CERN-LHC",
+  "collaboration": {
+    "name": "LHCb collaboration",
+    "recid": "456"
+  },
+  "collections": [
+    "LHCb-Collision-Datasets"
+  ],
+  "collision_information": {
+    "energy": "13TeV",
+    "type": "pp"
+  },
+  "date_created": [
+    "2016"
+  ],
+  "date_published": "2026",
+  "date_reprocessed": "2020",
+  "distribution": {
+    "formats": [
+      "MDST"
+    ],
+    "number_events": 3014371975,
+    "number_files": 13042,
+    "size": 46208503639425
+  },
+  "experiment": [
+    "LHCb"
+  ],
+  "magnet_polarity": "MagUp",
+  "methodology": {
+    "description": "<p> This dataset was created in several production steps. These steps, software used and the configuration is provided below. </p><p> <strong> Prod ID: &nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;</strong> 102982<p> <strong>Prod type:&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp; </strong> Merge<p> <strong> Parent Prod ID:&nbsp;&nbsp;&nbsp;&nbsp; </strong> 102838<p> <strong> Parent Prod type: </strong> DataStripping<p> <strong> Conditions: </strong><p>dddb-20190206-3<p>cond-20191004-1</strong><p> <strong> List of Trigger Configuration Keys (TCK): </strong> </p> <p><p><strong>TCK &nbsp;&nbsp;&nbsp;&nbsp;&nbsp; Number of Files </strong><p>0x11361609 &nbsp;&nbsp;&nbsp;&nbsp;&nbsp; 6406<p>0x11321609 &nbsp;&nbsp;&nbsp;&nbsp;&nbsp; 1992<p>0x11341609 &nbsp;&nbsp;&nbsp;&nbsp;&nbsp; 2114<p>0x11381611 &nbsp;&nbsp;&nbsp;&nbsp;&nbsp; 743<p>0x11381612 &nbsp;&nbsp;&nbsp;&nbsp;&nbsp; 1418<p>0x11351609 &nbsp;&nbsp;&nbsp;&nbsp;&nbsp; 369",
+    "steps": [
+      {
+        "configuration_files": [
+          {
+            "title": "DaVinci/DV-Stripping28r2-Stripping.py"
+          },
+          {
+            "title": "DaVinci/DV-RedoCaloPID-Stripping_28_24.py"
+          },
+          {
+            "title": "DaVinci/DataType-2016.py"
+          },
+          {
+            "title": "DaVinci/InputType-RDST.py"
+          },
+          {
+            "title": "Persistency/Compression-ZLIB-1.py"
+          },
+          {
+            "title": "DaVinci/DV-RawEventJuggler-0_3-to-4_3.py"
+          }
+        ],
+        "release": "DaVinci.v44r10p5 AppConfig.v3r393 Det/SQLDDDB.v7r10 TMVAWeights.v1r16",
+        "type": "Stripping28r2"
+      },
+      {
+        "configuration_files": [
+          {
+            "title": "Merging/DV-Stripping-Merging.py"
+          },
+          {
+            "title": "Persistency/Compression-LZMA-4.py"
+          }
+        ],
+        "release": "DaVinci.v44r10p5 AppConfig.v3r393 Det/SQLDDDB.v7r10",
+        "type": "Stripping28r2-Merging"
+      },
+      {
+        "configuration_files": [
+          {
+            "title": "DaVinci/DV-Stripping28r2-Stripping.py"
+          },
+          {
+            "title": "DaVinci/DV-RedoCaloPID-Stripping_28_24.py"
+          },
+          {
+            "title": "DaVinci/DataType-2016.py"
+          },
+          {
+            "title": "DaVinci/InputType-RDST.py"
+          },
+          {
+            "title": "Persistency/Compression-ZLIB-1.py"
+          },
+          {
+            "title": "DaVinci/DV-RawEventJuggler-0_3-to-4_3.py"
+          }
+        ],
+        "release": "DaVinci.v44r10p5 AppConfig.v3r393 Det/SQLDDDB.v7r10 TMVAWeights.v1r16",
+        "type": "Stripping28r2"
+      },
+      {
+        "configuration_files": [
+          {
+            "title": "Merging/DV-Stripping-Merging.py"
+          },
+          {
+            "title": "Persistency/Compression-LZMA-4.py"
+          }
+        ],
+        "release": "DaVinci.v44r10p5 AppConfig.v3r393 Det/SQLDDDB.v7r10",
+        "type": "Stripping28r2-Merging"
+      },
+      {
+        "configuration_files": [
+          {
+            "title": "DaVinci/DV-Stripping28r2-Stripping.py"
+          },
+          {
+            "title": "DaVinci/DV-RedoCaloPID-Stripping_28_24.py"
+          },
+          {
+            "title": "DaVinci/DataType-2016.py"
+          },
+          {
+            "title": "DaVinci/InputType-RDST.py"
+          },
+          {
+            "title": "Persistency/Compression-ZLIB-1.py"
+          },
+          {
+            "title": "DaVinci/DV-RawEventJuggler-0_3-to-4_3.py"
+          }
+        ],
+        "release": "DaVinci.v44r10p5 AppConfig.v3r393 Det/SQLDDDB.v7r10 TMVAWeights.v1r16",
+        "type": "Stripping28r2"
+      },
+      {
+        "configuration_files": [
+          {
+            "title": "Merging/DV-Stripping-Merging.py"
+          },
+          {
+            "title": "Persistency/Compression-LZMA-4.py"
+          }
+        ],
+        "release": "DaVinci.v44r10p5 AppConfig.v3r393 Det/SQLDDDB.v7r10",
+        "type": "Stripping28r2-Merging"
+      },
+      {
+        "configuration_files": [
+          {
+            "title": "DaVinci/DV-Stripping28r2-Stripping.py"
+          },
+          {
+            "title": "DaVinci/DV-RedoCaloPID-Stripping_28_24.py"
+          },
+          {
+            "title": "DaVinci/DataType-2016.py"
+          },
+          {
+            "title": "DaVinci/InputType-RDST.py"
+          },
+          {
+            "title": "Persistency/Compression-ZLIB-1.py"
+          },
+          {
+            "title": "DaVinci/DV-RawEventJuggler-0_3-to-4_3.py"
+          }
+        ],
+        "release": "DaVinci.v44r10p5 AppConfig.v3r393 Det/SQLDDDB.v7r10 TMVAWeights.v1r16",
+        "type": "Stripping28r2"
+      },
+      {
+        "configuration_files": [
+          {
+            "title": "Merging/DV-Stripping-Merging.py"
+          },
+          {
+            "title": "Persistency/Compression-LZMA-4.py"
+          }
+        ],
+        "release": "DaVinci.v44r10p5 AppConfig.v3r393 Det/SQLDDDB.v7r10",
+        "type": "Stripping28r2-Merging"
+      }
+    ]
+  },
+  "publisher": "CERN Open Data Portal",
+  "recid": "24654",
+  "run_period": [
+    "2016"
+  ],
+  "stripping": {
+    "stream": "BHADRON",
+    "version": "stripping28r2"
+  },
+  "title": "LHCb 2016 Beam6500GeV MagUp BHADRON Stream Stripping28r2",
+  "title_additional": "",
+  "type": {
+    "primary": "Dataset",
+    "secondary": [
+      "Collision"
+    ]
+  },
+  "usage": {
+    "description": "<p> The Run 1 and 2 data collected by the LHCb detector is available using the LHCb Ntupling Service, while the Run 1 data is additionally available in .DST and .mDST formats. The data obtained from the LHCb Ntupling Service are ROOT ntuples and do not require custom software to analyze. <p> Links are provided to the LHCb Ntupling Service for exploration of available data and the LHCb Open Data Guide for usage instructions.",
+    "links": [
+      {
+        "description": "LHCb Ntupling Service",
+        "url": "https://opendata-lhcb-ntupling-service.app.cern.ch/"
+      },
+      {
+        "description": "LHCb Open Data Guide",
+        "url": "https://lhcb-opendata-guide.web.cern.ch/"
+      }
+    ]
+  }
+}]

--- a/data/records/LHCb_2016_Beam6500GeV_VeloClosed_MagUp_RealData_Reco16_Stripping28r2_CHARMCOMPLETEEVENT_DST.json
+++ b/data/records/LHCb_2016_Beam6500GeV_VeloClosed_MagUp_RealData_Reco16_Stripping28r2_CHARMCOMPLETEEVENT_DST.json
@@ -1,0 +1,213 @@
+[{
+  "abstract": {
+    "description": "Data from proton-proton (pp) collisions collected by the LHCb experiment in the year 2016 of Run2 of the LHC."
+  },
+  "accelerator": "CERN-LHC",
+  "collaboration": {
+    "name": "LHCb collaboration",
+    "recid": "456"
+  },
+  "collections": [
+    "LHCb-Collision-Datasets"
+  ],
+  "collision_information": {
+    "energy": "13TeV",
+    "type": "pp"
+  },
+  "date_created": [
+    "2016"
+  ],
+  "date_published": "2026",
+  "date_reprocessed": "2020",
+  "distribution": {
+    "formats": [
+      "DST"
+    ],
+    "number_events": 363164493,
+    "number_files": 9033,
+    "size": 29952647049207
+  },
+  "experiment": [
+    "LHCb"
+  ],
+  "magnet_polarity": "MagUp",
+  "methodology": {
+    "description": "<p> This dataset was created in several production steps. These steps, software used and the configuration is provided below. </p><p> <strong> Prod ID: &nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;</strong> 102982<p> <strong>Prod type:&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp; </strong> Merge<p> <strong> Parent Prod ID:&nbsp;&nbsp;&nbsp;&nbsp; </strong> 102838<p> <strong> Parent Prod type: </strong> DataStripping<p> <strong> Conditions: </strong><p>dddb-20190206-3<p>cond-20191004-1</strong><p> <strong> List of Trigger Configuration Keys (TCK): </strong> </p> <p><p><strong>TCK &nbsp;&nbsp;&nbsp;&nbsp;&nbsp; Number of Files </strong><p>0x11361609 &nbsp;&nbsp;&nbsp;&nbsp;&nbsp; 4224<p>0x11321609 &nbsp;&nbsp;&nbsp;&nbsp;&nbsp; 1439<p>0x11341609 &nbsp;&nbsp;&nbsp;&nbsp;&nbsp; 1538<p>0x11381611 &nbsp;&nbsp;&nbsp;&nbsp;&nbsp; 542<p>0x11381612 &nbsp;&nbsp;&nbsp;&nbsp;&nbsp; 1033<p>0x11351609 &nbsp;&nbsp;&nbsp;&nbsp;&nbsp; 257",
+    "steps": [
+      {
+        "configuration_files": [
+          {
+            "title": "DaVinci/DV-Stripping28r2-Stripping.py"
+          },
+          {
+            "title": "DaVinci/DV-RedoCaloPID-Stripping_28_24.py"
+          },
+          {
+            "title": "DaVinci/DataType-2016.py"
+          },
+          {
+            "title": "DaVinci/InputType-RDST.py"
+          },
+          {
+            "title": "Persistency/Compression-ZLIB-1.py"
+          },
+          {
+            "title": "DaVinci/DV-RawEventJuggler-0_3-to-4_3.py"
+          }
+        ],
+        "release": "DaVinci.v44r10p5 AppConfig.v3r393 Det/SQLDDDB.v7r10 TMVAWeights.v1r16",
+        "type": "Stripping28r2"
+      },
+      {
+        "configuration_files": [
+          {
+            "title": "Merging/DV-Stripping-Merging.py"
+          },
+          {
+            "title": "Persistency/Compression-LZMA-4.py"
+          }
+        ],
+        "release": "DaVinci.v44r10p5 AppConfig.v3r393 Det/SQLDDDB.v7r10",
+        "type": "Stripping28r2-Merging"
+      },
+      {
+        "configuration_files": [
+          {
+            "title": "DaVinci/DV-Stripping28r2-Stripping.py"
+          },
+          {
+            "title": "DaVinci/DV-RedoCaloPID-Stripping_28_24.py"
+          },
+          {
+            "title": "DaVinci/DataType-2016.py"
+          },
+          {
+            "title": "DaVinci/InputType-RDST.py"
+          },
+          {
+            "title": "Persistency/Compression-ZLIB-1.py"
+          },
+          {
+            "title": "DaVinci/DV-RawEventJuggler-0_3-to-4_3.py"
+          }
+        ],
+        "release": "DaVinci.v44r10p5 AppConfig.v3r393 Det/SQLDDDB.v7r10 TMVAWeights.v1r16",
+        "type": "Stripping28r2"
+      },
+      {
+        "configuration_files": [
+          {
+            "title": "Merging/DV-Stripping-Merging.py"
+          },
+          {
+            "title": "Persistency/Compression-LZMA-4.py"
+          }
+        ],
+        "release": "DaVinci.v44r10p5 AppConfig.v3r393 Det/SQLDDDB.v7r10",
+        "type": "Stripping28r2-Merging"
+      },
+      {
+        "configuration_files": [
+          {
+            "title": "DaVinci/DV-Stripping28r2-Stripping.py"
+          },
+          {
+            "title": "DaVinci/DV-RedoCaloPID-Stripping_28_24.py"
+          },
+          {
+            "title": "DaVinci/DataType-2016.py"
+          },
+          {
+            "title": "DaVinci/InputType-RDST.py"
+          },
+          {
+            "title": "Persistency/Compression-ZLIB-1.py"
+          },
+          {
+            "title": "DaVinci/DV-RawEventJuggler-0_3-to-4_3.py"
+          }
+        ],
+        "release": "DaVinci.v44r10p5 AppConfig.v3r393 Det/SQLDDDB.v7r10 TMVAWeights.v1r16",
+        "type": "Stripping28r2"
+      },
+      {
+        "configuration_files": [
+          {
+            "title": "Merging/DV-Stripping-Merging.py"
+          },
+          {
+            "title": "Persistency/Compression-LZMA-4.py"
+          }
+        ],
+        "release": "DaVinci.v44r10p5 AppConfig.v3r393 Det/SQLDDDB.v7r10",
+        "type": "Stripping28r2-Merging"
+      },
+      {
+        "configuration_files": [
+          {
+            "title": "DaVinci/DV-Stripping28r2-Stripping.py"
+          },
+          {
+            "title": "DaVinci/DV-RedoCaloPID-Stripping_28_24.py"
+          },
+          {
+            "title": "DaVinci/DataType-2016.py"
+          },
+          {
+            "title": "DaVinci/InputType-RDST.py"
+          },
+          {
+            "title": "Persistency/Compression-ZLIB-1.py"
+          },
+          {
+            "title": "DaVinci/DV-RawEventJuggler-0_3-to-4_3.py"
+          }
+        ],
+        "release": "DaVinci.v44r10p5 AppConfig.v3r393 Det/SQLDDDB.v7r10 TMVAWeights.v1r16",
+        "type": "Stripping28r2"
+      },
+      {
+        "configuration_files": [
+          {
+            "title": "Merging/DV-Stripping-Merging.py"
+          },
+          {
+            "title": "Persistency/Compression-LZMA-4.py"
+          }
+        ],
+        "release": "DaVinci.v44r10p5 AppConfig.v3r393 Det/SQLDDDB.v7r10",
+        "type": "Stripping28r2-Merging"
+      }
+    ]
+  },
+  "publisher": "CERN Open Data Portal",
+  "recid": "24657",
+  "run_period": [
+    "2016"
+  ],
+  "stripping": {
+    "stream": "CHARMCOMPLETEEVENT",
+    "version": "stripping28r2"
+  },
+  "title": "LHCb 2016 Beam6500GeV MagUp CHARMCOMPLETEEVENT Stream Stripping28r2",
+  "title_additional": "",
+  "type": {
+    "primary": "Dataset",
+    "secondary": [
+      "Collision"
+    ]
+  },
+  "usage": {
+    "description": "<p> The Run 1 and 2 data collected by the LHCb detector is available using the LHCb Ntupling Service, while the Run 1 data is additionally available in .DST and .mDST formats. The data obtained from the LHCb Ntupling Service are ROOT ntuples and do not require custom software to analyze. <p> Links are provided to the LHCb Ntupling Service for exploration of available data and the LHCb Open Data Guide for usage instructions.",
+    "links": [
+      {
+        "description": "LHCb Ntupling Service",
+        "url": "https://opendata-lhcb-ntupling-service.app.cern.ch/"
+      },
+      {
+        "description": "LHCb Open Data Guide",
+        "url": "https://lhcb-opendata-guide.web.cern.ch/"
+      }
+    ]
+  }
+}]

--- a/data/records/LHCb_2016_Beam6500GeV_VeloClosed_MagUp_RealData_Reco16_Stripping28r2_CHARM_MDST.json
+++ b/data/records/LHCb_2016_Beam6500GeV_VeloClosed_MagUp_RealData_Reco16_Stripping28r2_CHARM_MDST.json
@@ -1,0 +1,213 @@
+[{
+  "abstract": {
+    "description": "Data from proton-proton (pp) collisions collected by the LHCb experiment in the year 2016 of Run2 of the LHC."
+  },
+  "accelerator": "CERN-LHC",
+  "collaboration": {
+    "name": "LHCb collaboration",
+    "recid": "456"
+  },
+  "collections": [
+    "LHCb-Collision-Datasets"
+  ],
+  "collision_information": {
+    "energy": "13TeV",
+    "type": "pp"
+  },
+  "date_created": [
+    "2016"
+  ],
+  "date_published": "2026",
+  "date_reprocessed": "2020",
+  "distribution": {
+    "formats": [
+      "MDST"
+    ],
+    "number_events": 3605271646,
+    "number_files": 11782,
+    "size": 41324315673735
+  },
+  "experiment": [
+    "LHCb"
+  ],
+  "magnet_polarity": "MagUp",
+  "methodology": {
+    "description": "<p> This dataset was created in several production steps. These steps, software used and the configuration is provided below. </p><p> <strong> Prod ID: &nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;</strong> 103802<p> <strong>Prod type:&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp; </strong> Merge<p> <strong> Parent Prod ID:&nbsp;&nbsp;&nbsp;&nbsp; </strong> 102838<p> <strong> Parent Prod type: </strong> DataStripping<p> <strong> Conditions: </strong><p>dddb-20190206-3<p>cond-20191004-1</strong><p> <strong> List of Trigger Configuration Keys (TCK): </strong> </p> <p><p><strong>TCK &nbsp;&nbsp;&nbsp;&nbsp;&nbsp; Number of Files </strong><p>0x11361609 &nbsp;&nbsp;&nbsp;&nbsp;&nbsp; 5647<p>0x11321609 &nbsp;&nbsp;&nbsp;&nbsp;&nbsp; 1890<p>0x11341609 &nbsp;&nbsp;&nbsp;&nbsp;&nbsp; 1967<p>0x11381611 &nbsp;&nbsp;&nbsp;&nbsp;&nbsp; 668<p>0x11381612 &nbsp;&nbsp;&nbsp;&nbsp;&nbsp; 1278<p>0x11351609 &nbsp;&nbsp;&nbsp;&nbsp;&nbsp; 332",
+    "steps": [
+      {
+        "configuration_files": [
+          {
+            "title": "DaVinci/DV-Stripping28r2-Stripping.py"
+          },
+          {
+            "title": "DaVinci/DV-RedoCaloPID-Stripping_28_24.py"
+          },
+          {
+            "title": "DaVinci/DataType-2016.py"
+          },
+          {
+            "title": "DaVinci/InputType-RDST.py"
+          },
+          {
+            "title": "Persistency/Compression-ZLIB-1.py"
+          },
+          {
+            "title": "DaVinci/DV-RawEventJuggler-0_3-to-4_3.py"
+          }
+        ],
+        "release": "DaVinci.v44r10p5 AppConfig.v3r393 Det/SQLDDDB.v7r10 TMVAWeights.v1r16",
+        "type": "Stripping28r2"
+      },
+      {
+        "configuration_files": [
+          {
+            "title": "Merging/DV-Stripping-Merging.py"
+          },
+          {
+            "title": "Persistency/Compression-LZMA-4.py"
+          }
+        ],
+        "release": "DaVinci.v44r10p5 AppConfig.v3r393 Det/SQLDDDB.v7r10",
+        "type": "Stripping28r2-Merging"
+      },
+      {
+        "configuration_files": [
+          {
+            "title": "DaVinci/DV-Stripping28r2-Stripping.py"
+          },
+          {
+            "title": "DaVinci/DV-RedoCaloPID-Stripping_28_24.py"
+          },
+          {
+            "title": "DaVinci/DataType-2016.py"
+          },
+          {
+            "title": "DaVinci/InputType-RDST.py"
+          },
+          {
+            "title": "Persistency/Compression-ZLIB-1.py"
+          },
+          {
+            "title": "DaVinci/DV-RawEventJuggler-0_3-to-4_3.py"
+          }
+        ],
+        "release": "DaVinci.v44r10p5 AppConfig.v3r393 Det/SQLDDDB.v7r10 TMVAWeights.v1r16",
+        "type": "Stripping28r2"
+      },
+      {
+        "configuration_files": [
+          {
+            "title": "Merging/DV-Stripping-Merging.py"
+          },
+          {
+            "title": "Persistency/Compression-LZMA-4.py"
+          }
+        ],
+        "release": "DaVinci.v44r10p5 AppConfig.v3r393 Det/SQLDDDB.v7r10",
+        "type": "Stripping28r2-Merging"
+      },
+      {
+        "configuration_files": [
+          {
+            "title": "DaVinci/DV-Stripping28r2-Stripping.py"
+          },
+          {
+            "title": "DaVinci/DV-RedoCaloPID-Stripping_28_24.py"
+          },
+          {
+            "title": "DaVinci/DataType-2016.py"
+          },
+          {
+            "title": "DaVinci/InputType-RDST.py"
+          },
+          {
+            "title": "Persistency/Compression-ZLIB-1.py"
+          },
+          {
+            "title": "DaVinci/DV-RawEventJuggler-0_3-to-4_3.py"
+          }
+        ],
+        "release": "DaVinci.v44r10p5 AppConfig.v3r393 Det/SQLDDDB.v7r10 TMVAWeights.v1r16",
+        "type": "Stripping28r2"
+      },
+      {
+        "configuration_files": [
+          {
+            "title": "Merging/DV-Stripping-Merging.py"
+          },
+          {
+            "title": "Persistency/Compression-LZMA-4.py"
+          }
+        ],
+        "release": "DaVinci.v44r10p5 AppConfig.v3r393 Det/SQLDDDB.v7r10",
+        "type": "Stripping28r2-Merging"
+      },
+      {
+        "configuration_files": [
+          {
+            "title": "DaVinci/DV-Stripping28r2-Stripping.py"
+          },
+          {
+            "title": "DaVinci/DV-RedoCaloPID-Stripping_28_24.py"
+          },
+          {
+            "title": "DaVinci/DataType-2016.py"
+          },
+          {
+            "title": "DaVinci/InputType-RDST.py"
+          },
+          {
+            "title": "Persistency/Compression-ZLIB-1.py"
+          },
+          {
+            "title": "DaVinci/DV-RawEventJuggler-0_3-to-4_3.py"
+          }
+        ],
+        "release": "DaVinci.v44r10p5 AppConfig.v3r393 Det/SQLDDDB.v7r10 TMVAWeights.v1r16",
+        "type": "Stripping28r2"
+      },
+      {
+        "configuration_files": [
+          {
+            "title": "Merging/DV-Stripping-Merging.py"
+          },
+          {
+            "title": "Persistency/Compression-LZMA-4.py"
+          }
+        ],
+        "release": "DaVinci.v44r10p5 AppConfig.v3r393 Det/SQLDDDB.v7r10",
+        "type": "Stripping28r2-Merging"
+      }
+    ]
+  },
+  "publisher": "CERN Open Data Portal",
+  "recid": "24656",
+  "run_period": [
+    "2016"
+  ],
+  "stripping": {
+    "stream": "CHARM",
+    "version": "stripping28r2"
+  },
+  "title": "LHCb 2016 Beam6500GeV MagUp CHARM Stream Stripping28r2",
+  "title_additional": "",
+  "type": {
+    "primary": "Dataset",
+    "secondary": [
+      "Collision"
+    ]
+  },
+  "usage": {
+    "description": "<p> The Run 1 and 2 data collected by the LHCb detector is available using the LHCb Ntupling Service, while the Run 1 data is additionally available in .DST and .mDST formats. The data obtained from the LHCb Ntupling Service are ROOT ntuples and do not require custom software to analyze. <p> Links are provided to the LHCb Ntupling Service for exploration of available data and the LHCb Open Data Guide for usage instructions.",
+    "links": [
+      {
+        "description": "LHCb Ntupling Service",
+        "url": "https://opendata-lhcb-ntupling-service.app.cern.ch/"
+      },
+      {
+        "description": "LHCb Open Data Guide",
+        "url": "https://lhcb-opendata-guide.web.cern.ch/"
+      }
+    ]
+  }
+}]

--- a/data/records/LHCb_2016_Beam6500GeV_VeloClosed_MagUp_RealData_Reco16_Stripping28r2_DIMUON_DST.json
+++ b/data/records/LHCb_2016_Beam6500GeV_VeloClosed_MagUp_RealData_Reco16_Stripping28r2_DIMUON_DST.json
@@ -1,0 +1,213 @@
+[{
+  "abstract": {
+    "description": "Data from proton-proton (pp) collisions collected by the LHCb experiment in the year 2016 of Run2 of the LHC."
+  },
+  "accelerator": "CERN-LHC",
+  "collaboration": {
+    "name": "LHCb collaboration",
+    "recid": "456"
+  },
+  "collections": [
+    "LHCb-Collision-Datasets"
+  ],
+  "collision_information": {
+    "energy": "13TeV",
+    "type": "pp"
+  },
+  "date_created": [
+    "2016"
+  ],
+  "date_published": "2026",
+  "date_reprocessed": "2020",
+  "distribution": {
+    "formats": [
+      "DST"
+    ],
+    "number_events": 541327456,
+    "number_files": 14722,
+    "size": 52876893632826
+  },
+  "experiment": [
+    "LHCb"
+  ],
+  "magnet_polarity": "MagUp",
+  "methodology": {
+    "description": "<p> This dataset was created in several production steps. These steps, software used and the configuration is provided below. </p><p> <strong> Prod ID: &nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;</strong> 102839<p> <strong>Prod type:&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp; </strong> Merge<p> <strong> Parent Prod ID:&nbsp;&nbsp;&nbsp;&nbsp; </strong> 102838<p> <strong> Parent Prod type: </strong> DataStripping<p> <strong> Conditions: </strong><p>dddb-20190206-3<p>cond-20191004-1</strong><p> <strong> List of Trigger Configuration Keys (TCK): </strong> </p> <p><p><strong>TCK &nbsp;&nbsp;&nbsp;&nbsp;&nbsp; Number of Files </strong><p>0x11361609 &nbsp;&nbsp;&nbsp;&nbsp;&nbsp; 7275<p>0x11321609 &nbsp;&nbsp;&nbsp;&nbsp;&nbsp; 2273<p>0x11341609 &nbsp;&nbsp;&nbsp;&nbsp;&nbsp; 2439<p>0x11381611 &nbsp;&nbsp;&nbsp;&nbsp;&nbsp; 799<p>0x11381612 &nbsp;&nbsp;&nbsp;&nbsp;&nbsp; 1511<p>0x11351609 &nbsp;&nbsp;&nbsp;&nbsp;&nbsp; 425",
+    "steps": [
+      {
+        "configuration_files": [
+          {
+            "title": "DaVinci/DV-Stripping28r2-Stripping.py"
+          },
+          {
+            "title": "DaVinci/DV-RedoCaloPID-Stripping_28_24.py"
+          },
+          {
+            "title": "DaVinci/DataType-2016.py"
+          },
+          {
+            "title": "DaVinci/InputType-RDST.py"
+          },
+          {
+            "title": "Persistency/Compression-ZLIB-1.py"
+          },
+          {
+            "title": "DaVinci/DV-RawEventJuggler-0_3-to-4_3.py"
+          }
+        ],
+        "release": "DaVinci.v44r10p5 AppConfig.v3r393 Det/SQLDDDB.v7r10 TMVAWeights.v1r16",
+        "type": "Stripping28r2"
+      },
+      {
+        "configuration_files": [
+          {
+            "title": "Merging/DV-Stripping-Merging.py"
+          },
+          {
+            "title": "Persistency/Compression-LZMA-4.py"
+          }
+        ],
+        "release": "DaVinci.v44r10p5 AppConfig.v3r393 Det/SQLDDDB.v7r10",
+        "type": "Stripping28r2-Merging"
+      },
+      {
+        "configuration_files": [
+          {
+            "title": "DaVinci/DV-Stripping28r2-Stripping.py"
+          },
+          {
+            "title": "DaVinci/DV-RedoCaloPID-Stripping_28_24.py"
+          },
+          {
+            "title": "DaVinci/DataType-2016.py"
+          },
+          {
+            "title": "DaVinci/InputType-RDST.py"
+          },
+          {
+            "title": "Persistency/Compression-ZLIB-1.py"
+          },
+          {
+            "title": "DaVinci/DV-RawEventJuggler-0_3-to-4_3.py"
+          }
+        ],
+        "release": "DaVinci.v44r10p5 AppConfig.v3r393 Det/SQLDDDB.v7r10 TMVAWeights.v1r16",
+        "type": "Stripping28r2"
+      },
+      {
+        "configuration_files": [
+          {
+            "title": "Merging/DV-Stripping-Merging.py"
+          },
+          {
+            "title": "Persistency/Compression-LZMA-4.py"
+          }
+        ],
+        "release": "DaVinci.v44r10p5 AppConfig.v3r393 Det/SQLDDDB.v7r10",
+        "type": "Stripping28r2-Merging"
+      },
+      {
+        "configuration_files": [
+          {
+            "title": "DaVinci/DV-Stripping28r2-Stripping.py"
+          },
+          {
+            "title": "DaVinci/DV-RedoCaloPID-Stripping_28_24.py"
+          },
+          {
+            "title": "DaVinci/DataType-2016.py"
+          },
+          {
+            "title": "DaVinci/InputType-RDST.py"
+          },
+          {
+            "title": "Persistency/Compression-ZLIB-1.py"
+          },
+          {
+            "title": "DaVinci/DV-RawEventJuggler-0_3-to-4_3.py"
+          }
+        ],
+        "release": "DaVinci.v44r10p5 AppConfig.v3r393 Det/SQLDDDB.v7r10 TMVAWeights.v1r16",
+        "type": "Stripping28r2"
+      },
+      {
+        "configuration_files": [
+          {
+            "title": "Merging/DV-Stripping-Merging.py"
+          },
+          {
+            "title": "Persistency/Compression-LZMA-4.py"
+          }
+        ],
+        "release": "DaVinci.v44r10p5 AppConfig.v3r393 Det/SQLDDDB.v7r10",
+        "type": "Stripping28r2-Merging"
+      },
+      {
+        "configuration_files": [
+          {
+            "title": "DaVinci/DV-Stripping28r2-Stripping.py"
+          },
+          {
+            "title": "DaVinci/DV-RedoCaloPID-Stripping_28_24.py"
+          },
+          {
+            "title": "DaVinci/DataType-2016.py"
+          },
+          {
+            "title": "DaVinci/InputType-RDST.py"
+          },
+          {
+            "title": "Persistency/Compression-ZLIB-1.py"
+          },
+          {
+            "title": "DaVinci/DV-RawEventJuggler-0_3-to-4_3.py"
+          }
+        ],
+        "release": "DaVinci.v44r10p5 AppConfig.v3r393 Det/SQLDDDB.v7r10 TMVAWeights.v1r16",
+        "type": "Stripping28r2"
+      },
+      {
+        "configuration_files": [
+          {
+            "title": "Merging/DV-Stripping-Merging.py"
+          },
+          {
+            "title": "Persistency/Compression-LZMA-4.py"
+          }
+        ],
+        "release": "DaVinci.v44r10p5 AppConfig.v3r393 Det/SQLDDDB.v7r10",
+        "type": "Stripping28r2-Merging"
+      }
+    ]
+  },
+  "publisher": "CERN Open Data Portal",
+  "recid": "24658",
+  "run_period": [
+    "2016"
+  ],
+  "stripping": {
+    "stream": "DIMUON",
+    "version": "stripping28r2"
+  },
+  "title": "LHCb 2016 Beam6500GeV MagUp DIMUON Stream Stripping28r2",
+  "title_additional": "",
+  "type": {
+    "primary": "Dataset",
+    "secondary": [
+      "Collision"
+    ]
+  },
+  "usage": {
+    "description": "<p> The Run 1 and 2 data collected by the LHCb detector is available using the LHCb Ntupling Service, while the Run 1 data is additionally available in .DST and .mDST formats. The data obtained from the LHCb Ntupling Service are ROOT ntuples and do not require custom software to analyze. <p> Links are provided to the LHCb Ntupling Service for exploration of available data and the LHCb Open Data Guide for usage instructions.",
+    "links": [
+      {
+        "description": "LHCb Ntupling Service",
+        "url": "https://opendata-lhcb-ntupling-service.app.cern.ch/"
+      },
+      {
+        "description": "LHCb Open Data Guide",
+        "url": "https://lhcb-opendata-guide.web.cern.ch/"
+      }
+    ]
+  }
+}]

--- a/data/records/LHCb_2016_Beam6500GeV_VeloClosed_MagUp_RealData_Reco16_Stripping28r2_EW_DST.json
+++ b/data/records/LHCb_2016_Beam6500GeV_VeloClosed_MagUp_RealData_Reco16_Stripping28r2_EW_DST.json
@@ -1,0 +1,213 @@
+[{
+  "abstract": {
+    "description": "Data from proton-proton (pp) collisions collected by the LHCb experiment in the year 2016 of Run2 of the LHC."
+  },
+  "accelerator": "CERN-LHC",
+  "collaboration": {
+    "name": "LHCb collaboration",
+    "recid": "456"
+  },
+  "collections": [
+    "LHCb-Collision-Datasets"
+  ],
+  "collision_information": {
+    "energy": "13TeV",
+    "type": "pp"
+  },
+  "date_created": [
+    "2016"
+  ],
+  "date_published": "2026",
+  "date_reprocessed": "2020",
+  "distribution": {
+    "formats": [
+      "DST"
+    ],
+    "number_events": 296366899,
+    "number_files": 7923,
+    "size": 26160709397063
+  },
+  "experiment": [
+    "LHCb"
+  ],
+  "magnet_polarity": "MagUp",
+  "methodology": {
+    "description": "<p> This dataset was created in several production steps. These steps, software used and the configuration is provided below. </p><p> <strong> Prod ID: &nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;</strong> 102982<p> <strong>Prod type:&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp; </strong> Merge<p> <strong> Parent Prod ID:&nbsp;&nbsp;&nbsp;&nbsp; </strong> 102838<p> <strong> Parent Prod type: </strong> DataStripping<p> <strong> Conditions: </strong><p>dddb-20190206-3<p>cond-20191004-1</strong><p> <strong> List of Trigger Configuration Keys (TCK): </strong> </p> <p><p><strong>TCK &nbsp;&nbsp;&nbsp;&nbsp;&nbsp; Number of Files </strong><p>0x11361609 &nbsp;&nbsp;&nbsp;&nbsp;&nbsp; 3763<p>0x11321609 &nbsp;&nbsp;&nbsp;&nbsp;&nbsp; 1295<p>0x11341609 &nbsp;&nbsp;&nbsp;&nbsp;&nbsp; 1356<p>0x11381611 &nbsp;&nbsp;&nbsp;&nbsp;&nbsp; 436<p>0x11381612 &nbsp;&nbsp;&nbsp;&nbsp;&nbsp; 828<p>0x11351609 &nbsp;&nbsp;&nbsp;&nbsp;&nbsp; 245",
+    "steps": [
+      {
+        "configuration_files": [
+          {
+            "title": "DaVinci/DV-Stripping28r2-Stripping.py"
+          },
+          {
+            "title": "DaVinci/DV-RedoCaloPID-Stripping_28_24.py"
+          },
+          {
+            "title": "DaVinci/DataType-2016.py"
+          },
+          {
+            "title": "DaVinci/InputType-RDST.py"
+          },
+          {
+            "title": "Persistency/Compression-ZLIB-1.py"
+          },
+          {
+            "title": "DaVinci/DV-RawEventJuggler-0_3-to-4_3.py"
+          }
+        ],
+        "release": "DaVinci.v44r10p5 AppConfig.v3r393 Det/SQLDDDB.v7r10 TMVAWeights.v1r16",
+        "type": "Stripping28r2"
+      },
+      {
+        "configuration_files": [
+          {
+            "title": "Merging/DV-Stripping-Merging.py"
+          },
+          {
+            "title": "Persistency/Compression-LZMA-4.py"
+          }
+        ],
+        "release": "DaVinci.v44r10p5 AppConfig.v3r393 Det/SQLDDDB.v7r10",
+        "type": "Stripping28r2-Merging"
+      },
+      {
+        "configuration_files": [
+          {
+            "title": "DaVinci/DV-Stripping28r2-Stripping.py"
+          },
+          {
+            "title": "DaVinci/DV-RedoCaloPID-Stripping_28_24.py"
+          },
+          {
+            "title": "DaVinci/DataType-2016.py"
+          },
+          {
+            "title": "DaVinci/InputType-RDST.py"
+          },
+          {
+            "title": "Persistency/Compression-ZLIB-1.py"
+          },
+          {
+            "title": "DaVinci/DV-RawEventJuggler-0_3-to-4_3.py"
+          }
+        ],
+        "release": "DaVinci.v44r10p5 AppConfig.v3r393 Det/SQLDDDB.v7r10 TMVAWeights.v1r16",
+        "type": "Stripping28r2"
+      },
+      {
+        "configuration_files": [
+          {
+            "title": "Merging/DV-Stripping-Merging.py"
+          },
+          {
+            "title": "Persistency/Compression-LZMA-4.py"
+          }
+        ],
+        "release": "DaVinci.v44r10p5 AppConfig.v3r393 Det/SQLDDDB.v7r10",
+        "type": "Stripping28r2-Merging"
+      },
+      {
+        "configuration_files": [
+          {
+            "title": "DaVinci/DV-Stripping28r2-Stripping.py"
+          },
+          {
+            "title": "DaVinci/DV-RedoCaloPID-Stripping_28_24.py"
+          },
+          {
+            "title": "DaVinci/DataType-2016.py"
+          },
+          {
+            "title": "DaVinci/InputType-RDST.py"
+          },
+          {
+            "title": "Persistency/Compression-ZLIB-1.py"
+          },
+          {
+            "title": "DaVinci/DV-RawEventJuggler-0_3-to-4_3.py"
+          }
+        ],
+        "release": "DaVinci.v44r10p5 AppConfig.v3r393 Det/SQLDDDB.v7r10 TMVAWeights.v1r16",
+        "type": "Stripping28r2"
+      },
+      {
+        "configuration_files": [
+          {
+            "title": "Merging/DV-Stripping-Merging.py"
+          },
+          {
+            "title": "Persistency/Compression-LZMA-4.py"
+          }
+        ],
+        "release": "DaVinci.v44r10p5 AppConfig.v3r393 Det/SQLDDDB.v7r10",
+        "type": "Stripping28r2-Merging"
+      },
+      {
+        "configuration_files": [
+          {
+            "title": "DaVinci/DV-Stripping28r2-Stripping.py"
+          },
+          {
+            "title": "DaVinci/DV-RedoCaloPID-Stripping_28_24.py"
+          },
+          {
+            "title": "DaVinci/DataType-2016.py"
+          },
+          {
+            "title": "DaVinci/InputType-RDST.py"
+          },
+          {
+            "title": "Persistency/Compression-ZLIB-1.py"
+          },
+          {
+            "title": "DaVinci/DV-RawEventJuggler-0_3-to-4_3.py"
+          }
+        ],
+        "release": "DaVinci.v44r10p5 AppConfig.v3r393 Det/SQLDDDB.v7r10 TMVAWeights.v1r16",
+        "type": "Stripping28r2"
+      },
+      {
+        "configuration_files": [
+          {
+            "title": "Merging/DV-Stripping-Merging.py"
+          },
+          {
+            "title": "Persistency/Compression-LZMA-4.py"
+          }
+        ],
+        "release": "DaVinci.v44r10p5 AppConfig.v3r393 Det/SQLDDDB.v7r10",
+        "type": "Stripping28r2-Merging"
+      }
+    ]
+  },
+  "publisher": "CERN Open Data Portal",
+  "recid": "24650",
+  "run_period": [
+    "2016"
+  ],
+  "stripping": {
+    "stream": "EW",
+    "version": "stripping28r2"
+  },
+  "title": "LHCb 2016 Beam6500GeV MagUp EW Stream Stripping28r2",
+  "title_additional": "",
+  "type": {
+    "primary": "Dataset",
+    "secondary": [
+      "Collision"
+    ]
+  },
+  "usage": {
+    "description": "<p> The Run 1 and 2 data collected by the LHCb detector is available using the LHCb Ntupling Service, while the Run 1 data is additionally available in .DST and .mDST formats. The data obtained from the LHCb Ntupling Service are ROOT ntuples and do not require custom software to analyze. <p> Links are provided to the LHCb Ntupling Service for exploration of available data and the LHCb Open Data Guide for usage instructions.",
+    "links": [
+      {
+        "description": "LHCb Ntupling Service",
+        "url": "https://opendata-lhcb-ntupling-service.app.cern.ch/"
+      },
+      {
+        "description": "LHCb Open Data Guide",
+        "url": "https://lhcb-opendata-guide.web.cern.ch/"
+      }
+    ]
+  }
+}]

--- a/data/records/LHCb_2016_Beam6500GeV_VeloClosed_MagUp_RealData_Reco16_Stripping28r2_LEPTONIC_MDST.json
+++ b/data/records/LHCb_2016_Beam6500GeV_VeloClosed_MagUp_RealData_Reco16_Stripping28r2_LEPTONIC_MDST.json
@@ -1,0 +1,213 @@
+[{
+  "abstract": {
+    "description": "Data from proton-proton (pp) collisions collected by the LHCb experiment in the year 2016 of Run2 of the LHC."
+  },
+  "accelerator": "CERN-LHC",
+  "collaboration": {
+    "name": "LHCb collaboration",
+    "recid": "456"
+  },
+  "collections": [
+    "LHCb-Collision-Datasets"
+  ],
+  "collision_information": {
+    "energy": "13TeV",
+    "type": "pp"
+  },
+  "date_created": [
+    "2016"
+  ],
+  "date_published": "2026",
+  "date_reprocessed": "2020",
+  "distribution": {
+    "formats": [
+      "MDST"
+    ],
+    "number_events": 4072546670,
+    "number_files": 13758,
+    "size": 50692422105127
+  },
+  "experiment": [
+    "LHCb"
+  ],
+  "magnet_polarity": "MagUp",
+  "methodology": {
+    "description": "<p> This dataset was created in several production steps. These steps, software used and the configuration is provided below. </p><p> <strong> Prod ID: &nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;</strong> 103102<p> <strong>Prod type:&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp; </strong> Merge<p> <strong> Parent Prod ID:&nbsp;&nbsp;&nbsp;&nbsp; </strong> 102838<p> <strong> Parent Prod type: </strong> DataStripping<p> <strong> Conditions: </strong><p>dddb-20190206-3<p>cond-20191004-1</strong><p> <strong> List of Trigger Configuration Keys (TCK): </strong> </p> <p><p><strong>TCK &nbsp;&nbsp;&nbsp;&nbsp;&nbsp; Number of Files </strong><p>0x11361609 &nbsp;&nbsp;&nbsp;&nbsp;&nbsp; 6620<p>0x11321609 &nbsp;&nbsp;&nbsp;&nbsp;&nbsp; 2234<p>0x11341609 &nbsp;&nbsp;&nbsp;&nbsp;&nbsp; 2289<p>0x11381611 &nbsp;&nbsp;&nbsp;&nbsp;&nbsp; 764<p>0x11381612 &nbsp;&nbsp;&nbsp;&nbsp;&nbsp; 1457<p>0x11351609 &nbsp;&nbsp;&nbsp;&nbsp;&nbsp; 394",
+    "steps": [
+      {
+        "configuration_files": [
+          {
+            "title": "DaVinci/DV-Stripping28r2-Stripping.py"
+          },
+          {
+            "title": "DaVinci/DV-RedoCaloPID-Stripping_28_24.py"
+          },
+          {
+            "title": "DaVinci/DataType-2016.py"
+          },
+          {
+            "title": "DaVinci/InputType-RDST.py"
+          },
+          {
+            "title": "Persistency/Compression-ZLIB-1.py"
+          },
+          {
+            "title": "DaVinci/DV-RawEventJuggler-0_3-to-4_3.py"
+          }
+        ],
+        "release": "DaVinci.v44r10p5 AppConfig.v3r393 Det/SQLDDDB.v7r10 TMVAWeights.v1r16",
+        "type": "Stripping28r2"
+      },
+      {
+        "configuration_files": [
+          {
+            "title": "Merging/DV-Stripping-Merging.py"
+          },
+          {
+            "title": "Persistency/Compression-LZMA-4.py"
+          }
+        ],
+        "release": "DaVinci.v44r10p5 AppConfig.v3r393 Det/SQLDDDB.v7r10",
+        "type": "Stripping28r2-Merging"
+      },
+      {
+        "configuration_files": [
+          {
+            "title": "DaVinci/DV-Stripping28r2-Stripping.py"
+          },
+          {
+            "title": "DaVinci/DV-RedoCaloPID-Stripping_28_24.py"
+          },
+          {
+            "title": "DaVinci/DataType-2016.py"
+          },
+          {
+            "title": "DaVinci/InputType-RDST.py"
+          },
+          {
+            "title": "Persistency/Compression-ZLIB-1.py"
+          },
+          {
+            "title": "DaVinci/DV-RawEventJuggler-0_3-to-4_3.py"
+          }
+        ],
+        "release": "DaVinci.v44r10p5 AppConfig.v3r393 Det/SQLDDDB.v7r10 TMVAWeights.v1r16",
+        "type": "Stripping28r2"
+      },
+      {
+        "configuration_files": [
+          {
+            "title": "Merging/DV-Stripping-Merging.py"
+          },
+          {
+            "title": "Persistency/Compression-LZMA-4.py"
+          }
+        ],
+        "release": "DaVinci.v44r10p5 AppConfig.v3r393 Det/SQLDDDB.v7r10",
+        "type": "Stripping28r2-Merging"
+      },
+      {
+        "configuration_files": [
+          {
+            "title": "DaVinci/DV-Stripping28r2-Stripping.py"
+          },
+          {
+            "title": "DaVinci/DV-RedoCaloPID-Stripping_28_24.py"
+          },
+          {
+            "title": "DaVinci/DataType-2016.py"
+          },
+          {
+            "title": "DaVinci/InputType-RDST.py"
+          },
+          {
+            "title": "Persistency/Compression-ZLIB-1.py"
+          },
+          {
+            "title": "DaVinci/DV-RawEventJuggler-0_3-to-4_3.py"
+          }
+        ],
+        "release": "DaVinci.v44r10p5 AppConfig.v3r393 Det/SQLDDDB.v7r10 TMVAWeights.v1r16",
+        "type": "Stripping28r2"
+      },
+      {
+        "configuration_files": [
+          {
+            "title": "Merging/DV-Stripping-Merging.py"
+          },
+          {
+            "title": "Persistency/Compression-LZMA-4.py"
+          }
+        ],
+        "release": "DaVinci.v44r10p5 AppConfig.v3r393 Det/SQLDDDB.v7r10",
+        "type": "Stripping28r2-Merging"
+      },
+      {
+        "configuration_files": [
+          {
+            "title": "DaVinci/DV-Stripping28r2-Stripping.py"
+          },
+          {
+            "title": "DaVinci/DV-RedoCaloPID-Stripping_28_24.py"
+          },
+          {
+            "title": "DaVinci/DataType-2016.py"
+          },
+          {
+            "title": "DaVinci/InputType-RDST.py"
+          },
+          {
+            "title": "Persistency/Compression-ZLIB-1.py"
+          },
+          {
+            "title": "DaVinci/DV-RawEventJuggler-0_3-to-4_3.py"
+          }
+        ],
+        "release": "DaVinci.v44r10p5 AppConfig.v3r393 Det/SQLDDDB.v7r10 TMVAWeights.v1r16",
+        "type": "Stripping28r2"
+      },
+      {
+        "configuration_files": [
+          {
+            "title": "Merging/DV-Stripping-Merging.py"
+          },
+          {
+            "title": "Persistency/Compression-LZMA-4.py"
+          }
+        ],
+        "release": "DaVinci.v44r10p5 AppConfig.v3r393 Det/SQLDDDB.v7r10",
+        "type": "Stripping28r2-Merging"
+      }
+    ]
+  },
+  "publisher": "CERN Open Data Portal",
+  "recid": "24651",
+  "run_period": [
+    "2016"
+  ],
+  "stripping": {
+    "stream": "LEPTONIC",
+    "version": "stripping28r2"
+  },
+  "title": "LHCb 2016 Beam6500GeV MagUp LEPTONIC Stream Stripping28r2",
+  "title_additional": "",
+  "type": {
+    "primary": "Dataset",
+    "secondary": [
+      "Collision"
+    ]
+  },
+  "usage": {
+    "description": "<p> The Run 1 and 2 data collected by the LHCb detector is available using the LHCb Ntupling Service, while the Run 1 data is additionally available in .DST and .mDST formats. The data obtained from the LHCb Ntupling Service are ROOT ntuples and do not require custom software to analyze. <p> Links are provided to the LHCb Ntupling Service for exploration of available data and the LHCb Open Data Guide for usage instructions.",
+    "links": [
+      {
+        "description": "LHCb Ntupling Service",
+        "url": "https://opendata-lhcb-ntupling-service.app.cern.ch/"
+      },
+      {
+        "description": "LHCb Open Data Guide",
+        "url": "https://lhcb-opendata-guide.web.cern.ch/"
+      }
+    ]
+  }
+}]

--- a/data/records/LHCb_2016_Beam6500GeV_VeloClosed_MagUp_RealData_Reco16_Stripping28r2_LOWMULT_DST.json
+++ b/data/records/LHCb_2016_Beam6500GeV_VeloClosed_MagUp_RealData_Reco16_Stripping28r2_LOWMULT_DST.json
@@ -1,0 +1,213 @@
+[{
+  "abstract": {
+    "description": "Data from proton-proton (pp) collisions collected by the LHCb experiment in the year 2016 of Run2 of the LHC."
+  },
+  "accelerator": "CERN-LHC",
+  "collaboration": {
+    "name": "LHCb collaboration",
+    "recid": "456"
+  },
+  "collections": [
+    "LHCb-Collision-Datasets"
+  ],
+  "collision_information": {
+    "energy": "13TeV",
+    "type": "pp"
+  },
+  "date_created": [
+    "2016"
+  ],
+  "date_published": "2026",
+  "date_reprocessed": "2020",
+  "distribution": {
+    "formats": [
+      "DST"
+    ],
+    "number_events": 2775292359,
+    "number_files": 7415,
+    "size": 22380493212961
+  },
+  "experiment": [
+    "LHCb"
+  ],
+  "magnet_polarity": "MagUp",
+  "methodology": {
+    "description": "<p> This dataset was created in several production steps. These steps, software used and the configuration is provided below. </p><p> <strong> Prod ID: &nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;</strong> 102839<p> <strong>Prod type:&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp; </strong> Merge<p> <strong> Parent Prod ID:&nbsp;&nbsp;&nbsp;&nbsp; </strong> 102838<p> <strong> Parent Prod type: </strong> DataStripping<p> <strong> Conditions: </strong><p>dddb-20190206-3<p>cond-20191004-1</strong><p> <strong> List of Trigger Configuration Keys (TCK): </strong> </p> <p><p><strong>TCK &nbsp;&nbsp;&nbsp;&nbsp;&nbsp; Number of Files </strong><p>0x11361609 &nbsp;&nbsp;&nbsp;&nbsp;&nbsp; 2994<p>0x11321609 &nbsp;&nbsp;&nbsp;&nbsp;&nbsp; 1467<p>0x11341609 &nbsp;&nbsp;&nbsp;&nbsp;&nbsp; 1628<p>0x11381611 &nbsp;&nbsp;&nbsp;&nbsp;&nbsp; 349<p>0x11381612 &nbsp;&nbsp;&nbsp;&nbsp;&nbsp; 672<p>0x11351609 &nbsp;&nbsp;&nbsp;&nbsp;&nbsp; 305",
+    "steps": [
+      {
+        "configuration_files": [
+          {
+            "title": "DaVinci/DV-Stripping28r2-Stripping.py"
+          },
+          {
+            "title": "DaVinci/DV-RedoCaloPID-Stripping_28_24.py"
+          },
+          {
+            "title": "DaVinci/DataType-2016.py"
+          },
+          {
+            "title": "DaVinci/InputType-RDST.py"
+          },
+          {
+            "title": "Persistency/Compression-ZLIB-1.py"
+          },
+          {
+            "title": "DaVinci/DV-RawEventJuggler-0_3-to-4_3.py"
+          }
+        ],
+        "release": "DaVinci.v44r10p5 AppConfig.v3r393 Det/SQLDDDB.v7r10 TMVAWeights.v1r16",
+        "type": "Stripping28r2"
+      },
+      {
+        "configuration_files": [
+          {
+            "title": "Merging/DV-Stripping-Merging.py"
+          },
+          {
+            "title": "Persistency/Compression-LZMA-4.py"
+          }
+        ],
+        "release": "DaVinci.v44r10p5 AppConfig.v3r393 Det/SQLDDDB.v7r10",
+        "type": "Stripping28r2-Merging"
+      },
+      {
+        "configuration_files": [
+          {
+            "title": "DaVinci/DV-Stripping28r2-Stripping.py"
+          },
+          {
+            "title": "DaVinci/DV-RedoCaloPID-Stripping_28_24.py"
+          },
+          {
+            "title": "DaVinci/DataType-2016.py"
+          },
+          {
+            "title": "DaVinci/InputType-RDST.py"
+          },
+          {
+            "title": "Persistency/Compression-ZLIB-1.py"
+          },
+          {
+            "title": "DaVinci/DV-RawEventJuggler-0_3-to-4_3.py"
+          }
+        ],
+        "release": "DaVinci.v44r10p5 AppConfig.v3r393 Det/SQLDDDB.v7r10 TMVAWeights.v1r16",
+        "type": "Stripping28r2"
+      },
+      {
+        "configuration_files": [
+          {
+            "title": "Merging/DV-Stripping-Merging.py"
+          },
+          {
+            "title": "Persistency/Compression-LZMA-4.py"
+          }
+        ],
+        "release": "DaVinci.v44r10p5 AppConfig.v3r393 Det/SQLDDDB.v7r10",
+        "type": "Stripping28r2-Merging"
+      },
+      {
+        "configuration_files": [
+          {
+            "title": "DaVinci/DV-Stripping28r2-Stripping.py"
+          },
+          {
+            "title": "DaVinci/DV-RedoCaloPID-Stripping_28_24.py"
+          },
+          {
+            "title": "DaVinci/DataType-2016.py"
+          },
+          {
+            "title": "DaVinci/InputType-RDST.py"
+          },
+          {
+            "title": "Persistency/Compression-ZLIB-1.py"
+          },
+          {
+            "title": "DaVinci/DV-RawEventJuggler-0_3-to-4_3.py"
+          }
+        ],
+        "release": "DaVinci.v44r10p5 AppConfig.v3r393 Det/SQLDDDB.v7r10 TMVAWeights.v1r16",
+        "type": "Stripping28r2"
+      },
+      {
+        "configuration_files": [
+          {
+            "title": "Merging/DV-Stripping-Merging.py"
+          },
+          {
+            "title": "Persistency/Compression-LZMA-4.py"
+          }
+        ],
+        "release": "DaVinci.v44r10p5 AppConfig.v3r393 Det/SQLDDDB.v7r10",
+        "type": "Stripping28r2-Merging"
+      },
+      {
+        "configuration_files": [
+          {
+            "title": "DaVinci/DV-Stripping28r2-Stripping.py"
+          },
+          {
+            "title": "DaVinci/DV-RedoCaloPID-Stripping_28_24.py"
+          },
+          {
+            "title": "DaVinci/DataType-2016.py"
+          },
+          {
+            "title": "DaVinci/InputType-RDST.py"
+          },
+          {
+            "title": "Persistency/Compression-ZLIB-1.py"
+          },
+          {
+            "title": "DaVinci/DV-RawEventJuggler-0_3-to-4_3.py"
+          }
+        ],
+        "release": "DaVinci.v44r10p5 AppConfig.v3r393 Det/SQLDDDB.v7r10 TMVAWeights.v1r16",
+        "type": "Stripping28r2"
+      },
+      {
+        "configuration_files": [
+          {
+            "title": "Merging/DV-Stripping-Merging.py"
+          },
+          {
+            "title": "Persistency/Compression-LZMA-4.py"
+          }
+        ],
+        "release": "DaVinci.v44r10p5 AppConfig.v3r393 Det/SQLDDDB.v7r10",
+        "type": "Stripping28r2-Merging"
+      }
+    ]
+  },
+  "publisher": "CERN Open Data Portal",
+  "recid": "24652",
+  "run_period": [
+    "2016"
+  ],
+  "stripping": {
+    "stream": "LOWMULT",
+    "version": "stripping28r2"
+  },
+  "title": "LHCb 2016 Beam6500GeV MagUp LOWMULT Stream Stripping28r2",
+  "title_additional": "",
+  "type": {
+    "primary": "Dataset",
+    "secondary": [
+      "Collision"
+    ]
+  },
+  "usage": {
+    "description": "<p> The Run 1 and 2 data collected by the LHCb detector is available using the LHCb Ntupling Service, while the Run 1 data is additionally available in .DST and .mDST formats. The data obtained from the LHCb Ntupling Service are ROOT ntuples and do not require custom software to analyze. <p> Links are provided to the LHCb Ntupling Service for exploration of available data and the LHCb Open Data Guide for usage instructions.",
+    "links": [
+      {
+        "description": "LHCb Ntupling Service",
+        "url": "https://opendata-lhcb-ntupling-service.app.cern.ch/"
+      },
+      {
+        "description": "LHCb Open Data Guide",
+        "url": "https://lhcb-opendata-guide.web.cern.ch/"
+      }
+    ]
+  }
+}]

--- a/data/records/LHCb_2016_Beam6500GeV_VeloClosed_MagUp_RealData_Reco16_Stripping28r2_SEMILEPTONIC_DST.json
+++ b/data/records/LHCb_2016_Beam6500GeV_VeloClosed_MagUp_RealData_Reco16_Stripping28r2_SEMILEPTONIC_DST.json
@@ -1,0 +1,213 @@
+[{
+  "abstract": {
+    "description": "Data from proton-proton (pp) collisions collected by the LHCb experiment in the year 2016 of Run2 of the LHC."
+  },
+  "accelerator": "CERN-LHC",
+  "collaboration": {
+    "name": "LHCb collaboration",
+    "recid": "456"
+  },
+  "collections": [
+    "LHCb-Collision-Datasets"
+  ],
+  "collision_information": {
+    "energy": "13TeV",
+    "type": "pp"
+  },
+  "date_created": [
+    "2016"
+  ],
+  "date_published": "2026",
+  "date_reprocessed": "2020",
+  "distribution": {
+    "formats": [
+      "DST"
+    ],
+    "number_events": 946833490,
+    "number_files": 19927,
+    "size": 71332062154496
+  },
+  "experiment": [
+    "LHCb"
+  ],
+  "magnet_polarity": "MagUp",
+  "methodology": {
+    "description": "<p> This dataset was created in several production steps. These steps, software used and the configuration is provided below. </p><p> <strong> Prod ID: &nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;</strong> 103102<p> <strong>Prod type:&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp; </strong> Merge<p> <strong> Parent Prod ID:&nbsp;&nbsp;&nbsp;&nbsp; </strong> 102838<p> <strong> Parent Prod type: </strong> DataStripping<p> <strong> Conditions: </strong><p>dddb-20190206-3<p>cond-20191004-1</strong><p> <strong> List of Trigger Configuration Keys (TCK): </strong> </p> <p><p><strong>TCK &nbsp;&nbsp;&nbsp;&nbsp;&nbsp; Number of Files </strong><p>0x11361609 &nbsp;&nbsp;&nbsp;&nbsp;&nbsp; 10043<p>0x11321609 &nbsp;&nbsp;&nbsp;&nbsp;&nbsp; 2918<p>0x11341609 &nbsp;&nbsp;&nbsp;&nbsp;&nbsp; 3143<p>0x11381611 &nbsp;&nbsp;&nbsp;&nbsp;&nbsp; 1105<p>0x11381612 &nbsp;&nbsp;&nbsp;&nbsp;&nbsp; 2140<p>0x11351609 &nbsp;&nbsp;&nbsp;&nbsp;&nbsp; 578",
+    "steps": [
+      {
+        "configuration_files": [
+          {
+            "title": "DaVinci/DV-Stripping28r2-Stripping.py"
+          },
+          {
+            "title": "DaVinci/DV-RedoCaloPID-Stripping_28_24.py"
+          },
+          {
+            "title": "DaVinci/DataType-2016.py"
+          },
+          {
+            "title": "DaVinci/InputType-RDST.py"
+          },
+          {
+            "title": "Persistency/Compression-ZLIB-1.py"
+          },
+          {
+            "title": "DaVinci/DV-RawEventJuggler-0_3-to-4_3.py"
+          }
+        ],
+        "release": "DaVinci.v44r10p5 AppConfig.v3r393 Det/SQLDDDB.v7r10 TMVAWeights.v1r16",
+        "type": "Stripping28r2"
+      },
+      {
+        "configuration_files": [
+          {
+            "title": "Merging/DV-Stripping-Merging.py"
+          },
+          {
+            "title": "Persistency/Compression-LZMA-4.py"
+          }
+        ],
+        "release": "DaVinci.v44r10p5 AppConfig.v3r393 Det/SQLDDDB.v7r10",
+        "type": "Stripping28r2-Merging"
+      },
+      {
+        "configuration_files": [
+          {
+            "title": "DaVinci/DV-Stripping28r2-Stripping.py"
+          },
+          {
+            "title": "DaVinci/DV-RedoCaloPID-Stripping_28_24.py"
+          },
+          {
+            "title": "DaVinci/DataType-2016.py"
+          },
+          {
+            "title": "DaVinci/InputType-RDST.py"
+          },
+          {
+            "title": "Persistency/Compression-ZLIB-1.py"
+          },
+          {
+            "title": "DaVinci/DV-RawEventJuggler-0_3-to-4_3.py"
+          }
+        ],
+        "release": "DaVinci.v44r10p5 AppConfig.v3r393 Det/SQLDDDB.v7r10 TMVAWeights.v1r16",
+        "type": "Stripping28r2"
+      },
+      {
+        "configuration_files": [
+          {
+            "title": "Merging/DV-Stripping-Merging.py"
+          },
+          {
+            "title": "Persistency/Compression-LZMA-4.py"
+          }
+        ],
+        "release": "DaVinci.v44r10p5 AppConfig.v3r393 Det/SQLDDDB.v7r10",
+        "type": "Stripping28r2-Merging"
+      },
+      {
+        "configuration_files": [
+          {
+            "title": "DaVinci/DV-Stripping28r2-Stripping.py"
+          },
+          {
+            "title": "DaVinci/DV-RedoCaloPID-Stripping_28_24.py"
+          },
+          {
+            "title": "DaVinci/DataType-2016.py"
+          },
+          {
+            "title": "DaVinci/InputType-RDST.py"
+          },
+          {
+            "title": "Persistency/Compression-ZLIB-1.py"
+          },
+          {
+            "title": "DaVinci/DV-RawEventJuggler-0_3-to-4_3.py"
+          }
+        ],
+        "release": "DaVinci.v44r10p5 AppConfig.v3r393 Det/SQLDDDB.v7r10 TMVAWeights.v1r16",
+        "type": "Stripping28r2"
+      },
+      {
+        "configuration_files": [
+          {
+            "title": "Merging/DV-Stripping-Merging.py"
+          },
+          {
+            "title": "Persistency/Compression-LZMA-4.py"
+          }
+        ],
+        "release": "DaVinci.v44r10p5 AppConfig.v3r393 Det/SQLDDDB.v7r10",
+        "type": "Stripping28r2-Merging"
+      },
+      {
+        "configuration_files": [
+          {
+            "title": "DaVinci/DV-Stripping28r2-Stripping.py"
+          },
+          {
+            "title": "DaVinci/DV-RedoCaloPID-Stripping_28_24.py"
+          },
+          {
+            "title": "DaVinci/DataType-2016.py"
+          },
+          {
+            "title": "DaVinci/InputType-RDST.py"
+          },
+          {
+            "title": "Persistency/Compression-ZLIB-1.py"
+          },
+          {
+            "title": "DaVinci/DV-RawEventJuggler-0_3-to-4_3.py"
+          }
+        ],
+        "release": "DaVinci.v44r10p5 AppConfig.v3r393 Det/SQLDDDB.v7r10 TMVAWeights.v1r16",
+        "type": "Stripping28r2"
+      },
+      {
+        "configuration_files": [
+          {
+            "title": "Merging/DV-Stripping-Merging.py"
+          },
+          {
+            "title": "Persistency/Compression-LZMA-4.py"
+          }
+        ],
+        "release": "DaVinci.v44r10p5 AppConfig.v3r393 Det/SQLDDDB.v7r10",
+        "type": "Stripping28r2-Merging"
+      }
+    ]
+  },
+  "publisher": "CERN Open Data Portal",
+  "recid": "24659",
+  "run_period": [
+    "2016"
+  ],
+  "stripping": {
+    "stream": "SEMILEPTONIC",
+    "version": "stripping28r2"
+  },
+  "title": "LHCb 2016 Beam6500GeV MagUp SEMILEPTONIC Stream Stripping28r2",
+  "title_additional": "",
+  "type": {
+    "primary": "Dataset",
+    "secondary": [
+      "Collision"
+    ]
+  },
+  "usage": {
+    "description": "<p> The Run 1 and 2 data collected by the LHCb detector is available using the LHCb Ntupling Service, while the Run 1 data is additionally available in .DST and .mDST formats. The data obtained from the LHCb Ntupling Service are ROOT ntuples and do not require custom software to analyze. <p> Links are provided to the LHCb Ntupling Service for exploration of available data and the LHCb Open Data Guide for usage instructions.",
+    "links": [
+      {
+        "description": "LHCb Ntupling Service",
+        "url": "https://opendata-lhcb-ntupling-service.app.cern.ch/"
+      },
+      {
+        "description": "LHCb Open Data Guide",
+        "url": "https://lhcb-opendata-guide.web.cern.ch/"
+      }
+    ]
+  }
+}]

--- a/data/records/LHCb_2016_Beam6500GeV_VeloClosed_MagUp_RealData_Reco16_Stripping28r2p1_BHADRONCOMPLETEEVENT_DST.json
+++ b/data/records/LHCb_2016_Beam6500GeV_VeloClosed_MagUp_RealData_Reco16_Stripping28r2p1_BHADRONCOMPLETEEVENT_DST.json
@@ -1,0 +1,213 @@
+[{
+  "abstract": {
+    "description": "Data from proton-proton (pp) collisions collected by the LHCb experiment in the year 2016 of Run2 of the LHC."
+  },
+  "accelerator": "CERN-LHC",
+  "collaboration": {
+    "name": "LHCb collaboration",
+    "recid": "456"
+  },
+  "collections": [
+    "LHCb-Collision-Datasets"
+  ],
+  "collision_information": {
+    "energy": "13TeV",
+    "type": "pp"
+  },
+  "date_created": [
+    "2016"
+  ],
+  "date_published": "2026",
+  "date_reprocessed": "2021",
+  "distribution": {
+    "formats": [
+      "DST"
+    ],
+    "number_events": 387722398,
+    "number_files": 11875,
+    "size": 42514760343168
+  },
+  "experiment": [
+    "LHCb"
+  ],
+  "magnet_polarity": "MagUp",
+  "methodology": {
+    "description": "<p> This dataset was created in several production steps. These steps, software used and the configuration is provided below. </p><p> <strong> Prod ID: &nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;</strong> 153030<p> <strong>Prod type:&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp; </strong> Merge<p> <strong> Parent Prod ID:&nbsp;&nbsp;&nbsp;&nbsp; </strong> 151976<p> <strong> Parent Prod type: </strong> DataStripping<p> <strong> Conditions: </strong><p>dddb-20210528-6<p>cond-20191004-1</strong><p> <strong> List of Trigger Configuration Keys (TCK): </strong> </p> <p><p><strong>TCK &nbsp;&nbsp;&nbsp;&nbsp;&nbsp; Number of Files </strong><p>0x11341609 &nbsp;&nbsp;&nbsp;&nbsp;&nbsp; 1929<p>0x11351609 &nbsp;&nbsp;&nbsp;&nbsp;&nbsp; 339<p>0x11361609 &nbsp;&nbsp;&nbsp;&nbsp;&nbsp; 5869<p>0x11381611 &nbsp;&nbsp;&nbsp;&nbsp;&nbsp; 651<p>0x11381612 &nbsp;&nbsp;&nbsp;&nbsp;&nbsp; 1270<p>0x11321609 &nbsp;&nbsp;&nbsp;&nbsp;&nbsp; 1817",
+    "steps": [
+      {
+        "configuration_files": [
+          {
+            "title": "DaVinci/DV-Stripping28r2p1-Stripping.py"
+          },
+          {
+            "title": "DaVinci/DataType-2016.py"
+          },
+          {
+            "title": "DaVinci/InputType-RDST.py"
+          },
+          {
+            "title": "DaVinci/DV-RawEventJuggler-0_3-to-4_3.py"
+          },
+          {
+            "title": "Persistency/Compression-ZLIB-1.py"
+          },
+          {
+            "title": "DaVinci/DV-RedoCaloPID-Stripping_28_24.py"
+          }
+        ],
+        "release": "DaVinci.v44r11p4 AppConfig.v3r407 Det/SQLDDDB.v7r10 TMVAWeights.v1r17",
+        "type": "Stripping28r2p1"
+      },
+      {
+        "configuration_files": [
+          {
+            "title": "Merging/DV-Stripping-Merging.py"
+          },
+          {
+            "title": "Persistency/Compression-LZMA-4.py"
+          }
+        ],
+        "release": "DaVinci.v44r11p4 AppConfig.v3r407 Det/SQLDDDB.v7r10",
+        "type": "Stripping28r2p1-Merging"
+      },
+      {
+        "configuration_files": [
+          {
+            "title": "DaVinci/DV-Stripping28r2p1-Stripping.py"
+          },
+          {
+            "title": "DaVinci/DataType-2016.py"
+          },
+          {
+            "title": "DaVinci/InputType-RDST.py"
+          },
+          {
+            "title": "DaVinci/DV-RawEventJuggler-0_3-to-4_3.py"
+          },
+          {
+            "title": "Persistency/Compression-ZLIB-1.py"
+          },
+          {
+            "title": "DaVinci/DV-RedoCaloPID-Stripping_28_24.py"
+          }
+        ],
+        "release": "DaVinci.v44r11p4 AppConfig.v3r407 Det/SQLDDDB.v7r10 TMVAWeights.v1r17",
+        "type": "Stripping28r2p1"
+      },
+      {
+        "configuration_files": [
+          {
+            "title": "Merging/DV-Stripping-Merging.py"
+          },
+          {
+            "title": "Persistency/Compression-LZMA-4.py"
+          }
+        ],
+        "release": "DaVinci.v44r11p4 AppConfig.v3r407 Det/SQLDDDB.v7r10",
+        "type": "Stripping28r2p1-Merging"
+      },
+      {
+        "configuration_files": [
+          {
+            "title": "DaVinci/DV-Stripping28r2p1-Stripping.py"
+          },
+          {
+            "title": "DaVinci/DataType-2016.py"
+          },
+          {
+            "title": "DaVinci/InputType-RDST.py"
+          },
+          {
+            "title": "DaVinci/DV-RawEventJuggler-0_3-to-4_3.py"
+          },
+          {
+            "title": "Persistency/Compression-ZLIB-1.py"
+          },
+          {
+            "title": "DaVinci/DV-RedoCaloPID-Stripping_28_24.py"
+          }
+        ],
+        "release": "DaVinci.v44r11p4 AppConfig.v3r407 Det/SQLDDDB.v7r10 TMVAWeights.v1r17",
+        "type": "Stripping28r2p1"
+      },
+      {
+        "configuration_files": [
+          {
+            "title": "Merging/DV-Stripping-Merging.py"
+          },
+          {
+            "title": "Persistency/Compression-LZMA-4.py"
+          }
+        ],
+        "release": "DaVinci.v44r11p4 AppConfig.v3r407 Det/SQLDDDB.v7r10",
+        "type": "Stripping28r2p1-Merging"
+      },
+      {
+        "configuration_files": [
+          {
+            "title": "DaVinci/DV-Stripping28r2p1-Stripping.py"
+          },
+          {
+            "title": "DaVinci/DataType-2016.py"
+          },
+          {
+            "title": "DaVinci/InputType-RDST.py"
+          },
+          {
+            "title": "DaVinci/DV-RawEventJuggler-0_3-to-4_3.py"
+          },
+          {
+            "title": "Persistency/Compression-ZLIB-1.py"
+          },
+          {
+            "title": "DaVinci/DV-RedoCaloPID-Stripping_28_24.py"
+          }
+        ],
+        "release": "DaVinci.v44r11p4 AppConfig.v3r407 Det/SQLDDDB.v7r10 TMVAWeights.v1r17",
+        "type": "Stripping28r2p1"
+      },
+      {
+        "configuration_files": [
+          {
+            "title": "Merging/DV-Stripping-Merging.py"
+          },
+          {
+            "title": "Persistency/Compression-LZMA-4.py"
+          }
+        ],
+        "release": "DaVinci.v44r11p4 AppConfig.v3r407 Det/SQLDDDB.v7r10",
+        "type": "Stripping28r2p1-Merging"
+      }
+    ]
+  },
+  "publisher": "CERN Open Data Portal",
+  "recid": "24675",
+  "run_period": [
+    "2016"
+  ],
+  "stripping": {
+    "stream": "BHADRONCOMPLETEEVENT",
+    "version": "stripping28r2p1"
+  },
+  "title": "LHCb 2016 Beam6500GeV MagUp BHADRONCOMPLETEEVENT Stream Stripping28r2p1",
+  "title_additional": "",
+  "type": {
+    "primary": "Dataset",
+    "secondary": [
+      "Collision"
+    ]
+  },
+  "usage": {
+    "description": "<p> The Run 1 and 2 data collected by the LHCb detector is available using the LHCb Ntupling Service, while the Run 1 data is additionally available in .DST and .mDST formats. The data obtained from the LHCb Ntupling Service are ROOT ntuples and do not require custom software to analyze. <p> Links are provided to the LHCb Ntupling Service for exploration of available data and the LHCb Open Data Guide for usage instructions.",
+    "links": [
+      {
+        "description": "LHCb Ntupling Service",
+        "url": "https://opendata-lhcb-ntupling-service.app.cern.ch/"
+      },
+      {
+        "description": "LHCb Open Data Guide",
+        "url": "https://lhcb-opendata-guide.web.cern.ch/"
+      }
+    ]
+  }
+}]

--- a/data/records/LHCb_2016_Beam6500GeV_VeloClosed_MagUp_RealData_Reco16_Stripping28r2p1_BHADRON_MDST.json
+++ b/data/records/LHCb_2016_Beam6500GeV_VeloClosed_MagUp_RealData_Reco16_Stripping28r2p1_BHADRON_MDST.json
@@ -1,0 +1,213 @@
+[{
+  "abstract": {
+    "description": "Data from proton-proton (pp) collisions collected by the LHCb experiment in the year 2016 of Run2 of the LHC."
+  },
+  "accelerator": "CERN-LHC",
+  "collaboration": {
+    "name": "LHCb collaboration",
+    "recid": "456"
+  },
+  "collections": [
+    "LHCb-Collision-Datasets"
+  ],
+  "collision_information": {
+    "energy": "13TeV",
+    "type": "pp"
+  },
+  "date_created": [
+    "2016"
+  ],
+  "date_published": "2026",
+  "date_reprocessed": "2021",
+  "distribution": {
+    "formats": [
+      "MDST"
+    ],
+    "number_events": 771806002,
+    "number_files": 5453,
+    "size": 14526392939660
+  },
+  "experiment": [
+    "LHCb"
+  ],
+  "magnet_polarity": "MagUp",
+  "methodology": {
+    "description": "<p> This dataset was created in several production steps. These steps, software used and the configuration is provided below. </p><p> <strong> Prod ID: &nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;</strong> 153030<p> <strong>Prod type:&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp; </strong> Merge<p> <strong> Parent Prod ID:&nbsp;&nbsp;&nbsp;&nbsp; </strong> 151976<p> <strong> Parent Prod type: </strong> DataStripping<p> <strong> Conditions: </strong><p>dddb-20210528-6<p>cond-20191004-1</strong><p> <strong> List of Trigger Configuration Keys (TCK): </strong> </p> <p><p><strong>TCK &nbsp;&nbsp;&nbsp;&nbsp;&nbsp; Number of Files </strong><p>0x11341609 &nbsp;&nbsp;&nbsp;&nbsp;&nbsp; 946<p>0x11351609 &nbsp;&nbsp;&nbsp;&nbsp;&nbsp; 169<p>0x11361609 &nbsp;&nbsp;&nbsp;&nbsp;&nbsp; 2698<p>0x11381611 &nbsp;&nbsp;&nbsp;&nbsp;&nbsp; 271<p>0x11381612 &nbsp;&nbsp;&nbsp;&nbsp;&nbsp; 526<p>0x11321609 &nbsp;&nbsp;&nbsp;&nbsp;&nbsp; 843",
+    "steps": [
+      {
+        "configuration_files": [
+          {
+            "title": "DaVinci/DV-Stripping28r2p1-Stripping.py"
+          },
+          {
+            "title": "DaVinci/DataType-2016.py"
+          },
+          {
+            "title": "DaVinci/InputType-RDST.py"
+          },
+          {
+            "title": "DaVinci/DV-RawEventJuggler-0_3-to-4_3.py"
+          },
+          {
+            "title": "Persistency/Compression-ZLIB-1.py"
+          },
+          {
+            "title": "DaVinci/DV-RedoCaloPID-Stripping_28_24.py"
+          }
+        ],
+        "release": "DaVinci.v44r11p4 AppConfig.v3r407 Det/SQLDDDB.v7r10 TMVAWeights.v1r17",
+        "type": "Stripping28r2p1"
+      },
+      {
+        "configuration_files": [
+          {
+            "title": "Merging/DV-Stripping-Merging.py"
+          },
+          {
+            "title": "Persistency/Compression-LZMA-4.py"
+          }
+        ],
+        "release": "DaVinci.v44r11p4 AppConfig.v3r407 Det/SQLDDDB.v7r10",
+        "type": "Stripping28r2p1-Merging"
+      },
+      {
+        "configuration_files": [
+          {
+            "title": "DaVinci/DV-Stripping28r2p1-Stripping.py"
+          },
+          {
+            "title": "DaVinci/DataType-2016.py"
+          },
+          {
+            "title": "DaVinci/InputType-RDST.py"
+          },
+          {
+            "title": "DaVinci/DV-RawEventJuggler-0_3-to-4_3.py"
+          },
+          {
+            "title": "Persistency/Compression-ZLIB-1.py"
+          },
+          {
+            "title": "DaVinci/DV-RedoCaloPID-Stripping_28_24.py"
+          }
+        ],
+        "release": "DaVinci.v44r11p4 AppConfig.v3r407 Det/SQLDDDB.v7r10 TMVAWeights.v1r17",
+        "type": "Stripping28r2p1"
+      },
+      {
+        "configuration_files": [
+          {
+            "title": "Merging/DV-Stripping-Merging.py"
+          },
+          {
+            "title": "Persistency/Compression-LZMA-4.py"
+          }
+        ],
+        "release": "DaVinci.v44r11p4 AppConfig.v3r407 Det/SQLDDDB.v7r10",
+        "type": "Stripping28r2p1-Merging"
+      },
+      {
+        "configuration_files": [
+          {
+            "title": "DaVinci/DV-Stripping28r2p1-Stripping.py"
+          },
+          {
+            "title": "DaVinci/DataType-2016.py"
+          },
+          {
+            "title": "DaVinci/InputType-RDST.py"
+          },
+          {
+            "title": "DaVinci/DV-RawEventJuggler-0_3-to-4_3.py"
+          },
+          {
+            "title": "Persistency/Compression-ZLIB-1.py"
+          },
+          {
+            "title": "DaVinci/DV-RedoCaloPID-Stripping_28_24.py"
+          }
+        ],
+        "release": "DaVinci.v44r11p4 AppConfig.v3r407 Det/SQLDDDB.v7r10 TMVAWeights.v1r17",
+        "type": "Stripping28r2p1"
+      },
+      {
+        "configuration_files": [
+          {
+            "title": "Merging/DV-Stripping-Merging.py"
+          },
+          {
+            "title": "Persistency/Compression-LZMA-4.py"
+          }
+        ],
+        "release": "DaVinci.v44r11p4 AppConfig.v3r407 Det/SQLDDDB.v7r10",
+        "type": "Stripping28r2p1-Merging"
+      },
+      {
+        "configuration_files": [
+          {
+            "title": "DaVinci/DV-Stripping28r2p1-Stripping.py"
+          },
+          {
+            "title": "DaVinci/DataType-2016.py"
+          },
+          {
+            "title": "DaVinci/InputType-RDST.py"
+          },
+          {
+            "title": "DaVinci/DV-RawEventJuggler-0_3-to-4_3.py"
+          },
+          {
+            "title": "Persistency/Compression-ZLIB-1.py"
+          },
+          {
+            "title": "DaVinci/DV-RedoCaloPID-Stripping_28_24.py"
+          }
+        ],
+        "release": "DaVinci.v44r11p4 AppConfig.v3r407 Det/SQLDDDB.v7r10 TMVAWeights.v1r17",
+        "type": "Stripping28r2p1"
+      },
+      {
+        "configuration_files": [
+          {
+            "title": "Merging/DV-Stripping-Merging.py"
+          },
+          {
+            "title": "Persistency/Compression-LZMA-4.py"
+          }
+        ],
+        "release": "DaVinci.v44r11p4 AppConfig.v3r407 Det/SQLDDDB.v7r10",
+        "type": "Stripping28r2p1-Merging"
+      }
+    ]
+  },
+  "publisher": "CERN Open Data Portal",
+  "recid": "24674",
+  "run_period": [
+    "2016"
+  ],
+  "stripping": {
+    "stream": "BHADRON",
+    "version": "stripping28r2p1"
+  },
+  "title": "LHCb 2016 Beam6500GeV MagUp BHADRON Stream Stripping28r2p1",
+  "title_additional": "",
+  "type": {
+    "primary": "Dataset",
+    "secondary": [
+      "Collision"
+    ]
+  },
+  "usage": {
+    "description": "<p> The Run 1 and 2 data collected by the LHCb detector is available using the LHCb Ntupling Service, while the Run 1 data is additionally available in .DST and .mDST formats. The data obtained from the LHCb Ntupling Service are ROOT ntuples and do not require custom software to analyze. <p> Links are provided to the LHCb Ntupling Service for exploration of available data and the LHCb Open Data Guide for usage instructions.",
+    "links": [
+      {
+        "description": "LHCb Ntupling Service",
+        "url": "https://opendata-lhcb-ntupling-service.app.cern.ch/"
+      },
+      {
+        "description": "LHCb Open Data Guide",
+        "url": "https://lhcb-opendata-guide.web.cern.ch/"
+      }
+    ]
+  }
+}]

--- a/data/records/LHCb_2016_Beam6500GeV_VeloClosed_MagUp_RealData_Reco16_Stripping28r2p1_CHARMCOMPLETEEVENT_DST.json
+++ b/data/records/LHCb_2016_Beam6500GeV_VeloClosed_MagUp_RealData_Reco16_Stripping28r2p1_CHARMCOMPLETEEVENT_DST.json
@@ -1,0 +1,213 @@
+[{
+  "abstract": {
+    "description": "Data from proton-proton (pp) collisions collected by the LHCb experiment in the year 2016 of Run2 of the LHC."
+  },
+  "accelerator": "CERN-LHC",
+  "collaboration": {
+    "name": "LHCb collaboration",
+    "recid": "456"
+  },
+  "collections": [
+    "LHCb-Collision-Datasets"
+  ],
+  "collision_information": {
+    "energy": "13TeV",
+    "type": "pp"
+  },
+  "date_created": [
+    "2016"
+  ],
+  "date_published": "2026",
+  "date_reprocessed": "2021",
+  "distribution": {
+    "formats": [
+      "DST"
+    ],
+    "number_events": 243156807,
+    "number_files": 7453,
+    "size": 23790504183683
+  },
+  "experiment": [
+    "LHCb"
+  ],
+  "magnet_polarity": "MagUp",
+  "methodology": {
+    "description": "<p> This dataset was created in several production steps. These steps, software used and the configuration is provided below. </p><p> <strong> Prod ID: &nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;</strong> 151977<p> <strong>Prod type:&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp; </strong> Merge<p> <strong> Parent Prod ID:&nbsp;&nbsp;&nbsp;&nbsp; </strong> 151976<p> <strong> Parent Prod type: </strong> DataStripping<p> <strong> Conditions: </strong><p>dddb-20210528-6<p>cond-20191004-1</strong><p> <strong> List of Trigger Configuration Keys (TCK): </strong> </p> <p><p><strong>TCK &nbsp;&nbsp;&nbsp;&nbsp;&nbsp; Number of Files </strong><p>0x11341609 &nbsp;&nbsp;&nbsp;&nbsp;&nbsp; 1245<p>0x11351609 &nbsp;&nbsp;&nbsp;&nbsp;&nbsp; 216<p>0x11361609 &nbsp;&nbsp;&nbsp;&nbsp;&nbsp; 3645<p>0x11381612 &nbsp;&nbsp;&nbsp;&nbsp;&nbsp; 781<p>0x11381611 &nbsp;&nbsp;&nbsp;&nbsp;&nbsp; 404<p>0x11321609 &nbsp;&nbsp;&nbsp;&nbsp;&nbsp; 1162",
+    "steps": [
+      {
+        "configuration_files": [
+          {
+            "title": "DaVinci/DV-Stripping28r2p1-Stripping.py"
+          },
+          {
+            "title": "DaVinci/DataType-2016.py"
+          },
+          {
+            "title": "DaVinci/InputType-RDST.py"
+          },
+          {
+            "title": "DaVinci/DV-RawEventJuggler-0_3-to-4_3.py"
+          },
+          {
+            "title": "Persistency/Compression-ZLIB-1.py"
+          },
+          {
+            "title": "DaVinci/DV-RedoCaloPID-Stripping_28_24.py"
+          }
+        ],
+        "release": "DaVinci.v44r11p4 AppConfig.v3r407 Det/SQLDDDB.v7r10 TMVAWeights.v1r17",
+        "type": "Stripping28r2p1"
+      },
+      {
+        "configuration_files": [
+          {
+            "title": "Merging/DV-Stripping-Merging.py"
+          },
+          {
+            "title": "Persistency/Compression-LZMA-4.py"
+          }
+        ],
+        "release": "DaVinci.v44r11p4 AppConfig.v3r407 Det/SQLDDDB.v7r10",
+        "type": "Stripping28r2p1-Merging"
+      },
+      {
+        "configuration_files": [
+          {
+            "title": "DaVinci/DV-Stripping28r2p1-Stripping.py"
+          },
+          {
+            "title": "DaVinci/DataType-2016.py"
+          },
+          {
+            "title": "DaVinci/InputType-RDST.py"
+          },
+          {
+            "title": "DaVinci/DV-RawEventJuggler-0_3-to-4_3.py"
+          },
+          {
+            "title": "Persistency/Compression-ZLIB-1.py"
+          },
+          {
+            "title": "DaVinci/DV-RedoCaloPID-Stripping_28_24.py"
+          }
+        ],
+        "release": "DaVinci.v44r11p4 AppConfig.v3r407 Det/SQLDDDB.v7r10 TMVAWeights.v1r17",
+        "type": "Stripping28r2p1"
+      },
+      {
+        "configuration_files": [
+          {
+            "title": "Merging/DV-Stripping-Merging.py"
+          },
+          {
+            "title": "Persistency/Compression-LZMA-4.py"
+          }
+        ],
+        "release": "DaVinci.v44r11p4 AppConfig.v3r407 Det/SQLDDDB.v7r10",
+        "type": "Stripping28r2p1-Merging"
+      },
+      {
+        "configuration_files": [
+          {
+            "title": "DaVinci/DV-Stripping28r2p1-Stripping.py"
+          },
+          {
+            "title": "DaVinci/DataType-2016.py"
+          },
+          {
+            "title": "DaVinci/InputType-RDST.py"
+          },
+          {
+            "title": "DaVinci/DV-RawEventJuggler-0_3-to-4_3.py"
+          },
+          {
+            "title": "Persistency/Compression-ZLIB-1.py"
+          },
+          {
+            "title": "DaVinci/DV-RedoCaloPID-Stripping_28_24.py"
+          }
+        ],
+        "release": "DaVinci.v44r11p4 AppConfig.v3r407 Det/SQLDDDB.v7r10 TMVAWeights.v1r17",
+        "type": "Stripping28r2p1"
+      },
+      {
+        "configuration_files": [
+          {
+            "title": "Merging/DV-Stripping-Merging.py"
+          },
+          {
+            "title": "Persistency/Compression-LZMA-4.py"
+          }
+        ],
+        "release": "DaVinci.v44r11p4 AppConfig.v3r407 Det/SQLDDDB.v7r10",
+        "type": "Stripping28r2p1-Merging"
+      },
+      {
+        "configuration_files": [
+          {
+            "title": "DaVinci/DV-Stripping28r2p1-Stripping.py"
+          },
+          {
+            "title": "DaVinci/DataType-2016.py"
+          },
+          {
+            "title": "DaVinci/InputType-RDST.py"
+          },
+          {
+            "title": "DaVinci/DV-RawEventJuggler-0_3-to-4_3.py"
+          },
+          {
+            "title": "Persistency/Compression-ZLIB-1.py"
+          },
+          {
+            "title": "DaVinci/DV-RedoCaloPID-Stripping_28_24.py"
+          }
+        ],
+        "release": "DaVinci.v44r11p4 AppConfig.v3r407 Det/SQLDDDB.v7r10 TMVAWeights.v1r17",
+        "type": "Stripping28r2p1"
+      },
+      {
+        "configuration_files": [
+          {
+            "title": "Merging/DV-Stripping-Merging.py"
+          },
+          {
+            "title": "Persistency/Compression-LZMA-4.py"
+          }
+        ],
+        "release": "DaVinci.v44r11p4 AppConfig.v3r407 Det/SQLDDDB.v7r10",
+        "type": "Stripping28r2p1-Merging"
+      }
+    ]
+  },
+  "publisher": "CERN Open Data Portal",
+  "recid": "24677",
+  "run_period": [
+    "2016"
+  ],
+  "stripping": {
+    "stream": "CHARMCOMPLETEEVENT",
+    "version": "stripping28r2p1"
+  },
+  "title": "LHCb 2016 Beam6500GeV MagUp CHARMCOMPLETEEVENT Stream Stripping28r2p1",
+  "title_additional": "",
+  "type": {
+    "primary": "Dataset",
+    "secondary": [
+      "Collision"
+    ]
+  },
+  "usage": {
+    "description": "<p> The Run 1 and 2 data collected by the LHCb detector is available using the LHCb Ntupling Service, while the Run 1 data is additionally available in .DST and .mDST formats. The data obtained from the LHCb Ntupling Service are ROOT ntuples and do not require custom software to analyze. <p> Links are provided to the LHCb Ntupling Service for exploration of available data and the LHCb Open Data Guide for usage instructions.",
+    "links": [
+      {
+        "description": "LHCb Ntupling Service",
+        "url": "https://opendata-lhcb-ntupling-service.app.cern.ch/"
+      },
+      {
+        "description": "LHCb Open Data Guide",
+        "url": "https://lhcb-opendata-guide.web.cern.ch/"
+      }
+    ]
+  }
+}]

--- a/data/records/LHCb_2016_Beam6500GeV_VeloClosed_MagUp_RealData_Reco16_Stripping28r2p1_CHARM_MDST.json
+++ b/data/records/LHCb_2016_Beam6500GeV_VeloClosed_MagUp_RealData_Reco16_Stripping28r2p1_CHARM_MDST.json
@@ -1,0 +1,213 @@
+[{
+  "abstract": {
+    "description": "Data from proton-proton (pp) collisions collected by the LHCb experiment in the year 2016 of Run2 of the LHC."
+  },
+  "accelerator": "CERN-LHC",
+  "collaboration": {
+    "name": "LHCb collaboration",
+    "recid": "456"
+  },
+  "collections": [
+    "LHCb-Collision-Datasets"
+  ],
+  "collision_information": {
+    "energy": "13TeV",
+    "type": "pp"
+  },
+  "date_created": [
+    "2016"
+  ],
+  "date_published": "2026",
+  "date_reprocessed": "2021",
+  "distribution": {
+    "formats": [
+      "MDST"
+    ],
+    "number_events": 1018678266,
+    "number_files": 5506,
+    "size": 17630863899968
+  },
+  "experiment": [
+    "LHCb"
+  ],
+  "magnet_polarity": "MagUp",
+  "methodology": {
+    "description": "<p> This dataset was created in several production steps. These steps, software used and the configuration is provided below. </p><p> <strong> Prod ID: &nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;</strong> 153030<p> <strong>Prod type:&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp; </strong> Merge<p> <strong> Parent Prod ID:&nbsp;&nbsp;&nbsp;&nbsp; </strong> 151976<p> <strong> Parent Prod type: </strong> DataStripping<p> <strong> Conditions: </strong><p>dddb-20210528-6<p>cond-20191004-1</strong><p> <strong> List of Trigger Configuration Keys (TCK): </strong> </p> <p><p><strong>TCK &nbsp;&nbsp;&nbsp;&nbsp;&nbsp; Number of Files </strong><p>0x11341609 &nbsp;&nbsp;&nbsp;&nbsp;&nbsp; 949<p>0x11351609 &nbsp;&nbsp;&nbsp;&nbsp;&nbsp; 169<p>0x11361609 &nbsp;&nbsp;&nbsp;&nbsp;&nbsp; 2724<p>0x11381611 &nbsp;&nbsp;&nbsp;&nbsp;&nbsp; 273<p>0x11381612 &nbsp;&nbsp;&nbsp;&nbsp;&nbsp; 546<p>0x11321609 &nbsp;&nbsp;&nbsp;&nbsp;&nbsp; 845",
+    "steps": [
+      {
+        "configuration_files": [
+          {
+            "title": "DaVinci/DV-Stripping28r2p1-Stripping.py"
+          },
+          {
+            "title": "DaVinci/DataType-2016.py"
+          },
+          {
+            "title": "DaVinci/InputType-RDST.py"
+          },
+          {
+            "title": "DaVinci/DV-RawEventJuggler-0_3-to-4_3.py"
+          },
+          {
+            "title": "Persistency/Compression-ZLIB-1.py"
+          },
+          {
+            "title": "DaVinci/DV-RedoCaloPID-Stripping_28_24.py"
+          }
+        ],
+        "release": "DaVinci.v44r11p4 AppConfig.v3r407 Det/SQLDDDB.v7r10 TMVAWeights.v1r17",
+        "type": "Stripping28r2p1"
+      },
+      {
+        "configuration_files": [
+          {
+            "title": "Merging/DV-Stripping-Merging.py"
+          },
+          {
+            "title": "Persistency/Compression-LZMA-4.py"
+          }
+        ],
+        "release": "DaVinci.v44r11p4 AppConfig.v3r407 Det/SQLDDDB.v7r10",
+        "type": "Stripping28r2p1-Merging"
+      },
+      {
+        "configuration_files": [
+          {
+            "title": "DaVinci/DV-Stripping28r2p1-Stripping.py"
+          },
+          {
+            "title": "DaVinci/DataType-2016.py"
+          },
+          {
+            "title": "DaVinci/InputType-RDST.py"
+          },
+          {
+            "title": "DaVinci/DV-RawEventJuggler-0_3-to-4_3.py"
+          },
+          {
+            "title": "Persistency/Compression-ZLIB-1.py"
+          },
+          {
+            "title": "DaVinci/DV-RedoCaloPID-Stripping_28_24.py"
+          }
+        ],
+        "release": "DaVinci.v44r11p4 AppConfig.v3r407 Det/SQLDDDB.v7r10 TMVAWeights.v1r17",
+        "type": "Stripping28r2p1"
+      },
+      {
+        "configuration_files": [
+          {
+            "title": "Merging/DV-Stripping-Merging.py"
+          },
+          {
+            "title": "Persistency/Compression-LZMA-4.py"
+          }
+        ],
+        "release": "DaVinci.v44r11p4 AppConfig.v3r407 Det/SQLDDDB.v7r10",
+        "type": "Stripping28r2p1-Merging"
+      },
+      {
+        "configuration_files": [
+          {
+            "title": "DaVinci/DV-Stripping28r2p1-Stripping.py"
+          },
+          {
+            "title": "DaVinci/DataType-2016.py"
+          },
+          {
+            "title": "DaVinci/InputType-RDST.py"
+          },
+          {
+            "title": "DaVinci/DV-RawEventJuggler-0_3-to-4_3.py"
+          },
+          {
+            "title": "Persistency/Compression-ZLIB-1.py"
+          },
+          {
+            "title": "DaVinci/DV-RedoCaloPID-Stripping_28_24.py"
+          }
+        ],
+        "release": "DaVinci.v44r11p4 AppConfig.v3r407 Det/SQLDDDB.v7r10 TMVAWeights.v1r17",
+        "type": "Stripping28r2p1"
+      },
+      {
+        "configuration_files": [
+          {
+            "title": "Merging/DV-Stripping-Merging.py"
+          },
+          {
+            "title": "Persistency/Compression-LZMA-4.py"
+          }
+        ],
+        "release": "DaVinci.v44r11p4 AppConfig.v3r407 Det/SQLDDDB.v7r10",
+        "type": "Stripping28r2p1-Merging"
+      },
+      {
+        "configuration_files": [
+          {
+            "title": "DaVinci/DV-Stripping28r2p1-Stripping.py"
+          },
+          {
+            "title": "DaVinci/DataType-2016.py"
+          },
+          {
+            "title": "DaVinci/InputType-RDST.py"
+          },
+          {
+            "title": "DaVinci/DV-RawEventJuggler-0_3-to-4_3.py"
+          },
+          {
+            "title": "Persistency/Compression-ZLIB-1.py"
+          },
+          {
+            "title": "DaVinci/DV-RedoCaloPID-Stripping_28_24.py"
+          }
+        ],
+        "release": "DaVinci.v44r11p4 AppConfig.v3r407 Det/SQLDDDB.v7r10 TMVAWeights.v1r17",
+        "type": "Stripping28r2p1"
+      },
+      {
+        "configuration_files": [
+          {
+            "title": "Merging/DV-Stripping-Merging.py"
+          },
+          {
+            "title": "Persistency/Compression-LZMA-4.py"
+          }
+        ],
+        "release": "DaVinci.v44r11p4 AppConfig.v3r407 Det/SQLDDDB.v7r10",
+        "type": "Stripping28r2p1-Merging"
+      }
+    ]
+  },
+  "publisher": "CERN Open Data Portal",
+  "recid": "24676",
+  "run_period": [
+    "2016"
+  ],
+  "stripping": {
+    "stream": "CHARM",
+    "version": "stripping28r2p1"
+  },
+  "title": "LHCb 2016 Beam6500GeV MagUp CHARM Stream Stripping28r2p1",
+  "title_additional": "",
+  "type": {
+    "primary": "Dataset",
+    "secondary": [
+      "Collision"
+    ]
+  },
+  "usage": {
+    "description": "<p> The Run 1 and 2 data collected by the LHCb detector is available using the LHCb Ntupling Service, while the Run 1 data is additionally available in .DST and .mDST formats. The data obtained from the LHCb Ntupling Service are ROOT ntuples and do not require custom software to analyze. <p> Links are provided to the LHCb Ntupling Service for exploration of available data and the LHCb Open Data Guide for usage instructions.",
+    "links": [
+      {
+        "description": "LHCb Ntupling Service",
+        "url": "https://opendata-lhcb-ntupling-service.app.cern.ch/"
+      },
+      {
+        "description": "LHCb Open Data Guide",
+        "url": "https://lhcb-opendata-guide.web.cern.ch/"
+      }
+    ]
+  }
+}]

--- a/data/records/LHCb_2016_Beam6500GeV_VeloClosed_MagUp_RealData_Reco16_Stripping28r2p1_DIMUON_DST.json
+++ b/data/records/LHCb_2016_Beam6500GeV_VeloClosed_MagUp_RealData_Reco16_Stripping28r2p1_DIMUON_DST.json
@@ -1,0 +1,213 @@
+[{
+  "abstract": {
+    "description": "Data from proton-proton (pp) collisions collected by the LHCb experiment in the year 2016 of Run2 of the LHC."
+  },
+  "accelerator": "CERN-LHC",
+  "collaboration": {
+    "name": "LHCb collaboration",
+    "recid": "456"
+  },
+  "collections": [
+    "LHCb-Collision-Datasets"
+  ],
+  "collision_information": {
+    "energy": "13TeV",
+    "type": "pp"
+  },
+  "date_created": [
+    "2016"
+  ],
+  "date_published": "2026",
+  "date_reprocessed": "2021",
+  "distribution": {
+    "formats": [
+      "DST"
+    ],
+    "number_events": 290036208,
+    "number_files": 8915,
+    "size": 30654993670459
+  },
+  "experiment": [
+    "LHCb"
+  ],
+  "magnet_polarity": "MagUp",
+  "methodology": {
+    "description": "<p> This dataset was created in several production steps. These steps, software used and the configuration is provided below. </p><p> <strong> Prod ID: &nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;</strong> 151977<p> <strong>Prod type:&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp; </strong> Merge<p> <strong> Parent Prod ID:&nbsp;&nbsp;&nbsp;&nbsp; </strong> 151976<p> <strong> Parent Prod type: </strong> DataStripping<p> <strong> Conditions: </strong><p>dddb-20210528-6<p>cond-20191004-1</strong><p> <strong> List of Trigger Configuration Keys (TCK): </strong> </p> <p><p><strong>TCK &nbsp;&nbsp;&nbsp;&nbsp;&nbsp; Number of Files </strong><p>0x11341609 &nbsp;&nbsp;&nbsp;&nbsp;&nbsp; 1490<p>0x11351609 &nbsp;&nbsp;&nbsp;&nbsp;&nbsp; 268<p>0x11361609 &nbsp;&nbsp;&nbsp;&nbsp;&nbsp; 4455<p>0x11381611 &nbsp;&nbsp;&nbsp;&nbsp;&nbsp; 469<p>0x11381612 &nbsp;&nbsp;&nbsp;&nbsp;&nbsp; 905<p>0x11321609 &nbsp;&nbsp;&nbsp;&nbsp;&nbsp; 1328",
+    "steps": [
+      {
+        "configuration_files": [
+          {
+            "title": "DaVinci/DV-Stripping28r2p1-Stripping.py"
+          },
+          {
+            "title": "DaVinci/DataType-2016.py"
+          },
+          {
+            "title": "DaVinci/InputType-RDST.py"
+          },
+          {
+            "title": "DaVinci/DV-RawEventJuggler-0_3-to-4_3.py"
+          },
+          {
+            "title": "Persistency/Compression-ZLIB-1.py"
+          },
+          {
+            "title": "DaVinci/DV-RedoCaloPID-Stripping_28_24.py"
+          }
+        ],
+        "release": "DaVinci.v44r11p4 AppConfig.v3r407 Det/SQLDDDB.v7r10 TMVAWeights.v1r17",
+        "type": "Stripping28r2p1"
+      },
+      {
+        "configuration_files": [
+          {
+            "title": "Merging/DV-Stripping-Merging.py"
+          },
+          {
+            "title": "Persistency/Compression-LZMA-4.py"
+          }
+        ],
+        "release": "DaVinci.v44r11p4 AppConfig.v3r407 Det/SQLDDDB.v7r10",
+        "type": "Stripping28r2p1-Merging"
+      },
+      {
+        "configuration_files": [
+          {
+            "title": "DaVinci/DV-Stripping28r2p1-Stripping.py"
+          },
+          {
+            "title": "DaVinci/DataType-2016.py"
+          },
+          {
+            "title": "DaVinci/InputType-RDST.py"
+          },
+          {
+            "title": "DaVinci/DV-RawEventJuggler-0_3-to-4_3.py"
+          },
+          {
+            "title": "Persistency/Compression-ZLIB-1.py"
+          },
+          {
+            "title": "DaVinci/DV-RedoCaloPID-Stripping_28_24.py"
+          }
+        ],
+        "release": "DaVinci.v44r11p4 AppConfig.v3r407 Det/SQLDDDB.v7r10 TMVAWeights.v1r17",
+        "type": "Stripping28r2p1"
+      },
+      {
+        "configuration_files": [
+          {
+            "title": "Merging/DV-Stripping-Merging.py"
+          },
+          {
+            "title": "Persistency/Compression-LZMA-4.py"
+          }
+        ],
+        "release": "DaVinci.v44r11p4 AppConfig.v3r407 Det/SQLDDDB.v7r10",
+        "type": "Stripping28r2p1-Merging"
+      },
+      {
+        "configuration_files": [
+          {
+            "title": "DaVinci/DV-Stripping28r2p1-Stripping.py"
+          },
+          {
+            "title": "DaVinci/DataType-2016.py"
+          },
+          {
+            "title": "DaVinci/InputType-RDST.py"
+          },
+          {
+            "title": "DaVinci/DV-RawEventJuggler-0_3-to-4_3.py"
+          },
+          {
+            "title": "Persistency/Compression-ZLIB-1.py"
+          },
+          {
+            "title": "DaVinci/DV-RedoCaloPID-Stripping_28_24.py"
+          }
+        ],
+        "release": "DaVinci.v44r11p4 AppConfig.v3r407 Det/SQLDDDB.v7r10 TMVAWeights.v1r17",
+        "type": "Stripping28r2p1"
+      },
+      {
+        "configuration_files": [
+          {
+            "title": "Merging/DV-Stripping-Merging.py"
+          },
+          {
+            "title": "Persistency/Compression-LZMA-4.py"
+          }
+        ],
+        "release": "DaVinci.v44r11p4 AppConfig.v3r407 Det/SQLDDDB.v7r10",
+        "type": "Stripping28r2p1-Merging"
+      },
+      {
+        "configuration_files": [
+          {
+            "title": "DaVinci/DV-Stripping28r2p1-Stripping.py"
+          },
+          {
+            "title": "DaVinci/DataType-2016.py"
+          },
+          {
+            "title": "DaVinci/InputType-RDST.py"
+          },
+          {
+            "title": "DaVinci/DV-RawEventJuggler-0_3-to-4_3.py"
+          },
+          {
+            "title": "Persistency/Compression-ZLIB-1.py"
+          },
+          {
+            "title": "DaVinci/DV-RedoCaloPID-Stripping_28_24.py"
+          }
+        ],
+        "release": "DaVinci.v44r11p4 AppConfig.v3r407 Det/SQLDDDB.v7r10 TMVAWeights.v1r17",
+        "type": "Stripping28r2p1"
+      },
+      {
+        "configuration_files": [
+          {
+            "title": "Merging/DV-Stripping-Merging.py"
+          },
+          {
+            "title": "Persistency/Compression-LZMA-4.py"
+          }
+        ],
+        "release": "DaVinci.v44r11p4 AppConfig.v3r407 Det/SQLDDDB.v7r10",
+        "type": "Stripping28r2p1-Merging"
+      }
+    ]
+  },
+  "publisher": "CERN Open Data Portal",
+  "recid": "24678",
+  "run_period": [
+    "2016"
+  ],
+  "stripping": {
+    "stream": "DIMUON",
+    "version": "stripping28r2p1"
+  },
+  "title": "LHCb 2016 Beam6500GeV MagUp DIMUON Stream Stripping28r2p1",
+  "title_additional": "",
+  "type": {
+    "primary": "Dataset",
+    "secondary": [
+      "Collision"
+    ]
+  },
+  "usage": {
+    "description": "<p> The Run 1 and 2 data collected by the LHCb detector is available using the LHCb Ntupling Service, while the Run 1 data is additionally available in .DST and .mDST formats. The data obtained from the LHCb Ntupling Service are ROOT ntuples and do not require custom software to analyze. <p> Links are provided to the LHCb Ntupling Service for exploration of available data and the LHCb Open Data Guide for usage instructions.",
+    "links": [
+      {
+        "description": "LHCb Ntupling Service",
+        "url": "https://opendata-lhcb-ntupling-service.app.cern.ch/"
+      },
+      {
+        "description": "LHCb Open Data Guide",
+        "url": "https://lhcb-opendata-guide.web.cern.ch/"
+      }
+    ]
+  }
+}]

--- a/data/records/LHCb_2016_Beam6500GeV_VeloClosed_MagUp_RealData_Reco16_Stripping28r2p1_LEPTONIC_MDST.json
+++ b/data/records/LHCb_2016_Beam6500GeV_VeloClosed_MagUp_RealData_Reco16_Stripping28r2p1_LEPTONIC_MDST.json
@@ -1,0 +1,213 @@
+[{
+  "abstract": {
+    "description": "Data from proton-proton (pp) collisions collected by the LHCb experiment in the year 2016 of Run2 of the LHC."
+  },
+  "accelerator": "CERN-LHC",
+  "collaboration": {
+    "name": "LHCb collaboration",
+    "recid": "456"
+  },
+  "collections": [
+    "LHCb-Collision-Datasets"
+  ],
+  "collision_information": {
+    "energy": "13TeV",
+    "type": "pp"
+  },
+  "date_created": [
+    "2016"
+  ],
+  "date_published": "2026",
+  "date_reprocessed": "2021",
+  "distribution": {
+    "formats": [
+      "MDST"
+    ],
+    "number_events": 1996808488,
+    "number_files": 14298,
+    "size": 57766646659998
+  },
+  "experiment": [
+    "LHCb"
+  ],
+  "magnet_polarity": "MagUp",
+  "methodology": {
+    "description": "<p> This dataset was created in several production steps. These steps, software used and the configuration is provided below. </p><p> <strong> Prod ID: &nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;</strong> 152413<p> <strong>Prod type:&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp; </strong> Merge<p> <strong> Parent Prod ID:&nbsp;&nbsp;&nbsp;&nbsp; </strong> 151976<p> <strong> Parent Prod type: </strong> DataStripping<p> <strong> Conditions: </strong><p>dddb-20210528-6<p>cond-20191004-1</strong><p> <strong> List of Trigger Configuration Keys (TCK): </strong> </p> <p><p><strong>TCK &nbsp;&nbsp;&nbsp;&nbsp;&nbsp; Number of Files </strong><p>0x11341609 &nbsp;&nbsp;&nbsp;&nbsp;&nbsp; 2363<p>0x11351609 &nbsp;&nbsp;&nbsp;&nbsp;&nbsp; 407<p>0x11361609 &nbsp;&nbsp;&nbsp;&nbsp;&nbsp; 7065<p>0x11381611 &nbsp;&nbsp;&nbsp;&nbsp;&nbsp; 768<p>0x11381612 &nbsp;&nbsp;&nbsp;&nbsp;&nbsp; 1480<p>0x11321609 &nbsp;&nbsp;&nbsp;&nbsp;&nbsp; 2215",
+    "steps": [
+      {
+        "configuration_files": [
+          {
+            "title": "DaVinci/DV-Stripping28r2p1-Stripping.py"
+          },
+          {
+            "title": "DaVinci/DataType-2016.py"
+          },
+          {
+            "title": "DaVinci/InputType-RDST.py"
+          },
+          {
+            "title": "DaVinci/DV-RawEventJuggler-0_3-to-4_3.py"
+          },
+          {
+            "title": "Persistency/Compression-ZLIB-1.py"
+          },
+          {
+            "title": "DaVinci/DV-RedoCaloPID-Stripping_28_24.py"
+          }
+        ],
+        "release": "DaVinci.v44r11p4 AppConfig.v3r407 Det/SQLDDDB.v7r10 TMVAWeights.v1r17",
+        "type": "Stripping28r2p1"
+      },
+      {
+        "configuration_files": [
+          {
+            "title": "Merging/DV-Stripping-Merging.py"
+          },
+          {
+            "title": "Persistency/Compression-LZMA-4.py"
+          }
+        ],
+        "release": "DaVinci.v44r11p4 AppConfig.v3r407 Det/SQLDDDB.v7r10",
+        "type": "Stripping28r2p1-Merging"
+      },
+      {
+        "configuration_files": [
+          {
+            "title": "DaVinci/DV-Stripping28r2p1-Stripping.py"
+          },
+          {
+            "title": "DaVinci/DataType-2016.py"
+          },
+          {
+            "title": "DaVinci/InputType-RDST.py"
+          },
+          {
+            "title": "DaVinci/DV-RawEventJuggler-0_3-to-4_3.py"
+          },
+          {
+            "title": "Persistency/Compression-ZLIB-1.py"
+          },
+          {
+            "title": "DaVinci/DV-RedoCaloPID-Stripping_28_24.py"
+          }
+        ],
+        "release": "DaVinci.v44r11p4 AppConfig.v3r407 Det/SQLDDDB.v7r10 TMVAWeights.v1r17",
+        "type": "Stripping28r2p1"
+      },
+      {
+        "configuration_files": [
+          {
+            "title": "Merging/DV-Stripping-Merging.py"
+          },
+          {
+            "title": "Persistency/Compression-LZMA-4.py"
+          }
+        ],
+        "release": "DaVinci.v44r11p4 AppConfig.v3r407 Det/SQLDDDB.v7r10",
+        "type": "Stripping28r2p1-Merging"
+      },
+      {
+        "configuration_files": [
+          {
+            "title": "DaVinci/DV-Stripping28r2p1-Stripping.py"
+          },
+          {
+            "title": "DaVinci/DataType-2016.py"
+          },
+          {
+            "title": "DaVinci/InputType-RDST.py"
+          },
+          {
+            "title": "DaVinci/DV-RawEventJuggler-0_3-to-4_3.py"
+          },
+          {
+            "title": "Persistency/Compression-ZLIB-1.py"
+          },
+          {
+            "title": "DaVinci/DV-RedoCaloPID-Stripping_28_24.py"
+          }
+        ],
+        "release": "DaVinci.v44r11p4 AppConfig.v3r407 Det/SQLDDDB.v7r10 TMVAWeights.v1r17",
+        "type": "Stripping28r2p1"
+      },
+      {
+        "configuration_files": [
+          {
+            "title": "Merging/DV-Stripping-Merging.py"
+          },
+          {
+            "title": "Persistency/Compression-LZMA-4.py"
+          }
+        ],
+        "release": "DaVinci.v44r11p4 AppConfig.v3r407 Det/SQLDDDB.v7r10",
+        "type": "Stripping28r2p1-Merging"
+      },
+      {
+        "configuration_files": [
+          {
+            "title": "DaVinci/DV-Stripping28r2p1-Stripping.py"
+          },
+          {
+            "title": "DaVinci/DataType-2016.py"
+          },
+          {
+            "title": "DaVinci/InputType-RDST.py"
+          },
+          {
+            "title": "DaVinci/DV-RawEventJuggler-0_3-to-4_3.py"
+          },
+          {
+            "title": "Persistency/Compression-ZLIB-1.py"
+          },
+          {
+            "title": "DaVinci/DV-RedoCaloPID-Stripping_28_24.py"
+          }
+        ],
+        "release": "DaVinci.v44r11p4 AppConfig.v3r407 Det/SQLDDDB.v7r10 TMVAWeights.v1r17",
+        "type": "Stripping28r2p1"
+      },
+      {
+        "configuration_files": [
+          {
+            "title": "Merging/DV-Stripping-Merging.py"
+          },
+          {
+            "title": "Persistency/Compression-LZMA-4.py"
+          }
+        ],
+        "release": "DaVinci.v44r11p4 AppConfig.v3r407 Det/SQLDDDB.v7r10",
+        "type": "Stripping28r2p1-Merging"
+      }
+    ]
+  },
+  "publisher": "CERN Open Data Portal",
+  "recid": "24671",
+  "run_period": [
+    "2016"
+  ],
+  "stripping": {
+    "stream": "LEPTONIC",
+    "version": "stripping28r2p1"
+  },
+  "title": "LHCb 2016 Beam6500GeV MagUp LEPTONIC Stream Stripping28r2p1",
+  "title_additional": "",
+  "type": {
+    "primary": "Dataset",
+    "secondary": [
+      "Collision"
+    ]
+  },
+  "usage": {
+    "description": "<p> The Run 1 and 2 data collected by the LHCb detector is available using the LHCb Ntupling Service, while the Run 1 data is additionally available in .DST and .mDST formats. The data obtained from the LHCb Ntupling Service are ROOT ntuples and do not require custom software to analyze. <p> Links are provided to the LHCb Ntupling Service for exploration of available data and the LHCb Open Data Guide for usage instructions.",
+    "links": [
+      {
+        "description": "LHCb Ntupling Service",
+        "url": "https://opendata-lhcb-ntupling-service.app.cern.ch/"
+      },
+      {
+        "description": "LHCb Open Data Guide",
+        "url": "https://lhcb-opendata-guide.web.cern.ch/"
+      }
+    ]
+  }
+}]

--- a/data/records/LHCb_2016_Beam6500GeV_VeloClosed_MagUp_RealData_Reco16_Stripping28r2p1_SEMILEPTONIC_DST.json
+++ b/data/records/LHCb_2016_Beam6500GeV_VeloClosed_MagUp_RealData_Reco16_Stripping28r2p1_SEMILEPTONIC_DST.json
@@ -1,0 +1,213 @@
+[{
+  "abstract": {
+    "description": "Data from proton-proton (pp) collisions collected by the LHCb experiment in the year 2016 of Run2 of the LHC."
+  },
+  "accelerator": "CERN-LHC",
+  "collaboration": {
+    "name": "LHCb collaboration",
+    "recid": "456"
+  },
+  "collections": [
+    "LHCb-Collision-Datasets"
+  ],
+  "collision_information": {
+    "energy": "13TeV",
+    "type": "pp"
+  },
+  "date_created": [
+    "2016"
+  ],
+  "date_published": "2026",
+  "date_reprocessed": "2021",
+  "distribution": {
+    "formats": [
+      "DST"
+    ],
+    "number_events": 91252442,
+    "number_files": 5454,
+    "size": 8888439798828
+  },
+  "experiment": [
+    "LHCb"
+  ],
+  "magnet_polarity": "MagUp",
+  "methodology": {
+    "description": "<p> This dataset was created in several production steps. These steps, software used and the configuration is provided below. </p><p> <strong> Prod ID: &nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;</strong> 152413<p> <strong>Prod type:&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp; </strong> Merge<p> <strong> Parent Prod ID:&nbsp;&nbsp;&nbsp;&nbsp; </strong> 151976<p> <strong> Parent Prod type: </strong> DataStripping<p> <strong> Conditions: </strong><p>dddb-20210528-6<p>cond-20191004-1</strong><p> <strong> List of Trigger Configuration Keys (TCK): </strong> </p> <p><p><strong>TCK &nbsp;&nbsp;&nbsp;&nbsp;&nbsp; Number of Files </strong><p>0x11341609 &nbsp;&nbsp;&nbsp;&nbsp;&nbsp; 946<p>0x11351609 &nbsp;&nbsp;&nbsp;&nbsp;&nbsp; 169<p>0x11361609 &nbsp;&nbsp;&nbsp;&nbsp;&nbsp; 2698<p>0x11381612 &nbsp;&nbsp;&nbsp;&nbsp;&nbsp; 526<p>0x11381611 &nbsp;&nbsp;&nbsp;&nbsp;&nbsp; 271<p>0x11321609 &nbsp;&nbsp;&nbsp;&nbsp;&nbsp; 844",
+    "steps": [
+      {
+        "configuration_files": [
+          {
+            "title": "DaVinci/DV-Stripping28r2p1-Stripping.py"
+          },
+          {
+            "title": "DaVinci/DataType-2016.py"
+          },
+          {
+            "title": "DaVinci/InputType-RDST.py"
+          },
+          {
+            "title": "DaVinci/DV-RawEventJuggler-0_3-to-4_3.py"
+          },
+          {
+            "title": "Persistency/Compression-ZLIB-1.py"
+          },
+          {
+            "title": "DaVinci/DV-RedoCaloPID-Stripping_28_24.py"
+          }
+        ],
+        "release": "DaVinci.v44r11p4 AppConfig.v3r407 Det/SQLDDDB.v7r10 TMVAWeights.v1r17",
+        "type": "Stripping28r2p1"
+      },
+      {
+        "configuration_files": [
+          {
+            "title": "Merging/DV-Stripping-Merging.py"
+          },
+          {
+            "title": "Persistency/Compression-LZMA-4.py"
+          }
+        ],
+        "release": "DaVinci.v44r11p4 AppConfig.v3r407 Det/SQLDDDB.v7r10",
+        "type": "Stripping28r2p1-Merging"
+      },
+      {
+        "configuration_files": [
+          {
+            "title": "DaVinci/DV-Stripping28r2p1-Stripping.py"
+          },
+          {
+            "title": "DaVinci/DataType-2016.py"
+          },
+          {
+            "title": "DaVinci/InputType-RDST.py"
+          },
+          {
+            "title": "DaVinci/DV-RawEventJuggler-0_3-to-4_3.py"
+          },
+          {
+            "title": "Persistency/Compression-ZLIB-1.py"
+          },
+          {
+            "title": "DaVinci/DV-RedoCaloPID-Stripping_28_24.py"
+          }
+        ],
+        "release": "DaVinci.v44r11p4 AppConfig.v3r407 Det/SQLDDDB.v7r10 TMVAWeights.v1r17",
+        "type": "Stripping28r2p1"
+      },
+      {
+        "configuration_files": [
+          {
+            "title": "Merging/DV-Stripping-Merging.py"
+          },
+          {
+            "title": "Persistency/Compression-LZMA-4.py"
+          }
+        ],
+        "release": "DaVinci.v44r11p4 AppConfig.v3r407 Det/SQLDDDB.v7r10",
+        "type": "Stripping28r2p1-Merging"
+      },
+      {
+        "configuration_files": [
+          {
+            "title": "DaVinci/DV-Stripping28r2p1-Stripping.py"
+          },
+          {
+            "title": "DaVinci/DataType-2016.py"
+          },
+          {
+            "title": "DaVinci/InputType-RDST.py"
+          },
+          {
+            "title": "DaVinci/DV-RawEventJuggler-0_3-to-4_3.py"
+          },
+          {
+            "title": "Persistency/Compression-ZLIB-1.py"
+          },
+          {
+            "title": "DaVinci/DV-RedoCaloPID-Stripping_28_24.py"
+          }
+        ],
+        "release": "DaVinci.v44r11p4 AppConfig.v3r407 Det/SQLDDDB.v7r10 TMVAWeights.v1r17",
+        "type": "Stripping28r2p1"
+      },
+      {
+        "configuration_files": [
+          {
+            "title": "Merging/DV-Stripping-Merging.py"
+          },
+          {
+            "title": "Persistency/Compression-LZMA-4.py"
+          }
+        ],
+        "release": "DaVinci.v44r11p4 AppConfig.v3r407 Det/SQLDDDB.v7r10",
+        "type": "Stripping28r2p1-Merging"
+      },
+      {
+        "configuration_files": [
+          {
+            "title": "DaVinci/DV-Stripping28r2p1-Stripping.py"
+          },
+          {
+            "title": "DaVinci/DataType-2016.py"
+          },
+          {
+            "title": "DaVinci/InputType-RDST.py"
+          },
+          {
+            "title": "DaVinci/DV-RawEventJuggler-0_3-to-4_3.py"
+          },
+          {
+            "title": "Persistency/Compression-ZLIB-1.py"
+          },
+          {
+            "title": "DaVinci/DV-RedoCaloPID-Stripping_28_24.py"
+          }
+        ],
+        "release": "DaVinci.v44r11p4 AppConfig.v3r407 Det/SQLDDDB.v7r10 TMVAWeights.v1r17",
+        "type": "Stripping28r2p1"
+      },
+      {
+        "configuration_files": [
+          {
+            "title": "Merging/DV-Stripping-Merging.py"
+          },
+          {
+            "title": "Persistency/Compression-LZMA-4.py"
+          }
+        ],
+        "release": "DaVinci.v44r11p4 AppConfig.v3r407 Det/SQLDDDB.v7r10",
+        "type": "Stripping28r2p1-Merging"
+      }
+    ]
+  },
+  "publisher": "CERN Open Data Portal",
+  "recid": "24679",
+  "run_period": [
+    "2016"
+  ],
+  "stripping": {
+    "stream": "SEMILEPTONIC",
+    "version": "stripping28r2p1"
+  },
+  "title": "LHCb 2016 Beam6500GeV MagUp SEMILEPTONIC Stream Stripping28r2p1",
+  "title_additional": "",
+  "type": {
+    "primary": "Dataset",
+    "secondary": [
+      "Collision"
+    ]
+  },
+  "usage": {
+    "description": "<p> The Run 1 and 2 data collected by the LHCb detector is available using the LHCb Ntupling Service, while the Run 1 data is additionally available in .DST and .mDST formats. The data obtained from the LHCb Ntupling Service are ROOT ntuples and do not require custom software to analyze. <p> Links are provided to the LHCb Ntupling Service for exploration of available data and the LHCb Open Data Guide for usage instructions.",
+    "links": [
+      {
+        "description": "LHCb Ntupling Service",
+        "url": "https://opendata-lhcb-ntupling-service.app.cern.ch/"
+      },
+      {
+        "description": "LHCb Open Data Guide",
+        "url": "https://lhcb-opendata-guide.web.cern.ch/"
+      }
+    ]
+  }
+}]

--- a/data/records/LHCb_2016_Beam6500GeV_VeloClosed_MagUp_RealData_Reco16_Stripping28r2p2_BHADRONCOMPLETEEVENT_DST.json
+++ b/data/records/LHCb_2016_Beam6500GeV_VeloClosed_MagUp_RealData_Reco16_Stripping28r2p2_BHADRONCOMPLETEEVENT_DST.json
@@ -1,0 +1,177 @@
+[{
+  "abstract": {
+    "description": "Data from proton-proton (pp) collisions collected by the LHCb experiment in the year 2016 of Run2 of the LHC."
+  },
+  "accelerator": "CERN-LHC",
+  "collaboration": {
+    "name": "LHCb collaboration",
+    "recid": "456"
+  },
+  "collections": [
+    "LHCb-Collision-Datasets"
+  ],
+  "collision_information": {
+    "energy": "13TeV",
+    "type": "pp"
+  },
+  "date_created": [
+    "2016"
+  ],
+  "date_published": "2026",
+  "date_reprocessed": "2023",
+  "distribution": {
+    "formats": [
+      "DST"
+    ],
+    "number_events": 452167802,
+    "number_files": 14450,
+    "size": 53264062339695
+  },
+  "experiment": [
+    "LHCb"
+  ],
+  "magnet_polarity": "MagUp",
+  "methodology": {
+    "description": "<p> This dataset was created in several production steps. These steps, software used and the configuration is provided below. </p><p> <strong> Prod ID: &nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;</strong> 205486<p> <strong>Prod type:&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp; </strong> Merge<p> <strong> Parent Prod ID:&nbsp;&nbsp;&nbsp;&nbsp; </strong> 204881<p> <strong> Parent Prod type: </strong> DataStripping<p> <strong> Conditions: </strong><p>dddb-20220927-2016<p>cond-20191004-1</strong><p> <strong> List of Trigger Configuration Keys (TCK): </strong> </p> <p><p><strong>TCK &nbsp;&nbsp;&nbsp;&nbsp;&nbsp; Number of Files </strong><p>0x11351609 &nbsp;&nbsp;&nbsp;&nbsp;&nbsp; 412<p>0x11361609 &nbsp;&nbsp;&nbsp;&nbsp;&nbsp; 6980<p>0x11341609 &nbsp;&nbsp;&nbsp;&nbsp;&nbsp; 2354<p>0x11321609 &nbsp;&nbsp;&nbsp;&nbsp;&nbsp; 2315<p>0x11381612 &nbsp;&nbsp;&nbsp;&nbsp;&nbsp; 1584<p>0x11381611 &nbsp;&nbsp;&nbsp;&nbsp;&nbsp; 805",
+    "steps": [
+      {
+        "configuration_files": [
+          {
+            "title": "DaVinci/DV-Stripping28r2p2-Stripping.py"
+          },
+          {
+            "title": "DaVinci/DataType-2016.py"
+          },
+          {
+            "title": "DaVinci/InputType-RDST.py"
+          },
+          {
+            "title": "DaVinci/DV-RawEventJuggler-0_3-to-4_3.py"
+          },
+          {
+            "title": "Persistency/Compression-ZLIB-1.py"
+          },
+          {
+            "title": "DaVinci/DV-RedoCaloPID-Stripping_28_24.py"
+          }
+        ],
+        "release": "DaVinci.v44r11p6 AppConfig.v3r421 Det/SQLDDDB.v7r12 TMVAWeights.v1r18",
+        "type": "Stripping28r2p2_mu"
+      },
+      {
+        "configuration_files": [
+          {
+            "title": "Merging/DV-Stripping-Merging.py"
+          },
+          {
+            "title": "Persistency/Compression-LZMA-4.py"
+          }
+        ],
+        "release": "DaVinci.v44r11p6 AppConfig.v3r421 Det/SQLDDDB.v7r12 TMVAWeights.v1r18",
+        "type": "Merge_Stripping28r2p2_mu"
+      },
+      {
+        "configuration_files": [
+          {
+            "title": "DaVinci/DV-Stripping28r2p2-Stripping.py"
+          },
+          {
+            "title": "DaVinci/DataType-2016.py"
+          },
+          {
+            "title": "DaVinci/InputType-RDST.py"
+          },
+          {
+            "title": "DaVinci/DV-RawEventJuggler-0_3-to-4_3.py"
+          },
+          {
+            "title": "Persistency/Compression-ZLIB-1.py"
+          },
+          {
+            "title": "DaVinci/DV-RedoCaloPID-Stripping_28_24.py"
+          }
+        ],
+        "release": "DaVinci.v44r11p6 AppConfig.v3r421 Det/SQLDDDB.v7r12 TMVAWeights.v1r18",
+        "type": "Stripping28r2p2_mu"
+      },
+      {
+        "configuration_files": [
+          {
+            "title": "Merging/DV-Stripping-Merging.py"
+          },
+          {
+            "title": "Persistency/Compression-LZMA-4.py"
+          }
+        ],
+        "release": "DaVinci.v44r11p6 AppConfig.v3r421 Det/SQLDDDB.v7r12 TMVAWeights.v1r18",
+        "type": "Merge_Stripping28r2p2_mu"
+      },
+      {
+        "configuration_files": [
+          {
+            "title": "DaVinci/DV-Stripping28r2p2-Stripping.py"
+          },
+          {
+            "title": "DaVinci/DataType-2016.py"
+          },
+          {
+            "title": "DaVinci/InputType-RDST.py"
+          },
+          {
+            "title": "DaVinci/DV-RawEventJuggler-0_3-to-4_3.py"
+          },
+          {
+            "title": "Persistency/Compression-ZLIB-1.py"
+          },
+          {
+            "title": "DaVinci/DV-RedoCaloPID-Stripping_28_24.py"
+          }
+        ],
+        "release": "DaVinci.v44r11p6 AppConfig.v3r421 Det/SQLDDDB.v7r12 TMVAWeights.v1r18",
+        "type": "Stripping28r2p2_mu"
+      },
+      {
+        "configuration_files": [
+          {
+            "title": "Merging/DV-Stripping-Merging.py"
+          },
+          {
+            "title": "Persistency/Compression-LZMA-4.py"
+          }
+        ],
+        "release": "DaVinci.v44r11p6 AppConfig.v3r421 Det/SQLDDDB.v7r12 TMVAWeights.v1r18",
+        "type": "Merge_Stripping28r2p2_mu"
+      }
+    ]
+  },
+  "publisher": "CERN Open Data Portal",
+  "recid": "24695",
+  "run_period": [
+    "2016"
+  ],
+  "stripping": {
+    "stream": "BHADRONCOMPLETEEVENT",
+    "version": "stripping28r2p2"
+  },
+  "title": "LHCb 2016 Beam6500GeV MagUp BHADRONCOMPLETEEVENT Stream Stripping28r2p2",
+  "title_additional": "",
+  "type": {
+    "primary": "Dataset",
+    "secondary": [
+      "Collision"
+    ]
+  },
+  "usage": {
+    "description": "<p> The Run 1 and 2 data collected by the LHCb detector is available using the LHCb Ntupling Service, while the Run 1 data is additionally available in .DST and .mDST formats. The data obtained from the LHCb Ntupling Service are ROOT ntuples and do not require custom software to analyze. <p> Links are provided to the LHCb Ntupling Service for exploration of available data and the LHCb Open Data Guide for usage instructions.",
+    "links": [
+      {
+        "description": "LHCb Ntupling Service",
+        "url": "https://opendata-lhcb-ntupling-service.app.cern.ch/"
+      },
+      {
+        "description": "LHCb Open Data Guide",
+        "url": "https://lhcb-opendata-guide.web.cern.ch/"
+      }
+    ]
+  }
+}]

--- a/data/records/LHCb_2016_Beam6500GeV_VeloClosed_MagUp_RealData_Reco16_Stripping28r2p2_BHADRON_MDST.json
+++ b/data/records/LHCb_2016_Beam6500GeV_VeloClosed_MagUp_RealData_Reco16_Stripping28r2p2_BHADRON_MDST.json
@@ -1,0 +1,105 @@
+[{
+  "abstract": {
+    "description": "Data from proton-proton (pp) collisions collected by the LHCb experiment in the year 2016 of Run2 of the LHC."
+  },
+  "accelerator": "CERN-LHC",
+  "collaboration": {
+    "name": "LHCb collaboration",
+    "recid": "456"
+  },
+  "collections": [
+    "LHCb-Collision-Datasets"
+  ],
+  "collision_information": {
+    "energy": "13TeV",
+    "type": "pp"
+  },
+  "date_created": [
+    "2016"
+  ],
+  "date_published": "2026",
+  "date_reprocessed": "2023",
+  "distribution": {
+    "formats": [
+      "MDST"
+    ],
+    "number_events": 1836634997,
+    "number_files": 11012,
+    "size": 37265774759128
+  },
+  "experiment": [
+    "LHCb"
+  ],
+  "magnet_polarity": "MagUp",
+  "methodology": {
+    "description": "<p> This dataset was created in several production steps. These steps, software used and the configuration is provided below. </p><p> <strong> Prod ID: &nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;</strong> 212880<p> <strong>Prod type:&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp; </strong> Merge<p> <strong> Parent Prod ID:&nbsp;&nbsp;&nbsp;&nbsp; </strong> 204881<p> <strong> Parent Prod type: </strong> DataStripping<p> <strong> Conditions: </strong><p>dddb-20220927-2016<p>cond-20191004-1</strong><p> <strong> List of Trigger Configuration Keys (TCK): </strong> </p> <p><p><strong>TCK &nbsp;&nbsp;&nbsp;&nbsp;&nbsp; Number of Files </strong><p>0x11341609 &nbsp;&nbsp;&nbsp;&nbsp;&nbsp; 1770<p>0x11361609 &nbsp;&nbsp;&nbsp;&nbsp;&nbsp; 5432<p>0x11351609 &nbsp;&nbsp;&nbsp;&nbsp;&nbsp; 316<p>0x11321609 &nbsp;&nbsp;&nbsp;&nbsp;&nbsp; 1684<p>0x11381611 &nbsp;&nbsp;&nbsp;&nbsp;&nbsp; 604<p>0x11381612 &nbsp;&nbsp;&nbsp;&nbsp;&nbsp; 1206",
+    "steps": [
+      {
+        "configuration_files": [
+          {
+            "title": "DaVinci/DV-Stripping28r2p2-Stripping.py"
+          },
+          {
+            "title": "DaVinci/DataType-2016.py"
+          },
+          {
+            "title": "DaVinci/InputType-RDST.py"
+          },
+          {
+            "title": "DaVinci/DV-RawEventJuggler-0_3-to-4_3.py"
+          },
+          {
+            "title": "Persistency/Compression-ZLIB-1.py"
+          },
+          {
+            "title": "DaVinci/DV-RedoCaloPID-Stripping_28_24.py"
+          }
+        ],
+        "release": "DaVinci.v44r11p6 AppConfig.v3r421 Det/SQLDDDB.v7r12 TMVAWeights.v1r18",
+        "type": "Stripping28r2p2_mu"
+      },
+      {
+        "configuration_files": [
+          {
+            "title": "Merging/DV-Stripping-Merging.py"
+          },
+          {
+            "title": "Persistency/Compression-LZMA-4.py"
+          }
+        ],
+        "release": "DaVinci.v44r11p6 AppConfig.v3r421 Det/SQLDDDB.v7r12 TMVAWeights.v1r18",
+        "type": "Merge_Stripping28r2p2_mu"
+      }
+    ]
+  },
+  "publisher": "CERN Open Data Portal",
+  "recid": "24694",
+  "run_period": [
+    "2016"
+  ],
+  "stripping": {
+    "stream": "BHADRON",
+    "version": "stripping28r2p2"
+  },
+  "title": "LHCb 2016 Beam6500GeV MagUp BHADRON Stream Stripping28r2p2",
+  "title_additional": "",
+  "type": {
+    "primary": "Dataset",
+    "secondary": [
+      "Collision"
+    ]
+  },
+  "usage": {
+    "description": "<p> The Run 1 and 2 data collected by the LHCb detector is available using the LHCb Ntupling Service, while the Run 1 data is additionally available in .DST and .mDST formats. The data obtained from the LHCb Ntupling Service are ROOT ntuples and do not require custom software to analyze. <p> Links are provided to the LHCb Ntupling Service for exploration of available data and the LHCb Open Data Guide for usage instructions.",
+    "links": [
+      {
+        "description": "LHCb Ntupling Service",
+        "url": "https://opendata-lhcb-ntupling-service.app.cern.ch/"
+      },
+      {
+        "description": "LHCb Open Data Guide",
+        "url": "https://lhcb-opendata-guide.web.cern.ch/"
+      }
+    ]
+  }
+}]

--- a/data/records/LHCb_2016_Beam6500GeV_VeloClosed_MagUp_RealData_Reco16_Stripping28r2p2_CHARMCOMPLETEEVENT_DST.json
+++ b/data/records/LHCb_2016_Beam6500GeV_VeloClosed_MagUp_RealData_Reco16_Stripping28r2p2_CHARMCOMPLETEEVENT_DST.json
@@ -1,0 +1,105 @@
+[{
+  "abstract": {
+    "description": "Data from proton-proton (pp) collisions collected by the LHCb experiment in the year 2016 of Run2 of the LHC."
+  },
+  "accelerator": "CERN-LHC",
+  "collaboration": {
+    "name": "LHCb collaboration",
+    "recid": "456"
+  },
+  "collections": [
+    "LHCb-Collision-Datasets"
+  ],
+  "collision_information": {
+    "energy": "13TeV",
+    "type": "pp"
+  },
+  "date_created": [
+    "2016"
+  ],
+  "date_published": "2026",
+  "date_reprocessed": "2023",
+  "distribution": {
+    "formats": [
+      "DST"
+    ],
+    "number_events": 133545664,
+    "number_files": 4865,
+    "size": 11354558859160
+  },
+  "experiment": [
+    "LHCb"
+  ],
+  "magnet_polarity": "MagUp",
+  "methodology": {
+    "description": "<p> This dataset was created in several production steps. These steps, software used and the configuration is provided below. </p><p> <strong> Prod ID: &nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;</strong> 204882<p> <strong>Prod type:&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp; </strong> Merge<p> <strong> Parent Prod ID:&nbsp;&nbsp;&nbsp;&nbsp; </strong> 204881<p> <strong> Parent Prod type: </strong> DataStripping<p> <strong> Conditions: </strong><p>dddb-20220927-2016<p>cond-20191004-1</strong><p> <strong> List of Trigger Configuration Keys (TCK): </strong> </p> <p><p><strong>TCK &nbsp;&nbsp;&nbsp;&nbsp;&nbsp; Number of Files </strong><p>0x11351609 &nbsp;&nbsp;&nbsp;&nbsp;&nbsp; 139<p>0x11361609 &nbsp;&nbsp;&nbsp;&nbsp;&nbsp; 2440<p>0x11341609 &nbsp;&nbsp;&nbsp;&nbsp;&nbsp; 752<p>0x11321609 &nbsp;&nbsp;&nbsp;&nbsp;&nbsp; 713<p>0x11381612 &nbsp;&nbsp;&nbsp;&nbsp;&nbsp; 545<p>0x11381611 &nbsp;&nbsp;&nbsp;&nbsp;&nbsp; 276",
+    "steps": [
+      {
+        "configuration_files": [
+          {
+            "title": "DaVinci/DV-Stripping28r2p2-Stripping.py"
+          },
+          {
+            "title": "DaVinci/DataType-2016.py"
+          },
+          {
+            "title": "DaVinci/InputType-RDST.py"
+          },
+          {
+            "title": "DaVinci/DV-RawEventJuggler-0_3-to-4_3.py"
+          },
+          {
+            "title": "Persistency/Compression-ZLIB-1.py"
+          },
+          {
+            "title": "DaVinci/DV-RedoCaloPID-Stripping_28_24.py"
+          }
+        ],
+        "release": "DaVinci.v44r11p6 AppConfig.v3r421 Det/SQLDDDB.v7r12 TMVAWeights.v1r18",
+        "type": "Stripping28r2p2_mu"
+      },
+      {
+        "configuration_files": [
+          {
+            "title": "Merging/DV-Stripping-Merging.py"
+          },
+          {
+            "title": "Persistency/Compression-LZMA-4.py"
+          }
+        ],
+        "release": "DaVinci.v44r11p6 AppConfig.v3r421 Det/SQLDDDB.v7r12 TMVAWeights.v1r18",
+        "type": "Merge_Stripping28r2p2_mu"
+      }
+    ]
+  },
+  "publisher": "CERN Open Data Portal",
+  "recid": "24697",
+  "run_period": [
+    "2016"
+  ],
+  "stripping": {
+    "stream": "CHARMCOMPLETEEVENT",
+    "version": "stripping28r2p2"
+  },
+  "title": "LHCb 2016 Beam6500GeV MagUp CHARMCOMPLETEEVENT Stream Stripping28r2p2",
+  "title_additional": "",
+  "type": {
+    "primary": "Dataset",
+    "secondary": [
+      "Collision"
+    ]
+  },
+  "usage": {
+    "description": "<p> The Run 1 and 2 data collected by the LHCb detector is available using the LHCb Ntupling Service, while the Run 1 data is additionally available in .DST and .mDST formats. The data obtained from the LHCb Ntupling Service are ROOT ntuples and do not require custom software to analyze. <p> Links are provided to the LHCb Ntupling Service for exploration of available data and the LHCb Open Data Guide for usage instructions.",
+    "links": [
+      {
+        "description": "LHCb Ntupling Service",
+        "url": "https://opendata-lhcb-ntupling-service.app.cern.ch/"
+      },
+      {
+        "description": "LHCb Open Data Guide",
+        "url": "https://lhcb-opendata-guide.web.cern.ch/"
+      }
+    ]
+  }
+}]

--- a/data/records/LHCb_2016_Beam6500GeV_VeloClosed_MagUp_RealData_Reco16_Stripping28r2p2_CHARM_MDST.json
+++ b/data/records/LHCb_2016_Beam6500GeV_VeloClosed_MagUp_RealData_Reco16_Stripping28r2p2_CHARM_MDST.json
@@ -1,0 +1,105 @@
+[{
+  "abstract": {
+    "description": "Data from proton-proton (pp) collisions collected by the LHCb experiment in the year 2016 of Run2 of the LHC."
+  },
+  "accelerator": "CERN-LHC",
+  "collaboration": {
+    "name": "LHCb collaboration",
+    "recid": "456"
+  },
+  "collections": [
+    "LHCb-Collision-Datasets"
+  ],
+  "collision_information": {
+    "energy": "13TeV",
+    "type": "pp"
+  },
+  "date_created": [
+    "2016"
+  ],
+  "date_published": "2026",
+  "date_reprocessed": "2023",
+  "distribution": {
+    "formats": [
+      "MDST"
+    ],
+    "number_events": 1919857300,
+    "number_files": 7622,
+    "size": 24708916236285
+  },
+  "experiment": [
+    "LHCb"
+  ],
+  "magnet_polarity": "MagUp",
+  "methodology": {
+    "description": "<p> This dataset was created in several production steps. These steps, software used and the configuration is provided below. </p><p> <strong> Prod ID: &nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;</strong> 212880<p> <strong>Prod type:&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp; </strong> Merge<p> <strong> Parent Prod ID:&nbsp;&nbsp;&nbsp;&nbsp; </strong> 204881<p> <strong> Parent Prod type: </strong> DataStripping<p> <strong> Conditions: </strong><p>dddb-20220927-2016<p>cond-20191004-1</strong><p> <strong> List of Trigger Configuration Keys (TCK): </strong> </p> <p><p><strong>TCK &nbsp;&nbsp;&nbsp;&nbsp;&nbsp; Number of Files </strong><p>0x11341609 &nbsp;&nbsp;&nbsp;&nbsp;&nbsp; 1279<p>0x11351609 &nbsp;&nbsp;&nbsp;&nbsp;&nbsp; 227<p>0x11361609 &nbsp;&nbsp;&nbsp;&nbsp;&nbsp; 3661<p>0x11321609 &nbsp;&nbsp;&nbsp;&nbsp;&nbsp; 1239<p>0x11381611 &nbsp;&nbsp;&nbsp;&nbsp;&nbsp; 409<p>0x11381612 &nbsp;&nbsp;&nbsp;&nbsp;&nbsp; 807",
+    "steps": [
+      {
+        "configuration_files": [
+          {
+            "title": "DaVinci/DV-Stripping28r2p2-Stripping.py"
+          },
+          {
+            "title": "DaVinci/DataType-2016.py"
+          },
+          {
+            "title": "DaVinci/InputType-RDST.py"
+          },
+          {
+            "title": "DaVinci/DV-RawEventJuggler-0_3-to-4_3.py"
+          },
+          {
+            "title": "Persistency/Compression-ZLIB-1.py"
+          },
+          {
+            "title": "DaVinci/DV-RedoCaloPID-Stripping_28_24.py"
+          }
+        ],
+        "release": "DaVinci.v44r11p6 AppConfig.v3r421 Det/SQLDDDB.v7r12 TMVAWeights.v1r18",
+        "type": "Stripping28r2p2_mu"
+      },
+      {
+        "configuration_files": [
+          {
+            "title": "Merging/DV-Stripping-Merging.py"
+          },
+          {
+            "title": "Persistency/Compression-LZMA-4.py"
+          }
+        ],
+        "release": "DaVinci.v44r11p6 AppConfig.v3r421 Det/SQLDDDB.v7r12 TMVAWeights.v1r18",
+        "type": "Merge_Stripping28r2p2_mu"
+      }
+    ]
+  },
+  "publisher": "CERN Open Data Portal",
+  "recid": "24696",
+  "run_period": [
+    "2016"
+  ],
+  "stripping": {
+    "stream": "CHARM",
+    "version": "stripping28r2p2"
+  },
+  "title": "LHCb 2016 Beam6500GeV MagUp CHARM Stream Stripping28r2p2",
+  "title_additional": "",
+  "type": {
+    "primary": "Dataset",
+    "secondary": [
+      "Collision"
+    ]
+  },
+  "usage": {
+    "description": "<p> The Run 1 and 2 data collected by the LHCb detector is available using the LHCb Ntupling Service, while the Run 1 data is additionally available in .DST and .mDST formats. The data obtained from the LHCb Ntupling Service are ROOT ntuples and do not require custom software to analyze. <p> Links are provided to the LHCb Ntupling Service for exploration of available data and the LHCb Open Data Guide for usage instructions.",
+    "links": [
+      {
+        "description": "LHCb Ntupling Service",
+        "url": "https://opendata-lhcb-ntupling-service.app.cern.ch/"
+      },
+      {
+        "description": "LHCb Open Data Guide",
+        "url": "https://lhcb-opendata-guide.web.cern.ch/"
+      }
+    ]
+  }
+}]

--- a/data/records/LHCb_2016_Beam6500GeV_VeloClosed_MagUp_RealData_Reco16_Stripping28r2p2_DIMUON_DST.json
+++ b/data/records/LHCb_2016_Beam6500GeV_VeloClosed_MagUp_RealData_Reco16_Stripping28r2p2_DIMUON_DST.json
@@ -1,0 +1,105 @@
+[{
+  "abstract": {
+    "description": "Data from proton-proton (pp) collisions collected by the LHCb experiment in the year 2016 of Run2 of the LHC."
+  },
+  "accelerator": "CERN-LHC",
+  "collaboration": {
+    "name": "LHCb collaboration",
+    "recid": "456"
+  },
+  "collections": [
+    "LHCb-Collision-Datasets"
+  ],
+  "collision_information": {
+    "energy": "13TeV",
+    "type": "pp"
+  },
+  "date_created": [
+    "2016"
+  ],
+  "date_published": "2026",
+  "date_reprocessed": "2023",
+  "distribution": {
+    "formats": [
+      "DST"
+    ],
+    "number_events": 100173860,
+    "number_files": 5089,
+    "size": 12778798923363
+  },
+  "experiment": [
+    "LHCb"
+  ],
+  "magnet_polarity": "MagUp",
+  "methodology": {
+    "description": "<p> This dataset was created in several production steps. These steps, software used and the configuration is provided below. </p><p> <strong> Prod ID: &nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;</strong> 204882<p> <strong>Prod type:&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp; </strong> Merge<p> <strong> Parent Prod ID:&nbsp;&nbsp;&nbsp;&nbsp; </strong> 204881<p> <strong> Parent Prod type: </strong> DataStripping<p> <strong> Conditions: </strong><p>dddb-20220927-2016<p>cond-20191004-1</strong><p> <strong> List of Trigger Configuration Keys (TCK): </strong> </p> <p><p><strong>TCK &nbsp;&nbsp;&nbsp;&nbsp;&nbsp; Number of Files </strong><p>0x11341609 &nbsp;&nbsp;&nbsp;&nbsp;&nbsp; 815<p>0x11361609 &nbsp;&nbsp;&nbsp;&nbsp;&nbsp; 2533<p>0x11351609 &nbsp;&nbsp;&nbsp;&nbsp;&nbsp; 149<p>0x11321609 &nbsp;&nbsp;&nbsp;&nbsp;&nbsp; 772<p>0x11381611 &nbsp;&nbsp;&nbsp;&nbsp;&nbsp; 275<p>0x11381612 &nbsp;&nbsp;&nbsp;&nbsp;&nbsp; 545",
+    "steps": [
+      {
+        "configuration_files": [
+          {
+            "title": "DaVinci/DV-Stripping28r2p2-Stripping.py"
+          },
+          {
+            "title": "DaVinci/DataType-2016.py"
+          },
+          {
+            "title": "DaVinci/InputType-RDST.py"
+          },
+          {
+            "title": "DaVinci/DV-RawEventJuggler-0_3-to-4_3.py"
+          },
+          {
+            "title": "Persistency/Compression-ZLIB-1.py"
+          },
+          {
+            "title": "DaVinci/DV-RedoCaloPID-Stripping_28_24.py"
+          }
+        ],
+        "release": "DaVinci.v44r11p6 AppConfig.v3r421 Det/SQLDDDB.v7r12 TMVAWeights.v1r18",
+        "type": "Stripping28r2p2_mu"
+      },
+      {
+        "configuration_files": [
+          {
+            "title": "Merging/DV-Stripping-Merging.py"
+          },
+          {
+            "title": "Persistency/Compression-LZMA-4.py"
+          }
+        ],
+        "release": "DaVinci.v44r11p6 AppConfig.v3r421 Det/SQLDDDB.v7r12 TMVAWeights.v1r18",
+        "type": "Merge_Stripping28r2p2_mu"
+      }
+    ]
+  },
+  "publisher": "CERN Open Data Portal",
+  "recid": "24698",
+  "run_period": [
+    "2016"
+  ],
+  "stripping": {
+    "stream": "DIMUON",
+    "version": "stripping28r2p2"
+  },
+  "title": "LHCb 2016 Beam6500GeV MagUp DIMUON Stream Stripping28r2p2",
+  "title_additional": "",
+  "type": {
+    "primary": "Dataset",
+    "secondary": [
+      "Collision"
+    ]
+  },
+  "usage": {
+    "description": "<p> The Run 1 and 2 data collected by the LHCb detector is available using the LHCb Ntupling Service, while the Run 1 data is additionally available in .DST and .mDST formats. The data obtained from the LHCb Ntupling Service are ROOT ntuples and do not require custom software to analyze. <p> Links are provided to the LHCb Ntupling Service for exploration of available data and the LHCb Open Data Guide for usage instructions.",
+    "links": [
+      {
+        "description": "LHCb Ntupling Service",
+        "url": "https://opendata-lhcb-ntupling-service.app.cern.ch/"
+      },
+      {
+        "description": "LHCb Open Data Guide",
+        "url": "https://lhcb-opendata-guide.web.cern.ch/"
+      }
+    ]
+  }
+}]

--- a/data/records/LHCb_2016_Beam6500GeV_VeloClosed_MagUp_RealData_Reco16_Stripping28r2p2_EW_DST.json
+++ b/data/records/LHCb_2016_Beam6500GeV_VeloClosed_MagUp_RealData_Reco16_Stripping28r2p2_EW_DST.json
@@ -1,0 +1,105 @@
+[{
+  "abstract": {
+    "description": "Data from proton-proton (pp) collisions collected by the LHCb experiment in the year 2016 of Run2 of the LHC."
+  },
+  "accelerator": "CERN-LHC",
+  "collaboration": {
+    "name": "LHCb collaboration",
+    "recid": "456"
+  },
+  "collections": [
+    "LHCb-Collision-Datasets"
+  ],
+  "collision_information": {
+    "energy": "13TeV",
+    "type": "pp"
+  },
+  "date_created": [
+    "2016"
+  ],
+  "date_published": "2026",
+  "date_reprocessed": "2023",
+  "distribution": {
+    "formats": [
+      "DST"
+    ],
+    "number_events": 56901968,
+    "number_files": 4487,
+    "size": 3628749217138
+  },
+  "experiment": [
+    "LHCb"
+  ],
+  "magnet_polarity": "MagUp",
+  "methodology": {
+    "description": "<p> This dataset was created in several production steps. These steps, software used and the configuration is provided below. </p><p> <strong> Prod ID: &nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;</strong> 212880<p> <strong>Prod type:&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp; </strong> Merge<p> <strong> Parent Prod ID:&nbsp;&nbsp;&nbsp;&nbsp; </strong> 204881<p> <strong> Parent Prod type: </strong> DataStripping<p> <strong> Conditions: </strong><p>dddb-20220927-2016<p>cond-20191004-1</strong><p> <strong> List of Trigger Configuration Keys (TCK): </strong> </p> <p><p><strong>TCK &nbsp;&nbsp;&nbsp;&nbsp;&nbsp; Number of Files </strong><p>0x11351609 &nbsp;&nbsp;&nbsp;&nbsp;&nbsp; 122<p>0x11341609 &nbsp;&nbsp;&nbsp;&nbsp;&nbsp; 640<p>0x11361609 &nbsp;&nbsp;&nbsp;&nbsp;&nbsp; 2304<p>0x11321609 &nbsp;&nbsp;&nbsp;&nbsp;&nbsp; 601<p>0x11381611 &nbsp;&nbsp;&nbsp;&nbsp;&nbsp; 275<p>0x11381612 &nbsp;&nbsp;&nbsp;&nbsp;&nbsp; 545",
+    "steps": [
+      {
+        "configuration_files": [
+          {
+            "title": "DaVinci/DV-Stripping28r2p2-Stripping.py"
+          },
+          {
+            "title": "DaVinci/DataType-2016.py"
+          },
+          {
+            "title": "DaVinci/InputType-RDST.py"
+          },
+          {
+            "title": "DaVinci/DV-RawEventJuggler-0_3-to-4_3.py"
+          },
+          {
+            "title": "Persistency/Compression-ZLIB-1.py"
+          },
+          {
+            "title": "DaVinci/DV-RedoCaloPID-Stripping_28_24.py"
+          }
+        ],
+        "release": "DaVinci.v44r11p6 AppConfig.v3r421 Det/SQLDDDB.v7r12 TMVAWeights.v1r18",
+        "type": "Stripping28r2p2_mu"
+      },
+      {
+        "configuration_files": [
+          {
+            "title": "Merging/DV-Stripping-Merging.py"
+          },
+          {
+            "title": "Persistency/Compression-LZMA-4.py"
+          }
+        ],
+        "release": "DaVinci.v44r11p6 AppConfig.v3r421 Det/SQLDDDB.v7r12 TMVAWeights.v1r18",
+        "type": "Merge_Stripping28r2p2_mu"
+      }
+    ]
+  },
+  "publisher": "CERN Open Data Portal",
+  "recid": "24690",
+  "run_period": [
+    "2016"
+  ],
+  "stripping": {
+    "stream": "EW",
+    "version": "stripping28r2p2"
+  },
+  "title": "LHCb 2016 Beam6500GeV MagUp EW Stream Stripping28r2p2",
+  "title_additional": "",
+  "type": {
+    "primary": "Dataset",
+    "secondary": [
+      "Collision"
+    ]
+  },
+  "usage": {
+    "description": "<p> The Run 1 and 2 data collected by the LHCb detector is available using the LHCb Ntupling Service, while the Run 1 data is additionally available in .DST and .mDST formats. The data obtained from the LHCb Ntupling Service are ROOT ntuples and do not require custom software to analyze. <p> Links are provided to the LHCb Ntupling Service for exploration of available data and the LHCb Open Data Guide for usage instructions.",
+    "links": [
+      {
+        "description": "LHCb Ntupling Service",
+        "url": "https://opendata-lhcb-ntupling-service.app.cern.ch/"
+      },
+      {
+        "description": "LHCb Open Data Guide",
+        "url": "https://lhcb-opendata-guide.web.cern.ch/"
+      }
+    ]
+  }
+}]

--- a/data/records/LHCb_2016_Beam6500GeV_VeloClosed_MagUp_RealData_Reco16_Stripping28r2p2_LEPTONIC_MDST.json
+++ b/data/records/LHCb_2016_Beam6500GeV_VeloClosed_MagUp_RealData_Reco16_Stripping28r2p2_LEPTONIC_MDST.json
@@ -1,0 +1,105 @@
+[{
+  "abstract": {
+    "description": "Data from proton-proton (pp) collisions collected by the LHCb experiment in the year 2016 of Run2 of the LHC."
+  },
+  "accelerator": "CERN-LHC",
+  "collaboration": {
+    "name": "LHCb collaboration",
+    "recid": "456"
+  },
+  "collections": [
+    "LHCb-Collision-Datasets"
+  ],
+  "collision_information": {
+    "energy": "13TeV",
+    "type": "pp"
+  },
+  "date_created": [
+    "2016"
+  ],
+  "date_published": "2026",
+  "date_reprocessed": "2023",
+  "distribution": {
+    "formats": [
+      "MDST"
+    ],
+    "number_events": 1882711089,
+    "number_files": 12086,
+    "size": 46655672220017
+  },
+  "experiment": [
+    "LHCb"
+  ],
+  "magnet_polarity": "MagUp",
+  "methodology": {
+    "description": "<p> This dataset was created in several production steps. These steps, software used and the configuration is provided below. </p><p> <strong> Prod ID: &nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;</strong> 204882<p> <strong>Prod type:&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp; </strong> Merge<p> <strong> Parent Prod ID:&nbsp;&nbsp;&nbsp;&nbsp; </strong> 204881<p> <strong> Parent Prod type: </strong> DataStripping<p> <strong> Conditions: </strong><p>dddb-20220927-2016<p>cond-20191004-1</strong><p> <strong> List of Trigger Configuration Keys (TCK): </strong> </p> <p><p><strong>TCK &nbsp;&nbsp;&nbsp;&nbsp;&nbsp; Number of Files </strong><p>0x11361609 &nbsp;&nbsp;&nbsp;&nbsp;&nbsp; 5913<p>0x11341609 &nbsp;&nbsp;&nbsp;&nbsp;&nbsp; 2003<p>0x11351609 &nbsp;&nbsp;&nbsp;&nbsp;&nbsp; 350<p>0x11321609 &nbsp;&nbsp;&nbsp;&nbsp;&nbsp; 1904<p>0x11381611 &nbsp;&nbsp;&nbsp;&nbsp;&nbsp; 648<p>0x11381612 &nbsp;&nbsp;&nbsp;&nbsp;&nbsp; 1268",
+    "steps": [
+      {
+        "configuration_files": [
+          {
+            "title": "DaVinci/DV-Stripping28r2p2-Stripping.py"
+          },
+          {
+            "title": "DaVinci/DataType-2016.py"
+          },
+          {
+            "title": "DaVinci/InputType-RDST.py"
+          },
+          {
+            "title": "DaVinci/DV-RawEventJuggler-0_3-to-4_3.py"
+          },
+          {
+            "title": "Persistency/Compression-ZLIB-1.py"
+          },
+          {
+            "title": "DaVinci/DV-RedoCaloPID-Stripping_28_24.py"
+          }
+        ],
+        "release": "DaVinci.v44r11p6 AppConfig.v3r421 Det/SQLDDDB.v7r12 TMVAWeights.v1r18",
+        "type": "Stripping28r2p2_mu"
+      },
+      {
+        "configuration_files": [
+          {
+            "title": "Merging/DV-Stripping-Merging.py"
+          },
+          {
+            "title": "Persistency/Compression-LZMA-4.py"
+          }
+        ],
+        "release": "DaVinci.v44r11p6 AppConfig.v3r421 Det/SQLDDDB.v7r12 TMVAWeights.v1r18",
+        "type": "Merge_Stripping28r2p2_mu"
+      }
+    ]
+  },
+  "publisher": "CERN Open Data Portal",
+  "recid": "24691",
+  "run_period": [
+    "2016"
+  ],
+  "stripping": {
+    "stream": "LEPTONIC",
+    "version": "stripping28r2p2"
+  },
+  "title": "LHCb 2016 Beam6500GeV MagUp LEPTONIC Stream Stripping28r2p2",
+  "title_additional": "",
+  "type": {
+    "primary": "Dataset",
+    "secondary": [
+      "Collision"
+    ]
+  },
+  "usage": {
+    "description": "<p> The Run 1 and 2 data collected by the LHCb detector is available using the LHCb Ntupling Service, while the Run 1 data is additionally available in .DST and .mDST formats. The data obtained from the LHCb Ntupling Service are ROOT ntuples and do not require custom software to analyze. <p> Links are provided to the LHCb Ntupling Service for exploration of available data and the LHCb Open Data Guide for usage instructions.",
+    "links": [
+      {
+        "description": "LHCb Ntupling Service",
+        "url": "https://opendata-lhcb-ntupling-service.app.cern.ch/"
+      },
+      {
+        "description": "LHCb Open Data Guide",
+        "url": "https://lhcb-opendata-guide.web.cern.ch/"
+      }
+    ]
+  }
+}]

--- a/data/records/LHCb_2016_Beam6500GeV_VeloClosed_MagUp_RealData_Reco16_Stripping28r2p2_SEMILEPTONIC_DST.json
+++ b/data/records/LHCb_2016_Beam6500GeV_VeloClosed_MagUp_RealData_Reco16_Stripping28r2p2_SEMILEPTONIC_DST.json
@@ -1,0 +1,177 @@
+[{
+  "abstract": {
+    "description": "Data from proton-proton (pp) collisions collected by the LHCb experiment in the year 2016 of Run2 of the LHC."
+  },
+  "accelerator": "CERN-LHC",
+  "collaboration": {
+    "name": "LHCb collaboration",
+    "recid": "456"
+  },
+  "collections": [
+    "LHCb-Collision-Datasets"
+  ],
+  "collision_information": {
+    "energy": "13TeV",
+    "type": "pp"
+  },
+  "date_created": [
+    "2016"
+  ],
+  "date_published": "2026",
+  "date_reprocessed": "2023",
+  "distribution": {
+    "formats": [
+      "DST"
+    ],
+    "number_events": 517532994,
+    "number_files": 10736,
+    "size": 36148641279803
+  },
+  "experiment": [
+    "LHCb"
+  ],
+  "magnet_polarity": "MagUp",
+  "methodology": {
+    "description": "<p> This dataset was created in several production steps. These steps, software used and the configuration is provided below. </p><p> <strong> Prod ID: &nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;</strong> 205456<p> <strong>Prod type:&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp; </strong> Merge<p> <strong> Parent Prod ID:&nbsp;&nbsp;&nbsp;&nbsp; </strong> 204881<p> <strong> Parent Prod type: </strong> DataStripping<p> <strong> Conditions: </strong><p>dddb-20220927-2016<p>cond-20191004-1</strong><p> <strong> List of Trigger Configuration Keys (TCK): </strong> </p> <p><p><strong>TCK &nbsp;&nbsp;&nbsp;&nbsp;&nbsp; Number of Files </strong><p>0x11361609 &nbsp;&nbsp;&nbsp;&nbsp;&nbsp; 5405<p>0x11341609 &nbsp;&nbsp;&nbsp;&nbsp;&nbsp; 1723<p>0x11351609 &nbsp;&nbsp;&nbsp;&nbsp;&nbsp; 319<p>0x11321609 &nbsp;&nbsp;&nbsp;&nbsp;&nbsp; 1570<p>0x11381612 &nbsp;&nbsp;&nbsp;&nbsp;&nbsp; 1146<p>0x11381611 &nbsp;&nbsp;&nbsp;&nbsp;&nbsp; 573",
+    "steps": [
+      {
+        "configuration_files": [
+          {
+            "title": "DaVinci/DV-Stripping28r2p2-Stripping.py"
+          },
+          {
+            "title": "DaVinci/DataType-2016.py"
+          },
+          {
+            "title": "DaVinci/InputType-RDST.py"
+          },
+          {
+            "title": "DaVinci/DV-RawEventJuggler-0_3-to-4_3.py"
+          },
+          {
+            "title": "Persistency/Compression-ZLIB-1.py"
+          },
+          {
+            "title": "DaVinci/DV-RedoCaloPID-Stripping_28_24.py"
+          }
+        ],
+        "release": "DaVinci.v44r11p6 AppConfig.v3r421 Det/SQLDDDB.v7r12 TMVAWeights.v1r18",
+        "type": "Stripping28r2p2_mu"
+      },
+      {
+        "configuration_files": [
+          {
+            "title": "Merging/DV-Stripping-Merging.py"
+          },
+          {
+            "title": "Persistency/Compression-LZMA-4.py"
+          }
+        ],
+        "release": "DaVinci.v44r11p6 AppConfig.v3r421 Det/SQLDDDB.v7r12 TMVAWeights.v1r18",
+        "type": "Merge_Stripping28r2p2_mu"
+      },
+      {
+        "configuration_files": [
+          {
+            "title": "DaVinci/DV-Stripping28r2p2-Stripping.py"
+          },
+          {
+            "title": "DaVinci/DataType-2016.py"
+          },
+          {
+            "title": "DaVinci/InputType-RDST.py"
+          },
+          {
+            "title": "DaVinci/DV-RawEventJuggler-0_3-to-4_3.py"
+          },
+          {
+            "title": "Persistency/Compression-ZLIB-1.py"
+          },
+          {
+            "title": "DaVinci/DV-RedoCaloPID-Stripping_28_24.py"
+          }
+        ],
+        "release": "DaVinci.v44r11p6 AppConfig.v3r421 Det/SQLDDDB.v7r12 TMVAWeights.v1r18",
+        "type": "Stripping28r2p2_mu"
+      },
+      {
+        "configuration_files": [
+          {
+            "title": "Merging/DV-Stripping-Merging.py"
+          },
+          {
+            "title": "Persistency/Compression-LZMA-4.py"
+          }
+        ],
+        "release": "DaVinci.v44r11p6 AppConfig.v3r421 Det/SQLDDDB.v7r12 TMVAWeights.v1r18",
+        "type": "Merge_Stripping28r2p2_mu"
+      },
+      {
+        "configuration_files": [
+          {
+            "title": "DaVinci/DV-Stripping28r2p2-Stripping.py"
+          },
+          {
+            "title": "DaVinci/DataType-2016.py"
+          },
+          {
+            "title": "DaVinci/InputType-RDST.py"
+          },
+          {
+            "title": "DaVinci/DV-RawEventJuggler-0_3-to-4_3.py"
+          },
+          {
+            "title": "Persistency/Compression-ZLIB-1.py"
+          },
+          {
+            "title": "DaVinci/DV-RedoCaloPID-Stripping_28_24.py"
+          }
+        ],
+        "release": "DaVinci.v44r11p6 AppConfig.v3r421 Det/SQLDDDB.v7r12 TMVAWeights.v1r18",
+        "type": "Stripping28r2p2_mu"
+      },
+      {
+        "configuration_files": [
+          {
+            "title": "Merging/DV-Stripping-Merging.py"
+          },
+          {
+            "title": "Persistency/Compression-LZMA-4.py"
+          }
+        ],
+        "release": "DaVinci.v44r11p6 AppConfig.v3r421 Det/SQLDDDB.v7r12 TMVAWeights.v1r18",
+        "type": "Merge_Stripping28r2p2_mu"
+      }
+    ]
+  },
+  "publisher": "CERN Open Data Portal",
+  "recid": "24699",
+  "run_period": [
+    "2016"
+  ],
+  "stripping": {
+    "stream": "SEMILEPTONIC",
+    "version": "stripping28r2p2"
+  },
+  "title": "LHCb 2016 Beam6500GeV MagUp SEMILEPTONIC Stream Stripping28r2p2",
+  "title_additional": "",
+  "type": {
+    "primary": "Dataset",
+    "secondary": [
+      "Collision"
+    ]
+  },
+  "usage": {
+    "description": "<p> The Run 1 and 2 data collected by the LHCb detector is available using the LHCb Ntupling Service, while the Run 1 data is additionally available in .DST and .mDST formats. The data obtained from the LHCb Ntupling Service are ROOT ntuples and do not require custom software to analyze. <p> Links are provided to the LHCb Ntupling Service for exploration of available data and the LHCb Open Data Guide for usage instructions.",
+    "links": [
+      {
+        "description": "LHCb Ntupling Service",
+        "url": "https://opendata-lhcb-ntupling-service.app.cern.ch/"
+      },
+      {
+        "description": "LHCb Open Data Guide",
+        "url": "https://lhcb-opendata-guide.web.cern.ch/"
+      }
+    ]
+  }
+}]

--- a/data/records/LHCb_2017_Beam6500GeV_VeloClosed_MagDown_RealData_Reco17_Stripping29r2_BHADRONCOMPLETEEVENT_DST.json
+++ b/data/records/LHCb_2017_Beam6500GeV_VeloClosed_MagDown_RealData_Reco17_Stripping29r2_BHADRONCOMPLETEEVENT_DST.json
@@ -1,0 +1,201 @@
+[{
+  "abstract": {
+    "description": "Data from proton-proton (pp) collisions collected by the LHCb experiment in the year 2017 of Run2 of the LHC."
+  },
+  "accelerator": "CERN-LHC",
+  "collaboration": {
+    "name": "LHCb collaboration",
+    "recid": "456"
+  },
+  "collections": [
+    "LHCb-Collision-Datasets"
+  ],
+  "collision_information": {
+    "energy": "13TeV",
+    "type": "pp"
+  },
+  "date_created": [
+    "2017"
+  ],
+  "date_published": "2026",
+  "date_reprocessed": "2018",
+  "distribution": {
+    "formats": [
+      "DST"
+    ],
+    "number_events": 717101098,
+    "number_files": 17401,
+    "size": 63757606757910
+  },
+  "experiment": [
+    "LHCb"
+  ],
+  "magnet_polarity": "MagDown",
+  "methodology": {
+    "description": "<p> This dataset was created in several production steps. These steps, software used and the configuration is provided below. </p><p> <strong> Prod ID: &nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;</strong> 71571<p> <strong>Prod type:&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp; </strong> Merge<p> <strong> Parent Prod ID:&nbsp;&nbsp;&nbsp;&nbsp; </strong> 71500<p> <strong> Parent Prod type: </strong> DataStripping<p> <strong> Conditions: </strong><p>dddb-20170721-3<p>cond-20170724</strong><p> <strong> List of Trigger Configuration Keys (TCK): </strong> </p> <p><p><strong>TCK &nbsp;&nbsp;&nbsp;&nbsp;&nbsp; Number of Files </strong><p>0x11541707 &nbsp;&nbsp;&nbsp;&nbsp;&nbsp; 1823<p>0x115417a7 &nbsp;&nbsp;&nbsp;&nbsp;&nbsp; 24<p>0x11561707 &nbsp;&nbsp;&nbsp;&nbsp;&nbsp; 4314<p>0x11611708 &nbsp;&nbsp;&nbsp;&nbsp;&nbsp; 3026<p>0x11611707 &nbsp;&nbsp;&nbsp;&nbsp;&nbsp; 2454<p>0x11611709 &nbsp;&nbsp;&nbsp;&nbsp;&nbsp; 5760",
+    "steps": [
+      {
+        "configuration_files": [
+          {
+            "title": "DaVinci/DV-Stripping29r2-Stripping.py"
+          },
+          {
+            "title": "DaVinci/DataType-2017.py"
+          },
+          {
+            "title": "DaVinci/InputType-RDST.py"
+          },
+          {
+            "title": "DaVinci/DV-RawEventJuggler-0_3-to-4_2.py"
+          },
+          {
+            "title": "Persistency/Compression-ZLIB-1.py"
+          }
+        ],
+        "release": "DaVinci.v42r7p2 AppConfig.v3r353 Det/SQLDDDB.v7r10 TMVAWeights.v1r9",
+        "type": "Stripping29r2"
+      },
+      {
+        "configuration_files": [
+          {
+            "title": "Merging/DV-Stripping-Merging.py"
+          },
+          {
+            "title": "Persistency/Compression-LZMA-4.py"
+          }
+        ],
+        "release": "DaVinci.v42r7p2 AppConfig.v3r353 Det/SQLDDDB.v7r10",
+        "type": "Stripping29r2-Merging"
+      },
+      {
+        "configuration_files": [
+          {
+            "title": "DaVinci/DV-Stripping29r2-Stripping.py"
+          },
+          {
+            "title": "DaVinci/DataType-2017.py"
+          },
+          {
+            "title": "DaVinci/InputType-RDST.py"
+          },
+          {
+            "title": "DaVinci/DV-RawEventJuggler-0_3-to-4_2.py"
+          },
+          {
+            "title": "Persistency/Compression-ZLIB-1.py"
+          }
+        ],
+        "release": "DaVinci.v42r7p2 AppConfig.v3r353 Det/SQLDDDB.v7r10 TMVAWeights.v1r9",
+        "type": "Stripping29r2"
+      },
+      {
+        "configuration_files": [
+          {
+            "title": "Merging/DV-Stripping-Merging.py"
+          },
+          {
+            "title": "Persistency/Compression-LZMA-4.py"
+          }
+        ],
+        "release": "DaVinci.v42r7p2 AppConfig.v3r353 Det/SQLDDDB.v7r10",
+        "type": "Stripping29r2-Merging"
+      },
+      {
+        "configuration_files": [
+          {
+            "title": "DaVinci/DV-Stripping29r2-Stripping.py"
+          },
+          {
+            "title": "DaVinci/DataType-2017.py"
+          },
+          {
+            "title": "DaVinci/InputType-RDST.py"
+          },
+          {
+            "title": "DaVinci/DV-RawEventJuggler-0_3-to-4_2.py"
+          },
+          {
+            "title": "Persistency/Compression-ZLIB-1.py"
+          }
+        ],
+        "release": "DaVinci.v42r7p2 AppConfig.v3r353 Det/SQLDDDB.v7r10 TMVAWeights.v1r9",
+        "type": "Stripping29r2"
+      },
+      {
+        "configuration_files": [
+          {
+            "title": "Merging/DV-Stripping-Merging.py"
+          },
+          {
+            "title": "Persistency/Compression-LZMA-4.py"
+          }
+        ],
+        "release": "DaVinci.v42r7p2 AppConfig.v3r353 Det/SQLDDDB.v7r10",
+        "type": "Stripping29r2-Merging"
+      },
+      {
+        "configuration_files": [
+          {
+            "title": "DaVinci/DV-Stripping29r2-Stripping.py"
+          },
+          {
+            "title": "DaVinci/DataType-2017.py"
+          },
+          {
+            "title": "DaVinci/InputType-RDST.py"
+          },
+          {
+            "title": "DaVinci/DV-RawEventJuggler-0_3-to-4_2.py"
+          },
+          {
+            "title": "Persistency/Compression-ZLIB-1.py"
+          }
+        ],
+        "release": "DaVinci.v42r7p2 AppConfig.v3r353 Det/SQLDDDB.v7r10 TMVAWeights.v1r9",
+        "type": "Stripping29r2"
+      },
+      {
+        "configuration_files": [
+          {
+            "title": "Merging/DV-Stripping-Merging.py"
+          },
+          {
+            "title": "Persistency/Compression-LZMA-4.py"
+          }
+        ],
+        "release": "DaVinci.v42r7p2 AppConfig.v3r353 Det/SQLDDDB.v7r10",
+        "type": "Stripping29r2-Merging"
+      }
+    ]
+  },
+  "publisher": "CERN Open Data Portal",
+  "recid": "24705",
+  "run_period": [
+    "2017"
+  ],
+  "stripping": {
+    "stream": "BHADRONCOMPLETEEVENT",
+    "version": "stripping29r2"
+  },
+  "title": "LHCb 2017 Beam6500GeV MagDown BHADRONCOMPLETEEVENT Stream Stripping29r2",
+  "title_additional": "",
+  "type": {
+    "primary": "Dataset",
+    "secondary": [
+      "Collision"
+    ]
+  },
+  "usage": {
+    "description": "<p> The Run 1 and 2 data collected by the LHCb detector is available using the LHCb Ntupling Service, while the Run 1 data is additionally available in .DST and .mDST formats. The data obtained from the LHCb Ntupling Service are ROOT ntuples and do not require custom software to analyze. <p> Links are provided to the LHCb Ntupling Service for exploration of available data and the LHCb Open Data Guide for usage instructions.",
+    "links": [
+      {
+        "description": "LHCb Ntupling Service",
+        "url": "https://opendata-lhcb-ntupling-service.app.cern.ch/"
+      },
+      {
+        "description": "LHCb Open Data Guide",
+        "url": "https://lhcb-opendata-guide.web.cern.ch/"
+      }
+    ]
+  }
+}]

--- a/data/records/LHCb_2017_Beam6500GeV_VeloClosed_MagDown_RealData_Reco17_Stripping29r2_BHADRON_MDST.json
+++ b/data/records/LHCb_2017_Beam6500GeV_VeloClosed_MagDown_RealData_Reco17_Stripping29r2_BHADRON_MDST.json
@@ -1,0 +1,201 @@
+[{
+  "abstract": {
+    "description": "Data from proton-proton (pp) collisions collected by the LHCb experiment in the year 2017 of Run2 of the LHC."
+  },
+  "accelerator": "CERN-LHC",
+  "collaboration": {
+    "name": "LHCb collaboration",
+    "recid": "456"
+  },
+  "collections": [
+    "LHCb-Collision-Datasets"
+  ],
+  "collision_information": {
+    "energy": "13TeV",
+    "type": "pp"
+  },
+  "date_created": [
+    "2017"
+  ],
+  "date_published": "2026",
+  "date_reprocessed": "2018",
+  "distribution": {
+    "formats": [
+      "MDST"
+    ],
+    "number_events": 2976679581,
+    "number_files": 12273,
+    "size": 44390018172407
+  },
+  "experiment": [
+    "LHCb"
+  ],
+  "magnet_polarity": "MagDown",
+  "methodology": {
+    "description": "<p> This dataset was created in several production steps. These steps, software used and the configuration is provided below. </p><p> <strong> Prod ID: &nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;</strong> 71700<p> <strong>Prod type:&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp; </strong> Merge<p> <strong> Parent Prod ID:&nbsp;&nbsp;&nbsp;&nbsp; </strong> 71500<p> <strong> Parent Prod type: </strong> DataStripping<p> <strong> Conditions: </strong><p>dddb-20170721-3<p>cond-20170724</strong><p> <strong> List of Trigger Configuration Keys (TCK): </strong> </p> <p><p><strong>TCK &nbsp;&nbsp;&nbsp;&nbsp;&nbsp; Number of Files </strong><p>0x11541707 &nbsp;&nbsp;&nbsp;&nbsp;&nbsp; 1277<p>0x115417a7 &nbsp;&nbsp;&nbsp;&nbsp;&nbsp; 21<p>0x11561707 &nbsp;&nbsp;&nbsp;&nbsp;&nbsp; 2965<p>0x11611708 &nbsp;&nbsp;&nbsp;&nbsp;&nbsp; 2203<p>0x11611707 &nbsp;&nbsp;&nbsp;&nbsp;&nbsp; 1710<p>0x11611709 &nbsp;&nbsp;&nbsp;&nbsp;&nbsp; 4097",
+    "steps": [
+      {
+        "configuration_files": [
+          {
+            "title": "DaVinci/DV-Stripping29r2-Stripping.py"
+          },
+          {
+            "title": "DaVinci/DataType-2017.py"
+          },
+          {
+            "title": "DaVinci/InputType-RDST.py"
+          },
+          {
+            "title": "DaVinci/DV-RawEventJuggler-0_3-to-4_2.py"
+          },
+          {
+            "title": "Persistency/Compression-ZLIB-1.py"
+          }
+        ],
+        "release": "DaVinci.v42r7p2 AppConfig.v3r353 Det/SQLDDDB.v7r10 TMVAWeights.v1r9",
+        "type": "Stripping29r2"
+      },
+      {
+        "configuration_files": [
+          {
+            "title": "Merging/DV-Stripping-Merging.py"
+          },
+          {
+            "title": "Persistency/Compression-LZMA-4.py"
+          }
+        ],
+        "release": "DaVinci.v42r7p2 AppConfig.v3r353 Det/SQLDDDB.v7r10",
+        "type": "Stripping29r2-Merging"
+      },
+      {
+        "configuration_files": [
+          {
+            "title": "DaVinci/DV-Stripping29r2-Stripping.py"
+          },
+          {
+            "title": "DaVinci/DataType-2017.py"
+          },
+          {
+            "title": "DaVinci/InputType-RDST.py"
+          },
+          {
+            "title": "DaVinci/DV-RawEventJuggler-0_3-to-4_2.py"
+          },
+          {
+            "title": "Persistency/Compression-ZLIB-1.py"
+          }
+        ],
+        "release": "DaVinci.v42r7p2 AppConfig.v3r353 Det/SQLDDDB.v7r10 TMVAWeights.v1r9",
+        "type": "Stripping29r2"
+      },
+      {
+        "configuration_files": [
+          {
+            "title": "Merging/DV-Stripping-Merging.py"
+          },
+          {
+            "title": "Persistency/Compression-LZMA-4.py"
+          }
+        ],
+        "release": "DaVinci.v42r7p2 AppConfig.v3r353 Det/SQLDDDB.v7r10",
+        "type": "Stripping29r2-Merging"
+      },
+      {
+        "configuration_files": [
+          {
+            "title": "DaVinci/DV-Stripping29r2-Stripping.py"
+          },
+          {
+            "title": "DaVinci/DataType-2017.py"
+          },
+          {
+            "title": "DaVinci/InputType-RDST.py"
+          },
+          {
+            "title": "DaVinci/DV-RawEventJuggler-0_3-to-4_2.py"
+          },
+          {
+            "title": "Persistency/Compression-ZLIB-1.py"
+          }
+        ],
+        "release": "DaVinci.v42r7p2 AppConfig.v3r353 Det/SQLDDDB.v7r10 TMVAWeights.v1r9",
+        "type": "Stripping29r2"
+      },
+      {
+        "configuration_files": [
+          {
+            "title": "Merging/DV-Stripping-Merging.py"
+          },
+          {
+            "title": "Persistency/Compression-LZMA-4.py"
+          }
+        ],
+        "release": "DaVinci.v42r7p2 AppConfig.v3r353 Det/SQLDDDB.v7r10",
+        "type": "Stripping29r2-Merging"
+      },
+      {
+        "configuration_files": [
+          {
+            "title": "DaVinci/DV-Stripping29r2-Stripping.py"
+          },
+          {
+            "title": "DaVinci/DataType-2017.py"
+          },
+          {
+            "title": "DaVinci/InputType-RDST.py"
+          },
+          {
+            "title": "DaVinci/DV-RawEventJuggler-0_3-to-4_2.py"
+          },
+          {
+            "title": "Persistency/Compression-ZLIB-1.py"
+          }
+        ],
+        "release": "DaVinci.v42r7p2 AppConfig.v3r353 Det/SQLDDDB.v7r10 TMVAWeights.v1r9",
+        "type": "Stripping29r2"
+      },
+      {
+        "configuration_files": [
+          {
+            "title": "Merging/DV-Stripping-Merging.py"
+          },
+          {
+            "title": "Persistency/Compression-LZMA-4.py"
+          }
+        ],
+        "release": "DaVinci.v42r7p2 AppConfig.v3r353 Det/SQLDDDB.v7r10",
+        "type": "Stripping29r2-Merging"
+      }
+    ]
+  },
+  "publisher": "CERN Open Data Portal",
+  "recid": "24704",
+  "run_period": [
+    "2017"
+  ],
+  "stripping": {
+    "stream": "BHADRON",
+    "version": "stripping29r2"
+  },
+  "title": "LHCb 2017 Beam6500GeV MagDown BHADRON Stream Stripping29r2",
+  "title_additional": "",
+  "type": {
+    "primary": "Dataset",
+    "secondary": [
+      "Collision"
+    ]
+  },
+  "usage": {
+    "description": "<p> The Run 1 and 2 data collected by the LHCb detector is available using the LHCb Ntupling Service, while the Run 1 data is additionally available in .DST and .mDST formats. The data obtained from the LHCb Ntupling Service are ROOT ntuples and do not require custom software to analyze. <p> Links are provided to the LHCb Ntupling Service for exploration of available data and the LHCb Open Data Guide for usage instructions.",
+    "links": [
+      {
+        "description": "LHCb Ntupling Service",
+        "url": "https://opendata-lhcb-ntupling-service.app.cern.ch/"
+      },
+      {
+        "description": "LHCb Open Data Guide",
+        "url": "https://lhcb-opendata-guide.web.cern.ch/"
+      }
+    ]
+  }
+}]

--- a/data/records/LHCb_2017_Beam6500GeV_VeloClosed_MagDown_RealData_Reco17_Stripping29r2_CHARMCOMPLETEEVENT_DST.json
+++ b/data/records/LHCb_2017_Beam6500GeV_VeloClosed_MagDown_RealData_Reco17_Stripping29r2_CHARMCOMPLETEEVENT_DST.json
@@ -1,0 +1,201 @@
+[{
+  "abstract": {
+    "description": "Data from proton-proton (pp) collisions collected by the LHCb experiment in the year 2017 of Run2 of the LHC."
+  },
+  "accelerator": "CERN-LHC",
+  "collaboration": {
+    "name": "LHCb collaboration",
+    "recid": "456"
+  },
+  "collections": [
+    "LHCb-Collision-Datasets"
+  ],
+  "collision_information": {
+    "energy": "13TeV",
+    "type": "pp"
+  },
+  "date_created": [
+    "2017"
+  ],
+  "date_published": "2026",
+  "date_reprocessed": "2018",
+  "distribution": {
+    "formats": [
+      "DST"
+    ],
+    "number_events": 271426906,
+    "number_files": 6692,
+    "size": 21085949438778
+  },
+  "experiment": [
+    "LHCb"
+  ],
+  "magnet_polarity": "MagDown",
+  "methodology": {
+    "description": "<p> This dataset was created in several production steps. These steps, software used and the configuration is provided below. </p><p> <strong> Prod ID: &nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;</strong> 71907<p> <strong>Prod type:&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp; </strong> Merge<p> <strong> Parent Prod ID:&nbsp;&nbsp;&nbsp;&nbsp; </strong> 71500<p> <strong> Parent Prod type: </strong> DataStripping<p> <strong> Conditions: </strong><p>dddb-20170721-3<p>cond-20170724</strong><p> <strong> List of Trigger Configuration Keys (TCK): </strong> </p> <p><p><strong>TCK &nbsp;&nbsp;&nbsp;&nbsp;&nbsp; Number of Files </strong><p>0x11541707 &nbsp;&nbsp;&nbsp;&nbsp;&nbsp; 740<p>0x11561707 &nbsp;&nbsp;&nbsp;&nbsp;&nbsp; 1642<p>0x11611708 &nbsp;&nbsp;&nbsp;&nbsp;&nbsp; 1219<p>0x11611707 &nbsp;&nbsp;&nbsp;&nbsp;&nbsp; 933<p>0x11611709 &nbsp;&nbsp;&nbsp;&nbsp;&nbsp; 2141<p>0x115417a7 &nbsp;&nbsp;&nbsp;&nbsp;&nbsp; 17",
+    "steps": [
+      {
+        "configuration_files": [
+          {
+            "title": "DaVinci/DV-Stripping29r2-Stripping.py"
+          },
+          {
+            "title": "DaVinci/DataType-2017.py"
+          },
+          {
+            "title": "DaVinci/InputType-RDST.py"
+          },
+          {
+            "title": "DaVinci/DV-RawEventJuggler-0_3-to-4_2.py"
+          },
+          {
+            "title": "Persistency/Compression-ZLIB-1.py"
+          }
+        ],
+        "release": "DaVinci.v42r7p2 AppConfig.v3r353 Det/SQLDDDB.v7r10 TMVAWeights.v1r9",
+        "type": "Stripping29r2"
+      },
+      {
+        "configuration_files": [
+          {
+            "title": "Merging/DV-Stripping-Merging.py"
+          },
+          {
+            "title": "Persistency/Compression-LZMA-4.py"
+          }
+        ],
+        "release": "DaVinci.v42r7p2 AppConfig.v3r353 Det/SQLDDDB.v7r10",
+        "type": "Stripping29r2-Merging"
+      },
+      {
+        "configuration_files": [
+          {
+            "title": "DaVinci/DV-Stripping29r2-Stripping.py"
+          },
+          {
+            "title": "DaVinci/DataType-2017.py"
+          },
+          {
+            "title": "DaVinci/InputType-RDST.py"
+          },
+          {
+            "title": "DaVinci/DV-RawEventJuggler-0_3-to-4_2.py"
+          },
+          {
+            "title": "Persistency/Compression-ZLIB-1.py"
+          }
+        ],
+        "release": "DaVinci.v42r7p2 AppConfig.v3r353 Det/SQLDDDB.v7r10 TMVAWeights.v1r9",
+        "type": "Stripping29r2"
+      },
+      {
+        "configuration_files": [
+          {
+            "title": "Merging/DV-Stripping-Merging.py"
+          },
+          {
+            "title": "Persistency/Compression-LZMA-4.py"
+          }
+        ],
+        "release": "DaVinci.v42r7p2 AppConfig.v3r353 Det/SQLDDDB.v7r10",
+        "type": "Stripping29r2-Merging"
+      },
+      {
+        "configuration_files": [
+          {
+            "title": "DaVinci/DV-Stripping29r2-Stripping.py"
+          },
+          {
+            "title": "DaVinci/DataType-2017.py"
+          },
+          {
+            "title": "DaVinci/InputType-RDST.py"
+          },
+          {
+            "title": "DaVinci/DV-RawEventJuggler-0_3-to-4_2.py"
+          },
+          {
+            "title": "Persistency/Compression-ZLIB-1.py"
+          }
+        ],
+        "release": "DaVinci.v42r7p2 AppConfig.v3r353 Det/SQLDDDB.v7r10 TMVAWeights.v1r9",
+        "type": "Stripping29r2"
+      },
+      {
+        "configuration_files": [
+          {
+            "title": "Merging/DV-Stripping-Merging.py"
+          },
+          {
+            "title": "Persistency/Compression-LZMA-4.py"
+          }
+        ],
+        "release": "DaVinci.v42r7p2 AppConfig.v3r353 Det/SQLDDDB.v7r10",
+        "type": "Stripping29r2-Merging"
+      },
+      {
+        "configuration_files": [
+          {
+            "title": "DaVinci/DV-Stripping29r2-Stripping.py"
+          },
+          {
+            "title": "DaVinci/DataType-2017.py"
+          },
+          {
+            "title": "DaVinci/InputType-RDST.py"
+          },
+          {
+            "title": "DaVinci/DV-RawEventJuggler-0_3-to-4_2.py"
+          },
+          {
+            "title": "Persistency/Compression-ZLIB-1.py"
+          }
+        ],
+        "release": "DaVinci.v42r7p2 AppConfig.v3r353 Det/SQLDDDB.v7r10 TMVAWeights.v1r9",
+        "type": "Stripping29r2"
+      },
+      {
+        "configuration_files": [
+          {
+            "title": "Merging/DV-Stripping-Merging.py"
+          },
+          {
+            "title": "Persistency/Compression-LZMA-4.py"
+          }
+        ],
+        "release": "DaVinci.v42r7p2 AppConfig.v3r353 Det/SQLDDDB.v7r10",
+        "type": "Stripping29r2-Merging"
+      }
+    ]
+  },
+  "publisher": "CERN Open Data Portal",
+  "recid": "24707",
+  "run_period": [
+    "2017"
+  ],
+  "stripping": {
+    "stream": "CHARMCOMPLETEEVENT",
+    "version": "stripping29r2"
+  },
+  "title": "LHCb 2017 Beam6500GeV MagDown CHARMCOMPLETEEVENT Stream Stripping29r2",
+  "title_additional": "",
+  "type": {
+    "primary": "Dataset",
+    "secondary": [
+      "Collision"
+    ]
+  },
+  "usage": {
+    "description": "<p> The Run 1 and 2 data collected by the LHCb detector is available using the LHCb Ntupling Service, while the Run 1 data is additionally available in .DST and .mDST formats. The data obtained from the LHCb Ntupling Service are ROOT ntuples and do not require custom software to analyze. <p> Links are provided to the LHCb Ntupling Service for exploration of available data and the LHCb Open Data Guide for usage instructions.",
+    "links": [
+      {
+        "description": "LHCb Ntupling Service",
+        "url": "https://opendata-lhcb-ntupling-service.app.cern.ch/"
+      },
+      {
+        "description": "LHCb Open Data Guide",
+        "url": "https://lhcb-opendata-guide.web.cern.ch/"
+      }
+    ]
+  }
+}]

--- a/data/records/LHCb_2017_Beam6500GeV_VeloClosed_MagDown_RealData_Reco17_Stripping29r2_CHARM_MDST.json
+++ b/data/records/LHCb_2017_Beam6500GeV_VeloClosed_MagDown_RealData_Reco17_Stripping29r2_CHARM_MDST.json
@@ -1,0 +1,201 @@
+[{
+  "abstract": {
+    "description": "Data from proton-proton (pp) collisions collected by the LHCb experiment in the year 2017 of Run2 of the LHC."
+  },
+  "accelerator": "CERN-LHC",
+  "collaboration": {
+    "name": "LHCb collaboration",
+    "recid": "456"
+  },
+  "collections": [
+    "LHCb-Collision-Datasets"
+  ],
+  "collision_information": {
+    "energy": "13TeV",
+    "type": "pp"
+  },
+  "date_created": [
+    "2017"
+  ],
+  "date_published": "2026",
+  "date_reprocessed": "2018",
+  "distribution": {
+    "formats": [
+      "MDST"
+    ],
+    "number_events": 3011704798,
+    "number_files": 9200,
+    "size": 32036487115932
+  },
+  "experiment": [
+    "LHCb"
+  ],
+  "magnet_polarity": "MagDown",
+  "methodology": {
+    "description": "<p> This dataset was created in several production steps. These steps, software used and the configuration is provided below. </p><p> <strong> Prod ID: &nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;</strong> 71700<p> <strong>Prod type:&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp; </strong> Merge<p> <strong> Parent Prod ID:&nbsp;&nbsp;&nbsp;&nbsp; </strong> 71500<p> <strong> Parent Prod type: </strong> DataStripping<p> <strong> Conditions: </strong><p>dddb-20170721-3<p>cond-20170724</strong><p> <strong> List of Trigger Configuration Keys (TCK): </strong> </p> <p><p><strong>TCK &nbsp;&nbsp;&nbsp;&nbsp;&nbsp; Number of Files </strong><p>0x11541707 &nbsp;&nbsp;&nbsp;&nbsp;&nbsp; 973<p>0x115417a7 &nbsp;&nbsp;&nbsp;&nbsp;&nbsp; 20<p>0x11561707 &nbsp;&nbsp;&nbsp;&nbsp;&nbsp; 2220<p>0x11611708 &nbsp;&nbsp;&nbsp;&nbsp;&nbsp; 1655<p>0x11611707 &nbsp;&nbsp;&nbsp;&nbsp;&nbsp; 1281<p>0x11611709 &nbsp;&nbsp;&nbsp;&nbsp;&nbsp; 3051",
+    "steps": [
+      {
+        "configuration_files": [
+          {
+            "title": "DaVinci/DV-Stripping29r2-Stripping.py"
+          },
+          {
+            "title": "DaVinci/DataType-2017.py"
+          },
+          {
+            "title": "DaVinci/InputType-RDST.py"
+          },
+          {
+            "title": "DaVinci/DV-RawEventJuggler-0_3-to-4_2.py"
+          },
+          {
+            "title": "Persistency/Compression-ZLIB-1.py"
+          }
+        ],
+        "release": "DaVinci.v42r7p2 AppConfig.v3r353 Det/SQLDDDB.v7r10 TMVAWeights.v1r9",
+        "type": "Stripping29r2"
+      },
+      {
+        "configuration_files": [
+          {
+            "title": "Merging/DV-Stripping-Merging.py"
+          },
+          {
+            "title": "Persistency/Compression-LZMA-4.py"
+          }
+        ],
+        "release": "DaVinci.v42r7p2 AppConfig.v3r353 Det/SQLDDDB.v7r10",
+        "type": "Stripping29r2-Merging"
+      },
+      {
+        "configuration_files": [
+          {
+            "title": "DaVinci/DV-Stripping29r2-Stripping.py"
+          },
+          {
+            "title": "DaVinci/DataType-2017.py"
+          },
+          {
+            "title": "DaVinci/InputType-RDST.py"
+          },
+          {
+            "title": "DaVinci/DV-RawEventJuggler-0_3-to-4_2.py"
+          },
+          {
+            "title": "Persistency/Compression-ZLIB-1.py"
+          }
+        ],
+        "release": "DaVinci.v42r7p2 AppConfig.v3r353 Det/SQLDDDB.v7r10 TMVAWeights.v1r9",
+        "type": "Stripping29r2"
+      },
+      {
+        "configuration_files": [
+          {
+            "title": "Merging/DV-Stripping-Merging.py"
+          },
+          {
+            "title": "Persistency/Compression-LZMA-4.py"
+          }
+        ],
+        "release": "DaVinci.v42r7p2 AppConfig.v3r353 Det/SQLDDDB.v7r10",
+        "type": "Stripping29r2-Merging"
+      },
+      {
+        "configuration_files": [
+          {
+            "title": "DaVinci/DV-Stripping29r2-Stripping.py"
+          },
+          {
+            "title": "DaVinci/DataType-2017.py"
+          },
+          {
+            "title": "DaVinci/InputType-RDST.py"
+          },
+          {
+            "title": "DaVinci/DV-RawEventJuggler-0_3-to-4_2.py"
+          },
+          {
+            "title": "Persistency/Compression-ZLIB-1.py"
+          }
+        ],
+        "release": "DaVinci.v42r7p2 AppConfig.v3r353 Det/SQLDDDB.v7r10 TMVAWeights.v1r9",
+        "type": "Stripping29r2"
+      },
+      {
+        "configuration_files": [
+          {
+            "title": "Merging/DV-Stripping-Merging.py"
+          },
+          {
+            "title": "Persistency/Compression-LZMA-4.py"
+          }
+        ],
+        "release": "DaVinci.v42r7p2 AppConfig.v3r353 Det/SQLDDDB.v7r10",
+        "type": "Stripping29r2-Merging"
+      },
+      {
+        "configuration_files": [
+          {
+            "title": "DaVinci/DV-Stripping29r2-Stripping.py"
+          },
+          {
+            "title": "DaVinci/DataType-2017.py"
+          },
+          {
+            "title": "DaVinci/InputType-RDST.py"
+          },
+          {
+            "title": "DaVinci/DV-RawEventJuggler-0_3-to-4_2.py"
+          },
+          {
+            "title": "Persistency/Compression-ZLIB-1.py"
+          }
+        ],
+        "release": "DaVinci.v42r7p2 AppConfig.v3r353 Det/SQLDDDB.v7r10 TMVAWeights.v1r9",
+        "type": "Stripping29r2"
+      },
+      {
+        "configuration_files": [
+          {
+            "title": "Merging/DV-Stripping-Merging.py"
+          },
+          {
+            "title": "Persistency/Compression-LZMA-4.py"
+          }
+        ],
+        "release": "DaVinci.v42r7p2 AppConfig.v3r353 Det/SQLDDDB.v7r10",
+        "type": "Stripping29r2-Merging"
+      }
+    ]
+  },
+  "publisher": "CERN Open Data Portal",
+  "recid": "24706",
+  "run_period": [
+    "2017"
+  ],
+  "stripping": {
+    "stream": "CHARM",
+    "version": "stripping29r2"
+  },
+  "title": "LHCb 2017 Beam6500GeV MagDown CHARM Stream Stripping29r2",
+  "title_additional": "",
+  "type": {
+    "primary": "Dataset",
+    "secondary": [
+      "Collision"
+    ]
+  },
+  "usage": {
+    "description": "<p> The Run 1 and 2 data collected by the LHCb detector is available using the LHCb Ntupling Service, while the Run 1 data is additionally available in .DST and .mDST formats. The data obtained from the LHCb Ntupling Service are ROOT ntuples and do not require custom software to analyze. <p> Links are provided to the LHCb Ntupling Service for exploration of available data and the LHCb Open Data Guide for usage instructions.",
+    "links": [
+      {
+        "description": "LHCb Ntupling Service",
+        "url": "https://opendata-lhcb-ntupling-service.app.cern.ch/"
+      },
+      {
+        "description": "LHCb Open Data Guide",
+        "url": "https://lhcb-opendata-guide.web.cern.ch/"
+      }
+    ]
+  }
+}]

--- a/data/records/LHCb_2017_Beam6500GeV_VeloClosed_MagDown_RealData_Reco17_Stripping29r2_DIMUON_DST.json
+++ b/data/records/LHCb_2017_Beam6500GeV_VeloClosed_MagDown_RealData_Reco17_Stripping29r2_DIMUON_DST.json
@@ -1,0 +1,201 @@
+[{
+  "abstract": {
+    "description": "Data from proton-proton (pp) collisions collected by the LHCb experiment in the year 2017 of Run2 of the LHC."
+  },
+  "accelerator": "CERN-LHC",
+  "collaboration": {
+    "name": "LHCb collaboration",
+    "recid": "456"
+  },
+  "collections": [
+    "LHCb-Collision-Datasets"
+  ],
+  "collision_information": {
+    "energy": "13TeV",
+    "type": "pp"
+  },
+  "date_created": [
+    "2017"
+  ],
+  "date_published": "2026",
+  "date_reprocessed": "2018",
+  "distribution": {
+    "formats": [
+      "DST"
+    ],
+    "number_events": 411261199,
+    "number_files": 11033,
+    "size": 39007097797199
+  },
+  "experiment": [
+    "LHCb"
+  ],
+  "magnet_polarity": "MagDown",
+  "methodology": {
+    "description": "<p> This dataset was created in several production steps. These steps, software used and the configuration is provided below. </p><p> <strong> Prod ID: &nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;</strong> 71501<p> <strong>Prod type:&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp; </strong> Merge<p> <strong> Parent Prod ID:&nbsp;&nbsp;&nbsp;&nbsp; </strong> 71500<p> <strong> Parent Prod type: </strong> DataStripping<p> <strong> Conditions: </strong><p>dddb-20170721-3<p>cond-20170724</strong><p> <strong> List of Trigger Configuration Keys (TCK): </strong> </p> <p><p><strong>TCK &nbsp;&nbsp;&nbsp;&nbsp;&nbsp; Number of Files </strong><p>0x11541707 &nbsp;&nbsp;&nbsp;&nbsp;&nbsp; 1178<p>0x115417a7 &nbsp;&nbsp;&nbsp;&nbsp;&nbsp; 21<p>0x11561707 &nbsp;&nbsp;&nbsp;&nbsp;&nbsp; 2767<p>0x11611708 &nbsp;&nbsp;&nbsp;&nbsp;&nbsp; 1910<p>0x11611707 &nbsp;&nbsp;&nbsp;&nbsp;&nbsp; 1529<p>0x11611709 &nbsp;&nbsp;&nbsp;&nbsp;&nbsp; 3628",
+    "steps": [
+      {
+        "configuration_files": [
+          {
+            "title": "DaVinci/DV-Stripping29r2-Stripping.py"
+          },
+          {
+            "title": "DaVinci/DataType-2017.py"
+          },
+          {
+            "title": "DaVinci/InputType-RDST.py"
+          },
+          {
+            "title": "DaVinci/DV-RawEventJuggler-0_3-to-4_2.py"
+          },
+          {
+            "title": "Persistency/Compression-ZLIB-1.py"
+          }
+        ],
+        "release": "DaVinci.v42r7p2 AppConfig.v3r353 Det/SQLDDDB.v7r10 TMVAWeights.v1r9",
+        "type": "Stripping29r2"
+      },
+      {
+        "configuration_files": [
+          {
+            "title": "Merging/DV-Stripping-Merging.py"
+          },
+          {
+            "title": "Persistency/Compression-LZMA-4.py"
+          }
+        ],
+        "release": "DaVinci.v42r7p2 AppConfig.v3r353 Det/SQLDDDB.v7r10",
+        "type": "Stripping29r2-Merging"
+      },
+      {
+        "configuration_files": [
+          {
+            "title": "DaVinci/DV-Stripping29r2-Stripping.py"
+          },
+          {
+            "title": "DaVinci/DataType-2017.py"
+          },
+          {
+            "title": "DaVinci/InputType-RDST.py"
+          },
+          {
+            "title": "DaVinci/DV-RawEventJuggler-0_3-to-4_2.py"
+          },
+          {
+            "title": "Persistency/Compression-ZLIB-1.py"
+          }
+        ],
+        "release": "DaVinci.v42r7p2 AppConfig.v3r353 Det/SQLDDDB.v7r10 TMVAWeights.v1r9",
+        "type": "Stripping29r2"
+      },
+      {
+        "configuration_files": [
+          {
+            "title": "Merging/DV-Stripping-Merging.py"
+          },
+          {
+            "title": "Persistency/Compression-LZMA-4.py"
+          }
+        ],
+        "release": "DaVinci.v42r7p2 AppConfig.v3r353 Det/SQLDDDB.v7r10",
+        "type": "Stripping29r2-Merging"
+      },
+      {
+        "configuration_files": [
+          {
+            "title": "DaVinci/DV-Stripping29r2-Stripping.py"
+          },
+          {
+            "title": "DaVinci/DataType-2017.py"
+          },
+          {
+            "title": "DaVinci/InputType-RDST.py"
+          },
+          {
+            "title": "DaVinci/DV-RawEventJuggler-0_3-to-4_2.py"
+          },
+          {
+            "title": "Persistency/Compression-ZLIB-1.py"
+          }
+        ],
+        "release": "DaVinci.v42r7p2 AppConfig.v3r353 Det/SQLDDDB.v7r10 TMVAWeights.v1r9",
+        "type": "Stripping29r2"
+      },
+      {
+        "configuration_files": [
+          {
+            "title": "Merging/DV-Stripping-Merging.py"
+          },
+          {
+            "title": "Persistency/Compression-LZMA-4.py"
+          }
+        ],
+        "release": "DaVinci.v42r7p2 AppConfig.v3r353 Det/SQLDDDB.v7r10",
+        "type": "Stripping29r2-Merging"
+      },
+      {
+        "configuration_files": [
+          {
+            "title": "DaVinci/DV-Stripping29r2-Stripping.py"
+          },
+          {
+            "title": "DaVinci/DataType-2017.py"
+          },
+          {
+            "title": "DaVinci/InputType-RDST.py"
+          },
+          {
+            "title": "DaVinci/DV-RawEventJuggler-0_3-to-4_2.py"
+          },
+          {
+            "title": "Persistency/Compression-ZLIB-1.py"
+          }
+        ],
+        "release": "DaVinci.v42r7p2 AppConfig.v3r353 Det/SQLDDDB.v7r10 TMVAWeights.v1r9",
+        "type": "Stripping29r2"
+      },
+      {
+        "configuration_files": [
+          {
+            "title": "Merging/DV-Stripping-Merging.py"
+          },
+          {
+            "title": "Persistency/Compression-LZMA-4.py"
+          }
+        ],
+        "release": "DaVinci.v42r7p2 AppConfig.v3r353 Det/SQLDDDB.v7r10",
+        "type": "Stripping29r2-Merging"
+      }
+    ]
+  },
+  "publisher": "CERN Open Data Portal",
+  "recid": "24708",
+  "run_period": [
+    "2017"
+  ],
+  "stripping": {
+    "stream": "DIMUON",
+    "version": "stripping29r2"
+  },
+  "title": "LHCb 2017 Beam6500GeV MagDown DIMUON Stream Stripping29r2",
+  "title_additional": "",
+  "type": {
+    "primary": "Dataset",
+    "secondary": [
+      "Collision"
+    ]
+  },
+  "usage": {
+    "description": "<p> The Run 1 and 2 data collected by the LHCb detector is available using the LHCb Ntupling Service, while the Run 1 data is additionally available in .DST and .mDST formats. The data obtained from the LHCb Ntupling Service are ROOT ntuples and do not require custom software to analyze. <p> Links are provided to the LHCb Ntupling Service for exploration of available data and the LHCb Open Data Guide for usage instructions.",
+    "links": [
+      {
+        "description": "LHCb Ntupling Service",
+        "url": "https://opendata-lhcb-ntupling-service.app.cern.ch/"
+      },
+      {
+        "description": "LHCb Open Data Guide",
+        "url": "https://lhcb-opendata-guide.web.cern.ch/"
+      }
+    ]
+  }
+}]

--- a/data/records/LHCb_2017_Beam6500GeV_VeloClosed_MagDown_RealData_Reco17_Stripping29r2_EW_DST.json
+++ b/data/records/LHCb_2017_Beam6500GeV_VeloClosed_MagDown_RealData_Reco17_Stripping29r2_EW_DST.json
@@ -1,0 +1,201 @@
+[{
+  "abstract": {
+    "description": "Data from proton-proton (pp) collisions collected by the LHCb experiment in the year 2017 of Run2 of the LHC."
+  },
+  "accelerator": "CERN-LHC",
+  "collaboration": {
+    "name": "LHCb collaboration",
+    "recid": "456"
+  },
+  "collections": [
+    "LHCb-Collision-Datasets"
+  ],
+  "collision_information": {
+    "energy": "13TeV",
+    "type": "pp"
+  },
+  "date_created": [
+    "2017"
+  ],
+  "date_published": "2026",
+  "date_reprocessed": "2018",
+  "distribution": {
+    "formats": [
+      "DST"
+    ],
+    "number_events": 286851233,
+    "number_files": 7279,
+    "size": 23995239844600
+  },
+  "experiment": [
+    "LHCb"
+  ],
+  "magnet_polarity": "MagDown",
+  "methodology": {
+    "description": "<p> This dataset was created in several production steps. These steps, software used and the configuration is provided below. </p><p> <strong> Prod ID: &nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;</strong> 71501<p> <strong>Prod type:&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp; </strong> Merge<p> <strong> Parent Prod ID:&nbsp;&nbsp;&nbsp;&nbsp; </strong> 71500<p> <strong> Parent Prod type: </strong> DataStripping<p> <strong> Conditions: </strong><p>dddb-20170721-3<p>cond-20170724</strong><p> <strong> List of Trigger Configuration Keys (TCK): </strong> </p> <p><p><strong>TCK &nbsp;&nbsp;&nbsp;&nbsp;&nbsp; Number of Files </strong><p>0x11541707 &nbsp;&nbsp;&nbsp;&nbsp;&nbsp; 816<p>0x115417a7 &nbsp;&nbsp;&nbsp;&nbsp;&nbsp; 21<p>0x11561707 &nbsp;&nbsp;&nbsp;&nbsp;&nbsp; 1840<p>0x11611708 &nbsp;&nbsp;&nbsp;&nbsp;&nbsp; 1230<p>0x11611707 &nbsp;&nbsp;&nbsp;&nbsp;&nbsp; 1044<p>0x11611709 &nbsp;&nbsp;&nbsp;&nbsp;&nbsp; 2328",
+    "steps": [
+      {
+        "configuration_files": [
+          {
+            "title": "DaVinci/DV-Stripping29r2-Stripping.py"
+          },
+          {
+            "title": "DaVinci/DataType-2017.py"
+          },
+          {
+            "title": "DaVinci/InputType-RDST.py"
+          },
+          {
+            "title": "DaVinci/DV-RawEventJuggler-0_3-to-4_2.py"
+          },
+          {
+            "title": "Persistency/Compression-ZLIB-1.py"
+          }
+        ],
+        "release": "DaVinci.v42r7p2 AppConfig.v3r353 Det/SQLDDDB.v7r10 TMVAWeights.v1r9",
+        "type": "Stripping29r2"
+      },
+      {
+        "configuration_files": [
+          {
+            "title": "Merging/DV-Stripping-Merging.py"
+          },
+          {
+            "title": "Persistency/Compression-LZMA-4.py"
+          }
+        ],
+        "release": "DaVinci.v42r7p2 AppConfig.v3r353 Det/SQLDDDB.v7r10",
+        "type": "Stripping29r2-Merging"
+      },
+      {
+        "configuration_files": [
+          {
+            "title": "DaVinci/DV-Stripping29r2-Stripping.py"
+          },
+          {
+            "title": "DaVinci/DataType-2017.py"
+          },
+          {
+            "title": "DaVinci/InputType-RDST.py"
+          },
+          {
+            "title": "DaVinci/DV-RawEventJuggler-0_3-to-4_2.py"
+          },
+          {
+            "title": "Persistency/Compression-ZLIB-1.py"
+          }
+        ],
+        "release": "DaVinci.v42r7p2 AppConfig.v3r353 Det/SQLDDDB.v7r10 TMVAWeights.v1r9",
+        "type": "Stripping29r2"
+      },
+      {
+        "configuration_files": [
+          {
+            "title": "Merging/DV-Stripping-Merging.py"
+          },
+          {
+            "title": "Persistency/Compression-LZMA-4.py"
+          }
+        ],
+        "release": "DaVinci.v42r7p2 AppConfig.v3r353 Det/SQLDDDB.v7r10",
+        "type": "Stripping29r2-Merging"
+      },
+      {
+        "configuration_files": [
+          {
+            "title": "DaVinci/DV-Stripping29r2-Stripping.py"
+          },
+          {
+            "title": "DaVinci/DataType-2017.py"
+          },
+          {
+            "title": "DaVinci/InputType-RDST.py"
+          },
+          {
+            "title": "DaVinci/DV-RawEventJuggler-0_3-to-4_2.py"
+          },
+          {
+            "title": "Persistency/Compression-ZLIB-1.py"
+          }
+        ],
+        "release": "DaVinci.v42r7p2 AppConfig.v3r353 Det/SQLDDDB.v7r10 TMVAWeights.v1r9",
+        "type": "Stripping29r2"
+      },
+      {
+        "configuration_files": [
+          {
+            "title": "Merging/DV-Stripping-Merging.py"
+          },
+          {
+            "title": "Persistency/Compression-LZMA-4.py"
+          }
+        ],
+        "release": "DaVinci.v42r7p2 AppConfig.v3r353 Det/SQLDDDB.v7r10",
+        "type": "Stripping29r2-Merging"
+      },
+      {
+        "configuration_files": [
+          {
+            "title": "DaVinci/DV-Stripping29r2-Stripping.py"
+          },
+          {
+            "title": "DaVinci/DataType-2017.py"
+          },
+          {
+            "title": "DaVinci/InputType-RDST.py"
+          },
+          {
+            "title": "DaVinci/DV-RawEventJuggler-0_3-to-4_2.py"
+          },
+          {
+            "title": "Persistency/Compression-ZLIB-1.py"
+          }
+        ],
+        "release": "DaVinci.v42r7p2 AppConfig.v3r353 Det/SQLDDDB.v7r10 TMVAWeights.v1r9",
+        "type": "Stripping29r2"
+      },
+      {
+        "configuration_files": [
+          {
+            "title": "Merging/DV-Stripping-Merging.py"
+          },
+          {
+            "title": "Persistency/Compression-LZMA-4.py"
+          }
+        ],
+        "release": "DaVinci.v42r7p2 AppConfig.v3r353 Det/SQLDDDB.v7r10",
+        "type": "Stripping29r2-Merging"
+      }
+    ]
+  },
+  "publisher": "CERN Open Data Portal",
+  "recid": "24700",
+  "run_period": [
+    "2017"
+  ],
+  "stripping": {
+    "stream": "EW",
+    "version": "stripping29r2"
+  },
+  "title": "LHCb 2017 Beam6500GeV MagDown EW Stream Stripping29r2",
+  "title_additional": "",
+  "type": {
+    "primary": "Dataset",
+    "secondary": [
+      "Collision"
+    ]
+  },
+  "usage": {
+    "description": "<p> The Run 1 and 2 data collected by the LHCb detector is available using the LHCb Ntupling Service, while the Run 1 data is additionally available in .DST and .mDST formats. The data obtained from the LHCb Ntupling Service are ROOT ntuples and do not require custom software to analyze. <p> Links are provided to the LHCb Ntupling Service for exploration of available data and the LHCb Open Data Guide for usage instructions.",
+    "links": [
+      {
+        "description": "LHCb Ntupling Service",
+        "url": "https://opendata-lhcb-ntupling-service.app.cern.ch/"
+      },
+      {
+        "description": "LHCb Open Data Guide",
+        "url": "https://lhcb-opendata-guide.web.cern.ch/"
+      }
+    ]
+  }
+}]

--- a/data/records/LHCb_2017_Beam6500GeV_VeloClosed_MagDown_RealData_Reco17_Stripping29r2_LEPTONIC_MDST.json
+++ b/data/records/LHCb_2017_Beam6500GeV_VeloClosed_MagDown_RealData_Reco17_Stripping29r2_LEPTONIC_MDST.json
@@ -1,0 +1,201 @@
+[{
+  "abstract": {
+    "description": "Data from proton-proton (pp) collisions collected by the LHCb experiment in the year 2017 of Run2 of the LHC."
+  },
+  "accelerator": "CERN-LHC",
+  "collaboration": {
+    "name": "LHCb collaboration",
+    "recid": "456"
+  },
+  "collections": [
+    "LHCb-Collision-Datasets"
+  ],
+  "collision_information": {
+    "energy": "13TeV",
+    "type": "pp"
+  },
+  "date_created": [
+    "2017"
+  ],
+  "date_published": "2026",
+  "date_reprocessed": "2018",
+  "distribution": {
+    "formats": [
+      "MDST"
+    ],
+    "number_events": 3405859540,
+    "number_files": 10666,
+    "size": 38918293186153
+  },
+  "experiment": [
+    "LHCb"
+  ],
+  "magnet_polarity": "MagDown",
+  "methodology": {
+    "description": "<p> This dataset was created in several production steps. These steps, software used and the configuration is provided below. </p><p> <strong> Prod ID: &nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;</strong> 71907<p> <strong>Prod type:&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp; </strong> Merge<p> <strong> Parent Prod ID:&nbsp;&nbsp;&nbsp;&nbsp; </strong> 71500<p> <strong> Parent Prod type: </strong> DataStripping<p> <strong> Conditions: </strong><p>dddb-20170721-3<p>cond-20170724</strong><p> <strong> List of Trigger Configuration Keys (TCK): </strong> </p> <p><p><strong>TCK &nbsp;&nbsp;&nbsp;&nbsp;&nbsp; Number of Files </strong><p>0x11541707 &nbsp;&nbsp;&nbsp;&nbsp;&nbsp; 1151<p>0x115417a7 &nbsp;&nbsp;&nbsp;&nbsp;&nbsp; 20<p>0x11561707 &nbsp;&nbsp;&nbsp;&nbsp;&nbsp; 2654<p>0x11611708 &nbsp;&nbsp;&nbsp;&nbsp;&nbsp; 1834<p>0x11611707 &nbsp;&nbsp;&nbsp;&nbsp;&nbsp; 1470<p>0x11611709 &nbsp;&nbsp;&nbsp;&nbsp;&nbsp; 3537",
+    "steps": [
+      {
+        "configuration_files": [
+          {
+            "title": "DaVinci/DV-Stripping29r2-Stripping.py"
+          },
+          {
+            "title": "DaVinci/DataType-2017.py"
+          },
+          {
+            "title": "DaVinci/InputType-RDST.py"
+          },
+          {
+            "title": "DaVinci/DV-RawEventJuggler-0_3-to-4_2.py"
+          },
+          {
+            "title": "Persistency/Compression-ZLIB-1.py"
+          }
+        ],
+        "release": "DaVinci.v42r7p2 AppConfig.v3r353 Det/SQLDDDB.v7r10 TMVAWeights.v1r9",
+        "type": "Stripping29r2"
+      },
+      {
+        "configuration_files": [
+          {
+            "title": "Merging/DV-Stripping-Merging.py"
+          },
+          {
+            "title": "Persistency/Compression-LZMA-4.py"
+          }
+        ],
+        "release": "DaVinci.v42r7p2 AppConfig.v3r353 Det/SQLDDDB.v7r10",
+        "type": "Stripping29r2-Merging"
+      },
+      {
+        "configuration_files": [
+          {
+            "title": "DaVinci/DV-Stripping29r2-Stripping.py"
+          },
+          {
+            "title": "DaVinci/DataType-2017.py"
+          },
+          {
+            "title": "DaVinci/InputType-RDST.py"
+          },
+          {
+            "title": "DaVinci/DV-RawEventJuggler-0_3-to-4_2.py"
+          },
+          {
+            "title": "Persistency/Compression-ZLIB-1.py"
+          }
+        ],
+        "release": "DaVinci.v42r7p2 AppConfig.v3r353 Det/SQLDDDB.v7r10 TMVAWeights.v1r9",
+        "type": "Stripping29r2"
+      },
+      {
+        "configuration_files": [
+          {
+            "title": "Merging/DV-Stripping-Merging.py"
+          },
+          {
+            "title": "Persistency/Compression-LZMA-4.py"
+          }
+        ],
+        "release": "DaVinci.v42r7p2 AppConfig.v3r353 Det/SQLDDDB.v7r10",
+        "type": "Stripping29r2-Merging"
+      },
+      {
+        "configuration_files": [
+          {
+            "title": "DaVinci/DV-Stripping29r2-Stripping.py"
+          },
+          {
+            "title": "DaVinci/DataType-2017.py"
+          },
+          {
+            "title": "DaVinci/InputType-RDST.py"
+          },
+          {
+            "title": "DaVinci/DV-RawEventJuggler-0_3-to-4_2.py"
+          },
+          {
+            "title": "Persistency/Compression-ZLIB-1.py"
+          }
+        ],
+        "release": "DaVinci.v42r7p2 AppConfig.v3r353 Det/SQLDDDB.v7r10 TMVAWeights.v1r9",
+        "type": "Stripping29r2"
+      },
+      {
+        "configuration_files": [
+          {
+            "title": "Merging/DV-Stripping-Merging.py"
+          },
+          {
+            "title": "Persistency/Compression-LZMA-4.py"
+          }
+        ],
+        "release": "DaVinci.v42r7p2 AppConfig.v3r353 Det/SQLDDDB.v7r10",
+        "type": "Stripping29r2-Merging"
+      },
+      {
+        "configuration_files": [
+          {
+            "title": "DaVinci/DV-Stripping29r2-Stripping.py"
+          },
+          {
+            "title": "DaVinci/DataType-2017.py"
+          },
+          {
+            "title": "DaVinci/InputType-RDST.py"
+          },
+          {
+            "title": "DaVinci/DV-RawEventJuggler-0_3-to-4_2.py"
+          },
+          {
+            "title": "Persistency/Compression-ZLIB-1.py"
+          }
+        ],
+        "release": "DaVinci.v42r7p2 AppConfig.v3r353 Det/SQLDDDB.v7r10 TMVAWeights.v1r9",
+        "type": "Stripping29r2"
+      },
+      {
+        "configuration_files": [
+          {
+            "title": "Merging/DV-Stripping-Merging.py"
+          },
+          {
+            "title": "Persistency/Compression-LZMA-4.py"
+          }
+        ],
+        "release": "DaVinci.v42r7p2 AppConfig.v3r353 Det/SQLDDDB.v7r10",
+        "type": "Stripping29r2-Merging"
+      }
+    ]
+  },
+  "publisher": "CERN Open Data Portal",
+  "recid": "24701",
+  "run_period": [
+    "2017"
+  ],
+  "stripping": {
+    "stream": "LEPTONIC",
+    "version": "stripping29r2"
+  },
+  "title": "LHCb 2017 Beam6500GeV MagDown LEPTONIC Stream Stripping29r2",
+  "title_additional": "",
+  "type": {
+    "primary": "Dataset",
+    "secondary": [
+      "Collision"
+    ]
+  },
+  "usage": {
+    "description": "<p> The Run 1 and 2 data collected by the LHCb detector is available using the LHCb Ntupling Service, while the Run 1 data is additionally available in .DST and .mDST formats. The data obtained from the LHCb Ntupling Service are ROOT ntuples and do not require custom software to analyze. <p> Links are provided to the LHCb Ntupling Service for exploration of available data and the LHCb Open Data Guide for usage instructions.",
+    "links": [
+      {
+        "description": "LHCb Ntupling Service",
+        "url": "https://opendata-lhcb-ntupling-service.app.cern.ch/"
+      },
+      {
+        "description": "LHCb Open Data Guide",
+        "url": "https://lhcb-opendata-guide.web.cern.ch/"
+      }
+    ]
+  }
+}]

--- a/data/records/LHCb_2017_Beam6500GeV_VeloClosed_MagDown_RealData_Reco17_Stripping29r2_SEMILEPTONIC_DST.json
+++ b/data/records/LHCb_2017_Beam6500GeV_VeloClosed_MagDown_RealData_Reco17_Stripping29r2_SEMILEPTONIC_DST.json
@@ -1,0 +1,201 @@
+[{
+  "abstract": {
+    "description": "Data from proton-proton (pp) collisions collected by the LHCb experiment in the year 2017 of Run2 of the LHC."
+  },
+  "accelerator": "CERN-LHC",
+  "collaboration": {
+    "name": "LHCb collaboration",
+    "recid": "456"
+  },
+  "collections": [
+    "LHCb-Collision-Datasets"
+  ],
+  "collision_information": {
+    "energy": "13TeV",
+    "type": "pp"
+  },
+  "date_created": [
+    "2017"
+  ],
+  "date_published": "2026",
+  "date_reprocessed": "2018",
+  "distribution": {
+    "formats": [
+      "DST"
+    ],
+    "number_events": 678615770,
+    "number_files": 14049,
+    "size": 49233005474135
+  },
+  "experiment": [
+    "LHCb"
+  ],
+  "magnet_polarity": "MagDown",
+  "methodology": {
+    "description": "<p> This dataset was created in several production steps. These steps, software used and the configuration is provided below. </p><p> <strong> Prod ID: &nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;</strong> 71571<p> <strong>Prod type:&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp; </strong> Merge<p> <strong> Parent Prod ID:&nbsp;&nbsp;&nbsp;&nbsp; </strong> 71500<p> <strong> Parent Prod type: </strong> DataStripping<p> <strong> Conditions: </strong><p>dddb-20170721-3<p>cond-20170724</strong><p> <strong> List of Trigger Configuration Keys (TCK): </strong> </p> <p><p><strong>TCK &nbsp;&nbsp;&nbsp;&nbsp;&nbsp; Number of Files </strong><p>0x11541707 &nbsp;&nbsp;&nbsp;&nbsp;&nbsp; 1457<p>0x115417a7 &nbsp;&nbsp;&nbsp;&nbsp;&nbsp; 21<p>0x11561707 &nbsp;&nbsp;&nbsp;&nbsp;&nbsp; 3444<p>0x11611708 &nbsp;&nbsp;&nbsp;&nbsp;&nbsp; 2477<p>0x11611707 &nbsp;&nbsp;&nbsp;&nbsp;&nbsp; 1942<p>0x11611709 &nbsp;&nbsp;&nbsp;&nbsp;&nbsp; 4708",
+    "steps": [
+      {
+        "configuration_files": [
+          {
+            "title": "DaVinci/DV-Stripping29r2-Stripping.py"
+          },
+          {
+            "title": "DaVinci/DataType-2017.py"
+          },
+          {
+            "title": "DaVinci/InputType-RDST.py"
+          },
+          {
+            "title": "DaVinci/DV-RawEventJuggler-0_3-to-4_2.py"
+          },
+          {
+            "title": "Persistency/Compression-ZLIB-1.py"
+          }
+        ],
+        "release": "DaVinci.v42r7p2 AppConfig.v3r353 Det/SQLDDDB.v7r10 TMVAWeights.v1r9",
+        "type": "Stripping29r2"
+      },
+      {
+        "configuration_files": [
+          {
+            "title": "Merging/DV-Stripping-Merging.py"
+          },
+          {
+            "title": "Persistency/Compression-LZMA-4.py"
+          }
+        ],
+        "release": "DaVinci.v42r7p2 AppConfig.v3r353 Det/SQLDDDB.v7r10",
+        "type": "Stripping29r2-Merging"
+      },
+      {
+        "configuration_files": [
+          {
+            "title": "DaVinci/DV-Stripping29r2-Stripping.py"
+          },
+          {
+            "title": "DaVinci/DataType-2017.py"
+          },
+          {
+            "title": "DaVinci/InputType-RDST.py"
+          },
+          {
+            "title": "DaVinci/DV-RawEventJuggler-0_3-to-4_2.py"
+          },
+          {
+            "title": "Persistency/Compression-ZLIB-1.py"
+          }
+        ],
+        "release": "DaVinci.v42r7p2 AppConfig.v3r353 Det/SQLDDDB.v7r10 TMVAWeights.v1r9",
+        "type": "Stripping29r2"
+      },
+      {
+        "configuration_files": [
+          {
+            "title": "Merging/DV-Stripping-Merging.py"
+          },
+          {
+            "title": "Persistency/Compression-LZMA-4.py"
+          }
+        ],
+        "release": "DaVinci.v42r7p2 AppConfig.v3r353 Det/SQLDDDB.v7r10",
+        "type": "Stripping29r2-Merging"
+      },
+      {
+        "configuration_files": [
+          {
+            "title": "DaVinci/DV-Stripping29r2-Stripping.py"
+          },
+          {
+            "title": "DaVinci/DataType-2017.py"
+          },
+          {
+            "title": "DaVinci/InputType-RDST.py"
+          },
+          {
+            "title": "DaVinci/DV-RawEventJuggler-0_3-to-4_2.py"
+          },
+          {
+            "title": "Persistency/Compression-ZLIB-1.py"
+          }
+        ],
+        "release": "DaVinci.v42r7p2 AppConfig.v3r353 Det/SQLDDDB.v7r10 TMVAWeights.v1r9",
+        "type": "Stripping29r2"
+      },
+      {
+        "configuration_files": [
+          {
+            "title": "Merging/DV-Stripping-Merging.py"
+          },
+          {
+            "title": "Persistency/Compression-LZMA-4.py"
+          }
+        ],
+        "release": "DaVinci.v42r7p2 AppConfig.v3r353 Det/SQLDDDB.v7r10",
+        "type": "Stripping29r2-Merging"
+      },
+      {
+        "configuration_files": [
+          {
+            "title": "DaVinci/DV-Stripping29r2-Stripping.py"
+          },
+          {
+            "title": "DaVinci/DataType-2017.py"
+          },
+          {
+            "title": "DaVinci/InputType-RDST.py"
+          },
+          {
+            "title": "DaVinci/DV-RawEventJuggler-0_3-to-4_2.py"
+          },
+          {
+            "title": "Persistency/Compression-ZLIB-1.py"
+          }
+        ],
+        "release": "DaVinci.v42r7p2 AppConfig.v3r353 Det/SQLDDDB.v7r10 TMVAWeights.v1r9",
+        "type": "Stripping29r2"
+      },
+      {
+        "configuration_files": [
+          {
+            "title": "Merging/DV-Stripping-Merging.py"
+          },
+          {
+            "title": "Persistency/Compression-LZMA-4.py"
+          }
+        ],
+        "release": "DaVinci.v42r7p2 AppConfig.v3r353 Det/SQLDDDB.v7r10",
+        "type": "Stripping29r2-Merging"
+      }
+    ]
+  },
+  "publisher": "CERN Open Data Portal",
+  "recid": "24709",
+  "run_period": [
+    "2017"
+  ],
+  "stripping": {
+    "stream": "SEMILEPTONIC",
+    "version": "stripping29r2"
+  },
+  "title": "LHCb 2017 Beam6500GeV MagDown SEMILEPTONIC Stream Stripping29r2",
+  "title_additional": "",
+  "type": {
+    "primary": "Dataset",
+    "secondary": [
+      "Collision"
+    ]
+  },
+  "usage": {
+    "description": "<p> The Run 1 and 2 data collected by the LHCb detector is available using the LHCb Ntupling Service, while the Run 1 data is additionally available in .DST and .mDST formats. The data obtained from the LHCb Ntupling Service are ROOT ntuples and do not require custom software to analyze. <p> Links are provided to the LHCb Ntupling Service for exploration of available data and the LHCb Open Data Guide for usage instructions.",
+    "links": [
+      {
+        "description": "LHCb Ntupling Service",
+        "url": "https://opendata-lhcb-ntupling-service.app.cern.ch/"
+      },
+      {
+        "description": "LHCb Open Data Guide",
+        "url": "https://lhcb-opendata-guide.web.cern.ch/"
+      }
+    ]
+  }
+}]

--- a/data/records/LHCb_2017_Beam6500GeV_VeloClosed_MagDown_RealData_Reco17_Stripping29r2p1_BHADRONCOMPLETEEVENT_DST.json
+++ b/data/records/LHCb_2017_Beam6500GeV_VeloClosed_MagDown_RealData_Reco17_Stripping29r2p1_BHADRONCOMPLETEEVENT_DST.json
@@ -1,0 +1,135 @@
+[{
+  "abstract": {
+    "description": "Data from proton-proton (pp) collisions collected by the LHCb experiment in the year 2017 of Run2 of the LHC."
+  },
+  "accelerator": "CERN-LHC",
+  "collaboration": {
+    "name": "LHCb collaboration",
+    "recid": "456"
+  },
+  "collections": [
+    "LHCb-Collision-Datasets"
+  ],
+  "collision_information": {
+    "energy": "13TeV",
+    "type": "pp"
+  },
+  "date_created": [
+    "2017"
+  ],
+  "date_published": "2026",
+  "date_reprocessed": "2020",
+  "distribution": {
+    "formats": [
+      "DST"
+    ],
+    "number_events": 432830071,
+    "number_files": 10612,
+    "size": 37912852596010
+  },
+  "experiment": [
+    "LHCb"
+  ],
+  "magnet_polarity": "MagDown",
+  "methodology": {
+    "description": "<p> This dataset was created in several production steps. These steps, software used and the configuration is provided below. </p><p> <strong> Prod ID: &nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;</strong> 104246<p> <strong>Prod type:&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp; </strong> Merge<p> <strong> Parent Prod ID:&nbsp;&nbsp;&nbsp;&nbsp; </strong> 104245<p> <strong> Parent Prod type: </strong> DataStripping<p> <strong> Conditions: </strong><p>dddb-20190206-3<p>cond-20191004-2 </strong><p> <strong> List of Trigger Configuration Keys (TCK): </strong> </p> <p><p><strong>TCK &nbsp;&nbsp;&nbsp;&nbsp;&nbsp; Number of Files </strong><p>0x11541707 &nbsp;&nbsp;&nbsp;&nbsp;&nbsp; 1062<p>0x115417a7 &nbsp;&nbsp;&nbsp;&nbsp;&nbsp; 9<p>0x11561707 &nbsp;&nbsp;&nbsp;&nbsp;&nbsp; 2559<p>0x11611708 &nbsp;&nbsp;&nbsp;&nbsp;&nbsp; 1920<p>0x11611707 &nbsp;&nbsp;&nbsp;&nbsp;&nbsp; 1476<p>0x11611709 &nbsp;&nbsp;&nbsp;&nbsp;&nbsp; 3586",
+    "steps": [
+      {
+        "configuration_files": [
+          {
+            "title": "DaVinci/DV-Stripping29r2p1-Stripping.py"
+          },
+          {
+            "title": "DaVinci/DataType-2017.py"
+          },
+          {
+            "title": "DaVinci/InputType-RDST.py"
+          },
+          {
+            "title": "DaVinci/DV-RawEventJuggler-0_3-to-4_3.py"
+          },
+          {
+            "title": "Persistency/Compression-ZLIB-1.py"
+          }
+        ],
+        "release": "DaVinci.v42r9p2 AppConfig.v3r394 Det/SQLDDDB.v7r10 TMVAWeights.v1r16",
+        "type": "Stripping29r2p1"
+      },
+      {
+        "configuration_files": [
+          {
+            "title": "Merging/DV-Stripping-Merging.py"
+          },
+          {
+            "title": "Persistency/Compression-LZMA-4.py"
+          }
+        ],
+        "release": "DaVinci.v42r9p2 AppConfig.v3r394 Det/SQLDDDB.v7r10",
+        "type": "Stripping29r2p1-Merging"
+      },
+      {
+        "configuration_files": [
+          {
+            "title": "DaVinci/DV-Stripping29r2p1-Stripping.py"
+          },
+          {
+            "title": "DaVinci/DataType-2017.py"
+          },
+          {
+            "title": "DaVinci/InputType-RDST.py"
+          },
+          {
+            "title": "DaVinci/DV-RawEventJuggler-0_3-to-4_3.py"
+          },
+          {
+            "title": "Persistency/Compression-ZLIB-1.py"
+          }
+        ],
+        "release": "DaVinci.v42r9p2 AppConfig.v3r394 Det/SQLDDDB.v7r10 TMVAWeights.v1r16",
+        "type": "Stripping29r2p1"
+      },
+      {
+        "configuration_files": [
+          {
+            "title": "Merging/DV-Stripping-Merging.py"
+          },
+          {
+            "title": "Persistency/Compression-LZMA-4.py"
+          }
+        ],
+        "release": "DaVinci.v42r9p2 AppConfig.v3r394 Det/SQLDDDB.v7r10",
+        "type": "Stripping29r2p1-Merging"
+      }
+    ]
+  },
+  "publisher": "CERN Open Data Portal",
+  "recid": "24725",
+  "run_period": [
+    "2017"
+  ],
+  "stripping": {
+    "stream": "BHADRONCOMPLETEEVENT",
+    "version": "stripping29r2p1"
+  },
+  "title": "LHCb 2017 Beam6500GeV MagDown BHADRONCOMPLETEEVENT Stream Stripping29r2p1",
+  "title_additional": "",
+  "type": {
+    "primary": "Dataset",
+    "secondary": [
+      "Collision"
+    ]
+  },
+  "usage": {
+    "description": "<p> The Run 1 and 2 data collected by the LHCb detector is available using the LHCb Ntupling Service, while the Run 1 data is additionally available in .DST and .mDST formats. The data obtained from the LHCb Ntupling Service are ROOT ntuples and do not require custom software to analyze. <p> Links are provided to the LHCb Ntupling Service for exploration of available data and the LHCb Open Data Guide for usage instructions.",
+    "links": [
+      {
+        "description": "LHCb Ntupling Service",
+        "url": "https://opendata-lhcb-ntupling-service.app.cern.ch/"
+      },
+      {
+        "description": "LHCb Open Data Guide",
+        "url": "https://lhcb-opendata-guide.web.cern.ch/"
+      }
+    ]
+  }
+}]

--- a/data/records/LHCb_2017_Beam6500GeV_VeloClosed_MagDown_RealData_Reco17_Stripping29r2p1_BHADRON_MDST.json
+++ b/data/records/LHCb_2017_Beam6500GeV_VeloClosed_MagDown_RealData_Reco17_Stripping29r2p1_BHADRON_MDST.json
@@ -1,0 +1,135 @@
+[{
+  "abstract": {
+    "description": "Data from proton-proton (pp) collisions collected by the LHCb experiment in the year 2017 of Run2 of the LHC."
+  },
+  "accelerator": "CERN-LHC",
+  "collaboration": {
+    "name": "LHCb collaboration",
+    "recid": "456"
+  },
+  "collections": [
+    "LHCb-Collision-Datasets"
+  ],
+  "collision_information": {
+    "energy": "13TeV",
+    "type": "pp"
+  },
+  "date_created": [
+    "2017"
+  ],
+  "date_published": "2026",
+  "date_reprocessed": "2020",
+  "distribution": {
+    "formats": [
+      "MDST"
+    ],
+    "number_events": 1567795760,
+    "number_files": 6471,
+    "size": 21810411308353
+  },
+  "experiment": [
+    "LHCb"
+  ],
+  "magnet_polarity": "MagDown",
+  "methodology": {
+    "description": "<p> This dataset was created in several production steps. These steps, software used and the configuration is provided below. </p><p> <strong> Prod ID: &nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;</strong> 104639<p> <strong>Prod type:&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp; </strong> Merge<p> <strong> Parent Prod ID:&nbsp;&nbsp;&nbsp;&nbsp; </strong> 104245<p> <strong> Parent Prod type: </strong> DataStripping<p> <strong> Conditions: </strong><p>dddb-20190206-3<p>cond-20191004-2 </strong><p> <strong> List of Trigger Configuration Keys (TCK): </strong> </p> <p><p><strong>TCK &nbsp;&nbsp;&nbsp;&nbsp;&nbsp; Number of Files </strong><p>0x11541707 &nbsp;&nbsp;&nbsp;&nbsp;&nbsp; 657<p>0x11561707 &nbsp;&nbsp;&nbsp;&nbsp;&nbsp; 1549<p>0x11611708 &nbsp;&nbsp;&nbsp;&nbsp;&nbsp; 1211<p>0x11611707 &nbsp;&nbsp;&nbsp;&nbsp;&nbsp; 898<p>0x11611709 &nbsp;&nbsp;&nbsp;&nbsp;&nbsp; 2149<p>0x115417a7 &nbsp;&nbsp;&nbsp;&nbsp;&nbsp; 7",
+    "steps": [
+      {
+        "configuration_files": [
+          {
+            "title": "DaVinci/DV-Stripping29r2p1-Stripping.py"
+          },
+          {
+            "title": "DaVinci/DataType-2017.py"
+          },
+          {
+            "title": "DaVinci/InputType-RDST.py"
+          },
+          {
+            "title": "DaVinci/DV-RawEventJuggler-0_3-to-4_3.py"
+          },
+          {
+            "title": "Persistency/Compression-ZLIB-1.py"
+          }
+        ],
+        "release": "DaVinci.v42r9p2 AppConfig.v3r394 Det/SQLDDDB.v7r10 TMVAWeights.v1r16",
+        "type": "Stripping29r2p1"
+      },
+      {
+        "configuration_files": [
+          {
+            "title": "Merging/DV-Stripping-Merging.py"
+          },
+          {
+            "title": "Persistency/Compression-LZMA-4.py"
+          }
+        ],
+        "release": "DaVinci.v42r9p2 AppConfig.v3r394 Det/SQLDDDB.v7r10",
+        "type": "Stripping29r2p1-Merging"
+      },
+      {
+        "configuration_files": [
+          {
+            "title": "DaVinci/DV-Stripping29r2p1-Stripping.py"
+          },
+          {
+            "title": "DaVinci/DataType-2017.py"
+          },
+          {
+            "title": "DaVinci/InputType-RDST.py"
+          },
+          {
+            "title": "DaVinci/DV-RawEventJuggler-0_3-to-4_3.py"
+          },
+          {
+            "title": "Persistency/Compression-ZLIB-1.py"
+          }
+        ],
+        "release": "DaVinci.v42r9p2 AppConfig.v3r394 Det/SQLDDDB.v7r10 TMVAWeights.v1r16",
+        "type": "Stripping29r2p1"
+      },
+      {
+        "configuration_files": [
+          {
+            "title": "Merging/DV-Stripping-Merging.py"
+          },
+          {
+            "title": "Persistency/Compression-LZMA-4.py"
+          }
+        ],
+        "release": "DaVinci.v42r9p2 AppConfig.v3r394 Det/SQLDDDB.v7r10",
+        "type": "Stripping29r2p1-Merging"
+      }
+    ]
+  },
+  "publisher": "CERN Open Data Portal",
+  "recid": "24724",
+  "run_period": [
+    "2017"
+  ],
+  "stripping": {
+    "stream": "BHADRON",
+    "version": "stripping29r2p1"
+  },
+  "title": "LHCb 2017 Beam6500GeV MagDown BHADRON Stream Stripping29r2p1",
+  "title_additional": "",
+  "type": {
+    "primary": "Dataset",
+    "secondary": [
+      "Collision"
+    ]
+  },
+  "usage": {
+    "description": "<p> The Run 1 and 2 data collected by the LHCb detector is available using the LHCb Ntupling Service, while the Run 1 data is additionally available in .DST and .mDST formats. The data obtained from the LHCb Ntupling Service are ROOT ntuples and do not require custom software to analyze. <p> Links are provided to the LHCb Ntupling Service for exploration of available data and the LHCb Open Data Guide for usage instructions.",
+    "links": [
+      {
+        "description": "LHCb Ntupling Service",
+        "url": "https://opendata-lhcb-ntupling-service.app.cern.ch/"
+      },
+      {
+        "description": "LHCb Open Data Guide",
+        "url": "https://lhcb-opendata-guide.web.cern.ch/"
+      }
+    ]
+  }
+}]

--- a/data/records/LHCb_2017_Beam6500GeV_VeloClosed_MagDown_RealData_Reco17_Stripping29r2p1_CHARMCOMPLETEEVENT_DST.json
+++ b/data/records/LHCb_2017_Beam6500GeV_VeloClosed_MagDown_RealData_Reco17_Stripping29r2p1_CHARMCOMPLETEEVENT_DST.json
@@ -1,0 +1,135 @@
+[{
+  "abstract": {
+    "description": "Data from proton-proton (pp) collisions collected by the LHCb experiment in the year 2017 of Run2 of the LHC."
+  },
+  "accelerator": "CERN-LHC",
+  "collaboration": {
+    "name": "LHCb collaboration",
+    "recid": "456"
+  },
+  "collections": [
+    "LHCb-Collision-Datasets"
+  ],
+  "collision_information": {
+    "energy": "13TeV",
+    "type": "pp"
+  },
+  "date_created": [
+    "2017"
+  ],
+  "date_published": "2026",
+  "date_reprocessed": "2020",
+  "distribution": {
+    "formats": [
+      "DST"
+    ],
+    "number_events": 103127718,
+    "number_files": 3260,
+    "size": 7291569709664
+  },
+  "experiment": [
+    "LHCb"
+  ],
+  "magnet_polarity": "MagDown",
+  "methodology": {
+    "description": "<p> This dataset was created in several production steps. These steps, software used and the configuration is provided below. </p><p> <strong> Prod ID: &nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;</strong> 104246<p> <strong>Prod type:&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp; </strong> Merge<p> <strong> Parent Prod ID:&nbsp;&nbsp;&nbsp;&nbsp; </strong> 104245<p> <strong> Parent Prod type: </strong> DataStripping<p> <strong> Conditions: </strong><p>dddb-20190206-3<p>cond-20191004-2 </strong><p> <strong> List of Trigger Configuration Keys (TCK): </strong> </p> <p><p><strong>TCK &nbsp;&nbsp;&nbsp;&nbsp;&nbsp; Number of Files </strong><p>0x11541707 &nbsp;&nbsp;&nbsp;&nbsp;&nbsp; 348<p>0x115417a7 &nbsp;&nbsp;&nbsp;&nbsp;&nbsp; 6<p>0x11561707 &nbsp;&nbsp;&nbsp;&nbsp;&nbsp; 763<p>0x11611708 &nbsp;&nbsp;&nbsp;&nbsp;&nbsp; 601<p>0x11611707 &nbsp;&nbsp;&nbsp;&nbsp;&nbsp; 439<p>0x11611709 &nbsp;&nbsp;&nbsp;&nbsp;&nbsp; 1103",
+    "steps": [
+      {
+        "configuration_files": [
+          {
+            "title": "DaVinci/DV-Stripping29r2p1-Stripping.py"
+          },
+          {
+            "title": "DaVinci/DataType-2017.py"
+          },
+          {
+            "title": "DaVinci/InputType-RDST.py"
+          },
+          {
+            "title": "DaVinci/DV-RawEventJuggler-0_3-to-4_3.py"
+          },
+          {
+            "title": "Persistency/Compression-ZLIB-1.py"
+          }
+        ],
+        "release": "DaVinci.v42r9p2 AppConfig.v3r394 Det/SQLDDDB.v7r10 TMVAWeights.v1r16",
+        "type": "Stripping29r2p1"
+      },
+      {
+        "configuration_files": [
+          {
+            "title": "Merging/DV-Stripping-Merging.py"
+          },
+          {
+            "title": "Persistency/Compression-LZMA-4.py"
+          }
+        ],
+        "release": "DaVinci.v42r9p2 AppConfig.v3r394 Det/SQLDDDB.v7r10",
+        "type": "Stripping29r2p1-Merging"
+      },
+      {
+        "configuration_files": [
+          {
+            "title": "DaVinci/DV-Stripping29r2p1-Stripping.py"
+          },
+          {
+            "title": "DaVinci/DataType-2017.py"
+          },
+          {
+            "title": "DaVinci/InputType-RDST.py"
+          },
+          {
+            "title": "DaVinci/DV-RawEventJuggler-0_3-to-4_3.py"
+          },
+          {
+            "title": "Persistency/Compression-ZLIB-1.py"
+          }
+        ],
+        "release": "DaVinci.v42r9p2 AppConfig.v3r394 Det/SQLDDDB.v7r10 TMVAWeights.v1r16",
+        "type": "Stripping29r2p1"
+      },
+      {
+        "configuration_files": [
+          {
+            "title": "Merging/DV-Stripping-Merging.py"
+          },
+          {
+            "title": "Persistency/Compression-LZMA-4.py"
+          }
+        ],
+        "release": "DaVinci.v42r9p2 AppConfig.v3r394 Det/SQLDDDB.v7r10",
+        "type": "Stripping29r2p1-Merging"
+      }
+    ]
+  },
+  "publisher": "CERN Open Data Portal",
+  "recid": "24727",
+  "run_period": [
+    "2017"
+  ],
+  "stripping": {
+    "stream": "CHARMCOMPLETEEVENT",
+    "version": "stripping29r2p1"
+  },
+  "title": "LHCb 2017 Beam6500GeV MagDown CHARMCOMPLETEEVENT Stream Stripping29r2p1",
+  "title_additional": "",
+  "type": {
+    "primary": "Dataset",
+    "secondary": [
+      "Collision"
+    ]
+  },
+  "usage": {
+    "description": "<p> The Run 1 and 2 data collected by the LHCb detector is available using the LHCb Ntupling Service, while the Run 1 data is additionally available in .DST and .mDST formats. The data obtained from the LHCb Ntupling Service are ROOT ntuples and do not require custom software to analyze. <p> Links are provided to the LHCb Ntupling Service for exploration of available data and the LHCb Open Data Guide for usage instructions.",
+    "links": [
+      {
+        "description": "LHCb Ntupling Service",
+        "url": "https://opendata-lhcb-ntupling-service.app.cern.ch/"
+      },
+      {
+        "description": "LHCb Open Data Guide",
+        "url": "https://lhcb-opendata-guide.web.cern.ch/"
+      }
+    ]
+  }
+}]

--- a/data/records/LHCb_2017_Beam6500GeV_VeloClosed_MagDown_RealData_Reco17_Stripping29r2p1_CHARM_MDST.json
+++ b/data/records/LHCb_2017_Beam6500GeV_VeloClosed_MagDown_RealData_Reco17_Stripping29r2p1_CHARM_MDST.json
@@ -1,0 +1,135 @@
+[{
+  "abstract": {
+    "description": "Data from proton-proton (pp) collisions collected by the LHCb experiment in the year 2017 of Run2 of the LHC."
+  },
+  "accelerator": "CERN-LHC",
+  "collaboration": {
+    "name": "LHCb collaboration",
+    "recid": "456"
+  },
+  "collections": [
+    "LHCb-Collision-Datasets"
+  ],
+  "collision_information": {
+    "energy": "13TeV",
+    "type": "pp"
+  },
+  "date_created": [
+    "2017"
+  ],
+  "date_published": "2026",
+  "date_reprocessed": "2020",
+  "distribution": {
+    "formats": [
+      "MDST"
+    ],
+    "number_events": 1832458358,
+    "number_files": 6072,
+    "size": 20447134772783
+  },
+  "experiment": [
+    "LHCb"
+  ],
+  "magnet_polarity": "MagDown",
+  "methodology": {
+    "description": "<p> This dataset was created in several production steps. These steps, software used and the configuration is provided below. </p><p> <strong> Prod ID: &nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;</strong> 104246<p> <strong>Prod type:&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp; </strong> Merge<p> <strong> Parent Prod ID:&nbsp;&nbsp;&nbsp;&nbsp; </strong> 104245<p> <strong> Parent Prod type: </strong> DataStripping<p> <strong> Conditions: </strong><p>dddb-20190206-3<p>cond-20191004-2 </strong><p> <strong> List of Trigger Configuration Keys (TCK): </strong> </p> <p><p><strong>TCK &nbsp;&nbsp;&nbsp;&nbsp;&nbsp; Number of Files </strong><p>0x11541707 &nbsp;&nbsp;&nbsp;&nbsp;&nbsp; 628<p>0x115417a7 &nbsp;&nbsp;&nbsp;&nbsp;&nbsp; 7<p>0x11561707 &nbsp;&nbsp;&nbsp;&nbsp;&nbsp; 1416<p>0x11611708 &nbsp;&nbsp;&nbsp;&nbsp;&nbsp; 1103<p>0x11611707 &nbsp;&nbsp;&nbsp;&nbsp;&nbsp; 849<p>0x11611709 &nbsp;&nbsp;&nbsp;&nbsp;&nbsp; 2069",
+    "steps": [
+      {
+        "configuration_files": [
+          {
+            "title": "DaVinci/DV-Stripping29r2p1-Stripping.py"
+          },
+          {
+            "title": "DaVinci/DataType-2017.py"
+          },
+          {
+            "title": "DaVinci/InputType-RDST.py"
+          },
+          {
+            "title": "DaVinci/DV-RawEventJuggler-0_3-to-4_3.py"
+          },
+          {
+            "title": "Persistency/Compression-ZLIB-1.py"
+          }
+        ],
+        "release": "DaVinci.v42r9p2 AppConfig.v3r394 Det/SQLDDDB.v7r10 TMVAWeights.v1r16",
+        "type": "Stripping29r2p1"
+      },
+      {
+        "configuration_files": [
+          {
+            "title": "Merging/DV-Stripping-Merging.py"
+          },
+          {
+            "title": "Persistency/Compression-LZMA-4.py"
+          }
+        ],
+        "release": "DaVinci.v42r9p2 AppConfig.v3r394 Det/SQLDDDB.v7r10",
+        "type": "Stripping29r2p1-Merging"
+      },
+      {
+        "configuration_files": [
+          {
+            "title": "DaVinci/DV-Stripping29r2p1-Stripping.py"
+          },
+          {
+            "title": "DaVinci/DataType-2017.py"
+          },
+          {
+            "title": "DaVinci/InputType-RDST.py"
+          },
+          {
+            "title": "DaVinci/DV-RawEventJuggler-0_3-to-4_3.py"
+          },
+          {
+            "title": "Persistency/Compression-ZLIB-1.py"
+          }
+        ],
+        "release": "DaVinci.v42r9p2 AppConfig.v3r394 Det/SQLDDDB.v7r10 TMVAWeights.v1r16",
+        "type": "Stripping29r2p1"
+      },
+      {
+        "configuration_files": [
+          {
+            "title": "Merging/DV-Stripping-Merging.py"
+          },
+          {
+            "title": "Persistency/Compression-LZMA-4.py"
+          }
+        ],
+        "release": "DaVinci.v42r9p2 AppConfig.v3r394 Det/SQLDDDB.v7r10",
+        "type": "Stripping29r2p1-Merging"
+      }
+    ]
+  },
+  "publisher": "CERN Open Data Portal",
+  "recid": "24726",
+  "run_period": [
+    "2017"
+  ],
+  "stripping": {
+    "stream": "CHARM",
+    "version": "stripping29r2p1"
+  },
+  "title": "LHCb 2017 Beam6500GeV MagDown CHARM Stream Stripping29r2p1",
+  "title_additional": "",
+  "type": {
+    "primary": "Dataset",
+    "secondary": [
+      "Collision"
+    ]
+  },
+  "usage": {
+    "description": "<p> The Run 1 and 2 data collected by the LHCb detector is available using the LHCb Ntupling Service, while the Run 1 data is additionally available in .DST and .mDST formats. The data obtained from the LHCb Ntupling Service are ROOT ntuples and do not require custom software to analyze. <p> Links are provided to the LHCb Ntupling Service for exploration of available data and the LHCb Open Data Guide for usage instructions.",
+    "links": [
+      {
+        "description": "LHCb Ntupling Service",
+        "url": "https://opendata-lhcb-ntupling-service.app.cern.ch/"
+      },
+      {
+        "description": "LHCb Open Data Guide",
+        "url": "https://lhcb-opendata-guide.web.cern.ch/"
+      }
+    ]
+  }
+}]

--- a/data/records/LHCb_2017_Beam6500GeV_VeloClosed_MagDown_RealData_Reco17_Stripping29r2p1_DIMUON_DST.json
+++ b/data/records/LHCb_2017_Beam6500GeV_VeloClosed_MagDown_RealData_Reco17_Stripping29r2p1_DIMUON_DST.json
@@ -1,0 +1,135 @@
+[{
+  "abstract": {
+    "description": "Data from proton-proton (pp) collisions collected by the LHCb experiment in the year 2017 of Run2 of the LHC."
+  },
+  "accelerator": "CERN-LHC",
+  "collaboration": {
+    "name": "LHCb collaboration",
+    "recid": "456"
+  },
+  "collections": [
+    "LHCb-Collision-Datasets"
+  ],
+  "collision_information": {
+    "energy": "13TeV",
+    "type": "pp"
+  },
+  "date_created": [
+    "2017"
+  ],
+  "date_published": "2026",
+  "date_reprocessed": "2020",
+  "distribution": {
+    "formats": [
+      "DST"
+    ],
+    "number_events": 93394911,
+    "number_files": 3271,
+    "size": 7970458043356
+  },
+  "experiment": [
+    "LHCb"
+  ],
+  "magnet_polarity": "MagDown",
+  "methodology": {
+    "description": "<p> This dataset was created in several production steps. These steps, software used and the configuration is provided below. </p><p> <strong> Prod ID: &nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;</strong> 104246<p> <strong>Prod type:&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp; </strong> Merge<p> <strong> Parent Prod ID:&nbsp;&nbsp;&nbsp;&nbsp; </strong> 104245<p> <strong> Parent Prod type: </strong> DataStripping<p> <strong> Conditions: </strong><p>dddb-20190206-3<p>cond-20191004-2 </strong><p> <strong> List of Trigger Configuration Keys (TCK): </strong> </p> <p><p><strong>TCK &nbsp;&nbsp;&nbsp;&nbsp;&nbsp; Number of Files </strong><p>0x11541707 &nbsp;&nbsp;&nbsp;&nbsp;&nbsp; 347<p>0x115417a7 &nbsp;&nbsp;&nbsp;&nbsp;&nbsp; 6<p>0x11561707 &nbsp;&nbsp;&nbsp;&nbsp;&nbsp; 769<p>0x11611708 &nbsp;&nbsp;&nbsp;&nbsp;&nbsp; 601<p>0x11611707 &nbsp;&nbsp;&nbsp;&nbsp;&nbsp; 445<p>0x11611709 &nbsp;&nbsp;&nbsp;&nbsp;&nbsp; 1103",
+    "steps": [
+      {
+        "configuration_files": [
+          {
+            "title": "DaVinci/DV-Stripping29r2p1-Stripping.py"
+          },
+          {
+            "title": "DaVinci/DataType-2017.py"
+          },
+          {
+            "title": "DaVinci/InputType-RDST.py"
+          },
+          {
+            "title": "DaVinci/DV-RawEventJuggler-0_3-to-4_3.py"
+          },
+          {
+            "title": "Persistency/Compression-ZLIB-1.py"
+          }
+        ],
+        "release": "DaVinci.v42r9p2 AppConfig.v3r394 Det/SQLDDDB.v7r10 TMVAWeights.v1r16",
+        "type": "Stripping29r2p1"
+      },
+      {
+        "configuration_files": [
+          {
+            "title": "Merging/DV-Stripping-Merging.py"
+          },
+          {
+            "title": "Persistency/Compression-LZMA-4.py"
+          }
+        ],
+        "release": "DaVinci.v42r9p2 AppConfig.v3r394 Det/SQLDDDB.v7r10",
+        "type": "Stripping29r2p1-Merging"
+      },
+      {
+        "configuration_files": [
+          {
+            "title": "DaVinci/DV-Stripping29r2p1-Stripping.py"
+          },
+          {
+            "title": "DaVinci/DataType-2017.py"
+          },
+          {
+            "title": "DaVinci/InputType-RDST.py"
+          },
+          {
+            "title": "DaVinci/DV-RawEventJuggler-0_3-to-4_3.py"
+          },
+          {
+            "title": "Persistency/Compression-ZLIB-1.py"
+          }
+        ],
+        "release": "DaVinci.v42r9p2 AppConfig.v3r394 Det/SQLDDDB.v7r10 TMVAWeights.v1r16",
+        "type": "Stripping29r2p1"
+      },
+      {
+        "configuration_files": [
+          {
+            "title": "Merging/DV-Stripping-Merging.py"
+          },
+          {
+            "title": "Persistency/Compression-LZMA-4.py"
+          }
+        ],
+        "release": "DaVinci.v42r9p2 AppConfig.v3r394 Det/SQLDDDB.v7r10",
+        "type": "Stripping29r2p1-Merging"
+      }
+    ]
+  },
+  "publisher": "CERN Open Data Portal",
+  "recid": "24728",
+  "run_period": [
+    "2017"
+  ],
+  "stripping": {
+    "stream": "DIMUON",
+    "version": "stripping29r2p1"
+  },
+  "title": "LHCb 2017 Beam6500GeV MagDown DIMUON Stream Stripping29r2p1",
+  "title_additional": "",
+  "type": {
+    "primary": "Dataset",
+    "secondary": [
+      "Collision"
+    ]
+  },
+  "usage": {
+    "description": "<p> The Run 1 and 2 data collected by the LHCb detector is available using the LHCb Ntupling Service, while the Run 1 data is additionally available in .DST and .mDST formats. The data obtained from the LHCb Ntupling Service are ROOT ntuples and do not require custom software to analyze. <p> Links are provided to the LHCb Ntupling Service for exploration of available data and the LHCb Open Data Guide for usage instructions.",
+    "links": [
+      {
+        "description": "LHCb Ntupling Service",
+        "url": "https://opendata-lhcb-ntupling-service.app.cern.ch/"
+      },
+      {
+        "description": "LHCb Open Data Guide",
+        "url": "https://lhcb-opendata-guide.web.cern.ch/"
+      }
+    ]
+  }
+}]

--- a/data/records/LHCb_2017_Beam6500GeV_VeloClosed_MagDown_RealData_Reco17_Stripping29r2p1_EW_DST.json
+++ b/data/records/LHCb_2017_Beam6500GeV_VeloClosed_MagDown_RealData_Reco17_Stripping29r2p1_EW_DST.json
@@ -1,0 +1,135 @@
+[{
+  "abstract": {
+    "description": "Data from proton-proton (pp) collisions collected by the LHCb experiment in the year 2017 of Run2 of the LHC."
+  },
+  "accelerator": "CERN-LHC",
+  "collaboration": {
+    "name": "LHCb collaboration",
+    "recid": "456"
+  },
+  "collections": [
+    "LHCb-Collision-Datasets"
+  ],
+  "collision_information": {
+    "energy": "13TeV",
+    "type": "pp"
+  },
+  "date_created": [
+    "2017"
+  ],
+  "date_published": "2026",
+  "date_reprocessed": "2020",
+  "distribution": {
+    "formats": [
+      "DST"
+    ],
+    "number_events": 29896291,
+    "number_files": 3260,
+    "size": 2496737665243
+  },
+  "experiment": [
+    "LHCb"
+  ],
+  "magnet_polarity": "MagDown",
+  "methodology": {
+    "description": "<p> This dataset was created in several production steps. These steps, software used and the configuration is provided below. </p><p> <strong> Prod ID: &nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;</strong> 104246<p> <strong>Prod type:&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp; </strong> Merge<p> <strong> Parent Prod ID:&nbsp;&nbsp;&nbsp;&nbsp; </strong> 104245<p> <strong> Parent Prod type: </strong> DataStripping<p> <strong> Conditions: </strong><p>dddb-20190206-3<p>cond-20191004-2 </strong><p> <strong> List of Trigger Configuration Keys (TCK): </strong> </p> <p><p><strong>TCK &nbsp;&nbsp;&nbsp;&nbsp;&nbsp; Number of Files </strong><p>0x11541707 &nbsp;&nbsp;&nbsp;&nbsp;&nbsp; 347<p>0x115417a7 &nbsp;&nbsp;&nbsp;&nbsp;&nbsp; 6<p>0x11561707 &nbsp;&nbsp;&nbsp;&nbsp;&nbsp; 764<p>0x11611708 &nbsp;&nbsp;&nbsp;&nbsp;&nbsp; 602<p>0x11611707 &nbsp;&nbsp;&nbsp;&nbsp;&nbsp; 438<p>0x11611709 &nbsp;&nbsp;&nbsp;&nbsp;&nbsp; 1103",
+    "steps": [
+      {
+        "configuration_files": [
+          {
+            "title": "DaVinci/DV-Stripping29r2p1-Stripping.py"
+          },
+          {
+            "title": "DaVinci/DataType-2017.py"
+          },
+          {
+            "title": "DaVinci/InputType-RDST.py"
+          },
+          {
+            "title": "DaVinci/DV-RawEventJuggler-0_3-to-4_3.py"
+          },
+          {
+            "title": "Persistency/Compression-ZLIB-1.py"
+          }
+        ],
+        "release": "DaVinci.v42r9p2 AppConfig.v3r394 Det/SQLDDDB.v7r10 TMVAWeights.v1r16",
+        "type": "Stripping29r2p1"
+      },
+      {
+        "configuration_files": [
+          {
+            "title": "Merging/DV-Stripping-Merging.py"
+          },
+          {
+            "title": "Persistency/Compression-LZMA-4.py"
+          }
+        ],
+        "release": "DaVinci.v42r9p2 AppConfig.v3r394 Det/SQLDDDB.v7r10",
+        "type": "Stripping29r2p1-Merging"
+      },
+      {
+        "configuration_files": [
+          {
+            "title": "DaVinci/DV-Stripping29r2p1-Stripping.py"
+          },
+          {
+            "title": "DaVinci/DataType-2017.py"
+          },
+          {
+            "title": "DaVinci/InputType-RDST.py"
+          },
+          {
+            "title": "DaVinci/DV-RawEventJuggler-0_3-to-4_3.py"
+          },
+          {
+            "title": "Persistency/Compression-ZLIB-1.py"
+          }
+        ],
+        "release": "DaVinci.v42r9p2 AppConfig.v3r394 Det/SQLDDDB.v7r10 TMVAWeights.v1r16",
+        "type": "Stripping29r2p1"
+      },
+      {
+        "configuration_files": [
+          {
+            "title": "Merging/DV-Stripping-Merging.py"
+          },
+          {
+            "title": "Persistency/Compression-LZMA-4.py"
+          }
+        ],
+        "release": "DaVinci.v42r9p2 AppConfig.v3r394 Det/SQLDDDB.v7r10",
+        "type": "Stripping29r2p1-Merging"
+      }
+    ]
+  },
+  "publisher": "CERN Open Data Portal",
+  "recid": "24720",
+  "run_period": [
+    "2017"
+  ],
+  "stripping": {
+    "stream": "EW",
+    "version": "stripping29r2p1"
+  },
+  "title": "LHCb 2017 Beam6500GeV MagDown EW Stream Stripping29r2p1",
+  "title_additional": "",
+  "type": {
+    "primary": "Dataset",
+    "secondary": [
+      "Collision"
+    ]
+  },
+  "usage": {
+    "description": "<p> The Run 1 and 2 data collected by the LHCb detector is available using the LHCb Ntupling Service, while the Run 1 data is additionally available in .DST and .mDST formats. The data obtained from the LHCb Ntupling Service are ROOT ntuples and do not require custom software to analyze. <p> Links are provided to the LHCb Ntupling Service for exploration of available data and the LHCb Open Data Guide for usage instructions.",
+    "links": [
+      {
+        "description": "LHCb Ntupling Service",
+        "url": "https://opendata-lhcb-ntupling-service.app.cern.ch/"
+      },
+      {
+        "description": "LHCb Open Data Guide",
+        "url": "https://lhcb-opendata-guide.web.cern.ch/"
+      }
+    ]
+  }
+}]

--- a/data/records/LHCb_2017_Beam6500GeV_VeloClosed_MagDown_RealData_Reco17_Stripping29r2p1_LEPTONIC_MDST.json
+++ b/data/records/LHCb_2017_Beam6500GeV_VeloClosed_MagDown_RealData_Reco17_Stripping29r2p1_LEPTONIC_MDST.json
@@ -1,0 +1,135 @@
+[{
+  "abstract": {
+    "description": "Data from proton-proton (pp) collisions collected by the LHCb experiment in the year 2017 of Run2 of the LHC."
+  },
+  "accelerator": "CERN-LHC",
+  "collaboration": {
+    "name": "LHCb collaboration",
+    "recid": "456"
+  },
+  "collections": [
+    "LHCb-Collision-Datasets"
+  ],
+  "collision_information": {
+    "energy": "13TeV",
+    "type": "pp"
+  },
+  "date_created": [
+    "2017"
+  ],
+  "date_published": "2026",
+  "date_reprocessed": "2020",
+  "distribution": {
+    "formats": [
+      "MDST"
+    ],
+    "number_events": 2286329694,
+    "number_files": 7459,
+    "size": 25874115435408
+  },
+  "experiment": [
+    "LHCb"
+  ],
+  "magnet_polarity": "MagDown",
+  "methodology": {
+    "description": "<p> This dataset was created in several production steps. These steps, software used and the configuration is provided below. </p><p> <strong> Prod ID: &nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;</strong> 104639<p> <strong>Prod type:&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp; </strong> Merge<p> <strong> Parent Prod ID:&nbsp;&nbsp;&nbsp;&nbsp; </strong> 104245<p> <strong> Parent Prod type: </strong> DataStripping<p> <strong> Conditions: </strong><p>dddb-20190206-3<p>cond-20191004-2 </strong><p> <strong> List of Trigger Configuration Keys (TCK): </strong> </p> <p><p><strong>TCK &nbsp;&nbsp;&nbsp;&nbsp;&nbsp; Number of Files </strong><p>0x11541707 &nbsp;&nbsp;&nbsp;&nbsp;&nbsp; 763<p>0x115417a7 &nbsp;&nbsp;&nbsp;&nbsp;&nbsp; 8<p>0x11561707 &nbsp;&nbsp;&nbsp;&nbsp;&nbsp; 1767<p>0x11611708 &nbsp;&nbsp;&nbsp;&nbsp;&nbsp; 1355<p>0x11611707 &nbsp;&nbsp;&nbsp;&nbsp;&nbsp; 1026<p>0x11611709 &nbsp;&nbsp;&nbsp;&nbsp;&nbsp; 2540",
+    "steps": [
+      {
+        "configuration_files": [
+          {
+            "title": "DaVinci/DV-Stripping29r2p1-Stripping.py"
+          },
+          {
+            "title": "DaVinci/DataType-2017.py"
+          },
+          {
+            "title": "DaVinci/InputType-RDST.py"
+          },
+          {
+            "title": "DaVinci/DV-RawEventJuggler-0_3-to-4_3.py"
+          },
+          {
+            "title": "Persistency/Compression-ZLIB-1.py"
+          }
+        ],
+        "release": "DaVinci.v42r9p2 AppConfig.v3r394 Det/SQLDDDB.v7r10 TMVAWeights.v1r16",
+        "type": "Stripping29r2p1"
+      },
+      {
+        "configuration_files": [
+          {
+            "title": "Merging/DV-Stripping-Merging.py"
+          },
+          {
+            "title": "Persistency/Compression-LZMA-4.py"
+          }
+        ],
+        "release": "DaVinci.v42r9p2 AppConfig.v3r394 Det/SQLDDDB.v7r10",
+        "type": "Stripping29r2p1-Merging"
+      },
+      {
+        "configuration_files": [
+          {
+            "title": "DaVinci/DV-Stripping29r2p1-Stripping.py"
+          },
+          {
+            "title": "DaVinci/DataType-2017.py"
+          },
+          {
+            "title": "DaVinci/InputType-RDST.py"
+          },
+          {
+            "title": "DaVinci/DV-RawEventJuggler-0_3-to-4_3.py"
+          },
+          {
+            "title": "Persistency/Compression-ZLIB-1.py"
+          }
+        ],
+        "release": "DaVinci.v42r9p2 AppConfig.v3r394 Det/SQLDDDB.v7r10 TMVAWeights.v1r16",
+        "type": "Stripping29r2p1"
+      },
+      {
+        "configuration_files": [
+          {
+            "title": "Merging/DV-Stripping-Merging.py"
+          },
+          {
+            "title": "Persistency/Compression-LZMA-4.py"
+          }
+        ],
+        "release": "DaVinci.v42r9p2 AppConfig.v3r394 Det/SQLDDDB.v7r10",
+        "type": "Stripping29r2p1-Merging"
+      }
+    ]
+  },
+  "publisher": "CERN Open Data Portal",
+  "recid": "24721",
+  "run_period": [
+    "2017"
+  ],
+  "stripping": {
+    "stream": "LEPTONIC",
+    "version": "stripping29r2p1"
+  },
+  "title": "LHCb 2017 Beam6500GeV MagDown LEPTONIC Stream Stripping29r2p1",
+  "title_additional": "",
+  "type": {
+    "primary": "Dataset",
+    "secondary": [
+      "Collision"
+    ]
+  },
+  "usage": {
+    "description": "<p> The Run 1 and 2 data collected by the LHCb detector is available using the LHCb Ntupling Service, while the Run 1 data is additionally available in .DST and .mDST formats. The data obtained from the LHCb Ntupling Service are ROOT ntuples and do not require custom software to analyze. <p> Links are provided to the LHCb Ntupling Service for exploration of available data and the LHCb Open Data Guide for usage instructions.",
+    "links": [
+      {
+        "description": "LHCb Ntupling Service",
+        "url": "https://opendata-lhcb-ntupling-service.app.cern.ch/"
+      },
+      {
+        "description": "LHCb Open Data Guide",
+        "url": "https://lhcb-opendata-guide.web.cern.ch/"
+      }
+    ]
+  }
+}]

--- a/data/records/LHCb_2017_Beam6500GeV_VeloClosed_MagDown_RealData_Reco17_Stripping29r2p1_SEMILEPTONIC_DST.json
+++ b/data/records/LHCb_2017_Beam6500GeV_VeloClosed_MagDown_RealData_Reco17_Stripping29r2p1_SEMILEPTONIC_DST.json
@@ -1,0 +1,135 @@
+[{
+  "abstract": {
+    "description": "Data from proton-proton (pp) collisions collected by the LHCb experiment in the year 2017 of Run2 of the LHC."
+  },
+  "accelerator": "CERN-LHC",
+  "collaboration": {
+    "name": "LHCb collaboration",
+    "recid": "456"
+  },
+  "collections": [
+    "LHCb-Collision-Datasets"
+  ],
+  "collision_information": {
+    "energy": "13TeV",
+    "type": "pp"
+  },
+  "date_created": [
+    "2017"
+  ],
+  "date_published": "2026",
+  "date_reprocessed": "2020",
+  "distribution": {
+    "formats": [
+      "DST"
+    ],
+    "number_events": 494285125,
+    "number_files": 9808,
+    "size": 33780910342583
+  },
+  "experiment": [
+    "LHCb"
+  ],
+  "magnet_polarity": "MagDown",
+  "methodology": {
+    "description": "<p> This dataset was created in several production steps. These steps, software used and the configuration is provided below. </p><p> <strong> Prod ID: &nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;</strong> 104246<p> <strong>Prod type:&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp; </strong> Merge<p> <strong> Parent Prod ID:&nbsp;&nbsp;&nbsp;&nbsp; </strong> 104245<p> <strong> Parent Prod type: </strong> DataStripping<p> <strong> Conditions: </strong><p>dddb-20190206-3<p>cond-20191004-2 </strong><p> <strong> List of Trigger Configuration Keys (TCK): </strong> </p> <p><p><strong>TCK &nbsp;&nbsp;&nbsp;&nbsp;&nbsp; Number of Files </strong><p>0x11541707 &nbsp;&nbsp;&nbsp;&nbsp;&nbsp; 999<p>0x115417a7 &nbsp;&nbsp;&nbsp;&nbsp;&nbsp; 9<p>0x11561707 &nbsp;&nbsp;&nbsp;&nbsp;&nbsp; 2414<p>0x11611708 &nbsp;&nbsp;&nbsp;&nbsp;&nbsp; 1737<p>0x11611707 &nbsp;&nbsp;&nbsp;&nbsp;&nbsp; 1367<p>0x11611709 &nbsp;&nbsp;&nbsp;&nbsp;&nbsp; 3282",
+    "steps": [
+      {
+        "configuration_files": [
+          {
+            "title": "DaVinci/DV-Stripping29r2p1-Stripping.py"
+          },
+          {
+            "title": "DaVinci/DataType-2017.py"
+          },
+          {
+            "title": "DaVinci/InputType-RDST.py"
+          },
+          {
+            "title": "DaVinci/DV-RawEventJuggler-0_3-to-4_3.py"
+          },
+          {
+            "title": "Persistency/Compression-ZLIB-1.py"
+          }
+        ],
+        "release": "DaVinci.v42r9p2 AppConfig.v3r394 Det/SQLDDDB.v7r10 TMVAWeights.v1r16",
+        "type": "Stripping29r2p1"
+      },
+      {
+        "configuration_files": [
+          {
+            "title": "Merging/DV-Stripping-Merging.py"
+          },
+          {
+            "title": "Persistency/Compression-LZMA-4.py"
+          }
+        ],
+        "release": "DaVinci.v42r9p2 AppConfig.v3r394 Det/SQLDDDB.v7r10",
+        "type": "Stripping29r2p1-Merging"
+      },
+      {
+        "configuration_files": [
+          {
+            "title": "DaVinci/DV-Stripping29r2p1-Stripping.py"
+          },
+          {
+            "title": "DaVinci/DataType-2017.py"
+          },
+          {
+            "title": "DaVinci/InputType-RDST.py"
+          },
+          {
+            "title": "DaVinci/DV-RawEventJuggler-0_3-to-4_3.py"
+          },
+          {
+            "title": "Persistency/Compression-ZLIB-1.py"
+          }
+        ],
+        "release": "DaVinci.v42r9p2 AppConfig.v3r394 Det/SQLDDDB.v7r10 TMVAWeights.v1r16",
+        "type": "Stripping29r2p1"
+      },
+      {
+        "configuration_files": [
+          {
+            "title": "Merging/DV-Stripping-Merging.py"
+          },
+          {
+            "title": "Persistency/Compression-LZMA-4.py"
+          }
+        ],
+        "release": "DaVinci.v42r9p2 AppConfig.v3r394 Det/SQLDDDB.v7r10",
+        "type": "Stripping29r2p1-Merging"
+      }
+    ]
+  },
+  "publisher": "CERN Open Data Portal",
+  "recid": "24729",
+  "run_period": [
+    "2017"
+  ],
+  "stripping": {
+    "stream": "SEMILEPTONIC",
+    "version": "stripping29r2p1"
+  },
+  "title": "LHCb 2017 Beam6500GeV MagDown SEMILEPTONIC Stream Stripping29r2p1",
+  "title_additional": "",
+  "type": {
+    "primary": "Dataset",
+    "secondary": [
+      "Collision"
+    ]
+  },
+  "usage": {
+    "description": "<p> The Run 1 and 2 data collected by the LHCb detector is available using the LHCb Ntupling Service, while the Run 1 data is additionally available in .DST and .mDST formats. The data obtained from the LHCb Ntupling Service are ROOT ntuples and do not require custom software to analyze. <p> Links are provided to the LHCb Ntupling Service for exploration of available data and the LHCb Open Data Guide for usage instructions.",
+    "links": [
+      {
+        "description": "LHCb Ntupling Service",
+        "url": "https://opendata-lhcb-ntupling-service.app.cern.ch/"
+      },
+      {
+        "description": "LHCb Open Data Guide",
+        "url": "https://lhcb-opendata-guide.web.cern.ch/"
+      }
+    ]
+  }
+}]

--- a/data/records/LHCb_2017_Beam6500GeV_VeloClosed_MagDown_RealData_Reco17_Stripping29r2p2_BHADRONCOMPLETEEVENT_DST.json
+++ b/data/records/LHCb_2017_Beam6500GeV_VeloClosed_MagDown_RealData_Reco17_Stripping29r2p2_BHADRONCOMPLETEEVENT_DST.json
@@ -1,0 +1,135 @@
+[{
+  "abstract": {
+    "description": "Data from proton-proton (pp) collisions collected by the LHCb experiment in the year 2017 of Run2 of the LHC."
+  },
+  "accelerator": "CERN-LHC",
+  "collaboration": {
+    "name": "LHCb collaboration",
+    "recid": "456"
+  },
+  "collections": [
+    "LHCb-Collision-Datasets"
+  ],
+  "collision_information": {
+    "energy": "13TeV",
+    "type": "pp"
+  },
+  "date_created": [
+    "2017"
+  ],
+  "date_published": "2026",
+  "date_reprocessed": "2021",
+  "distribution": {
+    "formats": [
+      "DST"
+    ],
+    "number_events": 345521432,
+    "number_files": 10308,
+    "size": 37900459159039
+  },
+  "experiment": [
+    "LHCb"
+  ],
+  "magnet_polarity": "MagDown",
+  "methodology": {
+    "description": "<p> This dataset was created in several production steps. These steps, software used and the configuration is provided below. </p><p> <strong> Prod ID: &nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;</strong> 141012<p> <strong>Prod type:&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp; </strong> Merge<p> <strong> Parent Prod ID:&nbsp;&nbsp;&nbsp;&nbsp; </strong> 140082<p> <strong> Parent Prod type: </strong> DataStripping<p> <strong> Conditions: </strong><p>dddb-20210215-7<p>cond-20191004-3</strong><p> <strong> List of Trigger Configuration Keys (TCK): </strong> </p> <p><p><strong>TCK &nbsp;&nbsp;&nbsp;&nbsp;&nbsp; Number of Files </strong><p>0x11611708 &nbsp;&nbsp;&nbsp;&nbsp;&nbsp; 1814<p>0x11611707 &nbsp;&nbsp;&nbsp;&nbsp;&nbsp; 1428<p>0x11611709 &nbsp;&nbsp;&nbsp;&nbsp;&nbsp; 3517<p>0x11541707 &nbsp;&nbsp;&nbsp;&nbsp;&nbsp; 1021<p>0x11561707 &nbsp;&nbsp;&nbsp;&nbsp;&nbsp; 2520<p>0x115417a7 &nbsp;&nbsp;&nbsp;&nbsp;&nbsp; 8",
+    "steps": [
+      {
+        "configuration_files": [
+          {
+            "title": "DaVinci/DV-Stripping29r2p2-Stripping.py"
+          },
+          {
+            "title": "DaVinci/DataType-2017.py"
+          },
+          {
+            "title": "DaVinci/InputType-RDST.py"
+          },
+          {
+            "title": "DaVinci/DV-RawEventJuggler-0_3-to-4_3.py"
+          },
+          {
+            "title": "Persistency/Compression-ZLIB-1.py"
+          }
+        ],
+        "release": "DaVinci.v42r11p2 AppConfig.v3r404 Det/SQLDDDB.v7r10 TMVAWeights.v1r16",
+        "type": "Stripping29r2p2"
+      },
+      {
+        "configuration_files": [
+          {
+            "title": "Merging/DV-Stripping-Merging.py"
+          },
+          {
+            "title": "Persistency/Compression-LZMA-4.py"
+          }
+        ],
+        "release": "DaVinci.v42r11p2 AppConfig.v3r404 Det/SQLDDDB.v7r10",
+        "type": "Stripping29r2p2-Merging"
+      },
+      {
+        "configuration_files": [
+          {
+            "title": "DaVinci/DV-Stripping29r2p2-Stripping.py"
+          },
+          {
+            "title": "DaVinci/DataType-2017.py"
+          },
+          {
+            "title": "DaVinci/InputType-RDST.py"
+          },
+          {
+            "title": "DaVinci/DV-RawEventJuggler-0_3-to-4_3.py"
+          },
+          {
+            "title": "Persistency/Compression-ZLIB-1.py"
+          }
+        ],
+        "release": "DaVinci.v42r11p2 AppConfig.v3r404 Det/SQLDDDB.v7r10 TMVAWeights.v1r16",
+        "type": "Stripping29r2p2"
+      },
+      {
+        "configuration_files": [
+          {
+            "title": "Merging/DV-Stripping-Merging.py"
+          },
+          {
+            "title": "Persistency/Compression-LZMA-4.py"
+          }
+        ],
+        "release": "DaVinci.v42r11p2 AppConfig.v3r404 Det/SQLDDDB.v7r10",
+        "type": "Stripping29r2p2-Merging"
+      }
+    ]
+  },
+  "publisher": "CERN Open Data Portal",
+  "recid": "24745",
+  "run_period": [
+    "2017"
+  ],
+  "stripping": {
+    "stream": "BHADRONCOMPLETEEVENT",
+    "version": "stripping29r2p2"
+  },
+  "title": "LHCb 2017 Beam6500GeV MagDown BHADRONCOMPLETEEVENT Stream Stripping29r2p2",
+  "title_additional": "",
+  "type": {
+    "primary": "Dataset",
+    "secondary": [
+      "Collision"
+    ]
+  },
+  "usage": {
+    "description": "<p> The Run 1 and 2 data collected by the LHCb detector is available using the LHCb Ntupling Service, while the Run 1 data is additionally available in .DST and .mDST formats. The data obtained from the LHCb Ntupling Service are ROOT ntuples and do not require custom software to analyze. <p> Links are provided to the LHCb Ntupling Service for exploration of available data and the LHCb Open Data Guide for usage instructions.",
+    "links": [
+      {
+        "description": "LHCb Ntupling Service",
+        "url": "https://opendata-lhcb-ntupling-service.app.cern.ch/"
+      },
+      {
+        "description": "LHCb Open Data Guide",
+        "url": "https://lhcb-opendata-guide.web.cern.ch/"
+      }
+    ]
+  }
+}]

--- a/data/records/LHCb_2017_Beam6500GeV_VeloClosed_MagDown_RealData_Reco17_Stripping29r2p2_BHADRON_MDST.json
+++ b/data/records/LHCb_2017_Beam6500GeV_VeloClosed_MagDown_RealData_Reco17_Stripping29r2p2_BHADRON_MDST.json
@@ -1,0 +1,135 @@
+[{
+  "abstract": {
+    "description": "Data from proton-proton (pp) collisions collected by the LHCb experiment in the year 2017 of Run2 of the LHC."
+  },
+  "accelerator": "CERN-LHC",
+  "collaboration": {
+    "name": "LHCb collaboration",
+    "recid": "456"
+  },
+  "collections": [
+    "LHCb-Collision-Datasets"
+  ],
+  "collision_information": {
+    "energy": "13TeV",
+    "type": "pp"
+  },
+  "date_created": [
+    "2017"
+  ],
+  "date_published": "2026",
+  "date_reprocessed": "2021",
+  "distribution": {
+    "formats": [
+      "MDST"
+    ],
+    "number_events": 593408314,
+    "number_files": 3477,
+    "size": 11223899787820
+  },
+  "experiment": [
+    "LHCb"
+  ],
+  "magnet_polarity": "MagDown",
+  "methodology": {
+    "description": "<p> This dataset was created in several production steps. These steps, software used and the configuration is provided below. </p><p> <strong> Prod ID: &nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;</strong> 140083<p> <strong>Prod type:&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp; </strong> Merge<p> <strong> Parent Prod ID:&nbsp;&nbsp;&nbsp;&nbsp; </strong> 140082<p> <strong> Parent Prod type: </strong> DataStripping<p> <strong> Conditions: </strong><p>dddb-20210215-7<p>cond-20191004-3</strong><p> <strong> List of Trigger Configuration Keys (TCK): </strong> </p> <p><p><strong>TCK &nbsp;&nbsp;&nbsp;&nbsp;&nbsp; Number of Files </strong><p>0x11611708 &nbsp;&nbsp;&nbsp;&nbsp;&nbsp; 608<p>0x11611707 &nbsp;&nbsp;&nbsp;&nbsp;&nbsp; 491<p>0x11611709 &nbsp;&nbsp;&nbsp;&nbsp;&nbsp; 1110<p>0x11541707 &nbsp;&nbsp;&nbsp;&nbsp;&nbsp; 359<p>0x11561707 &nbsp;&nbsp;&nbsp;&nbsp;&nbsp; 904<p>0x115417a7 &nbsp;&nbsp;&nbsp;&nbsp;&nbsp; 5",
+    "steps": [
+      {
+        "configuration_files": [
+          {
+            "title": "DaVinci/DV-Stripping29r2p2-Stripping.py"
+          },
+          {
+            "title": "DaVinci/DataType-2017.py"
+          },
+          {
+            "title": "DaVinci/InputType-RDST.py"
+          },
+          {
+            "title": "DaVinci/DV-RawEventJuggler-0_3-to-4_3.py"
+          },
+          {
+            "title": "Persistency/Compression-ZLIB-1.py"
+          }
+        ],
+        "release": "DaVinci.v42r11p2 AppConfig.v3r404 Det/SQLDDDB.v7r10 TMVAWeights.v1r16",
+        "type": "Stripping29r2p2"
+      },
+      {
+        "configuration_files": [
+          {
+            "title": "Merging/DV-Stripping-Merging.py"
+          },
+          {
+            "title": "Persistency/Compression-LZMA-4.py"
+          }
+        ],
+        "release": "DaVinci.v42r11p2 AppConfig.v3r404 Det/SQLDDDB.v7r10",
+        "type": "Stripping29r2p2-Merging"
+      },
+      {
+        "configuration_files": [
+          {
+            "title": "DaVinci/DV-Stripping29r2p2-Stripping.py"
+          },
+          {
+            "title": "DaVinci/DataType-2017.py"
+          },
+          {
+            "title": "DaVinci/InputType-RDST.py"
+          },
+          {
+            "title": "DaVinci/DV-RawEventJuggler-0_3-to-4_3.py"
+          },
+          {
+            "title": "Persistency/Compression-ZLIB-1.py"
+          }
+        ],
+        "release": "DaVinci.v42r11p2 AppConfig.v3r404 Det/SQLDDDB.v7r10 TMVAWeights.v1r16",
+        "type": "Stripping29r2p2"
+      },
+      {
+        "configuration_files": [
+          {
+            "title": "Merging/DV-Stripping-Merging.py"
+          },
+          {
+            "title": "Persistency/Compression-LZMA-4.py"
+          }
+        ],
+        "release": "DaVinci.v42r11p2 AppConfig.v3r404 Det/SQLDDDB.v7r10",
+        "type": "Stripping29r2p2-Merging"
+      }
+    ]
+  },
+  "publisher": "CERN Open Data Portal",
+  "recid": "24744",
+  "run_period": [
+    "2017"
+  ],
+  "stripping": {
+    "stream": "BHADRON",
+    "version": "stripping29r2p2"
+  },
+  "title": "LHCb 2017 Beam6500GeV MagDown BHADRON Stream Stripping29r2p2",
+  "title_additional": "",
+  "type": {
+    "primary": "Dataset",
+    "secondary": [
+      "Collision"
+    ]
+  },
+  "usage": {
+    "description": "<p> The Run 1 and 2 data collected by the LHCb detector is available using the LHCb Ntupling Service, while the Run 1 data is additionally available in .DST and .mDST formats. The data obtained from the LHCb Ntupling Service are ROOT ntuples and do not require custom software to analyze. <p> Links are provided to the LHCb Ntupling Service for exploration of available data and the LHCb Open Data Guide for usage instructions.",
+    "links": [
+      {
+        "description": "LHCb Ntupling Service",
+        "url": "https://opendata-lhcb-ntupling-service.app.cern.ch/"
+      },
+      {
+        "description": "LHCb Open Data Guide",
+        "url": "https://lhcb-opendata-guide.web.cern.ch/"
+      }
+    ]
+  }
+}]

--- a/data/records/LHCb_2017_Beam6500GeV_VeloClosed_MagDown_RealData_Reco17_Stripping29r2p2_CHARMCOMPLETEEVENT_DST.json
+++ b/data/records/LHCb_2017_Beam6500GeV_VeloClosed_MagDown_RealData_Reco17_Stripping29r2p2_CHARMCOMPLETEEVENT_DST.json
@@ -1,0 +1,135 @@
+[{
+  "abstract": {
+    "description": "Data from proton-proton (pp) collisions collected by the LHCb experiment in the year 2017 of Run2 of the LHC."
+  },
+  "accelerator": "CERN-LHC",
+  "collaboration": {
+    "name": "LHCb collaboration",
+    "recid": "456"
+  },
+  "collections": [
+    "LHCb-Collision-Datasets"
+  ],
+  "collision_information": {
+    "energy": "13TeV",
+    "type": "pp"
+  },
+  "date_created": [
+    "2017"
+  ],
+  "date_published": "2026",
+  "date_reprocessed": "2021",
+  "distribution": {
+    "formats": [
+      "DST"
+    ],
+    "number_events": 106804356,
+    "number_files": 3251,
+    "size": 8719217855578
+  },
+  "experiment": [
+    "LHCb"
+  ],
+  "magnet_polarity": "MagDown",
+  "methodology": {
+    "description": "<p> This dataset was created in several production steps. These steps, software used and the configuration is provided below. </p><p> <strong> Prod ID: &nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;</strong> 141012<p> <strong>Prod type:&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp; </strong> Merge<p> <strong> Parent Prod ID:&nbsp;&nbsp;&nbsp;&nbsp; </strong> 140082<p> <strong> Parent Prod type: </strong> DataStripping<p> <strong> Conditions: </strong><p>dddb-20210215-7<p>cond-20191004-3</strong><p> <strong> List of Trigger Configuration Keys (TCK): </strong> </p> <p><p><strong>TCK &nbsp;&nbsp;&nbsp;&nbsp;&nbsp; Number of Files </strong><p>0x11611708 &nbsp;&nbsp;&nbsp;&nbsp;&nbsp; 601<p>0x11611707 &nbsp;&nbsp;&nbsp;&nbsp;&nbsp; 447<p>0x11611709 &nbsp;&nbsp;&nbsp;&nbsp;&nbsp; 1072<p>0x11541707 &nbsp;&nbsp;&nbsp;&nbsp;&nbsp; 329<p>0x11561707 &nbsp;&nbsp;&nbsp;&nbsp;&nbsp; 797<p>0x115417a7 &nbsp;&nbsp;&nbsp;&nbsp;&nbsp; 5",
+    "steps": [
+      {
+        "configuration_files": [
+          {
+            "title": "DaVinci/DV-Stripping29r2p2-Stripping.py"
+          },
+          {
+            "title": "DaVinci/DataType-2017.py"
+          },
+          {
+            "title": "DaVinci/InputType-RDST.py"
+          },
+          {
+            "title": "DaVinci/DV-RawEventJuggler-0_3-to-4_3.py"
+          },
+          {
+            "title": "Persistency/Compression-ZLIB-1.py"
+          }
+        ],
+        "release": "DaVinci.v42r11p2 AppConfig.v3r404 Det/SQLDDDB.v7r10 TMVAWeights.v1r16",
+        "type": "Stripping29r2p2"
+      },
+      {
+        "configuration_files": [
+          {
+            "title": "Merging/DV-Stripping-Merging.py"
+          },
+          {
+            "title": "Persistency/Compression-LZMA-4.py"
+          }
+        ],
+        "release": "DaVinci.v42r11p2 AppConfig.v3r404 Det/SQLDDDB.v7r10",
+        "type": "Stripping29r2p2-Merging"
+      },
+      {
+        "configuration_files": [
+          {
+            "title": "DaVinci/DV-Stripping29r2p2-Stripping.py"
+          },
+          {
+            "title": "DaVinci/DataType-2017.py"
+          },
+          {
+            "title": "DaVinci/InputType-RDST.py"
+          },
+          {
+            "title": "DaVinci/DV-RawEventJuggler-0_3-to-4_3.py"
+          },
+          {
+            "title": "Persistency/Compression-ZLIB-1.py"
+          }
+        ],
+        "release": "DaVinci.v42r11p2 AppConfig.v3r404 Det/SQLDDDB.v7r10 TMVAWeights.v1r16",
+        "type": "Stripping29r2p2"
+      },
+      {
+        "configuration_files": [
+          {
+            "title": "Merging/DV-Stripping-Merging.py"
+          },
+          {
+            "title": "Persistency/Compression-LZMA-4.py"
+          }
+        ],
+        "release": "DaVinci.v42r11p2 AppConfig.v3r404 Det/SQLDDDB.v7r10",
+        "type": "Stripping29r2p2-Merging"
+      }
+    ]
+  },
+  "publisher": "CERN Open Data Portal",
+  "recid": "24747",
+  "run_period": [
+    "2017"
+  ],
+  "stripping": {
+    "stream": "CHARMCOMPLETEEVENT",
+    "version": "stripping29r2p2"
+  },
+  "title": "LHCb 2017 Beam6500GeV MagDown CHARMCOMPLETEEVENT Stream Stripping29r2p2",
+  "title_additional": "",
+  "type": {
+    "primary": "Dataset",
+    "secondary": [
+      "Collision"
+    ]
+  },
+  "usage": {
+    "description": "<p> The Run 1 and 2 data collected by the LHCb detector is available using the LHCb Ntupling Service, while the Run 1 data is additionally available in .DST and .mDST formats. The data obtained from the LHCb Ntupling Service are ROOT ntuples and do not require custom software to analyze. <p> Links are provided to the LHCb Ntupling Service for exploration of available data and the LHCb Open Data Guide for usage instructions.",
+    "links": [
+      {
+        "description": "LHCb Ntupling Service",
+        "url": "https://opendata-lhcb-ntupling-service.app.cern.ch/"
+      },
+      {
+        "description": "LHCb Open Data Guide",
+        "url": "https://lhcb-opendata-guide.web.cern.ch/"
+      }
+    ]
+  }
+}]

--- a/data/records/LHCb_2017_Beam6500GeV_VeloClosed_MagDown_RealData_Reco17_Stripping29r2p2_CHARM_MDST.json
+++ b/data/records/LHCb_2017_Beam6500GeV_VeloClosed_MagDown_RealData_Reco17_Stripping29r2p2_CHARM_MDST.json
@@ -1,0 +1,135 @@
+[{
+  "abstract": {
+    "description": "Data from proton-proton (pp) collisions collected by the LHCb experiment in the year 2017 of Run2 of the LHC."
+  },
+  "accelerator": "CERN-LHC",
+  "collaboration": {
+    "name": "LHCb collaboration",
+    "recid": "456"
+  },
+  "collections": [
+    "LHCb-Collision-Datasets"
+  ],
+  "collision_information": {
+    "energy": "13TeV",
+    "type": "pp"
+  },
+  "date_created": [
+    "2017"
+  ],
+  "date_published": "2026",
+  "date_reprocessed": "2021",
+  "distribution": {
+    "formats": [
+      "MDST"
+    ],
+    "number_events": 1029669059,
+    "number_files": 5313,
+    "size": 19753275575404
+  },
+  "experiment": [
+    "LHCb"
+  ],
+  "magnet_polarity": "MagDown",
+  "methodology": {
+    "description": "<p> This dataset was created in several production steps. These steps, software used and the configuration is provided below. </p><p> <strong> Prod ID: &nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;</strong> 141012<p> <strong>Prod type:&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp; </strong> Merge<p> <strong> Parent Prod ID:&nbsp;&nbsp;&nbsp;&nbsp; </strong> 140082<p> <strong> Parent Prod type: </strong> DataStripping<p> <strong> Conditions: </strong><p>dddb-20210215-7<p>cond-20191004-3</strong><p> <strong> List of Trigger Configuration Keys (TCK): </strong> </p> <p><p><strong>TCK &nbsp;&nbsp;&nbsp;&nbsp;&nbsp; Number of Files </strong><p>0x11611708 &nbsp;&nbsp;&nbsp;&nbsp;&nbsp; 924<p>0x11611707 &nbsp;&nbsp;&nbsp;&nbsp;&nbsp; 728<p>0x11611709 &nbsp;&nbsp;&nbsp;&nbsp;&nbsp; 1793<p>0x11541707 &nbsp;&nbsp;&nbsp;&nbsp;&nbsp; 545<p>0x11561707 &nbsp;&nbsp;&nbsp;&nbsp;&nbsp; 1317<p>0x115417a7 &nbsp;&nbsp;&nbsp;&nbsp;&nbsp; 6",
+    "steps": [
+      {
+        "configuration_files": [
+          {
+            "title": "DaVinci/DV-Stripping29r2p2-Stripping.py"
+          },
+          {
+            "title": "DaVinci/DataType-2017.py"
+          },
+          {
+            "title": "DaVinci/InputType-RDST.py"
+          },
+          {
+            "title": "DaVinci/DV-RawEventJuggler-0_3-to-4_3.py"
+          },
+          {
+            "title": "Persistency/Compression-ZLIB-1.py"
+          }
+        ],
+        "release": "DaVinci.v42r11p2 AppConfig.v3r404 Det/SQLDDDB.v7r10 TMVAWeights.v1r16",
+        "type": "Stripping29r2p2"
+      },
+      {
+        "configuration_files": [
+          {
+            "title": "Merging/DV-Stripping-Merging.py"
+          },
+          {
+            "title": "Persistency/Compression-LZMA-4.py"
+          }
+        ],
+        "release": "DaVinci.v42r11p2 AppConfig.v3r404 Det/SQLDDDB.v7r10",
+        "type": "Stripping29r2p2-Merging"
+      },
+      {
+        "configuration_files": [
+          {
+            "title": "DaVinci/DV-Stripping29r2p2-Stripping.py"
+          },
+          {
+            "title": "DaVinci/DataType-2017.py"
+          },
+          {
+            "title": "DaVinci/InputType-RDST.py"
+          },
+          {
+            "title": "DaVinci/DV-RawEventJuggler-0_3-to-4_3.py"
+          },
+          {
+            "title": "Persistency/Compression-ZLIB-1.py"
+          }
+        ],
+        "release": "DaVinci.v42r11p2 AppConfig.v3r404 Det/SQLDDDB.v7r10 TMVAWeights.v1r16",
+        "type": "Stripping29r2p2"
+      },
+      {
+        "configuration_files": [
+          {
+            "title": "Merging/DV-Stripping-Merging.py"
+          },
+          {
+            "title": "Persistency/Compression-LZMA-4.py"
+          }
+        ],
+        "release": "DaVinci.v42r11p2 AppConfig.v3r404 Det/SQLDDDB.v7r10",
+        "type": "Stripping29r2p2-Merging"
+      }
+    ]
+  },
+  "publisher": "CERN Open Data Portal",
+  "recid": "24746",
+  "run_period": [
+    "2017"
+  ],
+  "stripping": {
+    "stream": "CHARM",
+    "version": "stripping29r2p2"
+  },
+  "title": "LHCb 2017 Beam6500GeV MagDown CHARM Stream Stripping29r2p2",
+  "title_additional": "",
+  "type": {
+    "primary": "Dataset",
+    "secondary": [
+      "Collision"
+    ]
+  },
+  "usage": {
+    "description": "<p> The Run 1 and 2 data collected by the LHCb detector is available using the LHCb Ntupling Service, while the Run 1 data is additionally available in .DST and .mDST formats. The data obtained from the LHCb Ntupling Service are ROOT ntuples and do not require custom software to analyze. <p> Links are provided to the LHCb Ntupling Service for exploration of available data and the LHCb Open Data Guide for usage instructions.",
+    "links": [
+      {
+        "description": "LHCb Ntupling Service",
+        "url": "https://opendata-lhcb-ntupling-service.app.cern.ch/"
+      },
+      {
+        "description": "LHCb Open Data Guide",
+        "url": "https://lhcb-opendata-guide.web.cern.ch/"
+      }
+    ]
+  }
+}]

--- a/data/records/LHCb_2017_Beam6500GeV_VeloClosed_MagDown_RealData_Reco17_Stripping29r2p2_DIMUON_DST.json
+++ b/data/records/LHCb_2017_Beam6500GeV_VeloClosed_MagDown_RealData_Reco17_Stripping29r2p2_DIMUON_DST.json
@@ -1,0 +1,135 @@
+[{
+  "abstract": {
+    "description": "Data from proton-proton (pp) collisions collected by the LHCb experiment in the year 2017 of Run2 of the LHC."
+  },
+  "accelerator": "CERN-LHC",
+  "collaboration": {
+    "name": "LHCb collaboration",
+    "recid": "456"
+  },
+  "collections": [
+    "LHCb-Collision-Datasets"
+  ],
+  "collision_information": {
+    "energy": "13TeV",
+    "type": "pp"
+  },
+  "date_created": [
+    "2017"
+  ],
+  "date_published": "2026",
+  "date_reprocessed": "2021",
+  "distribution": {
+    "formats": [
+      "DST"
+    ],
+    "number_events": 177939793,
+    "number_files": 5487,
+    "size": 18558945266174
+  },
+  "experiment": [
+    "LHCb"
+  ],
+  "magnet_polarity": "MagDown",
+  "methodology": {
+    "description": "<p> This dataset was created in several production steps. These steps, software used and the configuration is provided below. </p><p> <strong> Prod ID: &nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;</strong> 141012<p> <strong>Prod type:&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp; </strong> Merge<p> <strong> Parent Prod ID:&nbsp;&nbsp;&nbsp;&nbsp; </strong> 140082<p> <strong> Parent Prod type: </strong> DataStripping<p> <strong> Conditions: </strong><p>dddb-20210215-7<p>cond-20191004-3</strong><p> <strong> List of Trigger Configuration Keys (TCK): </strong> </p> <p><p><strong>TCK &nbsp;&nbsp;&nbsp;&nbsp;&nbsp; Number of Files </strong><p>0x11611708 &nbsp;&nbsp;&nbsp;&nbsp;&nbsp; 968<p>0x11611707 &nbsp;&nbsp;&nbsp;&nbsp;&nbsp; 739<p>0x11611709 &nbsp;&nbsp;&nbsp;&nbsp;&nbsp; 1815<p>0x11541707 &nbsp;&nbsp;&nbsp;&nbsp;&nbsp; 560<p>0x11561707 &nbsp;&nbsp;&nbsp;&nbsp;&nbsp; 1399<p>0x115417a7 &nbsp;&nbsp;&nbsp;&nbsp;&nbsp; 6",
+    "steps": [
+      {
+        "configuration_files": [
+          {
+            "title": "DaVinci/DV-Stripping29r2p2-Stripping.py"
+          },
+          {
+            "title": "DaVinci/DataType-2017.py"
+          },
+          {
+            "title": "DaVinci/InputType-RDST.py"
+          },
+          {
+            "title": "DaVinci/DV-RawEventJuggler-0_3-to-4_3.py"
+          },
+          {
+            "title": "Persistency/Compression-ZLIB-1.py"
+          }
+        ],
+        "release": "DaVinci.v42r11p2 AppConfig.v3r404 Det/SQLDDDB.v7r10 TMVAWeights.v1r16",
+        "type": "Stripping29r2p2"
+      },
+      {
+        "configuration_files": [
+          {
+            "title": "Merging/DV-Stripping-Merging.py"
+          },
+          {
+            "title": "Persistency/Compression-LZMA-4.py"
+          }
+        ],
+        "release": "DaVinci.v42r11p2 AppConfig.v3r404 Det/SQLDDDB.v7r10",
+        "type": "Stripping29r2p2-Merging"
+      },
+      {
+        "configuration_files": [
+          {
+            "title": "DaVinci/DV-Stripping29r2p2-Stripping.py"
+          },
+          {
+            "title": "DaVinci/DataType-2017.py"
+          },
+          {
+            "title": "DaVinci/InputType-RDST.py"
+          },
+          {
+            "title": "DaVinci/DV-RawEventJuggler-0_3-to-4_3.py"
+          },
+          {
+            "title": "Persistency/Compression-ZLIB-1.py"
+          }
+        ],
+        "release": "DaVinci.v42r11p2 AppConfig.v3r404 Det/SQLDDDB.v7r10 TMVAWeights.v1r16",
+        "type": "Stripping29r2p2"
+      },
+      {
+        "configuration_files": [
+          {
+            "title": "Merging/DV-Stripping-Merging.py"
+          },
+          {
+            "title": "Persistency/Compression-LZMA-4.py"
+          }
+        ],
+        "release": "DaVinci.v42r11p2 AppConfig.v3r404 Det/SQLDDDB.v7r10",
+        "type": "Stripping29r2p2-Merging"
+      }
+    ]
+  },
+  "publisher": "CERN Open Data Portal",
+  "recid": "24748",
+  "run_period": [
+    "2017"
+  ],
+  "stripping": {
+    "stream": "DIMUON",
+    "version": "stripping29r2p2"
+  },
+  "title": "LHCb 2017 Beam6500GeV MagDown DIMUON Stream Stripping29r2p2",
+  "title_additional": "",
+  "type": {
+    "primary": "Dataset",
+    "secondary": [
+      "Collision"
+    ]
+  },
+  "usage": {
+    "description": "<p> The Run 1 and 2 data collected by the LHCb detector is available using the LHCb Ntupling Service, while the Run 1 data is additionally available in .DST and .mDST formats. The data obtained from the LHCb Ntupling Service are ROOT ntuples and do not require custom software to analyze. <p> Links are provided to the LHCb Ntupling Service for exploration of available data and the LHCb Open Data Guide for usage instructions.",
+    "links": [
+      {
+        "description": "LHCb Ntupling Service",
+        "url": "https://opendata-lhcb-ntupling-service.app.cern.ch/"
+      },
+      {
+        "description": "LHCb Open Data Guide",
+        "url": "https://lhcb-opendata-guide.web.cern.ch/"
+      }
+    ]
+  }
+}]

--- a/data/records/LHCb_2017_Beam6500GeV_VeloClosed_MagDown_RealData_Reco17_Stripping29r2p2_LEPTONIC_MDST.json
+++ b/data/records/LHCb_2017_Beam6500GeV_VeloClosed_MagDown_RealData_Reco17_Stripping29r2p2_LEPTONIC_MDST.json
@@ -1,0 +1,135 @@
+[{
+  "abstract": {
+    "description": "Data from proton-proton (pp) collisions collected by the LHCb experiment in the year 2017 of Run2 of the LHC."
+  },
+  "accelerator": "CERN-LHC",
+  "collaboration": {
+    "name": "LHCb collaboration",
+    "recid": "456"
+  },
+  "collections": [
+    "LHCb-Collision-Datasets"
+  ],
+  "collision_information": {
+    "energy": "13TeV",
+    "type": "pp"
+  },
+  "date_created": [
+    "2017"
+  ],
+  "date_published": "2026",
+  "date_reprocessed": "2021",
+  "distribution": {
+    "formats": [
+      "MDST"
+    ],
+    "number_events": 1617826630,
+    "number_files": 10341,
+    "size": 41577606973074
+  },
+  "experiment": [
+    "LHCb"
+  ],
+  "magnet_polarity": "MagDown",
+  "methodology": {
+    "description": "<p> This dataset was created in several production steps. These steps, software used and the configuration is provided below. </p><p> <strong> Prod ID: &nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;</strong> 140083<p> <strong>Prod type:&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp; </strong> Merge<p> <strong> Parent Prod ID:&nbsp;&nbsp;&nbsp;&nbsp; </strong> 140082<p> <strong> Parent Prod type: </strong> DataStripping<p> <strong> Conditions: </strong><p>dddb-20210215-7<p>cond-20191004-3</strong><p> <strong> List of Trigger Configuration Keys (TCK): </strong> </p> <p><p><strong>TCK &nbsp;&nbsp;&nbsp;&nbsp;&nbsp; Number of Files </strong><p>0x11611708 &nbsp;&nbsp;&nbsp;&nbsp;&nbsp; 1854<p>0x11611707 &nbsp;&nbsp;&nbsp;&nbsp;&nbsp; 1398<p>0x11611709 &nbsp;&nbsp;&nbsp;&nbsp;&nbsp; 3521<p>0x11541707 &nbsp;&nbsp;&nbsp;&nbsp;&nbsp; 1025<p>0x11561707 &nbsp;&nbsp;&nbsp;&nbsp;&nbsp; 2535<p>0x115417a7 &nbsp;&nbsp;&nbsp;&nbsp;&nbsp; 8",
+    "steps": [
+      {
+        "configuration_files": [
+          {
+            "title": "DaVinci/DV-Stripping29r2p2-Stripping.py"
+          },
+          {
+            "title": "DaVinci/DataType-2017.py"
+          },
+          {
+            "title": "DaVinci/InputType-RDST.py"
+          },
+          {
+            "title": "DaVinci/DV-RawEventJuggler-0_3-to-4_3.py"
+          },
+          {
+            "title": "Persistency/Compression-ZLIB-1.py"
+          }
+        ],
+        "release": "DaVinci.v42r11p2 AppConfig.v3r404 Det/SQLDDDB.v7r10 TMVAWeights.v1r16",
+        "type": "Stripping29r2p2"
+      },
+      {
+        "configuration_files": [
+          {
+            "title": "Merging/DV-Stripping-Merging.py"
+          },
+          {
+            "title": "Persistency/Compression-LZMA-4.py"
+          }
+        ],
+        "release": "DaVinci.v42r11p2 AppConfig.v3r404 Det/SQLDDDB.v7r10",
+        "type": "Stripping29r2p2-Merging"
+      },
+      {
+        "configuration_files": [
+          {
+            "title": "DaVinci/DV-Stripping29r2p2-Stripping.py"
+          },
+          {
+            "title": "DaVinci/DataType-2017.py"
+          },
+          {
+            "title": "DaVinci/InputType-RDST.py"
+          },
+          {
+            "title": "DaVinci/DV-RawEventJuggler-0_3-to-4_3.py"
+          },
+          {
+            "title": "Persistency/Compression-ZLIB-1.py"
+          }
+        ],
+        "release": "DaVinci.v42r11p2 AppConfig.v3r404 Det/SQLDDDB.v7r10 TMVAWeights.v1r16",
+        "type": "Stripping29r2p2"
+      },
+      {
+        "configuration_files": [
+          {
+            "title": "Merging/DV-Stripping-Merging.py"
+          },
+          {
+            "title": "Persistency/Compression-LZMA-4.py"
+          }
+        ],
+        "release": "DaVinci.v42r11p2 AppConfig.v3r404 Det/SQLDDDB.v7r10",
+        "type": "Stripping29r2p2-Merging"
+      }
+    ]
+  },
+  "publisher": "CERN Open Data Portal",
+  "recid": "24741",
+  "run_period": [
+    "2017"
+  ],
+  "stripping": {
+    "stream": "LEPTONIC",
+    "version": "stripping29r2p2"
+  },
+  "title": "LHCb 2017 Beam6500GeV MagDown LEPTONIC Stream Stripping29r2p2",
+  "title_additional": "",
+  "type": {
+    "primary": "Dataset",
+    "secondary": [
+      "Collision"
+    ]
+  },
+  "usage": {
+    "description": "<p> The Run 1 and 2 data collected by the LHCb detector is available using the LHCb Ntupling Service, while the Run 1 data is additionally available in .DST and .mDST formats. The data obtained from the LHCb Ntupling Service are ROOT ntuples and do not require custom software to analyze. <p> Links are provided to the LHCb Ntupling Service for exploration of available data and the LHCb Open Data Guide for usage instructions.",
+    "links": [
+      {
+        "description": "LHCb Ntupling Service",
+        "url": "https://opendata-lhcb-ntupling-service.app.cern.ch/"
+      },
+      {
+        "description": "LHCb Open Data Guide",
+        "url": "https://lhcb-opendata-guide.web.cern.ch/"
+      }
+    ]
+  }
+}]

--- a/data/records/LHCb_2017_Beam6500GeV_VeloClosed_MagDown_RealData_Reco17_Stripping29r2p2_SEMILEPTONIC_DST.json
+++ b/data/records/LHCb_2017_Beam6500GeV_VeloClosed_MagDown_RealData_Reco17_Stripping29r2p2_SEMILEPTONIC_DST.json
@@ -1,0 +1,135 @@
+[{
+  "abstract": {
+    "description": "Data from proton-proton (pp) collisions collected by the LHCb experiment in the year 2017 of Run2 of the LHC."
+  },
+  "accelerator": "CERN-LHC",
+  "collaboration": {
+    "name": "LHCb collaboration",
+    "recid": "456"
+  },
+  "collections": [
+    "LHCb-Collision-Datasets"
+  ],
+  "collision_information": {
+    "energy": "13TeV",
+    "type": "pp"
+  },
+  "date_created": [
+    "2017"
+  ],
+  "date_published": "2026",
+  "date_reprocessed": "2021",
+  "distribution": {
+    "formats": [
+      "DST"
+    ],
+    "number_events": 82261856,
+    "number_files": 3157,
+    "size": 7781398929025
+  },
+  "experiment": [
+    "LHCb"
+  ],
+  "magnet_polarity": "MagDown",
+  "methodology": {
+    "description": "<p> This dataset was created in several production steps. These steps, software used and the configuration is provided below. </p><p> <strong> Prod ID: &nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;</strong> 140083<p> <strong>Prod type:&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp; </strong> Merge<p> <strong> Parent Prod ID:&nbsp;&nbsp;&nbsp;&nbsp; </strong> 140082<p> <strong> Parent Prod type: </strong> DataStripping<p> <strong> Conditions: </strong><p>dddb-20210215-7<p>cond-20191004-3</strong><p> <strong> List of Trigger Configuration Keys (TCK): </strong> </p> <p><p><strong>TCK &nbsp;&nbsp;&nbsp;&nbsp;&nbsp; Number of Files </strong><p>0x11611708 &nbsp;&nbsp;&nbsp;&nbsp;&nbsp; 551<p>0x11611707 &nbsp;&nbsp;&nbsp;&nbsp;&nbsp; 415<p>0x11611709 &nbsp;&nbsp;&nbsp;&nbsp;&nbsp; 1069<p>0x11541707 &nbsp;&nbsp;&nbsp;&nbsp;&nbsp; 326<p>0x11561707 &nbsp;&nbsp;&nbsp;&nbsp;&nbsp; 791<p>0x115417a7 &nbsp;&nbsp;&nbsp;&nbsp;&nbsp; 5",
+    "steps": [
+      {
+        "configuration_files": [
+          {
+            "title": "DaVinci/DV-Stripping29r2p2-Stripping.py"
+          },
+          {
+            "title": "DaVinci/DataType-2017.py"
+          },
+          {
+            "title": "DaVinci/InputType-RDST.py"
+          },
+          {
+            "title": "DaVinci/DV-RawEventJuggler-0_3-to-4_3.py"
+          },
+          {
+            "title": "Persistency/Compression-ZLIB-1.py"
+          }
+        ],
+        "release": "DaVinci.v42r11p2 AppConfig.v3r404 Det/SQLDDDB.v7r10 TMVAWeights.v1r16",
+        "type": "Stripping29r2p2"
+      },
+      {
+        "configuration_files": [
+          {
+            "title": "Merging/DV-Stripping-Merging.py"
+          },
+          {
+            "title": "Persistency/Compression-LZMA-4.py"
+          }
+        ],
+        "release": "DaVinci.v42r11p2 AppConfig.v3r404 Det/SQLDDDB.v7r10",
+        "type": "Stripping29r2p2-Merging"
+      },
+      {
+        "configuration_files": [
+          {
+            "title": "DaVinci/DV-Stripping29r2p2-Stripping.py"
+          },
+          {
+            "title": "DaVinci/DataType-2017.py"
+          },
+          {
+            "title": "DaVinci/InputType-RDST.py"
+          },
+          {
+            "title": "DaVinci/DV-RawEventJuggler-0_3-to-4_3.py"
+          },
+          {
+            "title": "Persistency/Compression-ZLIB-1.py"
+          }
+        ],
+        "release": "DaVinci.v42r11p2 AppConfig.v3r404 Det/SQLDDDB.v7r10 TMVAWeights.v1r16",
+        "type": "Stripping29r2p2"
+      },
+      {
+        "configuration_files": [
+          {
+            "title": "Merging/DV-Stripping-Merging.py"
+          },
+          {
+            "title": "Persistency/Compression-LZMA-4.py"
+          }
+        ],
+        "release": "DaVinci.v42r11p2 AppConfig.v3r404 Det/SQLDDDB.v7r10",
+        "type": "Stripping29r2p2-Merging"
+      }
+    ]
+  },
+  "publisher": "CERN Open Data Portal",
+  "recid": "24749",
+  "run_period": [
+    "2017"
+  ],
+  "stripping": {
+    "stream": "SEMILEPTONIC",
+    "version": "stripping29r2p2"
+  },
+  "title": "LHCb 2017 Beam6500GeV MagDown SEMILEPTONIC Stream Stripping29r2p2",
+  "title_additional": "",
+  "type": {
+    "primary": "Dataset",
+    "secondary": [
+      "Collision"
+    ]
+  },
+  "usage": {
+    "description": "<p> The Run 1 and 2 data collected by the LHCb detector is available using the LHCb Ntupling Service, while the Run 1 data is additionally available in .DST and .mDST formats. The data obtained from the LHCb Ntupling Service are ROOT ntuples and do not require custom software to analyze. <p> Links are provided to the LHCb Ntupling Service for exploration of available data and the LHCb Open Data Guide for usage instructions.",
+    "links": [
+      {
+        "description": "LHCb Ntupling Service",
+        "url": "https://opendata-lhcb-ntupling-service.app.cern.ch/"
+      },
+      {
+        "description": "LHCb Open Data Guide",
+        "url": "https://lhcb-opendata-guide.web.cern.ch/"
+      }
+    ]
+  }
+}]

--- a/data/records/LHCb_2017_Beam6500GeV_VeloClosed_MagDown_RealData_Reco17_Stripping29r2p3_BHADRON_MDST.json
+++ b/data/records/LHCb_2017_Beam6500GeV_VeloClosed_MagDown_RealData_Reco17_Stripping29r2p3_BHADRON_MDST.json
@@ -1,0 +1,168 @@
+[{
+  "abstract": {
+    "description": "Data from proton-proton (pp) collisions collected by the LHCb experiment in the year 2017 of Run2 of the LHC."
+  },
+  "accelerator": "CERN-LHC",
+  "collaboration": {
+    "name": "LHCb collaboration",
+    "recid": "456"
+  },
+  "collections": [
+    "LHCb-Collision-Datasets"
+  ],
+  "collision_information": {
+    "energy": "13TeV",
+    "type": "pp"
+  },
+  "date_created": [
+    "2017"
+  ],
+  "date_published": "2026",
+  "date_reprocessed": "2023",
+  "distribution": {
+    "formats": [
+      "MDST"
+    ],
+    "number_events": 1919629705,
+    "number_files": 10751,
+    "size": 37267603983281
+  },
+  "experiment": [
+    "LHCb"
+  ],
+  "magnet_polarity": "MagDown",
+  "methodology": {
+    "description": "<p> This dataset was created in several production steps. These steps, software used and the configuration is provided below. </p><p> <strong> Prod ID: &nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;</strong> 207262<p> <strong>Prod type:&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp; </strong> Merge<p> <strong> Parent Prod ID:&nbsp;&nbsp;&nbsp;&nbsp; </strong> 207147<p> <strong> Parent Prod type: </strong> DataStripping<p> <strong> Conditions: </strong><p>dddb-20220927-2017<p>cond-20191004-2</strong><p> <strong> List of Trigger Configuration Keys (TCK): </strong> </p> <p><p><strong>TCK &nbsp;&nbsp;&nbsp;&nbsp;&nbsp; Number of Files </strong><p>0x11611708 &nbsp;&nbsp;&nbsp;&nbsp;&nbsp; 1926<p>0x11611707 &nbsp;&nbsp;&nbsp;&nbsp;&nbsp; 1515<p>0x11611709 &nbsp;&nbsp;&nbsp;&nbsp;&nbsp; 3672<p>0x11561707 &nbsp;&nbsp;&nbsp;&nbsp;&nbsp; 2574<p>0x11541707 &nbsp;&nbsp;&nbsp;&nbsp;&nbsp; 1054<p>0x115417a7 &nbsp;&nbsp;&nbsp;&nbsp;&nbsp; 10",
+    "steps": [
+      {
+        "configuration_files": [
+          {
+            "title": "DaVinci/DV-Stripping29r2p3-Stripping.py"
+          },
+          {
+            "title": "DaVinci/DataType-2017.py"
+          },
+          {
+            "title": "DaVinci/InputType-RDST.py"
+          },
+          {
+            "title": "DaVinci/DV-RawEventJuggler-0_3-to-4_3.py"
+          },
+          {
+            "title": "Persistency/Compression-ZLIB-1.py"
+          }
+        ],
+        "release": "DaVinci.v44r11p6 AppConfig.v3r421 Det/SQLDDDB.v7r12 TMVAWeights.v1r18",
+        "type": "Stripping29r2p3_md"
+      },
+      {
+        "configuration_files": [
+          {
+            "title": "Merging/DV-Stripping-Merging.py"
+          },
+          {
+            "title": "Persistency/Compression-LZMA-4.py"
+          }
+        ],
+        "release": "DaVinci.v44r11p6 AppConfig.v3r421 Det/SQLDDDB.v7r12 TMVAWeights.v1r18",
+        "type": "Merge_Stripping29r2p3_md"
+      },
+      {
+        "configuration_files": [
+          {
+            "title": "DaVinci/DV-Stripping29r2p3-Stripping.py"
+          },
+          {
+            "title": "DaVinci/DataType-2017.py"
+          },
+          {
+            "title": "DaVinci/InputType-RDST.py"
+          },
+          {
+            "title": "DaVinci/DV-RawEventJuggler-0_3-to-4_3.py"
+          },
+          {
+            "title": "Persistency/Compression-ZLIB-1.py"
+          }
+        ],
+        "release": "DaVinci.v44r11p6 AppConfig.v3r421 Det/SQLDDDB.v7r12 TMVAWeights.v1r18",
+        "type": "Stripping29r2p3_md"
+      },
+      {
+        "configuration_files": [
+          {
+            "title": "Merging/DV-Stripping-Merging.py"
+          },
+          {
+            "title": "Persistency/Compression-LZMA-4.py"
+          }
+        ],
+        "release": "DaVinci.v44r11p6 AppConfig.v3r421 Det/SQLDDDB.v7r12 TMVAWeights.v1r18",
+        "type": "Merge_Stripping29r2p3_md"
+      },
+      {
+        "configuration_files": [
+          {
+            "title": "DaVinci/DV-Stripping29r2p3-Stripping.py"
+          },
+          {
+            "title": "DaVinci/DataType-2017.py"
+          },
+          {
+            "title": "DaVinci/InputType-RDST.py"
+          },
+          {
+            "title": "DaVinci/DV-RawEventJuggler-0_3-to-4_3.py"
+          },
+          {
+            "title": "Persistency/Compression-ZLIB-1.py"
+          }
+        ],
+        "release": "DaVinci.v44r11p6 AppConfig.v3r421 Det/SQLDDDB.v7r12 TMVAWeights.v1r18",
+        "type": "Stripping29r2p3_md"
+      },
+      {
+        "configuration_files": [
+          {
+            "title": "Merging/DV-Stripping-Merging.py"
+          },
+          {
+            "title": "Persistency/Compression-LZMA-4.py"
+          }
+        ],
+        "release": "DaVinci.v44r11p6 AppConfig.v3r421 Det/SQLDDDB.v7r12 TMVAWeights.v1r18",
+        "type": "Merge_Stripping29r2p3_md"
+      }
+    ]
+  },
+  "publisher": "CERN Open Data Portal",
+  "recid": "24764",
+  "run_period": [
+    "2017"
+  ],
+  "stripping": {
+    "stream": "BHADRON",
+    "version": "stripping29r2p3"
+  },
+  "title": "LHCb 2017 Beam6500GeV MagDown BHADRON Stream Stripping29r2p3",
+  "title_additional": "",
+  "type": {
+    "primary": "Dataset",
+    "secondary": [
+      "Collision"
+    ]
+  },
+  "usage": {
+    "description": "<p> The Run 1 and 2 data collected by the LHCb detector is available using the LHCb Ntupling Service, while the Run 1 data is additionally available in .DST and .mDST formats. The data obtained from the LHCb Ntupling Service are ROOT ntuples and do not require custom software to analyze. <p> Links are provided to the LHCb Ntupling Service for exploration of available data and the LHCb Open Data Guide for usage instructions.",
+    "links": [
+      {
+        "description": "LHCb Ntupling Service",
+        "url": "https://opendata-lhcb-ntupling-service.app.cern.ch/"
+      },
+      {
+        "description": "LHCb Open Data Guide",
+        "url": "https://lhcb-opendata-guide.web.cern.ch/"
+      }
+    ]
+  }
+}]

--- a/data/records/LHCb_2017_Beam6500GeV_VeloClosed_MagDown_RealData_Reco17_Stripping29r2p3_CHARM_MDST.json
+++ b/data/records/LHCb_2017_Beam6500GeV_VeloClosed_MagDown_RealData_Reco17_Stripping29r2p3_CHARM_MDST.json
@@ -1,0 +1,168 @@
+[{
+  "abstract": {
+    "description": "Data from proton-proton (pp) collisions collected by the LHCb experiment in the year 2017 of Run2 of the LHC."
+  },
+  "accelerator": "CERN-LHC",
+  "collaboration": {
+    "name": "LHCb collaboration",
+    "recid": "456"
+  },
+  "collections": [
+    "LHCb-Collision-Datasets"
+  ],
+  "collision_information": {
+    "energy": "13TeV",
+    "type": "pp"
+  },
+  "date_created": [
+    "2017"
+  ],
+  "date_published": "2026",
+  "date_reprocessed": "2023",
+  "distribution": {
+    "formats": [
+      "MDST"
+    ],
+    "number_events": 2092228471,
+    "number_files": 7280,
+    "size": 24564042271801
+  },
+  "experiment": [
+    "LHCb"
+  ],
+  "magnet_polarity": "MagDown",
+  "methodology": {
+    "description": "<p> This dataset was created in several production steps. These steps, software used and the configuration is provided below. </p><p> <strong> Prod ID: &nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;</strong> 207148<p> <strong>Prod type:&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp; </strong> Merge<p> <strong> Parent Prod ID:&nbsp;&nbsp;&nbsp;&nbsp; </strong> 207147<p> <strong> Parent Prod type: </strong> DataStripping<p> <strong> Conditions: </strong><p>dddb-20220927-2017<p>cond-20191004-2</strong><p> <strong> List of Trigger Configuration Keys (TCK): </strong> </p> <p><p><strong>TCK &nbsp;&nbsp;&nbsp;&nbsp;&nbsp; Number of Files </strong><p>0x11611708 &nbsp;&nbsp;&nbsp;&nbsp;&nbsp; 1322<p>0x11611707 &nbsp;&nbsp;&nbsp;&nbsp;&nbsp; 1014<p>0x11611709 &nbsp;&nbsp;&nbsp;&nbsp;&nbsp; 2477<p>0x11541707 &nbsp;&nbsp;&nbsp;&nbsp;&nbsp; 716<p>0x11561707 &nbsp;&nbsp;&nbsp;&nbsp;&nbsp; 1742<p>0x115417a7 &nbsp;&nbsp;&nbsp;&nbsp;&nbsp; 9",
+    "steps": [
+      {
+        "configuration_files": [
+          {
+            "title": "DaVinci/DV-Stripping29r2p3-Stripping.py"
+          },
+          {
+            "title": "DaVinci/DataType-2017.py"
+          },
+          {
+            "title": "DaVinci/InputType-RDST.py"
+          },
+          {
+            "title": "DaVinci/DV-RawEventJuggler-0_3-to-4_3.py"
+          },
+          {
+            "title": "Persistency/Compression-ZLIB-1.py"
+          }
+        ],
+        "release": "DaVinci.v44r11p6 AppConfig.v3r421 Det/SQLDDDB.v7r12 TMVAWeights.v1r18",
+        "type": "Stripping29r2p3_md"
+      },
+      {
+        "configuration_files": [
+          {
+            "title": "Merging/DV-Stripping-Merging.py"
+          },
+          {
+            "title": "Persistency/Compression-LZMA-4.py"
+          }
+        ],
+        "release": "DaVinci.v44r11p6 AppConfig.v3r421 Det/SQLDDDB.v7r12 TMVAWeights.v1r18",
+        "type": "Merge_Stripping29r2p3_md"
+      },
+      {
+        "configuration_files": [
+          {
+            "title": "DaVinci/DV-Stripping29r2p3-Stripping.py"
+          },
+          {
+            "title": "DaVinci/DataType-2017.py"
+          },
+          {
+            "title": "DaVinci/InputType-RDST.py"
+          },
+          {
+            "title": "DaVinci/DV-RawEventJuggler-0_3-to-4_3.py"
+          },
+          {
+            "title": "Persistency/Compression-ZLIB-1.py"
+          }
+        ],
+        "release": "DaVinci.v44r11p6 AppConfig.v3r421 Det/SQLDDDB.v7r12 TMVAWeights.v1r18",
+        "type": "Stripping29r2p3_md"
+      },
+      {
+        "configuration_files": [
+          {
+            "title": "Merging/DV-Stripping-Merging.py"
+          },
+          {
+            "title": "Persistency/Compression-LZMA-4.py"
+          }
+        ],
+        "release": "DaVinci.v44r11p6 AppConfig.v3r421 Det/SQLDDDB.v7r12 TMVAWeights.v1r18",
+        "type": "Merge_Stripping29r2p3_md"
+      },
+      {
+        "configuration_files": [
+          {
+            "title": "DaVinci/DV-Stripping29r2p3-Stripping.py"
+          },
+          {
+            "title": "DaVinci/DataType-2017.py"
+          },
+          {
+            "title": "DaVinci/InputType-RDST.py"
+          },
+          {
+            "title": "DaVinci/DV-RawEventJuggler-0_3-to-4_3.py"
+          },
+          {
+            "title": "Persistency/Compression-ZLIB-1.py"
+          }
+        ],
+        "release": "DaVinci.v44r11p6 AppConfig.v3r421 Det/SQLDDDB.v7r12 TMVAWeights.v1r18",
+        "type": "Stripping29r2p3_md"
+      },
+      {
+        "configuration_files": [
+          {
+            "title": "Merging/DV-Stripping-Merging.py"
+          },
+          {
+            "title": "Persistency/Compression-LZMA-4.py"
+          }
+        ],
+        "release": "DaVinci.v44r11p6 AppConfig.v3r421 Det/SQLDDDB.v7r12 TMVAWeights.v1r18",
+        "type": "Merge_Stripping29r2p3_md"
+      }
+    ]
+  },
+  "publisher": "CERN Open Data Portal",
+  "recid": "24766",
+  "run_period": [
+    "2017"
+  ],
+  "stripping": {
+    "stream": "CHARM",
+    "version": "stripping29r2p3"
+  },
+  "title": "LHCb 2017 Beam6500GeV MagDown CHARM Stream Stripping29r2p3",
+  "title_additional": "",
+  "type": {
+    "primary": "Dataset",
+    "secondary": [
+      "Collision"
+    ]
+  },
+  "usage": {
+    "description": "<p> The Run 1 and 2 data collected by the LHCb detector is available using the LHCb Ntupling Service, while the Run 1 data is additionally available in .DST and .mDST formats. The data obtained from the LHCb Ntupling Service are ROOT ntuples and do not require custom software to analyze. <p> Links are provided to the LHCb Ntupling Service for exploration of available data and the LHCb Open Data Guide for usage instructions.",
+    "links": [
+      {
+        "description": "LHCb Ntupling Service",
+        "url": "https://opendata-lhcb-ntupling-service.app.cern.ch/"
+      },
+      {
+        "description": "LHCb Open Data Guide",
+        "url": "https://lhcb-opendata-guide.web.cern.ch/"
+      }
+    ]
+  }
+}]

--- a/data/records/LHCb_2017_Beam6500GeV_VeloClosed_MagDown_RealData_Reco17_Stripping29r2p3_DIMUON_DST.json
+++ b/data/records/LHCb_2017_Beam6500GeV_VeloClosed_MagDown_RealData_Reco17_Stripping29r2p3_DIMUON_DST.json
@@ -1,0 +1,168 @@
+[{
+  "abstract": {
+    "description": "Data from proton-proton (pp) collisions collected by the LHCb experiment in the year 2017 of Run2 of the LHC."
+  },
+  "accelerator": "CERN-LHC",
+  "collaboration": {
+    "name": "LHCb collaboration",
+    "recid": "456"
+  },
+  "collections": [
+    "LHCb-Collision-Datasets"
+  ],
+  "collision_information": {
+    "energy": "13TeV",
+    "type": "pp"
+  },
+  "date_created": [
+    "2017"
+  ],
+  "date_published": "2026",
+  "date_reprocessed": "2023",
+  "distribution": {
+    "formats": [
+      "DST"
+    ],
+    "number_events": 88091847,
+    "number_files": 3627,
+    "size": 10329435709062
+  },
+  "experiment": [
+    "LHCb"
+  ],
+  "magnet_polarity": "MagDown",
+  "methodology": {
+    "description": "<p> This dataset was created in several production steps. These steps, software used and the configuration is provided below. </p><p> <strong> Prod ID: &nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;</strong> 207262<p> <strong>Prod type:&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp; </strong> Merge<p> <strong> Parent Prod ID:&nbsp;&nbsp;&nbsp;&nbsp; </strong> 207147<p> <strong> Parent Prod type: </strong> DataStripping<p> <strong> Conditions: </strong><p>dddb-20220927-2017<p>cond-20191004-2</strong><p> <strong> List of Trigger Configuration Keys (TCK): </strong> </p> <p><p><strong>TCK &nbsp;&nbsp;&nbsp;&nbsp;&nbsp; Number of Files </strong><p>0x11611708 &nbsp;&nbsp;&nbsp;&nbsp;&nbsp; 630<p>0x11611707 &nbsp;&nbsp;&nbsp;&nbsp;&nbsp; 548<p>0x11611709 &nbsp;&nbsp;&nbsp;&nbsp;&nbsp; 1156<p>0x11541707 &nbsp;&nbsp;&nbsp;&nbsp;&nbsp; 384<p>0x11561707 &nbsp;&nbsp;&nbsp;&nbsp;&nbsp; 902<p>0x115417a7 &nbsp;&nbsp;&nbsp;&nbsp;&nbsp; 7",
+    "steps": [
+      {
+        "configuration_files": [
+          {
+            "title": "DaVinci/DV-Stripping29r2p3-Stripping.py"
+          },
+          {
+            "title": "DaVinci/DataType-2017.py"
+          },
+          {
+            "title": "DaVinci/InputType-RDST.py"
+          },
+          {
+            "title": "DaVinci/DV-RawEventJuggler-0_3-to-4_3.py"
+          },
+          {
+            "title": "Persistency/Compression-ZLIB-1.py"
+          }
+        ],
+        "release": "DaVinci.v44r11p6 AppConfig.v3r421 Det/SQLDDDB.v7r12 TMVAWeights.v1r18",
+        "type": "Stripping29r2p3_md"
+      },
+      {
+        "configuration_files": [
+          {
+            "title": "Merging/DV-Stripping-Merging.py"
+          },
+          {
+            "title": "Persistency/Compression-LZMA-4.py"
+          }
+        ],
+        "release": "DaVinci.v44r11p6 AppConfig.v3r421 Det/SQLDDDB.v7r12 TMVAWeights.v1r18",
+        "type": "Merge_Stripping29r2p3_md"
+      },
+      {
+        "configuration_files": [
+          {
+            "title": "DaVinci/DV-Stripping29r2p3-Stripping.py"
+          },
+          {
+            "title": "DaVinci/DataType-2017.py"
+          },
+          {
+            "title": "DaVinci/InputType-RDST.py"
+          },
+          {
+            "title": "DaVinci/DV-RawEventJuggler-0_3-to-4_3.py"
+          },
+          {
+            "title": "Persistency/Compression-ZLIB-1.py"
+          }
+        ],
+        "release": "DaVinci.v44r11p6 AppConfig.v3r421 Det/SQLDDDB.v7r12 TMVAWeights.v1r18",
+        "type": "Stripping29r2p3_md"
+      },
+      {
+        "configuration_files": [
+          {
+            "title": "Merging/DV-Stripping-Merging.py"
+          },
+          {
+            "title": "Persistency/Compression-LZMA-4.py"
+          }
+        ],
+        "release": "DaVinci.v44r11p6 AppConfig.v3r421 Det/SQLDDDB.v7r12 TMVAWeights.v1r18",
+        "type": "Merge_Stripping29r2p3_md"
+      },
+      {
+        "configuration_files": [
+          {
+            "title": "DaVinci/DV-Stripping29r2p3-Stripping.py"
+          },
+          {
+            "title": "DaVinci/DataType-2017.py"
+          },
+          {
+            "title": "DaVinci/InputType-RDST.py"
+          },
+          {
+            "title": "DaVinci/DV-RawEventJuggler-0_3-to-4_3.py"
+          },
+          {
+            "title": "Persistency/Compression-ZLIB-1.py"
+          }
+        ],
+        "release": "DaVinci.v44r11p6 AppConfig.v3r421 Det/SQLDDDB.v7r12 TMVAWeights.v1r18",
+        "type": "Stripping29r2p3_md"
+      },
+      {
+        "configuration_files": [
+          {
+            "title": "Merging/DV-Stripping-Merging.py"
+          },
+          {
+            "title": "Persistency/Compression-LZMA-4.py"
+          }
+        ],
+        "release": "DaVinci.v44r11p6 AppConfig.v3r421 Det/SQLDDDB.v7r12 TMVAWeights.v1r18",
+        "type": "Merge_Stripping29r2p3_md"
+      }
+    ]
+  },
+  "publisher": "CERN Open Data Portal",
+  "recid": "24768",
+  "run_period": [
+    "2017"
+  ],
+  "stripping": {
+    "stream": "DIMUON",
+    "version": "stripping29r2p3"
+  },
+  "title": "LHCb 2017 Beam6500GeV MagDown DIMUON Stream Stripping29r2p3",
+  "title_additional": "",
+  "type": {
+    "primary": "Dataset",
+    "secondary": [
+      "Collision"
+    ]
+  },
+  "usage": {
+    "description": "<p> The Run 1 and 2 data collected by the LHCb detector is available using the LHCb Ntupling Service, while the Run 1 data is additionally available in .DST and .mDST formats. The data obtained from the LHCb Ntupling Service are ROOT ntuples and do not require custom software to analyze. <p> Links are provided to the LHCb Ntupling Service for exploration of available data and the LHCb Open Data Guide for usage instructions.",
+    "links": [
+      {
+        "description": "LHCb Ntupling Service",
+        "url": "https://opendata-lhcb-ntupling-service.app.cern.ch/"
+      },
+      {
+        "description": "LHCb Open Data Guide",
+        "url": "https://lhcb-opendata-guide.web.cern.ch/"
+      }
+    ]
+  }
+}]

--- a/data/records/LHCb_2017_Beam6500GeV_VeloClosed_MagDown_RealData_Reco17_Stripping29r2p3_LEPTONIC_MDST.json
+++ b/data/records/LHCb_2017_Beam6500GeV_VeloClosed_MagDown_RealData_Reco17_Stripping29r2p3_LEPTONIC_MDST.json
@@ -1,0 +1,168 @@
+[{
+  "abstract": {
+    "description": "Data from proton-proton (pp) collisions collected by the LHCb experiment in the year 2017 of Run2 of the LHC."
+  },
+  "accelerator": "CERN-LHC",
+  "collaboration": {
+    "name": "LHCb collaboration",
+    "recid": "456"
+  },
+  "collections": [
+    "LHCb-Collision-Datasets"
+  ],
+  "collision_information": {
+    "energy": "13TeV",
+    "type": "pp"
+  },
+  "date_created": [
+    "2017"
+  ],
+  "date_published": "2026",
+  "date_reprocessed": "2023",
+  "distribution": {
+    "formats": [
+      "MDST"
+    ],
+    "number_events": 1926251742,
+    "number_files": 12062,
+    "size": 48268786155257
+  },
+  "experiment": [
+    "LHCb"
+  ],
+  "magnet_polarity": "MagDown",
+  "methodology": {
+    "description": "<p> This dataset was created in several production steps. These steps, software used and the configuration is provided below. </p><p> <strong> Prod ID: &nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;</strong> 207148<p> <strong>Prod type:&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp; </strong> Merge<p> <strong> Parent Prod ID:&nbsp;&nbsp;&nbsp;&nbsp; </strong> 207147<p> <strong> Parent Prod type: </strong> DataStripping<p> <strong> Conditions: </strong><p>dddb-20220927-2017<p>cond-20191004-2</strong><p> <strong> List of Trigger Configuration Keys (TCK): </strong> </p> <p><p><strong>TCK &nbsp;&nbsp;&nbsp;&nbsp;&nbsp; Number of Files </strong><p>0x11611707 &nbsp;&nbsp;&nbsp;&nbsp;&nbsp; 1675<p>0x11611708 &nbsp;&nbsp;&nbsp;&nbsp;&nbsp; 2161<p>0x11611709 &nbsp;&nbsp;&nbsp;&nbsp;&nbsp; 4080<p>0x11561707 &nbsp;&nbsp;&nbsp;&nbsp;&nbsp; 2913<p>0x11541707 &nbsp;&nbsp;&nbsp;&nbsp;&nbsp; 1223<p>0x115417a7 &nbsp;&nbsp;&nbsp;&nbsp;&nbsp; 10",
+    "steps": [
+      {
+        "configuration_files": [
+          {
+            "title": "DaVinci/DV-Stripping29r2p3-Stripping.py"
+          },
+          {
+            "title": "DaVinci/DataType-2017.py"
+          },
+          {
+            "title": "DaVinci/InputType-RDST.py"
+          },
+          {
+            "title": "DaVinci/DV-RawEventJuggler-0_3-to-4_3.py"
+          },
+          {
+            "title": "Persistency/Compression-ZLIB-1.py"
+          }
+        ],
+        "release": "DaVinci.v44r11p6 AppConfig.v3r421 Det/SQLDDDB.v7r12 TMVAWeights.v1r18",
+        "type": "Stripping29r2p3_md"
+      },
+      {
+        "configuration_files": [
+          {
+            "title": "Merging/DV-Stripping-Merging.py"
+          },
+          {
+            "title": "Persistency/Compression-LZMA-4.py"
+          }
+        ],
+        "release": "DaVinci.v44r11p6 AppConfig.v3r421 Det/SQLDDDB.v7r12 TMVAWeights.v1r18",
+        "type": "Merge_Stripping29r2p3_md"
+      },
+      {
+        "configuration_files": [
+          {
+            "title": "DaVinci/DV-Stripping29r2p3-Stripping.py"
+          },
+          {
+            "title": "DaVinci/DataType-2017.py"
+          },
+          {
+            "title": "DaVinci/InputType-RDST.py"
+          },
+          {
+            "title": "DaVinci/DV-RawEventJuggler-0_3-to-4_3.py"
+          },
+          {
+            "title": "Persistency/Compression-ZLIB-1.py"
+          }
+        ],
+        "release": "DaVinci.v44r11p6 AppConfig.v3r421 Det/SQLDDDB.v7r12 TMVAWeights.v1r18",
+        "type": "Stripping29r2p3_md"
+      },
+      {
+        "configuration_files": [
+          {
+            "title": "Merging/DV-Stripping-Merging.py"
+          },
+          {
+            "title": "Persistency/Compression-LZMA-4.py"
+          }
+        ],
+        "release": "DaVinci.v44r11p6 AppConfig.v3r421 Det/SQLDDDB.v7r12 TMVAWeights.v1r18",
+        "type": "Merge_Stripping29r2p3_md"
+      },
+      {
+        "configuration_files": [
+          {
+            "title": "DaVinci/DV-Stripping29r2p3-Stripping.py"
+          },
+          {
+            "title": "DaVinci/DataType-2017.py"
+          },
+          {
+            "title": "DaVinci/InputType-RDST.py"
+          },
+          {
+            "title": "DaVinci/DV-RawEventJuggler-0_3-to-4_3.py"
+          },
+          {
+            "title": "Persistency/Compression-ZLIB-1.py"
+          }
+        ],
+        "release": "DaVinci.v44r11p6 AppConfig.v3r421 Det/SQLDDDB.v7r12 TMVAWeights.v1r18",
+        "type": "Stripping29r2p3_md"
+      },
+      {
+        "configuration_files": [
+          {
+            "title": "Merging/DV-Stripping-Merging.py"
+          },
+          {
+            "title": "Persistency/Compression-LZMA-4.py"
+          }
+        ],
+        "release": "DaVinci.v44r11p6 AppConfig.v3r421 Det/SQLDDDB.v7r12 TMVAWeights.v1r18",
+        "type": "Merge_Stripping29r2p3_md"
+      }
+    ]
+  },
+  "publisher": "CERN Open Data Portal",
+  "recid": "24761",
+  "run_period": [
+    "2017"
+  ],
+  "stripping": {
+    "stream": "LEPTONIC",
+    "version": "stripping29r2p3"
+  },
+  "title": "LHCb 2017 Beam6500GeV MagDown LEPTONIC Stream Stripping29r2p3",
+  "title_additional": "",
+  "type": {
+    "primary": "Dataset",
+    "secondary": [
+      "Collision"
+    ]
+  },
+  "usage": {
+    "description": "<p> The Run 1 and 2 data collected by the LHCb detector is available using the LHCb Ntupling Service, while the Run 1 data is additionally available in .DST and .mDST formats. The data obtained from the LHCb Ntupling Service are ROOT ntuples and do not require custom software to analyze. <p> Links are provided to the LHCb Ntupling Service for exploration of available data and the LHCb Open Data Guide for usage instructions.",
+    "links": [
+      {
+        "description": "LHCb Ntupling Service",
+        "url": "https://opendata-lhcb-ntupling-service.app.cern.ch/"
+      },
+      {
+        "description": "LHCb Open Data Guide",
+        "url": "https://lhcb-opendata-guide.web.cern.ch/"
+      }
+    ]
+  }
+}]

--- a/data/records/LHCb_2017_Beam6500GeV_VeloClosed_MagDown_RealData_Reco17_Stripping29r2p3_SEMILEPTONIC_DST.json
+++ b/data/records/LHCb_2017_Beam6500GeV_VeloClosed_MagDown_RealData_Reco17_Stripping29r2p3_SEMILEPTONIC_DST.json
@@ -1,0 +1,168 @@
+[{
+  "abstract": {
+    "description": "Data from proton-proton (pp) collisions collected by the LHCb experiment in the year 2017 of Run2 of the LHC."
+  },
+  "accelerator": "CERN-LHC",
+  "collaboration": {
+    "name": "LHCb collaboration",
+    "recid": "456"
+  },
+  "collections": [
+    "LHCb-Collision-Datasets"
+  ],
+  "collision_information": {
+    "energy": "13TeV",
+    "type": "pp"
+  },
+  "date_created": [
+    "2017"
+  ],
+  "date_published": "2026",
+  "date_reprocessed": "2023",
+  "distribution": {
+    "formats": [
+      "DST"
+    ],
+    "number_events": 563834511,
+    "number_files": 10702,
+    "size": 37031441014325
+  },
+  "experiment": [
+    "LHCb"
+  ],
+  "magnet_polarity": "MagDown",
+  "methodology": {
+    "description": "<p> This dataset was created in several production steps. These steps, software used and the configuration is provided below. </p><p> <strong> Prod ID: &nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;</strong> 207148<p> <strong>Prod type:&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp; </strong> Merge<p> <strong> Parent Prod ID:&nbsp;&nbsp;&nbsp;&nbsp; </strong> 207147<p> <strong> Parent Prod type: </strong> DataStripping<p> <strong> Conditions: </strong><p>dddb-20220927-2017<p>cond-20191004-2</strong><p> <strong> List of Trigger Configuration Keys (TCK): </strong> </p> <p><p><strong>TCK &nbsp;&nbsp;&nbsp;&nbsp;&nbsp; Number of Files </strong><p>0x11611707 &nbsp;&nbsp;&nbsp;&nbsp;&nbsp; 1508<p>0x11611708 &nbsp;&nbsp;&nbsp;&nbsp;&nbsp; 1896<p>0x11611709 &nbsp;&nbsp;&nbsp;&nbsp;&nbsp; 3583<p>0x11561707 &nbsp;&nbsp;&nbsp;&nbsp;&nbsp; 2616<p>0x11541707 &nbsp;&nbsp;&nbsp;&nbsp;&nbsp; 1089<p>0x115417a7 &nbsp;&nbsp;&nbsp;&nbsp;&nbsp; 10",
+    "steps": [
+      {
+        "configuration_files": [
+          {
+            "title": "DaVinci/DV-Stripping29r2p3-Stripping.py"
+          },
+          {
+            "title": "DaVinci/DataType-2017.py"
+          },
+          {
+            "title": "DaVinci/InputType-RDST.py"
+          },
+          {
+            "title": "DaVinci/DV-RawEventJuggler-0_3-to-4_3.py"
+          },
+          {
+            "title": "Persistency/Compression-ZLIB-1.py"
+          }
+        ],
+        "release": "DaVinci.v44r11p6 AppConfig.v3r421 Det/SQLDDDB.v7r12 TMVAWeights.v1r18",
+        "type": "Stripping29r2p3_md"
+      },
+      {
+        "configuration_files": [
+          {
+            "title": "Merging/DV-Stripping-Merging.py"
+          },
+          {
+            "title": "Persistency/Compression-LZMA-4.py"
+          }
+        ],
+        "release": "DaVinci.v44r11p6 AppConfig.v3r421 Det/SQLDDDB.v7r12 TMVAWeights.v1r18",
+        "type": "Merge_Stripping29r2p3_md"
+      },
+      {
+        "configuration_files": [
+          {
+            "title": "DaVinci/DV-Stripping29r2p3-Stripping.py"
+          },
+          {
+            "title": "DaVinci/DataType-2017.py"
+          },
+          {
+            "title": "DaVinci/InputType-RDST.py"
+          },
+          {
+            "title": "DaVinci/DV-RawEventJuggler-0_3-to-4_3.py"
+          },
+          {
+            "title": "Persistency/Compression-ZLIB-1.py"
+          }
+        ],
+        "release": "DaVinci.v44r11p6 AppConfig.v3r421 Det/SQLDDDB.v7r12 TMVAWeights.v1r18",
+        "type": "Stripping29r2p3_md"
+      },
+      {
+        "configuration_files": [
+          {
+            "title": "Merging/DV-Stripping-Merging.py"
+          },
+          {
+            "title": "Persistency/Compression-LZMA-4.py"
+          }
+        ],
+        "release": "DaVinci.v44r11p6 AppConfig.v3r421 Det/SQLDDDB.v7r12 TMVAWeights.v1r18",
+        "type": "Merge_Stripping29r2p3_md"
+      },
+      {
+        "configuration_files": [
+          {
+            "title": "DaVinci/DV-Stripping29r2p3-Stripping.py"
+          },
+          {
+            "title": "DaVinci/DataType-2017.py"
+          },
+          {
+            "title": "DaVinci/InputType-RDST.py"
+          },
+          {
+            "title": "DaVinci/DV-RawEventJuggler-0_3-to-4_3.py"
+          },
+          {
+            "title": "Persistency/Compression-ZLIB-1.py"
+          }
+        ],
+        "release": "DaVinci.v44r11p6 AppConfig.v3r421 Det/SQLDDDB.v7r12 TMVAWeights.v1r18",
+        "type": "Stripping29r2p3_md"
+      },
+      {
+        "configuration_files": [
+          {
+            "title": "Merging/DV-Stripping-Merging.py"
+          },
+          {
+            "title": "Persistency/Compression-LZMA-4.py"
+          }
+        ],
+        "release": "DaVinci.v44r11p6 AppConfig.v3r421 Det/SQLDDDB.v7r12 TMVAWeights.v1r18",
+        "type": "Merge_Stripping29r2p3_md"
+      }
+    ]
+  },
+  "publisher": "CERN Open Data Portal",
+  "recid": "24769",
+  "run_period": [
+    "2017"
+  ],
+  "stripping": {
+    "stream": "SEMILEPTONIC",
+    "version": "stripping29r2p3"
+  },
+  "title": "LHCb 2017 Beam6500GeV MagDown SEMILEPTONIC Stream Stripping29r2p3",
+  "title_additional": "",
+  "type": {
+    "primary": "Dataset",
+    "secondary": [
+      "Collision"
+    ]
+  },
+  "usage": {
+    "description": "<p> The Run 1 and 2 data collected by the LHCb detector is available using the LHCb Ntupling Service, while the Run 1 data is additionally available in .DST and .mDST formats. The data obtained from the LHCb Ntupling Service are ROOT ntuples and do not require custom software to analyze. <p> Links are provided to the LHCb Ntupling Service for exploration of available data and the LHCb Open Data Guide for usage instructions.",
+    "links": [
+      {
+        "description": "LHCb Ntupling Service",
+        "url": "https://opendata-lhcb-ntupling-service.app.cern.ch/"
+      },
+      {
+        "description": "LHCb Open Data Guide",
+        "url": "https://lhcb-opendata-guide.web.cern.ch/"
+      }
+    ]
+  }
+}]

--- a/data/records/LHCb_2017_Beam6500GeV_VeloClosed_MagUp_RealData_Reco17_Stripping29r2_BHADRONCOMPLETEEVENT_DST.json
+++ b/data/records/LHCb_2017_Beam6500GeV_VeloClosed_MagUp_RealData_Reco17_Stripping29r2_BHADRONCOMPLETEEVENT_DST.json
@@ -1,0 +1,168 @@
+[{
+  "abstract": {
+    "description": "Data from proton-proton (pp) collisions collected by the LHCb experiment in the year 2017 of Run2 of the LHC."
+  },
+  "accelerator": "CERN-LHC",
+  "collaboration": {
+    "name": "LHCb collaboration",
+    "recid": "456"
+  },
+  "collections": [
+    "LHCb-Collision-Datasets"
+  ],
+  "collision_information": {
+    "energy": "13TeV",
+    "type": "pp"
+  },
+  "date_created": [
+    "2017"
+  ],
+  "date_published": "2026",
+  "date_reprocessed": "2018",
+  "distribution": {
+    "formats": [
+      "DST"
+    ],
+    "number_events": 690454041,
+    "number_files": 16848,
+    "size": 61404070250860
+  },
+  "experiment": [
+    "LHCb"
+  ],
+  "magnet_polarity": "MagUp",
+  "methodology": {
+    "description": "<p> This dataset was created in several production steps. These steps, software used and the configuration is provided below. </p><p> <strong> Prod ID: &nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;</strong> 71499<p> <strong>Prod type:&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp; </strong> Merge<p> <strong> Parent Prod ID:&nbsp;&nbsp;&nbsp;&nbsp; </strong> 71498<p> <strong> Parent Prod type: </strong> DataStripping<p> <strong> Conditions: </strong><p>dddb-20170721-3<p>cond-20170724</strong><p> <strong> List of Trigger Configuration Keys (TCK): </strong> </p> <p><p><strong>TCK &nbsp;&nbsp;&nbsp;&nbsp;&nbsp; Number of Files </strong><p>0x11501703 &nbsp;&nbsp;&nbsp;&nbsp;&nbsp; 544<p>0x114e1702 &nbsp;&nbsp;&nbsp;&nbsp;&nbsp; 252<p>0x114e1703 &nbsp;&nbsp;&nbsp;&nbsp;&nbsp; 64<p>0x11501704 &nbsp;&nbsp;&nbsp;&nbsp;&nbsp; 557<p>0x11501705 &nbsp;&nbsp;&nbsp;&nbsp;&nbsp; 2413<p>0x11501706 &nbsp;&nbsp;&nbsp;&nbsp;&nbsp; 512<p>0x114b1702 &nbsp;&nbsp;&nbsp;&nbsp;&nbsp; 12<p>0x11611709 &nbsp;&nbsp;&nbsp;&nbsp;&nbsp; 6214<p>0x11561707 &nbsp;&nbsp;&nbsp;&nbsp;&nbsp; 1684<p>0x11601707 &nbsp;&nbsp;&nbsp;&nbsp;&nbsp; 2340<p>0x11601708 &nbsp;&nbsp;&nbsp;&nbsp;&nbsp; 2256",
+    "steps": [
+      {
+        "configuration_files": [
+          {
+            "title": "DaVinci/DV-Stripping29r2-Stripping.py"
+          },
+          {
+            "title": "DaVinci/DataType-2017.py"
+          },
+          {
+            "title": "DaVinci/InputType-RDST.py"
+          },
+          {
+            "title": "DaVinci/DV-RawEventJuggler-0_3-to-4_2.py"
+          },
+          {
+            "title": "Persistency/Compression-ZLIB-1.py"
+          }
+        ],
+        "release": "DaVinci.v42r7p2 AppConfig.v3r353 Det/SQLDDDB.v7r10 TMVAWeights.v1r9",
+        "type": "Stripping29r2"
+      },
+      {
+        "configuration_files": [
+          {
+            "title": "Merging/DV-Stripping-Merging.py"
+          },
+          {
+            "title": "Persistency/Compression-LZMA-4.py"
+          }
+        ],
+        "release": "DaVinci.v42r7p2 AppConfig.v3r353 Det/SQLDDDB.v7r10",
+        "type": "Stripping29r2-Merging"
+      },
+      {
+        "configuration_files": [
+          {
+            "title": "DaVinci/DV-Stripping29r2-Stripping.py"
+          },
+          {
+            "title": "DaVinci/DataType-2017.py"
+          },
+          {
+            "title": "DaVinci/InputType-RDST.py"
+          },
+          {
+            "title": "DaVinci/DV-RawEventJuggler-0_3-to-4_2.py"
+          },
+          {
+            "title": "Persistency/Compression-ZLIB-1.py"
+          }
+        ],
+        "release": "DaVinci.v42r7p2 AppConfig.v3r353 Det/SQLDDDB.v7r10 TMVAWeights.v1r9",
+        "type": "Stripping29r2"
+      },
+      {
+        "configuration_files": [
+          {
+            "title": "Merging/DV-Stripping-Merging.py"
+          },
+          {
+            "title": "Persistency/Compression-LZMA-4.py"
+          }
+        ],
+        "release": "DaVinci.v42r7p2 AppConfig.v3r353 Det/SQLDDDB.v7r10",
+        "type": "Stripping29r2-Merging"
+      },
+      {
+        "configuration_files": [
+          {
+            "title": "DaVinci/DV-Stripping29r2-Stripping.py"
+          },
+          {
+            "title": "DaVinci/DataType-2017.py"
+          },
+          {
+            "title": "DaVinci/InputType-RDST.py"
+          },
+          {
+            "title": "DaVinci/DV-RawEventJuggler-0_3-to-4_2.py"
+          },
+          {
+            "title": "Persistency/Compression-ZLIB-1.py"
+          }
+        ],
+        "release": "DaVinci.v42r7p2 AppConfig.v3r353 Det/SQLDDDB.v7r10 TMVAWeights.v1r9",
+        "type": "Stripping29r2"
+      },
+      {
+        "configuration_files": [
+          {
+            "title": "Merging/DV-Stripping-Merging.py"
+          },
+          {
+            "title": "Persistency/Compression-LZMA-4.py"
+          }
+        ],
+        "release": "DaVinci.v42r7p2 AppConfig.v3r353 Det/SQLDDDB.v7r10",
+        "type": "Stripping29r2-Merging"
+      }
+    ]
+  },
+  "publisher": "CERN Open Data Portal",
+  "recid": "24715",
+  "run_period": [
+    "2017"
+  ],
+  "stripping": {
+    "stream": "BHADRONCOMPLETEEVENT",
+    "version": "stripping29r2"
+  },
+  "title": "LHCb 2017 Beam6500GeV MagUp BHADRONCOMPLETEEVENT Stream Stripping29r2",
+  "title_additional": "",
+  "type": {
+    "primary": "Dataset",
+    "secondary": [
+      "Collision"
+    ]
+  },
+  "usage": {
+    "description": "<p> The Run 1 and 2 data collected by the LHCb detector is available using the LHCb Ntupling Service, while the Run 1 data is additionally available in .DST and .mDST formats. The data obtained from the LHCb Ntupling Service are ROOT ntuples and do not require custom software to analyze. <p> Links are provided to the LHCb Ntupling Service for exploration of available data and the LHCb Open Data Guide for usage instructions.",
+    "links": [
+      {
+        "description": "LHCb Ntupling Service",
+        "url": "https://opendata-lhcb-ntupling-service.app.cern.ch/"
+      },
+      {
+        "description": "LHCb Open Data Guide",
+        "url": "https://lhcb-opendata-guide.web.cern.ch/"
+      }
+    ]
+  }
+}]

--- a/data/records/LHCb_2017_Beam6500GeV_VeloClosed_MagUp_RealData_Reco17_Stripping29r2_BHADRON_MDST.json
+++ b/data/records/LHCb_2017_Beam6500GeV_VeloClosed_MagUp_RealData_Reco17_Stripping29r2_BHADRON_MDST.json
@@ -1,0 +1,168 @@
+[{
+  "abstract": {
+    "description": "Data from proton-proton (pp) collisions collected by the LHCb experiment in the year 2017 of Run2 of the LHC."
+  },
+  "accelerator": "CERN-LHC",
+  "collaboration": {
+    "name": "LHCb collaboration",
+    "recid": "456"
+  },
+  "collections": [
+    "LHCb-Collision-Datasets"
+  ],
+  "collision_information": {
+    "energy": "13TeV",
+    "type": "pp"
+  },
+  "date_created": [
+    "2017"
+  ],
+  "date_published": "2026",
+  "date_reprocessed": "2018",
+  "distribution": {
+    "formats": [
+      "MDST"
+    ],
+    "number_events": 2837614536,
+    "number_files": 11814,
+    "size": 42045878792780
+  },
+  "experiment": [
+    "LHCb"
+  ],
+  "magnet_polarity": "MagUp",
+  "methodology": {
+    "description": "<p> This dataset was created in several production steps. These steps, software used and the configuration is provided below. </p><p> <strong> Prod ID: &nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;</strong> 71671<p> <strong>Prod type:&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp; </strong> Merge<p> <strong> Parent Prod ID:&nbsp;&nbsp;&nbsp;&nbsp; </strong> 71498<p> <strong> Parent Prod type: </strong> DataStripping<p> <strong> Conditions: </strong><p>dddb-20170721-3<p>cond-20170724</strong><p> <strong> List of Trigger Configuration Keys (TCK): </strong> </p> <p><p><strong>TCK &nbsp;&nbsp;&nbsp;&nbsp;&nbsp; Number of Files </strong><p>0x114e1702 &nbsp;&nbsp;&nbsp;&nbsp;&nbsp; 216<p>0x114e1703 &nbsp;&nbsp;&nbsp;&nbsp;&nbsp; 49<p>0x11501703 &nbsp;&nbsp;&nbsp;&nbsp;&nbsp; 390<p>0x11501705 &nbsp;&nbsp;&nbsp;&nbsp;&nbsp; 1657<p>0x11501704 &nbsp;&nbsp;&nbsp;&nbsp;&nbsp; 393<p>0x11501706 &nbsp;&nbsp;&nbsp;&nbsp;&nbsp; 337<p>0x114b1702 &nbsp;&nbsp;&nbsp;&nbsp;&nbsp; 12<p>0x11611709 &nbsp;&nbsp;&nbsp;&nbsp;&nbsp; 4397<p>0x11561707 &nbsp;&nbsp;&nbsp;&nbsp;&nbsp; 1146<p>0x11601707 &nbsp;&nbsp;&nbsp;&nbsp;&nbsp; 1601<p>0x11601708 &nbsp;&nbsp;&nbsp;&nbsp;&nbsp; 1616",
+    "steps": [
+      {
+        "configuration_files": [
+          {
+            "title": "DaVinci/DV-Stripping29r2-Stripping.py"
+          },
+          {
+            "title": "DaVinci/DataType-2017.py"
+          },
+          {
+            "title": "DaVinci/InputType-RDST.py"
+          },
+          {
+            "title": "DaVinci/DV-RawEventJuggler-0_3-to-4_2.py"
+          },
+          {
+            "title": "Persistency/Compression-ZLIB-1.py"
+          }
+        ],
+        "release": "DaVinci.v42r7p2 AppConfig.v3r353 Det/SQLDDDB.v7r10 TMVAWeights.v1r9",
+        "type": "Stripping29r2"
+      },
+      {
+        "configuration_files": [
+          {
+            "title": "Merging/DV-Stripping-Merging.py"
+          },
+          {
+            "title": "Persistency/Compression-LZMA-4.py"
+          }
+        ],
+        "release": "DaVinci.v42r7p2 AppConfig.v3r353 Det/SQLDDDB.v7r10",
+        "type": "Stripping29r2-Merging"
+      },
+      {
+        "configuration_files": [
+          {
+            "title": "DaVinci/DV-Stripping29r2-Stripping.py"
+          },
+          {
+            "title": "DaVinci/DataType-2017.py"
+          },
+          {
+            "title": "DaVinci/InputType-RDST.py"
+          },
+          {
+            "title": "DaVinci/DV-RawEventJuggler-0_3-to-4_2.py"
+          },
+          {
+            "title": "Persistency/Compression-ZLIB-1.py"
+          }
+        ],
+        "release": "DaVinci.v42r7p2 AppConfig.v3r353 Det/SQLDDDB.v7r10 TMVAWeights.v1r9",
+        "type": "Stripping29r2"
+      },
+      {
+        "configuration_files": [
+          {
+            "title": "Merging/DV-Stripping-Merging.py"
+          },
+          {
+            "title": "Persistency/Compression-LZMA-4.py"
+          }
+        ],
+        "release": "DaVinci.v42r7p2 AppConfig.v3r353 Det/SQLDDDB.v7r10",
+        "type": "Stripping29r2-Merging"
+      },
+      {
+        "configuration_files": [
+          {
+            "title": "DaVinci/DV-Stripping29r2-Stripping.py"
+          },
+          {
+            "title": "DaVinci/DataType-2017.py"
+          },
+          {
+            "title": "DaVinci/InputType-RDST.py"
+          },
+          {
+            "title": "DaVinci/DV-RawEventJuggler-0_3-to-4_2.py"
+          },
+          {
+            "title": "Persistency/Compression-ZLIB-1.py"
+          }
+        ],
+        "release": "DaVinci.v42r7p2 AppConfig.v3r353 Det/SQLDDDB.v7r10 TMVAWeights.v1r9",
+        "type": "Stripping29r2"
+      },
+      {
+        "configuration_files": [
+          {
+            "title": "Merging/DV-Stripping-Merging.py"
+          },
+          {
+            "title": "Persistency/Compression-LZMA-4.py"
+          }
+        ],
+        "release": "DaVinci.v42r7p2 AppConfig.v3r353 Det/SQLDDDB.v7r10",
+        "type": "Stripping29r2-Merging"
+      }
+    ]
+  },
+  "publisher": "CERN Open Data Portal",
+  "recid": "24714",
+  "run_period": [
+    "2017"
+  ],
+  "stripping": {
+    "stream": "BHADRON",
+    "version": "stripping29r2"
+  },
+  "title": "LHCb 2017 Beam6500GeV MagUp BHADRON Stream Stripping29r2",
+  "title_additional": "",
+  "type": {
+    "primary": "Dataset",
+    "secondary": [
+      "Collision"
+    ]
+  },
+  "usage": {
+    "description": "<p> The Run 1 and 2 data collected by the LHCb detector is available using the LHCb Ntupling Service, while the Run 1 data is additionally available in .DST and .mDST formats. The data obtained from the LHCb Ntupling Service are ROOT ntuples and do not require custom software to analyze. <p> Links are provided to the LHCb Ntupling Service for exploration of available data and the LHCb Open Data Guide for usage instructions.",
+    "links": [
+      {
+        "description": "LHCb Ntupling Service",
+        "url": "https://opendata-lhcb-ntupling-service.app.cern.ch/"
+      },
+      {
+        "description": "LHCb Open Data Guide",
+        "url": "https://lhcb-opendata-guide.web.cern.ch/"
+      }
+    ]
+  }
+}]

--- a/data/records/LHCb_2017_Beam6500GeV_VeloClosed_MagUp_RealData_Reco17_Stripping29r2_CHARMCOMPLETEEVENT_DST.json
+++ b/data/records/LHCb_2017_Beam6500GeV_VeloClosed_MagUp_RealData_Reco17_Stripping29r2_CHARMCOMPLETEEVENT_DST.json
@@ -1,0 +1,168 @@
+[{
+  "abstract": {
+    "description": "Data from proton-proton (pp) collisions collected by the LHCb experiment in the year 2017 of Run2 of the LHC."
+  },
+  "accelerator": "CERN-LHC",
+  "collaboration": {
+    "name": "LHCb collaboration",
+    "recid": "456"
+  },
+  "collections": [
+    "LHCb-Collision-Datasets"
+  ],
+  "collision_information": {
+    "energy": "13TeV",
+    "type": "pp"
+  },
+  "date_created": [
+    "2017"
+  ],
+  "date_published": "2026",
+  "date_reprocessed": "2018",
+  "distribution": {
+    "formats": [
+      "DST"
+    ],
+    "number_events": 250041082,
+    "number_files": 6397,
+    "size": 19485442921089
+  },
+  "experiment": [
+    "LHCb"
+  ],
+  "magnet_polarity": "MagUp",
+  "methodology": {
+    "description": "<p> This dataset was created in several production steps. These steps, software used and the configuration is provided below. </p><p> <strong> Prod ID: &nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;</strong> 71957<p> <strong>Prod type:&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp; </strong> Merge<p> <strong> Parent Prod ID:&nbsp;&nbsp;&nbsp;&nbsp; </strong> 71498<p> <strong> Parent Prod type: </strong> DataStripping<p> <strong> Conditions: </strong><p>dddb-20170721-3<p>cond-20170724</strong><p> <strong> List of Trigger Configuration Keys (TCK): </strong> </p> <p><p><strong>TCK &nbsp;&nbsp;&nbsp;&nbsp;&nbsp; Number of Files </strong><p>0x114e1702 &nbsp;&nbsp;&nbsp;&nbsp;&nbsp; 174<p>0x11501703 &nbsp;&nbsp;&nbsp;&nbsp;&nbsp; 221<p>0x11501704 &nbsp;&nbsp;&nbsp;&nbsp;&nbsp; 202<p>0x11501705 &nbsp;&nbsp;&nbsp;&nbsp;&nbsp; 791<p>0x114e1703 &nbsp;&nbsp;&nbsp;&nbsp;&nbsp; 34<p>0x114b1702 &nbsp;&nbsp;&nbsp;&nbsp;&nbsp; 12<p>0x11501706 &nbsp;&nbsp;&nbsp;&nbsp;&nbsp; 172<p>0x11611709 &nbsp;&nbsp;&nbsp;&nbsp;&nbsp; 2305<p>0x11561707 &nbsp;&nbsp;&nbsp;&nbsp;&nbsp; 654<p>0x11601707 &nbsp;&nbsp;&nbsp;&nbsp;&nbsp; 918<p>0x11601708 &nbsp;&nbsp;&nbsp;&nbsp;&nbsp; 914",
+    "steps": [
+      {
+        "configuration_files": [
+          {
+            "title": "DaVinci/DV-Stripping29r2-Stripping.py"
+          },
+          {
+            "title": "DaVinci/DataType-2017.py"
+          },
+          {
+            "title": "DaVinci/InputType-RDST.py"
+          },
+          {
+            "title": "DaVinci/DV-RawEventJuggler-0_3-to-4_2.py"
+          },
+          {
+            "title": "Persistency/Compression-ZLIB-1.py"
+          }
+        ],
+        "release": "DaVinci.v42r7p2 AppConfig.v3r353 Det/SQLDDDB.v7r10 TMVAWeights.v1r9",
+        "type": "Stripping29r2"
+      },
+      {
+        "configuration_files": [
+          {
+            "title": "Merging/DV-Stripping-Merging.py"
+          },
+          {
+            "title": "Persistency/Compression-LZMA-4.py"
+          }
+        ],
+        "release": "DaVinci.v42r7p2 AppConfig.v3r353 Det/SQLDDDB.v7r10",
+        "type": "Stripping29r2-Merging"
+      },
+      {
+        "configuration_files": [
+          {
+            "title": "DaVinci/DV-Stripping29r2-Stripping.py"
+          },
+          {
+            "title": "DaVinci/DataType-2017.py"
+          },
+          {
+            "title": "DaVinci/InputType-RDST.py"
+          },
+          {
+            "title": "DaVinci/DV-RawEventJuggler-0_3-to-4_2.py"
+          },
+          {
+            "title": "Persistency/Compression-ZLIB-1.py"
+          }
+        ],
+        "release": "DaVinci.v42r7p2 AppConfig.v3r353 Det/SQLDDDB.v7r10 TMVAWeights.v1r9",
+        "type": "Stripping29r2"
+      },
+      {
+        "configuration_files": [
+          {
+            "title": "Merging/DV-Stripping-Merging.py"
+          },
+          {
+            "title": "Persistency/Compression-LZMA-4.py"
+          }
+        ],
+        "release": "DaVinci.v42r7p2 AppConfig.v3r353 Det/SQLDDDB.v7r10",
+        "type": "Stripping29r2-Merging"
+      },
+      {
+        "configuration_files": [
+          {
+            "title": "DaVinci/DV-Stripping29r2-Stripping.py"
+          },
+          {
+            "title": "DaVinci/DataType-2017.py"
+          },
+          {
+            "title": "DaVinci/InputType-RDST.py"
+          },
+          {
+            "title": "DaVinci/DV-RawEventJuggler-0_3-to-4_2.py"
+          },
+          {
+            "title": "Persistency/Compression-ZLIB-1.py"
+          }
+        ],
+        "release": "DaVinci.v42r7p2 AppConfig.v3r353 Det/SQLDDDB.v7r10 TMVAWeights.v1r9",
+        "type": "Stripping29r2"
+      },
+      {
+        "configuration_files": [
+          {
+            "title": "Merging/DV-Stripping-Merging.py"
+          },
+          {
+            "title": "Persistency/Compression-LZMA-4.py"
+          }
+        ],
+        "release": "DaVinci.v42r7p2 AppConfig.v3r353 Det/SQLDDDB.v7r10",
+        "type": "Stripping29r2-Merging"
+      }
+    ]
+  },
+  "publisher": "CERN Open Data Portal",
+  "recid": "24717",
+  "run_period": [
+    "2017"
+  ],
+  "stripping": {
+    "stream": "CHARMCOMPLETEEVENT",
+    "version": "stripping29r2"
+  },
+  "title": "LHCb 2017 Beam6500GeV MagUp CHARMCOMPLETEEVENT Stream Stripping29r2",
+  "title_additional": "",
+  "type": {
+    "primary": "Dataset",
+    "secondary": [
+      "Collision"
+    ]
+  },
+  "usage": {
+    "description": "<p> The Run 1 and 2 data collected by the LHCb detector is available using the LHCb Ntupling Service, while the Run 1 data is additionally available in .DST and .mDST formats. The data obtained from the LHCb Ntupling Service are ROOT ntuples and do not require custom software to analyze. <p> Links are provided to the LHCb Ntupling Service for exploration of available data and the LHCb Open Data Guide for usage instructions.",
+    "links": [
+      {
+        "description": "LHCb Ntupling Service",
+        "url": "https://opendata-lhcb-ntupling-service.app.cern.ch/"
+      },
+      {
+        "description": "LHCb Open Data Guide",
+        "url": "https://lhcb-opendata-guide.web.cern.ch/"
+      }
+    ]
+  }
+}]

--- a/data/records/LHCb_2017_Beam6500GeV_VeloClosed_MagUp_RealData_Reco17_Stripping29r2_CHARM_MDST.json
+++ b/data/records/LHCb_2017_Beam6500GeV_VeloClosed_MagUp_RealData_Reco17_Stripping29r2_CHARM_MDST.json
@@ -1,0 +1,168 @@
+[{
+  "abstract": {
+    "description": "Data from proton-proton (pp) collisions collected by the LHCb experiment in the year 2017 of Run2 of the LHC."
+  },
+  "accelerator": "CERN-LHC",
+  "collaboration": {
+    "name": "LHCb collaboration",
+    "recid": "456"
+  },
+  "collections": [
+    "LHCb-Collision-Datasets"
+  ],
+  "collision_information": {
+    "energy": "13TeV",
+    "type": "pp"
+  },
+  "date_created": [
+    "2017"
+  ],
+  "date_published": "2026",
+  "date_reprocessed": "2018",
+  "distribution": {
+    "formats": [
+      "MDST"
+    ],
+    "number_events": 2904894811,
+    "number_files": 9020,
+    "size": 30843277542018
+  },
+  "experiment": [
+    "LHCb"
+  ],
+  "magnet_polarity": "MagUp",
+  "methodology": {
+    "description": "<p> This dataset was created in several production steps. These steps, software used and the configuration is provided below. </p><p> <strong> Prod ID: &nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;</strong> 71499<p> <strong>Prod type:&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp; </strong> Merge<p> <strong> Parent Prod ID:&nbsp;&nbsp;&nbsp;&nbsp; </strong> 71498<p> <strong> Parent Prod type: </strong> DataStripping<p> <strong> Conditions: </strong><p>dddb-20170721-3<p>cond-20170724</strong><p> <strong> List of Trigger Configuration Keys (TCK): </strong> </p> <p><p><strong>TCK &nbsp;&nbsp;&nbsp;&nbsp;&nbsp; Number of Files </strong><p>0x11501703 &nbsp;&nbsp;&nbsp;&nbsp;&nbsp; 318<p>0x114e1702 &nbsp;&nbsp;&nbsp;&nbsp;&nbsp; 196<p>0x11501704 &nbsp;&nbsp;&nbsp;&nbsp;&nbsp; 299<p>0x114e1703 &nbsp;&nbsp;&nbsp;&nbsp;&nbsp; 43<p>0x114b1702 &nbsp;&nbsp;&nbsp;&nbsp;&nbsp; 12<p>0x11501705 &nbsp;&nbsp;&nbsp;&nbsp;&nbsp; 1239<p>0x11501706 &nbsp;&nbsp;&nbsp;&nbsp;&nbsp; 258<p>0x11611709 &nbsp;&nbsp;&nbsp;&nbsp;&nbsp; 3328<p>0x11561707 &nbsp;&nbsp;&nbsp;&nbsp;&nbsp; 861<p>0x11601707 &nbsp;&nbsp;&nbsp;&nbsp;&nbsp; 1205<p>0x11601708 &nbsp;&nbsp;&nbsp;&nbsp;&nbsp; 1261",
+    "steps": [
+      {
+        "configuration_files": [
+          {
+            "title": "DaVinci/DV-Stripping29r2-Stripping.py"
+          },
+          {
+            "title": "DaVinci/DataType-2017.py"
+          },
+          {
+            "title": "DaVinci/InputType-RDST.py"
+          },
+          {
+            "title": "DaVinci/DV-RawEventJuggler-0_3-to-4_2.py"
+          },
+          {
+            "title": "Persistency/Compression-ZLIB-1.py"
+          }
+        ],
+        "release": "DaVinci.v42r7p2 AppConfig.v3r353 Det/SQLDDDB.v7r10 TMVAWeights.v1r9",
+        "type": "Stripping29r2"
+      },
+      {
+        "configuration_files": [
+          {
+            "title": "Merging/DV-Stripping-Merging.py"
+          },
+          {
+            "title": "Persistency/Compression-LZMA-4.py"
+          }
+        ],
+        "release": "DaVinci.v42r7p2 AppConfig.v3r353 Det/SQLDDDB.v7r10",
+        "type": "Stripping29r2-Merging"
+      },
+      {
+        "configuration_files": [
+          {
+            "title": "DaVinci/DV-Stripping29r2-Stripping.py"
+          },
+          {
+            "title": "DaVinci/DataType-2017.py"
+          },
+          {
+            "title": "DaVinci/InputType-RDST.py"
+          },
+          {
+            "title": "DaVinci/DV-RawEventJuggler-0_3-to-4_2.py"
+          },
+          {
+            "title": "Persistency/Compression-ZLIB-1.py"
+          }
+        ],
+        "release": "DaVinci.v42r7p2 AppConfig.v3r353 Det/SQLDDDB.v7r10 TMVAWeights.v1r9",
+        "type": "Stripping29r2"
+      },
+      {
+        "configuration_files": [
+          {
+            "title": "Merging/DV-Stripping-Merging.py"
+          },
+          {
+            "title": "Persistency/Compression-LZMA-4.py"
+          }
+        ],
+        "release": "DaVinci.v42r7p2 AppConfig.v3r353 Det/SQLDDDB.v7r10",
+        "type": "Stripping29r2-Merging"
+      },
+      {
+        "configuration_files": [
+          {
+            "title": "DaVinci/DV-Stripping29r2-Stripping.py"
+          },
+          {
+            "title": "DaVinci/DataType-2017.py"
+          },
+          {
+            "title": "DaVinci/InputType-RDST.py"
+          },
+          {
+            "title": "DaVinci/DV-RawEventJuggler-0_3-to-4_2.py"
+          },
+          {
+            "title": "Persistency/Compression-ZLIB-1.py"
+          }
+        ],
+        "release": "DaVinci.v42r7p2 AppConfig.v3r353 Det/SQLDDDB.v7r10 TMVAWeights.v1r9",
+        "type": "Stripping29r2"
+      },
+      {
+        "configuration_files": [
+          {
+            "title": "Merging/DV-Stripping-Merging.py"
+          },
+          {
+            "title": "Persistency/Compression-LZMA-4.py"
+          }
+        ],
+        "release": "DaVinci.v42r7p2 AppConfig.v3r353 Det/SQLDDDB.v7r10",
+        "type": "Stripping29r2-Merging"
+      }
+    ]
+  },
+  "publisher": "CERN Open Data Portal",
+  "recid": "24716",
+  "run_period": [
+    "2017"
+  ],
+  "stripping": {
+    "stream": "CHARM",
+    "version": "stripping29r2"
+  },
+  "title": "LHCb 2017 Beam6500GeV MagUp CHARM Stream Stripping29r2",
+  "title_additional": "",
+  "type": {
+    "primary": "Dataset",
+    "secondary": [
+      "Collision"
+    ]
+  },
+  "usage": {
+    "description": "<p> The Run 1 and 2 data collected by the LHCb detector is available using the LHCb Ntupling Service, while the Run 1 data is additionally available in .DST and .mDST formats. The data obtained from the LHCb Ntupling Service are ROOT ntuples and do not require custom software to analyze. <p> Links are provided to the LHCb Ntupling Service for exploration of available data and the LHCb Open Data Guide for usage instructions.",
+    "links": [
+      {
+        "description": "LHCb Ntupling Service",
+        "url": "https://opendata-lhcb-ntupling-service.app.cern.ch/"
+      },
+      {
+        "description": "LHCb Open Data Guide",
+        "url": "https://lhcb-opendata-guide.web.cern.ch/"
+      }
+    ]
+  }
+}]

--- a/data/records/LHCb_2017_Beam6500GeV_VeloClosed_MagUp_RealData_Reco17_Stripping29r2_DIMUON_DST.json
+++ b/data/records/LHCb_2017_Beam6500GeV_VeloClosed_MagUp_RealData_Reco17_Stripping29r2_DIMUON_DST.json
@@ -1,0 +1,168 @@
+[{
+  "abstract": {
+    "description": "Data from proton-proton (pp) collisions collected by the LHCb experiment in the year 2017 of Run2 of the LHC."
+  },
+  "accelerator": "CERN-LHC",
+  "collaboration": {
+    "name": "LHCb collaboration",
+    "recid": "456"
+  },
+  "collections": [
+    "LHCb-Collision-Datasets"
+  ],
+  "collision_information": {
+    "energy": "13TeV",
+    "type": "pp"
+  },
+  "date_created": [
+    "2017"
+  ],
+  "date_published": "2026",
+  "date_reprocessed": "2018",
+  "distribution": {
+    "formats": [
+      "DST"
+    ],
+    "number_events": 397444580,
+    "number_files": 10852,
+    "size": 37827505639048
+  },
+  "experiment": [
+    "LHCb"
+  ],
+  "magnet_polarity": "MagUp",
+  "methodology": {
+    "description": "<p> This dataset was created in several production steps. These steps, software used and the configuration is provided below. </p><p> <strong> Prod ID: &nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;</strong> 71957<p> <strong>Prod type:&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp; </strong> Merge<p> <strong> Parent Prod ID:&nbsp;&nbsp;&nbsp;&nbsp; </strong> 71498<p> <strong> Parent Prod type: </strong> DataStripping<p> <strong> Conditions: </strong><p>dddb-20170721-3<p>cond-20170724</strong><p> <strong> List of Trigger Configuration Keys (TCK): </strong> </p> <p><p><strong>TCK &nbsp;&nbsp;&nbsp;&nbsp;&nbsp; Number of Files </strong><p>0x11501703 &nbsp;&nbsp;&nbsp;&nbsp;&nbsp; 346<p>0x114e1702 &nbsp;&nbsp;&nbsp;&nbsp;&nbsp; 206<p>0x11501704 &nbsp;&nbsp;&nbsp;&nbsp;&nbsp; 350<p>0x114b1702 &nbsp;&nbsp;&nbsp;&nbsp;&nbsp; 12<p>0x11501705 &nbsp;&nbsp;&nbsp;&nbsp;&nbsp; 1575<p>0x114e1703 &nbsp;&nbsp;&nbsp;&nbsp;&nbsp; 44<p>0x11501706 &nbsp;&nbsp;&nbsp;&nbsp;&nbsp; 328<p>0x11611709 &nbsp;&nbsp;&nbsp;&nbsp;&nbsp; 3925<p>0x11561707 &nbsp;&nbsp;&nbsp;&nbsp;&nbsp; 1105<p>0x11601707 &nbsp;&nbsp;&nbsp;&nbsp;&nbsp; 1503<p>0x11601708 &nbsp;&nbsp;&nbsp;&nbsp;&nbsp; 1458",
+    "steps": [
+      {
+        "configuration_files": [
+          {
+            "title": "DaVinci/DV-Stripping29r2-Stripping.py"
+          },
+          {
+            "title": "DaVinci/DataType-2017.py"
+          },
+          {
+            "title": "DaVinci/InputType-RDST.py"
+          },
+          {
+            "title": "DaVinci/DV-RawEventJuggler-0_3-to-4_2.py"
+          },
+          {
+            "title": "Persistency/Compression-ZLIB-1.py"
+          }
+        ],
+        "release": "DaVinci.v42r7p2 AppConfig.v3r353 Det/SQLDDDB.v7r10 TMVAWeights.v1r9",
+        "type": "Stripping29r2"
+      },
+      {
+        "configuration_files": [
+          {
+            "title": "Merging/DV-Stripping-Merging.py"
+          },
+          {
+            "title": "Persistency/Compression-LZMA-4.py"
+          }
+        ],
+        "release": "DaVinci.v42r7p2 AppConfig.v3r353 Det/SQLDDDB.v7r10",
+        "type": "Stripping29r2-Merging"
+      },
+      {
+        "configuration_files": [
+          {
+            "title": "DaVinci/DV-Stripping29r2-Stripping.py"
+          },
+          {
+            "title": "DaVinci/DataType-2017.py"
+          },
+          {
+            "title": "DaVinci/InputType-RDST.py"
+          },
+          {
+            "title": "DaVinci/DV-RawEventJuggler-0_3-to-4_2.py"
+          },
+          {
+            "title": "Persistency/Compression-ZLIB-1.py"
+          }
+        ],
+        "release": "DaVinci.v42r7p2 AppConfig.v3r353 Det/SQLDDDB.v7r10 TMVAWeights.v1r9",
+        "type": "Stripping29r2"
+      },
+      {
+        "configuration_files": [
+          {
+            "title": "Merging/DV-Stripping-Merging.py"
+          },
+          {
+            "title": "Persistency/Compression-LZMA-4.py"
+          }
+        ],
+        "release": "DaVinci.v42r7p2 AppConfig.v3r353 Det/SQLDDDB.v7r10",
+        "type": "Stripping29r2-Merging"
+      },
+      {
+        "configuration_files": [
+          {
+            "title": "DaVinci/DV-Stripping29r2-Stripping.py"
+          },
+          {
+            "title": "DaVinci/DataType-2017.py"
+          },
+          {
+            "title": "DaVinci/InputType-RDST.py"
+          },
+          {
+            "title": "DaVinci/DV-RawEventJuggler-0_3-to-4_2.py"
+          },
+          {
+            "title": "Persistency/Compression-ZLIB-1.py"
+          }
+        ],
+        "release": "DaVinci.v42r7p2 AppConfig.v3r353 Det/SQLDDDB.v7r10 TMVAWeights.v1r9",
+        "type": "Stripping29r2"
+      },
+      {
+        "configuration_files": [
+          {
+            "title": "Merging/DV-Stripping-Merging.py"
+          },
+          {
+            "title": "Persistency/Compression-LZMA-4.py"
+          }
+        ],
+        "release": "DaVinci.v42r7p2 AppConfig.v3r353 Det/SQLDDDB.v7r10",
+        "type": "Stripping29r2-Merging"
+      }
+    ]
+  },
+  "publisher": "CERN Open Data Portal",
+  "recid": "24718",
+  "run_period": [
+    "2017"
+  ],
+  "stripping": {
+    "stream": "DIMUON",
+    "version": "stripping29r2"
+  },
+  "title": "LHCb 2017 Beam6500GeV MagUp DIMUON Stream Stripping29r2",
+  "title_additional": "",
+  "type": {
+    "primary": "Dataset",
+    "secondary": [
+      "Collision"
+    ]
+  },
+  "usage": {
+    "description": "<p> The Run 1 and 2 data collected by the LHCb detector is available using the LHCb Ntupling Service, while the Run 1 data is additionally available in .DST and .mDST formats. The data obtained from the LHCb Ntupling Service are ROOT ntuples and do not require custom software to analyze. <p> Links are provided to the LHCb Ntupling Service for exploration of available data and the LHCb Open Data Guide for usage instructions.",
+    "links": [
+      {
+        "description": "LHCb Ntupling Service",
+        "url": "https://opendata-lhcb-ntupling-service.app.cern.ch/"
+      },
+      {
+        "description": "LHCb Open Data Guide",
+        "url": "https://lhcb-opendata-guide.web.cern.ch/"
+      }
+    ]
+  }
+}]

--- a/data/records/LHCb_2017_Beam6500GeV_VeloClosed_MagUp_RealData_Reco17_Stripping29r2_EW_DST.json
+++ b/data/records/LHCb_2017_Beam6500GeV_VeloClosed_MagUp_RealData_Reco17_Stripping29r2_EW_DST.json
@@ -1,0 +1,168 @@
+[{
+  "abstract": {
+    "description": "Data from proton-proton (pp) collisions collected by the LHCb experiment in the year 2017 of Run2 of the LHC."
+  },
+  "accelerator": "CERN-LHC",
+  "collaboration": {
+    "name": "LHCb collaboration",
+    "recid": "456"
+  },
+  "collections": [
+    "LHCb-Collision-Datasets"
+  ],
+  "collision_information": {
+    "energy": "13TeV",
+    "type": "pp"
+  },
+  "date_created": [
+    "2017"
+  ],
+  "date_published": "2026",
+  "date_reprocessed": "2018",
+  "distribution": {
+    "formats": [
+      "DST"
+    ],
+    "number_events": 290055223,
+    "number_files": 7330,
+    "size": 23704914944969
+  },
+  "experiment": [
+    "LHCb"
+  ],
+  "magnet_polarity": "MagUp",
+  "methodology": {
+    "description": "<p> This dataset was created in several production steps. These steps, software used and the configuration is provided below. </p><p> <strong> Prod ID: &nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;</strong> 71499<p> <strong>Prod type:&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp; </strong> Merge<p> <strong> Parent Prod ID:&nbsp;&nbsp;&nbsp;&nbsp; </strong> 71498<p> <strong> Parent Prod type: </strong> DataStripping<p> <strong> Conditions: </strong><p>dddb-20170721-3<p>cond-20170724</strong><p> <strong> List of Trigger Configuration Keys (TCK): </strong> </p> <p><p><strong>TCK &nbsp;&nbsp;&nbsp;&nbsp;&nbsp; Number of Files </strong><p>0x114e1702 &nbsp;&nbsp;&nbsp;&nbsp;&nbsp; 270<p>0x11501703 &nbsp;&nbsp;&nbsp;&nbsp;&nbsp; 246<p>0x114b1702 &nbsp;&nbsp;&nbsp;&nbsp;&nbsp; 12<p>0x11501704 &nbsp;&nbsp;&nbsp;&nbsp;&nbsp; 239<p>0x114e1703 &nbsp;&nbsp;&nbsp;&nbsp;&nbsp; 35<p>0x11501705 &nbsp;&nbsp;&nbsp;&nbsp;&nbsp; 983<p>0x11501706 &nbsp;&nbsp;&nbsp;&nbsp;&nbsp; 218<p>0x11611709 &nbsp;&nbsp;&nbsp;&nbsp;&nbsp; 2515<p>0x11561707 &nbsp;&nbsp;&nbsp;&nbsp;&nbsp; 785<p>0x11601707 &nbsp;&nbsp;&nbsp;&nbsp;&nbsp; 1069<p>0x11601708 &nbsp;&nbsp;&nbsp;&nbsp;&nbsp; 958",
+    "steps": [
+      {
+        "configuration_files": [
+          {
+            "title": "DaVinci/DV-Stripping29r2-Stripping.py"
+          },
+          {
+            "title": "DaVinci/DataType-2017.py"
+          },
+          {
+            "title": "DaVinci/InputType-RDST.py"
+          },
+          {
+            "title": "DaVinci/DV-RawEventJuggler-0_3-to-4_2.py"
+          },
+          {
+            "title": "Persistency/Compression-ZLIB-1.py"
+          }
+        ],
+        "release": "DaVinci.v42r7p2 AppConfig.v3r353 Det/SQLDDDB.v7r10 TMVAWeights.v1r9",
+        "type": "Stripping29r2"
+      },
+      {
+        "configuration_files": [
+          {
+            "title": "Merging/DV-Stripping-Merging.py"
+          },
+          {
+            "title": "Persistency/Compression-LZMA-4.py"
+          }
+        ],
+        "release": "DaVinci.v42r7p2 AppConfig.v3r353 Det/SQLDDDB.v7r10",
+        "type": "Stripping29r2-Merging"
+      },
+      {
+        "configuration_files": [
+          {
+            "title": "DaVinci/DV-Stripping29r2-Stripping.py"
+          },
+          {
+            "title": "DaVinci/DataType-2017.py"
+          },
+          {
+            "title": "DaVinci/InputType-RDST.py"
+          },
+          {
+            "title": "DaVinci/DV-RawEventJuggler-0_3-to-4_2.py"
+          },
+          {
+            "title": "Persistency/Compression-ZLIB-1.py"
+          }
+        ],
+        "release": "DaVinci.v42r7p2 AppConfig.v3r353 Det/SQLDDDB.v7r10 TMVAWeights.v1r9",
+        "type": "Stripping29r2"
+      },
+      {
+        "configuration_files": [
+          {
+            "title": "Merging/DV-Stripping-Merging.py"
+          },
+          {
+            "title": "Persistency/Compression-LZMA-4.py"
+          }
+        ],
+        "release": "DaVinci.v42r7p2 AppConfig.v3r353 Det/SQLDDDB.v7r10",
+        "type": "Stripping29r2-Merging"
+      },
+      {
+        "configuration_files": [
+          {
+            "title": "DaVinci/DV-Stripping29r2-Stripping.py"
+          },
+          {
+            "title": "DaVinci/DataType-2017.py"
+          },
+          {
+            "title": "DaVinci/InputType-RDST.py"
+          },
+          {
+            "title": "DaVinci/DV-RawEventJuggler-0_3-to-4_2.py"
+          },
+          {
+            "title": "Persistency/Compression-ZLIB-1.py"
+          }
+        ],
+        "release": "DaVinci.v42r7p2 AppConfig.v3r353 Det/SQLDDDB.v7r10 TMVAWeights.v1r9",
+        "type": "Stripping29r2"
+      },
+      {
+        "configuration_files": [
+          {
+            "title": "Merging/DV-Stripping-Merging.py"
+          },
+          {
+            "title": "Persistency/Compression-LZMA-4.py"
+          }
+        ],
+        "release": "DaVinci.v42r7p2 AppConfig.v3r353 Det/SQLDDDB.v7r10",
+        "type": "Stripping29r2-Merging"
+      }
+    ]
+  },
+  "publisher": "CERN Open Data Portal",
+  "recid": "24710",
+  "run_period": [
+    "2017"
+  ],
+  "stripping": {
+    "stream": "EW",
+    "version": "stripping29r2"
+  },
+  "title": "LHCb 2017 Beam6500GeV MagUp EW Stream Stripping29r2",
+  "title_additional": "",
+  "type": {
+    "primary": "Dataset",
+    "secondary": [
+      "Collision"
+    ]
+  },
+  "usage": {
+    "description": "<p> The Run 1 and 2 data collected by the LHCb detector is available using the LHCb Ntupling Service, while the Run 1 data is additionally available in .DST and .mDST formats. The data obtained from the LHCb Ntupling Service are ROOT ntuples and do not require custom software to analyze. <p> Links are provided to the LHCb Ntupling Service for exploration of available data and the LHCb Open Data Guide for usage instructions.",
+    "links": [
+      {
+        "description": "LHCb Ntupling Service",
+        "url": "https://opendata-lhcb-ntupling-service.app.cern.ch/"
+      },
+      {
+        "description": "LHCb Open Data Guide",
+        "url": "https://lhcb-opendata-guide.web.cern.ch/"
+      }
+    ]
+  }
+}]

--- a/data/records/LHCb_2017_Beam6500GeV_VeloClosed_MagUp_RealData_Reco17_Stripping29r2_LEPTONIC_MDST.json
+++ b/data/records/LHCb_2017_Beam6500GeV_VeloClosed_MagUp_RealData_Reco17_Stripping29r2_LEPTONIC_MDST.json
@@ -1,0 +1,168 @@
+[{
+  "abstract": {
+    "description": "Data from proton-proton (pp) collisions collected by the LHCb experiment in the year 2017 of Run2 of the LHC."
+  },
+  "accelerator": "CERN-LHC",
+  "collaboration": {
+    "name": "LHCb collaboration",
+    "recid": "456"
+  },
+  "collections": [
+    "LHCb-Collision-Datasets"
+  ],
+  "collision_information": {
+    "energy": "13TeV",
+    "type": "pp"
+  },
+  "date_created": [
+    "2017"
+  ],
+  "date_published": "2026",
+  "date_reprocessed": "2018",
+  "distribution": {
+    "formats": [
+      "MDST"
+    ],
+    "number_events": 3276003248,
+    "number_files": 10410,
+    "size": 37311019847763
+  },
+  "experiment": [
+    "LHCb"
+  ],
+  "magnet_polarity": "MagUp",
+  "methodology": {
+    "description": "<p> This dataset was created in several production steps. These steps, software used and the configuration is provided below. </p><p> <strong> Prod ID: &nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;</strong> 71499<p> <strong>Prod type:&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp; </strong> Merge<p> <strong> Parent Prod ID:&nbsp;&nbsp;&nbsp;&nbsp; </strong> 71498<p> <strong> Parent Prod type: </strong> DataStripping<p> <strong> Conditions: </strong><p>dddb-20170721-3<p>cond-20170724</strong><p> <strong> List of Trigger Configuration Keys (TCK): </strong> </p> <p><p><strong>TCK &nbsp;&nbsp;&nbsp;&nbsp;&nbsp; Number of Files </strong><p>0x11501703 &nbsp;&nbsp;&nbsp;&nbsp;&nbsp; 351<p>0x114b1702 &nbsp;&nbsp;&nbsp;&nbsp;&nbsp; 12<p>0x114e1703 &nbsp;&nbsp;&nbsp;&nbsp;&nbsp; 44<p>0x11501705 &nbsp;&nbsp;&nbsp;&nbsp;&nbsp; 1477<p>0x11501704 &nbsp;&nbsp;&nbsp;&nbsp;&nbsp; 349<p>0x114e1702 &nbsp;&nbsp;&nbsp;&nbsp;&nbsp; 207<p>0x11501706 &nbsp;&nbsp;&nbsp;&nbsp;&nbsp; 310<p>0x11611709 &nbsp;&nbsp;&nbsp;&nbsp;&nbsp; 3803<p>0x11561707 &nbsp;&nbsp;&nbsp;&nbsp;&nbsp; 1031<p>0x11601707 &nbsp;&nbsp;&nbsp;&nbsp;&nbsp; 1428<p>0x11601708 &nbsp;&nbsp;&nbsp;&nbsp;&nbsp; 1398",
+    "steps": [
+      {
+        "configuration_files": [
+          {
+            "title": "DaVinci/DV-Stripping29r2-Stripping.py"
+          },
+          {
+            "title": "DaVinci/DataType-2017.py"
+          },
+          {
+            "title": "DaVinci/InputType-RDST.py"
+          },
+          {
+            "title": "DaVinci/DV-RawEventJuggler-0_3-to-4_2.py"
+          },
+          {
+            "title": "Persistency/Compression-ZLIB-1.py"
+          }
+        ],
+        "release": "DaVinci.v42r7p2 AppConfig.v3r353 Det/SQLDDDB.v7r10 TMVAWeights.v1r9",
+        "type": "Stripping29r2"
+      },
+      {
+        "configuration_files": [
+          {
+            "title": "Merging/DV-Stripping-Merging.py"
+          },
+          {
+            "title": "Persistency/Compression-LZMA-4.py"
+          }
+        ],
+        "release": "DaVinci.v42r7p2 AppConfig.v3r353 Det/SQLDDDB.v7r10",
+        "type": "Stripping29r2-Merging"
+      },
+      {
+        "configuration_files": [
+          {
+            "title": "DaVinci/DV-Stripping29r2-Stripping.py"
+          },
+          {
+            "title": "DaVinci/DataType-2017.py"
+          },
+          {
+            "title": "DaVinci/InputType-RDST.py"
+          },
+          {
+            "title": "DaVinci/DV-RawEventJuggler-0_3-to-4_2.py"
+          },
+          {
+            "title": "Persistency/Compression-ZLIB-1.py"
+          }
+        ],
+        "release": "DaVinci.v42r7p2 AppConfig.v3r353 Det/SQLDDDB.v7r10 TMVAWeights.v1r9",
+        "type": "Stripping29r2"
+      },
+      {
+        "configuration_files": [
+          {
+            "title": "Merging/DV-Stripping-Merging.py"
+          },
+          {
+            "title": "Persistency/Compression-LZMA-4.py"
+          }
+        ],
+        "release": "DaVinci.v42r7p2 AppConfig.v3r353 Det/SQLDDDB.v7r10",
+        "type": "Stripping29r2-Merging"
+      },
+      {
+        "configuration_files": [
+          {
+            "title": "DaVinci/DV-Stripping29r2-Stripping.py"
+          },
+          {
+            "title": "DaVinci/DataType-2017.py"
+          },
+          {
+            "title": "DaVinci/InputType-RDST.py"
+          },
+          {
+            "title": "DaVinci/DV-RawEventJuggler-0_3-to-4_2.py"
+          },
+          {
+            "title": "Persistency/Compression-ZLIB-1.py"
+          }
+        ],
+        "release": "DaVinci.v42r7p2 AppConfig.v3r353 Det/SQLDDDB.v7r10 TMVAWeights.v1r9",
+        "type": "Stripping29r2"
+      },
+      {
+        "configuration_files": [
+          {
+            "title": "Merging/DV-Stripping-Merging.py"
+          },
+          {
+            "title": "Persistency/Compression-LZMA-4.py"
+          }
+        ],
+        "release": "DaVinci.v42r7p2 AppConfig.v3r353 Det/SQLDDDB.v7r10",
+        "type": "Stripping29r2-Merging"
+      }
+    ]
+  },
+  "publisher": "CERN Open Data Portal",
+  "recid": "24711",
+  "run_period": [
+    "2017"
+  ],
+  "stripping": {
+    "stream": "LEPTONIC",
+    "version": "stripping29r2"
+  },
+  "title": "LHCb 2017 Beam6500GeV MagUp LEPTONIC Stream Stripping29r2",
+  "title_additional": "",
+  "type": {
+    "primary": "Dataset",
+    "secondary": [
+      "Collision"
+    ]
+  },
+  "usage": {
+    "description": "<p> The Run 1 and 2 data collected by the LHCb detector is available using the LHCb Ntupling Service, while the Run 1 data is additionally available in .DST and .mDST formats. The data obtained from the LHCb Ntupling Service are ROOT ntuples and do not require custom software to analyze. <p> Links are provided to the LHCb Ntupling Service for exploration of available data and the LHCb Open Data Guide for usage instructions.",
+    "links": [
+      {
+        "description": "LHCb Ntupling Service",
+        "url": "https://opendata-lhcb-ntupling-service.app.cern.ch/"
+      },
+      {
+        "description": "LHCb Open Data Guide",
+        "url": "https://lhcb-opendata-guide.web.cern.ch/"
+      }
+    ]
+  }
+}]

--- a/data/records/LHCb_2017_Beam6500GeV_VeloClosed_MagUp_RealData_Reco17_Stripping29r2_SEMILEPTONIC_DST.json
+++ b/data/records/LHCb_2017_Beam6500GeV_VeloClosed_MagUp_RealData_Reco17_Stripping29r2_SEMILEPTONIC_DST.json
@@ -1,0 +1,168 @@
+[{
+  "abstract": {
+    "description": "Data from proton-proton (pp) collisions collected by the LHCb experiment in the year 2017 of Run2 of the LHC."
+  },
+  "accelerator": "CERN-LHC",
+  "collaboration": {
+    "name": "LHCb collaboration",
+    "recid": "456"
+  },
+  "collections": [
+    "LHCb-Collision-Datasets"
+  ],
+  "collision_information": {
+    "energy": "13TeV",
+    "type": "pp"
+  },
+  "date_created": [
+    "2017"
+  ],
+  "date_published": "2026",
+  "date_reprocessed": "2018",
+  "distribution": {
+    "formats": [
+      "DST"
+    ],
+    "number_events": 658974662,
+    "number_files": 13802,
+    "size": 47873634473718
+  },
+  "experiment": [
+    "LHCb"
+  ],
+  "magnet_polarity": "MagUp",
+  "methodology": {
+    "description": "<p> This dataset was created in several production steps. These steps, software used and the configuration is provided below. </p><p> <strong> Prod ID: &nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;</strong> 71671<p> <strong>Prod type:&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp; </strong> Merge<p> <strong> Parent Prod ID:&nbsp;&nbsp;&nbsp;&nbsp; </strong> 71498<p> <strong> Parent Prod type: </strong> DataStripping<p> <strong> Conditions: </strong><p>dddb-20170721-3<p>cond-20170724</strong><p> <strong> List of Trigger Configuration Keys (TCK): </strong> </p> <p><p><strong>TCK &nbsp;&nbsp;&nbsp;&nbsp;&nbsp; Number of Files </strong><p>0x11501703 &nbsp;&nbsp;&nbsp;&nbsp;&nbsp; 448<p>0x114e1702 &nbsp;&nbsp;&nbsp;&nbsp;&nbsp; 224<p>0x11501704 &nbsp;&nbsp;&nbsp;&nbsp;&nbsp; 453<p>0x11501705 &nbsp;&nbsp;&nbsp;&nbsp;&nbsp; 1985<p>0x114e1703 &nbsp;&nbsp;&nbsp;&nbsp;&nbsp; 57<p>0x11501706 &nbsp;&nbsp;&nbsp;&nbsp;&nbsp; 399<p>0x11611709 &nbsp;&nbsp;&nbsp;&nbsp;&nbsp; 5108<p>0x11561707 &nbsp;&nbsp;&nbsp;&nbsp;&nbsp; 1357<p>0x11601707 &nbsp;&nbsp;&nbsp;&nbsp;&nbsp; 1878<p>0x11601708 &nbsp;&nbsp;&nbsp;&nbsp;&nbsp; 1881<p>0x114b1702 &nbsp;&nbsp;&nbsp;&nbsp;&nbsp; 12",
+    "steps": [
+      {
+        "configuration_files": [
+          {
+            "title": "DaVinci/DV-Stripping29r2-Stripping.py"
+          },
+          {
+            "title": "DaVinci/DataType-2017.py"
+          },
+          {
+            "title": "DaVinci/InputType-RDST.py"
+          },
+          {
+            "title": "DaVinci/DV-RawEventJuggler-0_3-to-4_2.py"
+          },
+          {
+            "title": "Persistency/Compression-ZLIB-1.py"
+          }
+        ],
+        "release": "DaVinci.v42r7p2 AppConfig.v3r353 Det/SQLDDDB.v7r10 TMVAWeights.v1r9",
+        "type": "Stripping29r2"
+      },
+      {
+        "configuration_files": [
+          {
+            "title": "Merging/DV-Stripping-Merging.py"
+          },
+          {
+            "title": "Persistency/Compression-LZMA-4.py"
+          }
+        ],
+        "release": "DaVinci.v42r7p2 AppConfig.v3r353 Det/SQLDDDB.v7r10",
+        "type": "Stripping29r2-Merging"
+      },
+      {
+        "configuration_files": [
+          {
+            "title": "DaVinci/DV-Stripping29r2-Stripping.py"
+          },
+          {
+            "title": "DaVinci/DataType-2017.py"
+          },
+          {
+            "title": "DaVinci/InputType-RDST.py"
+          },
+          {
+            "title": "DaVinci/DV-RawEventJuggler-0_3-to-4_2.py"
+          },
+          {
+            "title": "Persistency/Compression-ZLIB-1.py"
+          }
+        ],
+        "release": "DaVinci.v42r7p2 AppConfig.v3r353 Det/SQLDDDB.v7r10 TMVAWeights.v1r9",
+        "type": "Stripping29r2"
+      },
+      {
+        "configuration_files": [
+          {
+            "title": "Merging/DV-Stripping-Merging.py"
+          },
+          {
+            "title": "Persistency/Compression-LZMA-4.py"
+          }
+        ],
+        "release": "DaVinci.v42r7p2 AppConfig.v3r353 Det/SQLDDDB.v7r10",
+        "type": "Stripping29r2-Merging"
+      },
+      {
+        "configuration_files": [
+          {
+            "title": "DaVinci/DV-Stripping29r2-Stripping.py"
+          },
+          {
+            "title": "DaVinci/DataType-2017.py"
+          },
+          {
+            "title": "DaVinci/InputType-RDST.py"
+          },
+          {
+            "title": "DaVinci/DV-RawEventJuggler-0_3-to-4_2.py"
+          },
+          {
+            "title": "Persistency/Compression-ZLIB-1.py"
+          }
+        ],
+        "release": "DaVinci.v42r7p2 AppConfig.v3r353 Det/SQLDDDB.v7r10 TMVAWeights.v1r9",
+        "type": "Stripping29r2"
+      },
+      {
+        "configuration_files": [
+          {
+            "title": "Merging/DV-Stripping-Merging.py"
+          },
+          {
+            "title": "Persistency/Compression-LZMA-4.py"
+          }
+        ],
+        "release": "DaVinci.v42r7p2 AppConfig.v3r353 Det/SQLDDDB.v7r10",
+        "type": "Stripping29r2-Merging"
+      }
+    ]
+  },
+  "publisher": "CERN Open Data Portal",
+  "recid": "24719",
+  "run_period": [
+    "2017"
+  ],
+  "stripping": {
+    "stream": "SEMILEPTONIC",
+    "version": "stripping29r2"
+  },
+  "title": "LHCb 2017 Beam6500GeV MagUp SEMILEPTONIC Stream Stripping29r2",
+  "title_additional": "",
+  "type": {
+    "primary": "Dataset",
+    "secondary": [
+      "Collision"
+    ]
+  },
+  "usage": {
+    "description": "<p> The Run 1 and 2 data collected by the LHCb detector is available using the LHCb Ntupling Service, while the Run 1 data is additionally available in .DST and .mDST formats. The data obtained from the LHCb Ntupling Service are ROOT ntuples and do not require custom software to analyze. <p> Links are provided to the LHCb Ntupling Service for exploration of available data and the LHCb Open Data Guide for usage instructions.",
+    "links": [
+      {
+        "description": "LHCb Ntupling Service",
+        "url": "https://opendata-lhcb-ntupling-service.app.cern.ch/"
+      },
+      {
+        "description": "LHCb Open Data Guide",
+        "url": "https://lhcb-opendata-guide.web.cern.ch/"
+      }
+    ]
+  }
+}]

--- a/data/records/LHCb_2017_Beam6500GeV_VeloClosed_MagUp_RealData_Reco17_Stripping29r2p1_BHADRONCOMPLETEEVENT_DST.json
+++ b/data/records/LHCb_2017_Beam6500GeV_VeloClosed_MagUp_RealData_Reco17_Stripping29r2p1_BHADRONCOMPLETEEVENT_DST.json
@@ -1,0 +1,201 @@
+[{
+  "abstract": {
+    "description": "Data from proton-proton (pp) collisions collected by the LHCb experiment in the year 2017 of Run2 of the LHC."
+  },
+  "accelerator": "CERN-LHC",
+  "collaboration": {
+    "name": "LHCb collaboration",
+    "recid": "456"
+  },
+  "collections": [
+    "LHCb-Collision-Datasets"
+  ],
+  "collision_information": {
+    "energy": "13TeV",
+    "type": "pp"
+  },
+  "date_created": [
+    "2017"
+  ],
+  "date_published": "2026",
+  "date_reprocessed": "2020",
+  "distribution": {
+    "formats": [
+      "DST"
+    ],
+    "number_events": 413743957,
+    "number_files": 10143,
+    "size": 36331077377523
+  },
+  "experiment": [
+    "LHCb"
+  ],
+  "magnet_polarity": "MagUp",
+  "methodology": {
+    "description": "<p> This dataset was created in several production steps. These steps, software used and the configuration is provided below. </p><p> <strong> Prod ID: &nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;</strong> 104519<p> <strong>Prod type:&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp; </strong> Merge<p> <strong> Parent Prod ID:&nbsp;&nbsp;&nbsp;&nbsp; </strong> 104243<p> <strong> Parent Prod type: </strong> DataStripping<p> <strong> Conditions: </strong><p>dddb-20190206-3<p>cond-20191004-2 </strong><p> <strong> List of Trigger Configuration Keys (TCK): </strong> </p> <p><p><strong>TCK &nbsp;&nbsp;&nbsp;&nbsp;&nbsp; Number of Files </strong><p>0x11601707 &nbsp;&nbsp;&nbsp;&nbsp;&nbsp; 1397<p>0x11561707 &nbsp;&nbsp;&nbsp;&nbsp;&nbsp; 1000<p>0x11601708 &nbsp;&nbsp;&nbsp;&nbsp;&nbsp; 1391<p>0x114e1702 &nbsp;&nbsp;&nbsp;&nbsp;&nbsp; 50<p>0x114e1703 &nbsp;&nbsp;&nbsp;&nbsp;&nbsp; 28<p>0x11501703 &nbsp;&nbsp;&nbsp;&nbsp;&nbsp; 322<p>0x11501706 &nbsp;&nbsp;&nbsp;&nbsp;&nbsp; 292<p>0x11501705 &nbsp;&nbsp;&nbsp;&nbsp;&nbsp; 1421<p>0x11501704 &nbsp;&nbsp;&nbsp;&nbsp;&nbsp; 329<p>0x11611709 &nbsp;&nbsp;&nbsp;&nbsp;&nbsp; 3913",
+    "steps": [
+      {
+        "configuration_files": [
+          {
+            "title": "DaVinci/DV-Stripping29r2p1-Stripping.py"
+          },
+          {
+            "title": "DaVinci/DataType-2017.py"
+          },
+          {
+            "title": "DaVinci/InputType-RDST.py"
+          },
+          {
+            "title": "DaVinci/DV-RawEventJuggler-0_3-to-4_3.py"
+          },
+          {
+            "title": "Persistency/Compression-ZLIB-1.py"
+          }
+        ],
+        "release": "DaVinci.v42r9p2 AppConfig.v3r394 Det/SQLDDDB.v7r10 TMVAWeights.v1r16",
+        "type": "Stripping29r2p1"
+      },
+      {
+        "configuration_files": [
+          {
+            "title": "Merging/DV-Stripping-Merging.py"
+          },
+          {
+            "title": "Persistency/Compression-LZMA-4.py"
+          }
+        ],
+        "release": "DaVinci.v42r9p2 AppConfig.v3r394 Det/SQLDDDB.v7r10",
+        "type": "Stripping29r2p1-Merging"
+      },
+      {
+        "configuration_files": [
+          {
+            "title": "DaVinci/DV-Stripping29r2p1-Stripping.py"
+          },
+          {
+            "title": "DaVinci/DataType-2017.py"
+          },
+          {
+            "title": "DaVinci/InputType-RDST.py"
+          },
+          {
+            "title": "DaVinci/DV-RawEventJuggler-0_3-to-4_3.py"
+          },
+          {
+            "title": "Persistency/Compression-ZLIB-1.py"
+          }
+        ],
+        "release": "DaVinci.v42r9p2 AppConfig.v3r394 Det/SQLDDDB.v7r10 TMVAWeights.v1r16",
+        "type": "Stripping29r2p1"
+      },
+      {
+        "configuration_files": [
+          {
+            "title": "Merging/DV-Stripping-Merging.py"
+          },
+          {
+            "title": "Persistency/Compression-LZMA-4.py"
+          }
+        ],
+        "release": "DaVinci.v42r9p2 AppConfig.v3r394 Det/SQLDDDB.v7r10",
+        "type": "Stripping29r2p1-Merging"
+      },
+      {
+        "configuration_files": [
+          {
+            "title": "DaVinci/DV-Stripping29r2p1-Stripping.py"
+          },
+          {
+            "title": "DaVinci/DataType-2017.py"
+          },
+          {
+            "title": "DaVinci/InputType-RDST.py"
+          },
+          {
+            "title": "DaVinci/DV-RawEventJuggler-0_3-to-4_3.py"
+          },
+          {
+            "title": "Persistency/Compression-ZLIB-1.py"
+          }
+        ],
+        "release": "DaVinci.v42r9p2 AppConfig.v3r394 Det/SQLDDDB.v7r10 TMVAWeights.v1r16",
+        "type": "Stripping29r2p1"
+      },
+      {
+        "configuration_files": [
+          {
+            "title": "Merging/DV-Stripping-Merging.py"
+          },
+          {
+            "title": "Persistency/Compression-LZMA-4.py"
+          }
+        ],
+        "release": "DaVinci.v42r9p2 AppConfig.v3r394 Det/SQLDDDB.v7r10",
+        "type": "Stripping29r2p1-Merging"
+      },
+      {
+        "configuration_files": [
+          {
+            "title": "DaVinci/DV-Stripping29r2p1-Stripping.py"
+          },
+          {
+            "title": "DaVinci/DataType-2017.py"
+          },
+          {
+            "title": "DaVinci/InputType-RDST.py"
+          },
+          {
+            "title": "DaVinci/DV-RawEventJuggler-0_3-to-4_3.py"
+          },
+          {
+            "title": "Persistency/Compression-ZLIB-1.py"
+          }
+        ],
+        "release": "DaVinci.v42r9p2 AppConfig.v3r394 Det/SQLDDDB.v7r10 TMVAWeights.v1r16",
+        "type": "Stripping29r2p1"
+      },
+      {
+        "configuration_files": [
+          {
+            "title": "Merging/DV-Stripping-Merging.py"
+          },
+          {
+            "title": "Persistency/Compression-LZMA-4.py"
+          }
+        ],
+        "release": "DaVinci.v42r9p2 AppConfig.v3r394 Det/SQLDDDB.v7r10",
+        "type": "Stripping29r2p1-Merging"
+      }
+    ]
+  },
+  "publisher": "CERN Open Data Portal",
+  "recid": "24735",
+  "run_period": [
+    "2017"
+  ],
+  "stripping": {
+    "stream": "BHADRONCOMPLETEEVENT",
+    "version": "stripping29r2p1"
+  },
+  "title": "LHCb 2017 Beam6500GeV MagUp BHADRONCOMPLETEEVENT Stream Stripping29r2p1",
+  "title_additional": "",
+  "type": {
+    "primary": "Dataset",
+    "secondary": [
+      "Collision"
+    ]
+  },
+  "usage": {
+    "description": "<p> The Run 1 and 2 data collected by the LHCb detector is available using the LHCb Ntupling Service, while the Run 1 data is additionally available in .DST and .mDST formats. The data obtained from the LHCb Ntupling Service are ROOT ntuples and do not require custom software to analyze. <p> Links are provided to the LHCb Ntupling Service for exploration of available data and the LHCb Open Data Guide for usage instructions.",
+    "links": [
+      {
+        "description": "LHCb Ntupling Service",
+        "url": "https://opendata-lhcb-ntupling-service.app.cern.ch/"
+      },
+      {
+        "description": "LHCb Open Data Guide",
+        "url": "https://lhcb-opendata-guide.web.cern.ch/"
+      }
+    ]
+  }
+}]

--- a/data/records/LHCb_2017_Beam6500GeV_VeloClosed_MagUp_RealData_Reco17_Stripping29r2p1_BHADRON_MDST.json
+++ b/data/records/LHCb_2017_Beam6500GeV_VeloClosed_MagUp_RealData_Reco17_Stripping29r2p1_BHADRON_MDST.json
@@ -1,0 +1,201 @@
+[{
+  "abstract": {
+    "description": "Data from proton-proton (pp) collisions collected by the LHCb experiment in the year 2017 of Run2 of the LHC."
+  },
+  "accelerator": "CERN-LHC",
+  "collaboration": {
+    "name": "LHCb collaboration",
+    "recid": "456"
+  },
+  "collections": [
+    "LHCb-Collision-Datasets"
+  ],
+  "collision_information": {
+    "energy": "13TeV",
+    "type": "pp"
+  },
+  "date_created": [
+    "2017"
+  ],
+  "date_published": "2026",
+  "date_reprocessed": "2020",
+  "distribution": {
+    "formats": [
+      "MDST"
+    ],
+    "number_events": 1466912462,
+    "number_files": 5948,
+    "size": 20302809125922
+  },
+  "experiment": [
+    "LHCb"
+  ],
+  "magnet_polarity": "MagUp",
+  "methodology": {
+    "description": "<p> This dataset was created in several production steps. These steps, software used and the configuration is provided below. </p><p> <strong> Prod ID: &nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;</strong> 104841<p> <strong>Prod type:&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp; </strong> Merge<p> <strong> Parent Prod ID:&nbsp;&nbsp;&nbsp;&nbsp; </strong> 104243<p> <strong> Parent Prod type: </strong> DataStripping<p> <strong> Conditions: </strong><p>dddb-20190206-3<p>cond-20191004-2 </strong><p> <strong> List of Trigger Configuration Keys (TCK): </strong> </p> <p><p><strong>TCK &nbsp;&nbsp;&nbsp;&nbsp;&nbsp; Number of Files </strong><p>0x11601707 &nbsp;&nbsp;&nbsp;&nbsp;&nbsp; 833<p>0x11561707 &nbsp;&nbsp;&nbsp;&nbsp;&nbsp; 588<p>0x11601708 &nbsp;&nbsp;&nbsp;&nbsp;&nbsp; 814<p>0x114e1702 &nbsp;&nbsp;&nbsp;&nbsp;&nbsp; 32<p>0x114e1703 &nbsp;&nbsp;&nbsp;&nbsp;&nbsp; 18<p>0x11501706 &nbsp;&nbsp;&nbsp;&nbsp;&nbsp; 172<p>0x11501705 &nbsp;&nbsp;&nbsp;&nbsp;&nbsp; 830<p>0x11501703 &nbsp;&nbsp;&nbsp;&nbsp;&nbsp; 197<p>0x11501704 &nbsp;&nbsp;&nbsp;&nbsp;&nbsp; 194<p>0x11611709 &nbsp;&nbsp;&nbsp;&nbsp;&nbsp; 2270",
+    "steps": [
+      {
+        "configuration_files": [
+          {
+            "title": "DaVinci/DV-Stripping29r2p1-Stripping.py"
+          },
+          {
+            "title": "DaVinci/DataType-2017.py"
+          },
+          {
+            "title": "DaVinci/InputType-RDST.py"
+          },
+          {
+            "title": "DaVinci/DV-RawEventJuggler-0_3-to-4_3.py"
+          },
+          {
+            "title": "Persistency/Compression-ZLIB-1.py"
+          }
+        ],
+        "release": "DaVinci.v42r9p2 AppConfig.v3r394 Det/SQLDDDB.v7r10 TMVAWeights.v1r16",
+        "type": "Stripping29r2p1"
+      },
+      {
+        "configuration_files": [
+          {
+            "title": "Merging/DV-Stripping-Merging.py"
+          },
+          {
+            "title": "Persistency/Compression-LZMA-4.py"
+          }
+        ],
+        "release": "DaVinci.v42r9p2 AppConfig.v3r394 Det/SQLDDDB.v7r10",
+        "type": "Stripping29r2p1-Merging"
+      },
+      {
+        "configuration_files": [
+          {
+            "title": "DaVinci/DV-Stripping29r2p1-Stripping.py"
+          },
+          {
+            "title": "DaVinci/DataType-2017.py"
+          },
+          {
+            "title": "DaVinci/InputType-RDST.py"
+          },
+          {
+            "title": "DaVinci/DV-RawEventJuggler-0_3-to-4_3.py"
+          },
+          {
+            "title": "Persistency/Compression-ZLIB-1.py"
+          }
+        ],
+        "release": "DaVinci.v42r9p2 AppConfig.v3r394 Det/SQLDDDB.v7r10 TMVAWeights.v1r16",
+        "type": "Stripping29r2p1"
+      },
+      {
+        "configuration_files": [
+          {
+            "title": "Merging/DV-Stripping-Merging.py"
+          },
+          {
+            "title": "Persistency/Compression-LZMA-4.py"
+          }
+        ],
+        "release": "DaVinci.v42r9p2 AppConfig.v3r394 Det/SQLDDDB.v7r10",
+        "type": "Stripping29r2p1-Merging"
+      },
+      {
+        "configuration_files": [
+          {
+            "title": "DaVinci/DV-Stripping29r2p1-Stripping.py"
+          },
+          {
+            "title": "DaVinci/DataType-2017.py"
+          },
+          {
+            "title": "DaVinci/InputType-RDST.py"
+          },
+          {
+            "title": "DaVinci/DV-RawEventJuggler-0_3-to-4_3.py"
+          },
+          {
+            "title": "Persistency/Compression-ZLIB-1.py"
+          }
+        ],
+        "release": "DaVinci.v42r9p2 AppConfig.v3r394 Det/SQLDDDB.v7r10 TMVAWeights.v1r16",
+        "type": "Stripping29r2p1"
+      },
+      {
+        "configuration_files": [
+          {
+            "title": "Merging/DV-Stripping-Merging.py"
+          },
+          {
+            "title": "Persistency/Compression-LZMA-4.py"
+          }
+        ],
+        "release": "DaVinci.v42r9p2 AppConfig.v3r394 Det/SQLDDDB.v7r10",
+        "type": "Stripping29r2p1-Merging"
+      },
+      {
+        "configuration_files": [
+          {
+            "title": "DaVinci/DV-Stripping29r2p1-Stripping.py"
+          },
+          {
+            "title": "DaVinci/DataType-2017.py"
+          },
+          {
+            "title": "DaVinci/InputType-RDST.py"
+          },
+          {
+            "title": "DaVinci/DV-RawEventJuggler-0_3-to-4_3.py"
+          },
+          {
+            "title": "Persistency/Compression-ZLIB-1.py"
+          }
+        ],
+        "release": "DaVinci.v42r9p2 AppConfig.v3r394 Det/SQLDDDB.v7r10 TMVAWeights.v1r16",
+        "type": "Stripping29r2p1"
+      },
+      {
+        "configuration_files": [
+          {
+            "title": "Merging/DV-Stripping-Merging.py"
+          },
+          {
+            "title": "Persistency/Compression-LZMA-4.py"
+          }
+        ],
+        "release": "DaVinci.v42r9p2 AppConfig.v3r394 Det/SQLDDDB.v7r10",
+        "type": "Stripping29r2p1-Merging"
+      }
+    ]
+  },
+  "publisher": "CERN Open Data Portal",
+  "recid": "24734",
+  "run_period": [
+    "2017"
+  ],
+  "stripping": {
+    "stream": "BHADRON",
+    "version": "stripping29r2p1"
+  },
+  "title": "LHCb 2017 Beam6500GeV MagUp BHADRON Stream Stripping29r2p1",
+  "title_additional": "",
+  "type": {
+    "primary": "Dataset",
+    "secondary": [
+      "Collision"
+    ]
+  },
+  "usage": {
+    "description": "<p> The Run 1 and 2 data collected by the LHCb detector is available using the LHCb Ntupling Service, while the Run 1 data is additionally available in .DST and .mDST formats. The data obtained from the LHCb Ntupling Service are ROOT ntuples and do not require custom software to analyze. <p> Links are provided to the LHCb Ntupling Service for exploration of available data and the LHCb Open Data Guide for usage instructions.",
+    "links": [
+      {
+        "description": "LHCb Ntupling Service",
+        "url": "https://opendata-lhcb-ntupling-service.app.cern.ch/"
+      },
+      {
+        "description": "LHCb Open Data Guide",
+        "url": "https://lhcb-opendata-guide.web.cern.ch/"
+      }
+    ]
+  }
+}]

--- a/data/records/LHCb_2017_Beam6500GeV_VeloClosed_MagUp_RealData_Reco17_Stripping29r2p1_CHARMCOMPLETEEVENT_DST.json
+++ b/data/records/LHCb_2017_Beam6500GeV_VeloClosed_MagUp_RealData_Reco17_Stripping29r2p1_CHARMCOMPLETEEVENT_DST.json
@@ -1,0 +1,201 @@
+[{
+  "abstract": {
+    "description": "Data from proton-proton (pp) collisions collected by the LHCb experiment in the year 2017 of Run2 of the LHC."
+  },
+  "accelerator": "CERN-LHC",
+  "collaboration": {
+    "name": "LHCb collaboration",
+    "recid": "456"
+  },
+  "collections": [
+    "LHCb-Collision-Datasets"
+  ],
+  "collision_information": {
+    "energy": "13TeV",
+    "type": "pp"
+  },
+  "date_created": [
+    "2017"
+  ],
+  "date_published": "2026",
+  "date_reprocessed": "2020",
+  "distribution": {
+    "formats": [
+      "DST"
+    ],
+    "number_events": 94975378,
+    "number_files": 3106,
+    "size": 6790044449884
+  },
+  "experiment": [
+    "LHCb"
+  ],
+  "magnet_polarity": "MagUp",
+  "methodology": {
+    "description": "<p> This dataset was created in several production steps. These steps, software used and the configuration is provided below. </p><p> <strong> Prod ID: &nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;</strong> 104244<p> <strong>Prod type:&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp; </strong> Merge<p> <strong> Parent Prod ID:&nbsp;&nbsp;&nbsp;&nbsp; </strong> 104243<p> <strong> Parent Prod type: </strong> DataStripping<p> <strong> Conditions: </strong><p>dddb-20190206-3<p>cond-20191004-2 </strong><p> <strong> List of Trigger Configuration Keys (TCK): </strong> </p> <p><p><strong>TCK &nbsp;&nbsp;&nbsp;&nbsp;&nbsp; Number of Files </strong><p>0x11561707 &nbsp;&nbsp;&nbsp;&nbsp;&nbsp; 320<p>0x11601708 &nbsp;&nbsp;&nbsp;&nbsp;&nbsp; 401<p>0x11601707 &nbsp;&nbsp;&nbsp;&nbsp;&nbsp; 459<p>0x114e1702 &nbsp;&nbsp;&nbsp;&nbsp;&nbsp; 23<p>0x114e1703 &nbsp;&nbsp;&nbsp;&nbsp;&nbsp; 14<p>0x11501704 &nbsp;&nbsp;&nbsp;&nbsp;&nbsp; 97<p>0x11501705 &nbsp;&nbsp;&nbsp;&nbsp;&nbsp; 405<p>0x11501706 &nbsp;&nbsp;&nbsp;&nbsp;&nbsp; 93<p>0x11501703 &nbsp;&nbsp;&nbsp;&nbsp;&nbsp; 114<p>0x11611709 &nbsp;&nbsp;&nbsp;&nbsp;&nbsp; 1180",
+    "steps": [
+      {
+        "configuration_files": [
+          {
+            "title": "DaVinci/DV-Stripping29r2p1-Stripping.py"
+          },
+          {
+            "title": "DaVinci/DataType-2017.py"
+          },
+          {
+            "title": "DaVinci/InputType-RDST.py"
+          },
+          {
+            "title": "DaVinci/DV-RawEventJuggler-0_3-to-4_3.py"
+          },
+          {
+            "title": "Persistency/Compression-ZLIB-1.py"
+          }
+        ],
+        "release": "DaVinci.v42r9p2 AppConfig.v3r394 Det/SQLDDDB.v7r10 TMVAWeights.v1r16",
+        "type": "Stripping29r2p1"
+      },
+      {
+        "configuration_files": [
+          {
+            "title": "Merging/DV-Stripping-Merging.py"
+          },
+          {
+            "title": "Persistency/Compression-LZMA-4.py"
+          }
+        ],
+        "release": "DaVinci.v42r9p2 AppConfig.v3r394 Det/SQLDDDB.v7r10",
+        "type": "Stripping29r2p1-Merging"
+      },
+      {
+        "configuration_files": [
+          {
+            "title": "DaVinci/DV-Stripping29r2p1-Stripping.py"
+          },
+          {
+            "title": "DaVinci/DataType-2017.py"
+          },
+          {
+            "title": "DaVinci/InputType-RDST.py"
+          },
+          {
+            "title": "DaVinci/DV-RawEventJuggler-0_3-to-4_3.py"
+          },
+          {
+            "title": "Persistency/Compression-ZLIB-1.py"
+          }
+        ],
+        "release": "DaVinci.v42r9p2 AppConfig.v3r394 Det/SQLDDDB.v7r10 TMVAWeights.v1r16",
+        "type": "Stripping29r2p1"
+      },
+      {
+        "configuration_files": [
+          {
+            "title": "Merging/DV-Stripping-Merging.py"
+          },
+          {
+            "title": "Persistency/Compression-LZMA-4.py"
+          }
+        ],
+        "release": "DaVinci.v42r9p2 AppConfig.v3r394 Det/SQLDDDB.v7r10",
+        "type": "Stripping29r2p1-Merging"
+      },
+      {
+        "configuration_files": [
+          {
+            "title": "DaVinci/DV-Stripping29r2p1-Stripping.py"
+          },
+          {
+            "title": "DaVinci/DataType-2017.py"
+          },
+          {
+            "title": "DaVinci/InputType-RDST.py"
+          },
+          {
+            "title": "DaVinci/DV-RawEventJuggler-0_3-to-4_3.py"
+          },
+          {
+            "title": "Persistency/Compression-ZLIB-1.py"
+          }
+        ],
+        "release": "DaVinci.v42r9p2 AppConfig.v3r394 Det/SQLDDDB.v7r10 TMVAWeights.v1r16",
+        "type": "Stripping29r2p1"
+      },
+      {
+        "configuration_files": [
+          {
+            "title": "Merging/DV-Stripping-Merging.py"
+          },
+          {
+            "title": "Persistency/Compression-LZMA-4.py"
+          }
+        ],
+        "release": "DaVinci.v42r9p2 AppConfig.v3r394 Det/SQLDDDB.v7r10",
+        "type": "Stripping29r2p1-Merging"
+      },
+      {
+        "configuration_files": [
+          {
+            "title": "DaVinci/DV-Stripping29r2p1-Stripping.py"
+          },
+          {
+            "title": "DaVinci/DataType-2017.py"
+          },
+          {
+            "title": "DaVinci/InputType-RDST.py"
+          },
+          {
+            "title": "DaVinci/DV-RawEventJuggler-0_3-to-4_3.py"
+          },
+          {
+            "title": "Persistency/Compression-ZLIB-1.py"
+          }
+        ],
+        "release": "DaVinci.v42r9p2 AppConfig.v3r394 Det/SQLDDDB.v7r10 TMVAWeights.v1r16",
+        "type": "Stripping29r2p1"
+      },
+      {
+        "configuration_files": [
+          {
+            "title": "Merging/DV-Stripping-Merging.py"
+          },
+          {
+            "title": "Persistency/Compression-LZMA-4.py"
+          }
+        ],
+        "release": "DaVinci.v42r9p2 AppConfig.v3r394 Det/SQLDDDB.v7r10",
+        "type": "Stripping29r2p1-Merging"
+      }
+    ]
+  },
+  "publisher": "CERN Open Data Portal",
+  "recid": "24737",
+  "run_period": [
+    "2017"
+  ],
+  "stripping": {
+    "stream": "CHARMCOMPLETEEVENT",
+    "version": "stripping29r2p1"
+  },
+  "title": "LHCb 2017 Beam6500GeV MagUp CHARMCOMPLETEEVENT Stream Stripping29r2p1",
+  "title_additional": "",
+  "type": {
+    "primary": "Dataset",
+    "secondary": [
+      "Collision"
+    ]
+  },
+  "usage": {
+    "description": "<p> The Run 1 and 2 data collected by the LHCb detector is available using the LHCb Ntupling Service, while the Run 1 data is additionally available in .DST and .mDST formats. The data obtained from the LHCb Ntupling Service are ROOT ntuples and do not require custom software to analyze. <p> Links are provided to the LHCb Ntupling Service for exploration of available data and the LHCb Open Data Guide for usage instructions.",
+    "links": [
+      {
+        "description": "LHCb Ntupling Service",
+        "url": "https://opendata-lhcb-ntupling-service.app.cern.ch/"
+      },
+      {
+        "description": "LHCb Open Data Guide",
+        "url": "https://lhcb-opendata-guide.web.cern.ch/"
+      }
+    ]
+  }
+}]

--- a/data/records/LHCb_2017_Beam6500GeV_VeloClosed_MagUp_RealData_Reco17_Stripping29r2p1_CHARM_MDST.json
+++ b/data/records/LHCb_2017_Beam6500GeV_VeloClosed_MagUp_RealData_Reco17_Stripping29r2p1_CHARM_MDST.json
@@ -1,0 +1,201 @@
+[{
+  "abstract": {
+    "description": "Data from proton-proton (pp) collisions collected by the LHCb experiment in the year 2017 of Run2 of the LHC."
+  },
+  "accelerator": "CERN-LHC",
+  "collaboration": {
+    "name": "LHCb collaboration",
+    "recid": "456"
+  },
+  "collections": [
+    "LHCb-Collision-Datasets"
+  ],
+  "collision_information": {
+    "energy": "13TeV",
+    "type": "pp"
+  },
+  "date_created": [
+    "2017"
+  ],
+  "date_published": "2026",
+  "date_reprocessed": "2020",
+  "distribution": {
+    "formats": [
+      "MDST"
+    ],
+    "number_events": 1749581883,
+    "number_files": 5749,
+    "size": 19351517740363
+  },
+  "experiment": [
+    "LHCb"
+  ],
+  "magnet_polarity": "MagUp",
+  "methodology": {
+    "description": "<p> This dataset was created in several production steps. These steps, software used and the configuration is provided below. </p><p> <strong> Prod ID: &nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;</strong> 104841<p> <strong>Prod type:&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp; </strong> Merge<p> <strong> Parent Prod ID:&nbsp;&nbsp;&nbsp;&nbsp; </strong> 104243<p> <strong> Parent Prod type: </strong> DataStripping<p> <strong> Conditions: </strong><p>dddb-20190206-3<p>cond-20191004-2 </strong><p> <strong> List of Trigger Configuration Keys (TCK): </strong> </p> <p><p><strong>TCK &nbsp;&nbsp;&nbsp;&nbsp;&nbsp; Number of Files </strong><p>0x11601708 &nbsp;&nbsp;&nbsp;&nbsp;&nbsp; 784<p>0x11561707 &nbsp;&nbsp;&nbsp;&nbsp;&nbsp; 554<p>0x11601707 &nbsp;&nbsp;&nbsp;&nbsp;&nbsp; 775<p>0x114e1702 &nbsp;&nbsp;&nbsp;&nbsp;&nbsp; 32<p>0x114e1703 &nbsp;&nbsp;&nbsp;&nbsp;&nbsp; 18<p>0x11501705 &nbsp;&nbsp;&nbsp;&nbsp;&nbsp; 793<p>0x11501704 &nbsp;&nbsp;&nbsp;&nbsp;&nbsp; 190<p>0x11501703 &nbsp;&nbsp;&nbsp;&nbsp;&nbsp; 190<p>0x11501706 &nbsp;&nbsp;&nbsp;&nbsp;&nbsp; 169<p>0x11611709 &nbsp;&nbsp;&nbsp;&nbsp;&nbsp; 2244",
+    "steps": [
+      {
+        "configuration_files": [
+          {
+            "title": "DaVinci/DV-Stripping29r2p1-Stripping.py"
+          },
+          {
+            "title": "DaVinci/DataType-2017.py"
+          },
+          {
+            "title": "DaVinci/InputType-RDST.py"
+          },
+          {
+            "title": "DaVinci/DV-RawEventJuggler-0_3-to-4_3.py"
+          },
+          {
+            "title": "Persistency/Compression-ZLIB-1.py"
+          }
+        ],
+        "release": "DaVinci.v42r9p2 AppConfig.v3r394 Det/SQLDDDB.v7r10 TMVAWeights.v1r16",
+        "type": "Stripping29r2p1"
+      },
+      {
+        "configuration_files": [
+          {
+            "title": "Merging/DV-Stripping-Merging.py"
+          },
+          {
+            "title": "Persistency/Compression-LZMA-4.py"
+          }
+        ],
+        "release": "DaVinci.v42r9p2 AppConfig.v3r394 Det/SQLDDDB.v7r10",
+        "type": "Stripping29r2p1-Merging"
+      },
+      {
+        "configuration_files": [
+          {
+            "title": "DaVinci/DV-Stripping29r2p1-Stripping.py"
+          },
+          {
+            "title": "DaVinci/DataType-2017.py"
+          },
+          {
+            "title": "DaVinci/InputType-RDST.py"
+          },
+          {
+            "title": "DaVinci/DV-RawEventJuggler-0_3-to-4_3.py"
+          },
+          {
+            "title": "Persistency/Compression-ZLIB-1.py"
+          }
+        ],
+        "release": "DaVinci.v42r9p2 AppConfig.v3r394 Det/SQLDDDB.v7r10 TMVAWeights.v1r16",
+        "type": "Stripping29r2p1"
+      },
+      {
+        "configuration_files": [
+          {
+            "title": "Merging/DV-Stripping-Merging.py"
+          },
+          {
+            "title": "Persistency/Compression-LZMA-4.py"
+          }
+        ],
+        "release": "DaVinci.v42r9p2 AppConfig.v3r394 Det/SQLDDDB.v7r10",
+        "type": "Stripping29r2p1-Merging"
+      },
+      {
+        "configuration_files": [
+          {
+            "title": "DaVinci/DV-Stripping29r2p1-Stripping.py"
+          },
+          {
+            "title": "DaVinci/DataType-2017.py"
+          },
+          {
+            "title": "DaVinci/InputType-RDST.py"
+          },
+          {
+            "title": "DaVinci/DV-RawEventJuggler-0_3-to-4_3.py"
+          },
+          {
+            "title": "Persistency/Compression-ZLIB-1.py"
+          }
+        ],
+        "release": "DaVinci.v42r9p2 AppConfig.v3r394 Det/SQLDDDB.v7r10 TMVAWeights.v1r16",
+        "type": "Stripping29r2p1"
+      },
+      {
+        "configuration_files": [
+          {
+            "title": "Merging/DV-Stripping-Merging.py"
+          },
+          {
+            "title": "Persistency/Compression-LZMA-4.py"
+          }
+        ],
+        "release": "DaVinci.v42r9p2 AppConfig.v3r394 Det/SQLDDDB.v7r10",
+        "type": "Stripping29r2p1-Merging"
+      },
+      {
+        "configuration_files": [
+          {
+            "title": "DaVinci/DV-Stripping29r2p1-Stripping.py"
+          },
+          {
+            "title": "DaVinci/DataType-2017.py"
+          },
+          {
+            "title": "DaVinci/InputType-RDST.py"
+          },
+          {
+            "title": "DaVinci/DV-RawEventJuggler-0_3-to-4_3.py"
+          },
+          {
+            "title": "Persistency/Compression-ZLIB-1.py"
+          }
+        ],
+        "release": "DaVinci.v42r9p2 AppConfig.v3r394 Det/SQLDDDB.v7r10 TMVAWeights.v1r16",
+        "type": "Stripping29r2p1"
+      },
+      {
+        "configuration_files": [
+          {
+            "title": "Merging/DV-Stripping-Merging.py"
+          },
+          {
+            "title": "Persistency/Compression-LZMA-4.py"
+          }
+        ],
+        "release": "DaVinci.v42r9p2 AppConfig.v3r394 Det/SQLDDDB.v7r10",
+        "type": "Stripping29r2p1-Merging"
+      }
+    ]
+  },
+  "publisher": "CERN Open Data Portal",
+  "recid": "24736",
+  "run_period": [
+    "2017"
+  ],
+  "stripping": {
+    "stream": "CHARM",
+    "version": "stripping29r2p1"
+  },
+  "title": "LHCb 2017 Beam6500GeV MagUp CHARM Stream Stripping29r2p1",
+  "title_additional": "",
+  "type": {
+    "primary": "Dataset",
+    "secondary": [
+      "Collision"
+    ]
+  },
+  "usage": {
+    "description": "<p> The Run 1 and 2 data collected by the LHCb detector is available using the LHCb Ntupling Service, while the Run 1 data is additionally available in .DST and .mDST formats. The data obtained from the LHCb Ntupling Service are ROOT ntuples and do not require custom software to analyze. <p> Links are provided to the LHCb Ntupling Service for exploration of available data and the LHCb Open Data Guide for usage instructions.",
+    "links": [
+      {
+        "description": "LHCb Ntupling Service",
+        "url": "https://opendata-lhcb-ntupling-service.app.cern.ch/"
+      },
+      {
+        "description": "LHCb Open Data Guide",
+        "url": "https://lhcb-opendata-guide.web.cern.ch/"
+      }
+    ]
+  }
+}]

--- a/data/records/LHCb_2017_Beam6500GeV_VeloClosed_MagUp_RealData_Reco17_Stripping29r2p1_DIMUON_DST.json
+++ b/data/records/LHCb_2017_Beam6500GeV_VeloClosed_MagUp_RealData_Reco17_Stripping29r2p1_DIMUON_DST.json
@@ -1,0 +1,201 @@
+[{
+  "abstract": {
+    "description": "Data from proton-proton (pp) collisions collected by the LHCb experiment in the year 2017 of Run2 of the LHC."
+  },
+  "accelerator": "CERN-LHC",
+  "collaboration": {
+    "name": "LHCb collaboration",
+    "recid": "456"
+  },
+  "collections": [
+    "LHCb-Collision-Datasets"
+  ],
+  "collision_information": {
+    "energy": "13TeV",
+    "type": "pp"
+  },
+  "date_created": [
+    "2017"
+  ],
+  "date_published": "2026",
+  "date_reprocessed": "2020",
+  "distribution": {
+    "formats": [
+      "DST"
+    ],
+    "number_events": 86295905,
+    "number_files": 3120,
+    "size": 7362500849507
+  },
+  "experiment": [
+    "LHCb"
+  ],
+  "magnet_polarity": "MagUp",
+  "methodology": {
+    "description": "<p> This dataset was created in several production steps. These steps, software used and the configuration is provided below. </p><p> <strong> Prod ID: &nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;</strong> 104519<p> <strong>Prod type:&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp; </strong> Merge<p> <strong> Parent Prod ID:&nbsp;&nbsp;&nbsp;&nbsp; </strong> 104243<p> <strong> Parent Prod type: </strong> DataStripping<p> <strong> Conditions: </strong><p>dddb-20190206-3<p>cond-20191004-2 </strong><p> <strong> List of Trigger Configuration Keys (TCK): </strong> </p> <p><p><strong>TCK &nbsp;&nbsp;&nbsp;&nbsp;&nbsp; Number of Files </strong><p>0x11601708 &nbsp;&nbsp;&nbsp;&nbsp;&nbsp; 401<p>0x11561707 &nbsp;&nbsp;&nbsp;&nbsp;&nbsp; 320<p>0x11601707 &nbsp;&nbsp;&nbsp;&nbsp;&nbsp; 459<p>0x114e1702 &nbsp;&nbsp;&nbsp;&nbsp;&nbsp; 23<p>0x11501705 &nbsp;&nbsp;&nbsp;&nbsp;&nbsp; 417<p>0x11501704 &nbsp;&nbsp;&nbsp;&nbsp;&nbsp; 97<p>0x11501706 &nbsp;&nbsp;&nbsp;&nbsp;&nbsp; 93<p>0x11501703 &nbsp;&nbsp;&nbsp;&nbsp;&nbsp; 114<p>0x11611709 &nbsp;&nbsp;&nbsp;&nbsp;&nbsp; 1182<p>0x114e1703 &nbsp;&nbsp;&nbsp;&nbsp;&nbsp; 14",
+    "steps": [
+      {
+        "configuration_files": [
+          {
+            "title": "DaVinci/DV-Stripping29r2p1-Stripping.py"
+          },
+          {
+            "title": "DaVinci/DataType-2017.py"
+          },
+          {
+            "title": "DaVinci/InputType-RDST.py"
+          },
+          {
+            "title": "DaVinci/DV-RawEventJuggler-0_3-to-4_3.py"
+          },
+          {
+            "title": "Persistency/Compression-ZLIB-1.py"
+          }
+        ],
+        "release": "DaVinci.v42r9p2 AppConfig.v3r394 Det/SQLDDDB.v7r10 TMVAWeights.v1r16",
+        "type": "Stripping29r2p1"
+      },
+      {
+        "configuration_files": [
+          {
+            "title": "Merging/DV-Stripping-Merging.py"
+          },
+          {
+            "title": "Persistency/Compression-LZMA-4.py"
+          }
+        ],
+        "release": "DaVinci.v42r9p2 AppConfig.v3r394 Det/SQLDDDB.v7r10",
+        "type": "Stripping29r2p1-Merging"
+      },
+      {
+        "configuration_files": [
+          {
+            "title": "DaVinci/DV-Stripping29r2p1-Stripping.py"
+          },
+          {
+            "title": "DaVinci/DataType-2017.py"
+          },
+          {
+            "title": "DaVinci/InputType-RDST.py"
+          },
+          {
+            "title": "DaVinci/DV-RawEventJuggler-0_3-to-4_3.py"
+          },
+          {
+            "title": "Persistency/Compression-ZLIB-1.py"
+          }
+        ],
+        "release": "DaVinci.v42r9p2 AppConfig.v3r394 Det/SQLDDDB.v7r10 TMVAWeights.v1r16",
+        "type": "Stripping29r2p1"
+      },
+      {
+        "configuration_files": [
+          {
+            "title": "Merging/DV-Stripping-Merging.py"
+          },
+          {
+            "title": "Persistency/Compression-LZMA-4.py"
+          }
+        ],
+        "release": "DaVinci.v42r9p2 AppConfig.v3r394 Det/SQLDDDB.v7r10",
+        "type": "Stripping29r2p1-Merging"
+      },
+      {
+        "configuration_files": [
+          {
+            "title": "DaVinci/DV-Stripping29r2p1-Stripping.py"
+          },
+          {
+            "title": "DaVinci/DataType-2017.py"
+          },
+          {
+            "title": "DaVinci/InputType-RDST.py"
+          },
+          {
+            "title": "DaVinci/DV-RawEventJuggler-0_3-to-4_3.py"
+          },
+          {
+            "title": "Persistency/Compression-ZLIB-1.py"
+          }
+        ],
+        "release": "DaVinci.v42r9p2 AppConfig.v3r394 Det/SQLDDDB.v7r10 TMVAWeights.v1r16",
+        "type": "Stripping29r2p1"
+      },
+      {
+        "configuration_files": [
+          {
+            "title": "Merging/DV-Stripping-Merging.py"
+          },
+          {
+            "title": "Persistency/Compression-LZMA-4.py"
+          }
+        ],
+        "release": "DaVinci.v42r9p2 AppConfig.v3r394 Det/SQLDDDB.v7r10",
+        "type": "Stripping29r2p1-Merging"
+      },
+      {
+        "configuration_files": [
+          {
+            "title": "DaVinci/DV-Stripping29r2p1-Stripping.py"
+          },
+          {
+            "title": "DaVinci/DataType-2017.py"
+          },
+          {
+            "title": "DaVinci/InputType-RDST.py"
+          },
+          {
+            "title": "DaVinci/DV-RawEventJuggler-0_3-to-4_3.py"
+          },
+          {
+            "title": "Persistency/Compression-ZLIB-1.py"
+          }
+        ],
+        "release": "DaVinci.v42r9p2 AppConfig.v3r394 Det/SQLDDDB.v7r10 TMVAWeights.v1r16",
+        "type": "Stripping29r2p1"
+      },
+      {
+        "configuration_files": [
+          {
+            "title": "Merging/DV-Stripping-Merging.py"
+          },
+          {
+            "title": "Persistency/Compression-LZMA-4.py"
+          }
+        ],
+        "release": "DaVinci.v42r9p2 AppConfig.v3r394 Det/SQLDDDB.v7r10",
+        "type": "Stripping29r2p1-Merging"
+      }
+    ]
+  },
+  "publisher": "CERN Open Data Portal",
+  "recid": "24738",
+  "run_period": [
+    "2017"
+  ],
+  "stripping": {
+    "stream": "DIMUON",
+    "version": "stripping29r2p1"
+  },
+  "title": "LHCb 2017 Beam6500GeV MagUp DIMUON Stream Stripping29r2p1",
+  "title_additional": "",
+  "type": {
+    "primary": "Dataset",
+    "secondary": [
+      "Collision"
+    ]
+  },
+  "usage": {
+    "description": "<p> The Run 1 and 2 data collected by the LHCb detector is available using the LHCb Ntupling Service, while the Run 1 data is additionally available in .DST and .mDST formats. The data obtained from the LHCb Ntupling Service are ROOT ntuples and do not require custom software to analyze. <p> Links are provided to the LHCb Ntupling Service for exploration of available data and the LHCb Open Data Guide for usage instructions.",
+    "links": [
+      {
+        "description": "LHCb Ntupling Service",
+        "url": "https://opendata-lhcb-ntupling-service.app.cern.ch/"
+      },
+      {
+        "description": "LHCb Open Data Guide",
+        "url": "https://lhcb-opendata-guide.web.cern.ch/"
+      }
+    ]
+  }
+}]

--- a/data/records/LHCb_2017_Beam6500GeV_VeloClosed_MagUp_RealData_Reco17_Stripping29r2p1_EW_DST.json
+++ b/data/records/LHCb_2017_Beam6500GeV_VeloClosed_MagUp_RealData_Reco17_Stripping29r2p1_EW_DST.json
@@ -1,0 +1,201 @@
+[{
+  "abstract": {
+    "description": "Data from proton-proton (pp) collisions collected by the LHCb experiment in the year 2017 of Run2 of the LHC."
+  },
+  "accelerator": "CERN-LHC",
+  "collaboration": {
+    "name": "LHCb collaboration",
+    "recid": "456"
+  },
+  "collections": [
+    "LHCb-Collision-Datasets"
+  ],
+  "collision_information": {
+    "energy": "13TeV",
+    "type": "pp"
+  },
+  "date_created": [
+    "2017"
+  ],
+  "date_published": "2026",
+  "date_reprocessed": "2020",
+  "distribution": {
+    "formats": [
+      "DST"
+    ],
+    "number_events": 28635665,
+    "number_files": 3108,
+    "size": 2401925172127
+  },
+  "experiment": [
+    "LHCb"
+  ],
+  "magnet_polarity": "MagUp",
+  "methodology": {
+    "description": "<p> This dataset was created in several production steps. These steps, software used and the configuration is provided below. </p><p> <strong> Prod ID: &nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;</strong> 104244<p> <strong>Prod type:&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp; </strong> Merge<p> <strong> Parent Prod ID:&nbsp;&nbsp;&nbsp;&nbsp; </strong> 104243<p> <strong> Parent Prod type: </strong> DataStripping<p> <strong> Conditions: </strong><p>dddb-20190206-3<p>cond-20191004-2 </strong><p> <strong> List of Trigger Configuration Keys (TCK): </strong> </p> <p><p><strong>TCK &nbsp;&nbsp;&nbsp;&nbsp;&nbsp; Number of Files </strong><p>0x11601708 &nbsp;&nbsp;&nbsp;&nbsp;&nbsp; 402<p>0x11561707 &nbsp;&nbsp;&nbsp;&nbsp;&nbsp; 320<p>0x11601707 &nbsp;&nbsp;&nbsp;&nbsp;&nbsp; 458<p>0x114e1702 &nbsp;&nbsp;&nbsp;&nbsp;&nbsp; 23<p>0x11501705 &nbsp;&nbsp;&nbsp;&nbsp;&nbsp; 405<p>0x11501703 &nbsp;&nbsp;&nbsp;&nbsp;&nbsp; 114<p>0x11501704 &nbsp;&nbsp;&nbsp;&nbsp;&nbsp; 97<p>0x11501706 &nbsp;&nbsp;&nbsp;&nbsp;&nbsp; 93<p>0x114e1703 &nbsp;&nbsp;&nbsp;&nbsp;&nbsp; 14<p>0x11611709 &nbsp;&nbsp;&nbsp;&nbsp;&nbsp; 1182",
+    "steps": [
+      {
+        "configuration_files": [
+          {
+            "title": "DaVinci/DV-Stripping29r2p1-Stripping.py"
+          },
+          {
+            "title": "DaVinci/DataType-2017.py"
+          },
+          {
+            "title": "DaVinci/InputType-RDST.py"
+          },
+          {
+            "title": "DaVinci/DV-RawEventJuggler-0_3-to-4_3.py"
+          },
+          {
+            "title": "Persistency/Compression-ZLIB-1.py"
+          }
+        ],
+        "release": "DaVinci.v42r9p2 AppConfig.v3r394 Det/SQLDDDB.v7r10 TMVAWeights.v1r16",
+        "type": "Stripping29r2p1"
+      },
+      {
+        "configuration_files": [
+          {
+            "title": "Merging/DV-Stripping-Merging.py"
+          },
+          {
+            "title": "Persistency/Compression-LZMA-4.py"
+          }
+        ],
+        "release": "DaVinci.v42r9p2 AppConfig.v3r394 Det/SQLDDDB.v7r10",
+        "type": "Stripping29r2p1-Merging"
+      },
+      {
+        "configuration_files": [
+          {
+            "title": "DaVinci/DV-Stripping29r2p1-Stripping.py"
+          },
+          {
+            "title": "DaVinci/DataType-2017.py"
+          },
+          {
+            "title": "DaVinci/InputType-RDST.py"
+          },
+          {
+            "title": "DaVinci/DV-RawEventJuggler-0_3-to-4_3.py"
+          },
+          {
+            "title": "Persistency/Compression-ZLIB-1.py"
+          }
+        ],
+        "release": "DaVinci.v42r9p2 AppConfig.v3r394 Det/SQLDDDB.v7r10 TMVAWeights.v1r16",
+        "type": "Stripping29r2p1"
+      },
+      {
+        "configuration_files": [
+          {
+            "title": "Merging/DV-Stripping-Merging.py"
+          },
+          {
+            "title": "Persistency/Compression-LZMA-4.py"
+          }
+        ],
+        "release": "DaVinci.v42r9p2 AppConfig.v3r394 Det/SQLDDDB.v7r10",
+        "type": "Stripping29r2p1-Merging"
+      },
+      {
+        "configuration_files": [
+          {
+            "title": "DaVinci/DV-Stripping29r2p1-Stripping.py"
+          },
+          {
+            "title": "DaVinci/DataType-2017.py"
+          },
+          {
+            "title": "DaVinci/InputType-RDST.py"
+          },
+          {
+            "title": "DaVinci/DV-RawEventJuggler-0_3-to-4_3.py"
+          },
+          {
+            "title": "Persistency/Compression-ZLIB-1.py"
+          }
+        ],
+        "release": "DaVinci.v42r9p2 AppConfig.v3r394 Det/SQLDDDB.v7r10 TMVAWeights.v1r16",
+        "type": "Stripping29r2p1"
+      },
+      {
+        "configuration_files": [
+          {
+            "title": "Merging/DV-Stripping-Merging.py"
+          },
+          {
+            "title": "Persistency/Compression-LZMA-4.py"
+          }
+        ],
+        "release": "DaVinci.v42r9p2 AppConfig.v3r394 Det/SQLDDDB.v7r10",
+        "type": "Stripping29r2p1-Merging"
+      },
+      {
+        "configuration_files": [
+          {
+            "title": "DaVinci/DV-Stripping29r2p1-Stripping.py"
+          },
+          {
+            "title": "DaVinci/DataType-2017.py"
+          },
+          {
+            "title": "DaVinci/InputType-RDST.py"
+          },
+          {
+            "title": "DaVinci/DV-RawEventJuggler-0_3-to-4_3.py"
+          },
+          {
+            "title": "Persistency/Compression-ZLIB-1.py"
+          }
+        ],
+        "release": "DaVinci.v42r9p2 AppConfig.v3r394 Det/SQLDDDB.v7r10 TMVAWeights.v1r16",
+        "type": "Stripping29r2p1"
+      },
+      {
+        "configuration_files": [
+          {
+            "title": "Merging/DV-Stripping-Merging.py"
+          },
+          {
+            "title": "Persistency/Compression-LZMA-4.py"
+          }
+        ],
+        "release": "DaVinci.v42r9p2 AppConfig.v3r394 Det/SQLDDDB.v7r10",
+        "type": "Stripping29r2p1-Merging"
+      }
+    ]
+  },
+  "publisher": "CERN Open Data Portal",
+  "recid": "24730",
+  "run_period": [
+    "2017"
+  ],
+  "stripping": {
+    "stream": "EW",
+    "version": "stripping29r2p1"
+  },
+  "title": "LHCb 2017 Beam6500GeV MagUp EW Stream Stripping29r2p1",
+  "title_additional": "",
+  "type": {
+    "primary": "Dataset",
+    "secondary": [
+      "Collision"
+    ]
+  },
+  "usage": {
+    "description": "<p> The Run 1 and 2 data collected by the LHCb detector is available using the LHCb Ntupling Service, while the Run 1 data is additionally available in .DST and .mDST formats. The data obtained from the LHCb Ntupling Service are ROOT ntuples and do not require custom software to analyze. <p> Links are provided to the LHCb Ntupling Service for exploration of available data and the LHCb Open Data Guide for usage instructions.",
+    "links": [
+      {
+        "description": "LHCb Ntupling Service",
+        "url": "https://opendata-lhcb-ntupling-service.app.cern.ch/"
+      },
+      {
+        "description": "LHCb Open Data Guide",
+        "url": "https://lhcb-opendata-guide.web.cern.ch/"
+      }
+    ]
+  }
+}]

--- a/data/records/LHCb_2017_Beam6500GeV_VeloClosed_MagUp_RealData_Reco17_Stripping29r2p1_LEPTONIC_MDST.json
+++ b/data/records/LHCb_2017_Beam6500GeV_VeloClosed_MagUp_RealData_Reco17_Stripping29r2p1_LEPTONIC_MDST.json
@@ -1,0 +1,201 @@
+[{
+  "abstract": {
+    "description": "Data from proton-proton (pp) collisions collected by the LHCb experiment in the year 2017 of Run2 of the LHC."
+  },
+  "accelerator": "CERN-LHC",
+  "collaboration": {
+    "name": "LHCb collaboration",
+    "recid": "456"
+  },
+  "collections": [
+    "LHCb-Collision-Datasets"
+  ],
+  "collision_information": {
+    "energy": "13TeV",
+    "type": "pp"
+  },
+  "date_created": [
+    "2017"
+  ],
+  "date_published": "2026",
+  "date_reprocessed": "2020",
+  "distribution": {
+    "formats": [
+      "MDST"
+    ],
+    "number_events": 2187453953,
+    "number_files": 7117,
+    "size": 24700970264645
+  },
+  "experiment": [
+    "LHCb"
+  ],
+  "magnet_polarity": "MagUp",
+  "methodology": {
+    "description": "<p> This dataset was created in several production steps. These steps, software used and the configuration is provided below. </p><p> <strong> Prod ID: &nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;</strong> 104841<p> <strong>Prod type:&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp; </strong> Merge<p> <strong> Parent Prod ID:&nbsp;&nbsp;&nbsp;&nbsp; </strong> 104243<p> <strong> Parent Prod type: </strong> DataStripping<p> <strong> Conditions: </strong><p>dddb-20190206-3<p>cond-20191004-2 </strong><p> <strong> List of Trigger Configuration Keys (TCK): </strong> </p> <p><p><strong>TCK &nbsp;&nbsp;&nbsp;&nbsp;&nbsp; Number of Files </strong><p>0x11601707 &nbsp;&nbsp;&nbsp;&nbsp;&nbsp; 983<p>0x11601708 &nbsp;&nbsp;&nbsp;&nbsp;&nbsp; 969<p>0x11561707 &nbsp;&nbsp;&nbsp;&nbsp;&nbsp; 705<p>0x114e1702 &nbsp;&nbsp;&nbsp;&nbsp;&nbsp; 38<p>0x114e1703 &nbsp;&nbsp;&nbsp;&nbsp;&nbsp; 22<p>0x11501703 &nbsp;&nbsp;&nbsp;&nbsp;&nbsp; 238<p>0x11501705 &nbsp;&nbsp;&nbsp;&nbsp;&nbsp; 1003<p>0x11501706 &nbsp;&nbsp;&nbsp;&nbsp;&nbsp; 206<p>0x11501704 &nbsp;&nbsp;&nbsp;&nbsp;&nbsp; 242<p>0x11611709 &nbsp;&nbsp;&nbsp;&nbsp;&nbsp; 2711",
+    "steps": [
+      {
+        "configuration_files": [
+          {
+            "title": "DaVinci/DV-Stripping29r2p1-Stripping.py"
+          },
+          {
+            "title": "DaVinci/DataType-2017.py"
+          },
+          {
+            "title": "DaVinci/InputType-RDST.py"
+          },
+          {
+            "title": "DaVinci/DV-RawEventJuggler-0_3-to-4_3.py"
+          },
+          {
+            "title": "Persistency/Compression-ZLIB-1.py"
+          }
+        ],
+        "release": "DaVinci.v42r9p2 AppConfig.v3r394 Det/SQLDDDB.v7r10 TMVAWeights.v1r16",
+        "type": "Stripping29r2p1"
+      },
+      {
+        "configuration_files": [
+          {
+            "title": "Merging/DV-Stripping-Merging.py"
+          },
+          {
+            "title": "Persistency/Compression-LZMA-4.py"
+          }
+        ],
+        "release": "DaVinci.v42r9p2 AppConfig.v3r394 Det/SQLDDDB.v7r10",
+        "type": "Stripping29r2p1-Merging"
+      },
+      {
+        "configuration_files": [
+          {
+            "title": "DaVinci/DV-Stripping29r2p1-Stripping.py"
+          },
+          {
+            "title": "DaVinci/DataType-2017.py"
+          },
+          {
+            "title": "DaVinci/InputType-RDST.py"
+          },
+          {
+            "title": "DaVinci/DV-RawEventJuggler-0_3-to-4_3.py"
+          },
+          {
+            "title": "Persistency/Compression-ZLIB-1.py"
+          }
+        ],
+        "release": "DaVinci.v42r9p2 AppConfig.v3r394 Det/SQLDDDB.v7r10 TMVAWeights.v1r16",
+        "type": "Stripping29r2p1"
+      },
+      {
+        "configuration_files": [
+          {
+            "title": "Merging/DV-Stripping-Merging.py"
+          },
+          {
+            "title": "Persistency/Compression-LZMA-4.py"
+          }
+        ],
+        "release": "DaVinci.v42r9p2 AppConfig.v3r394 Det/SQLDDDB.v7r10",
+        "type": "Stripping29r2p1-Merging"
+      },
+      {
+        "configuration_files": [
+          {
+            "title": "DaVinci/DV-Stripping29r2p1-Stripping.py"
+          },
+          {
+            "title": "DaVinci/DataType-2017.py"
+          },
+          {
+            "title": "DaVinci/InputType-RDST.py"
+          },
+          {
+            "title": "DaVinci/DV-RawEventJuggler-0_3-to-4_3.py"
+          },
+          {
+            "title": "Persistency/Compression-ZLIB-1.py"
+          }
+        ],
+        "release": "DaVinci.v42r9p2 AppConfig.v3r394 Det/SQLDDDB.v7r10 TMVAWeights.v1r16",
+        "type": "Stripping29r2p1"
+      },
+      {
+        "configuration_files": [
+          {
+            "title": "Merging/DV-Stripping-Merging.py"
+          },
+          {
+            "title": "Persistency/Compression-LZMA-4.py"
+          }
+        ],
+        "release": "DaVinci.v42r9p2 AppConfig.v3r394 Det/SQLDDDB.v7r10",
+        "type": "Stripping29r2p1-Merging"
+      },
+      {
+        "configuration_files": [
+          {
+            "title": "DaVinci/DV-Stripping29r2p1-Stripping.py"
+          },
+          {
+            "title": "DaVinci/DataType-2017.py"
+          },
+          {
+            "title": "DaVinci/InputType-RDST.py"
+          },
+          {
+            "title": "DaVinci/DV-RawEventJuggler-0_3-to-4_3.py"
+          },
+          {
+            "title": "Persistency/Compression-ZLIB-1.py"
+          }
+        ],
+        "release": "DaVinci.v42r9p2 AppConfig.v3r394 Det/SQLDDDB.v7r10 TMVAWeights.v1r16",
+        "type": "Stripping29r2p1"
+      },
+      {
+        "configuration_files": [
+          {
+            "title": "Merging/DV-Stripping-Merging.py"
+          },
+          {
+            "title": "Persistency/Compression-LZMA-4.py"
+          }
+        ],
+        "release": "DaVinci.v42r9p2 AppConfig.v3r394 Det/SQLDDDB.v7r10",
+        "type": "Stripping29r2p1-Merging"
+      }
+    ]
+  },
+  "publisher": "CERN Open Data Portal",
+  "recid": "24731",
+  "run_period": [
+    "2017"
+  ],
+  "stripping": {
+    "stream": "LEPTONIC",
+    "version": "stripping29r2p1"
+  },
+  "title": "LHCb 2017 Beam6500GeV MagUp LEPTONIC Stream Stripping29r2p1",
+  "title_additional": "",
+  "type": {
+    "primary": "Dataset",
+    "secondary": [
+      "Collision"
+    ]
+  },
+  "usage": {
+    "description": "<p> The Run 1 and 2 data collected by the LHCb detector is available using the LHCb Ntupling Service, while the Run 1 data is additionally available in .DST and .mDST formats. The data obtained from the LHCb Ntupling Service are ROOT ntuples and do not require custom software to analyze. <p> Links are provided to the LHCb Ntupling Service for exploration of available data and the LHCb Open Data Guide for usage instructions.",
+    "links": [
+      {
+        "description": "LHCb Ntupling Service",
+        "url": "https://opendata-lhcb-ntupling-service.app.cern.ch/"
+      },
+      {
+        "description": "LHCb Open Data Guide",
+        "url": "https://lhcb-opendata-guide.web.cern.ch/"
+      }
+    ]
+  }
+}]

--- a/data/records/LHCb_2017_Beam6500GeV_VeloClosed_MagUp_RealData_Reco17_Stripping29r2p1_SEMILEPTONIC_DST.json
+++ b/data/records/LHCb_2017_Beam6500GeV_VeloClosed_MagUp_RealData_Reco17_Stripping29r2p1_SEMILEPTONIC_DST.json
@@ -1,0 +1,201 @@
+[{
+  "abstract": {
+    "description": "Data from proton-proton (pp) collisions collected by the LHCb experiment in the year 2017 of Run2 of the LHC."
+  },
+  "accelerator": "CERN-LHC",
+  "collaboration": {
+    "name": "LHCb collaboration",
+    "recid": "456"
+  },
+  "collections": [
+    "LHCb-Collision-Datasets"
+  ],
+  "collision_information": {
+    "energy": "13TeV",
+    "type": "pp"
+  },
+  "date_created": [
+    "2017"
+  ],
+  "date_published": "2026",
+  "date_reprocessed": "2020",
+  "distribution": {
+    "formats": [
+      "DST"
+    ],
+    "number_events": 476700961,
+    "number_files": 9460,
+    "size": 32738030950188
+  },
+  "experiment": [
+    "LHCb"
+  ],
+  "magnet_polarity": "MagUp",
+  "methodology": {
+    "description": "<p> This dataset was created in several production steps. These steps, software used and the configuration is provided below. </p><p> <strong> Prod ID: &nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;</strong> 104244<p> <strong>Prod type:&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp; </strong> Merge<p> <strong> Parent Prod ID:&nbsp;&nbsp;&nbsp;&nbsp; </strong> 104243<p> <strong> Parent Prod type: </strong> DataStripping<p> <strong> Conditions: </strong><p>dddb-20190206-3<p>cond-20191004-2 </strong><p> <strong> List of Trigger Configuration Keys (TCK): </strong> </p> <p><p><strong>TCK &nbsp;&nbsp;&nbsp;&nbsp;&nbsp; Number of Files </strong><p>0x11601707 &nbsp;&nbsp;&nbsp;&nbsp;&nbsp; 1326<p>0x11561707 &nbsp;&nbsp;&nbsp;&nbsp;&nbsp; 962<p>0x11601708 &nbsp;&nbsp;&nbsp;&nbsp;&nbsp; 1271<p>0x114e1703 &nbsp;&nbsp;&nbsp;&nbsp;&nbsp; 25<p>0x114e1702 &nbsp;&nbsp;&nbsp;&nbsp;&nbsp; 45<p>0x11501703 &nbsp;&nbsp;&nbsp;&nbsp;&nbsp; 297<p>0x11501705 &nbsp;&nbsp;&nbsp;&nbsp;&nbsp; 1376<p>0x11501704 &nbsp;&nbsp;&nbsp;&nbsp;&nbsp; 317<p>0x11501706 &nbsp;&nbsp;&nbsp;&nbsp;&nbsp; 282<p>0x11611709 &nbsp;&nbsp;&nbsp;&nbsp;&nbsp; 3559",
+    "steps": [
+      {
+        "configuration_files": [
+          {
+            "title": "DaVinci/DV-Stripping29r2p1-Stripping.py"
+          },
+          {
+            "title": "DaVinci/DataType-2017.py"
+          },
+          {
+            "title": "DaVinci/InputType-RDST.py"
+          },
+          {
+            "title": "DaVinci/DV-RawEventJuggler-0_3-to-4_3.py"
+          },
+          {
+            "title": "Persistency/Compression-ZLIB-1.py"
+          }
+        ],
+        "release": "DaVinci.v42r9p2 AppConfig.v3r394 Det/SQLDDDB.v7r10 TMVAWeights.v1r16",
+        "type": "Stripping29r2p1"
+      },
+      {
+        "configuration_files": [
+          {
+            "title": "Merging/DV-Stripping-Merging.py"
+          },
+          {
+            "title": "Persistency/Compression-LZMA-4.py"
+          }
+        ],
+        "release": "DaVinci.v42r9p2 AppConfig.v3r394 Det/SQLDDDB.v7r10",
+        "type": "Stripping29r2p1-Merging"
+      },
+      {
+        "configuration_files": [
+          {
+            "title": "DaVinci/DV-Stripping29r2p1-Stripping.py"
+          },
+          {
+            "title": "DaVinci/DataType-2017.py"
+          },
+          {
+            "title": "DaVinci/InputType-RDST.py"
+          },
+          {
+            "title": "DaVinci/DV-RawEventJuggler-0_3-to-4_3.py"
+          },
+          {
+            "title": "Persistency/Compression-ZLIB-1.py"
+          }
+        ],
+        "release": "DaVinci.v42r9p2 AppConfig.v3r394 Det/SQLDDDB.v7r10 TMVAWeights.v1r16",
+        "type": "Stripping29r2p1"
+      },
+      {
+        "configuration_files": [
+          {
+            "title": "Merging/DV-Stripping-Merging.py"
+          },
+          {
+            "title": "Persistency/Compression-LZMA-4.py"
+          }
+        ],
+        "release": "DaVinci.v42r9p2 AppConfig.v3r394 Det/SQLDDDB.v7r10",
+        "type": "Stripping29r2p1-Merging"
+      },
+      {
+        "configuration_files": [
+          {
+            "title": "DaVinci/DV-Stripping29r2p1-Stripping.py"
+          },
+          {
+            "title": "DaVinci/DataType-2017.py"
+          },
+          {
+            "title": "DaVinci/InputType-RDST.py"
+          },
+          {
+            "title": "DaVinci/DV-RawEventJuggler-0_3-to-4_3.py"
+          },
+          {
+            "title": "Persistency/Compression-ZLIB-1.py"
+          }
+        ],
+        "release": "DaVinci.v42r9p2 AppConfig.v3r394 Det/SQLDDDB.v7r10 TMVAWeights.v1r16",
+        "type": "Stripping29r2p1"
+      },
+      {
+        "configuration_files": [
+          {
+            "title": "Merging/DV-Stripping-Merging.py"
+          },
+          {
+            "title": "Persistency/Compression-LZMA-4.py"
+          }
+        ],
+        "release": "DaVinci.v42r9p2 AppConfig.v3r394 Det/SQLDDDB.v7r10",
+        "type": "Stripping29r2p1-Merging"
+      },
+      {
+        "configuration_files": [
+          {
+            "title": "DaVinci/DV-Stripping29r2p1-Stripping.py"
+          },
+          {
+            "title": "DaVinci/DataType-2017.py"
+          },
+          {
+            "title": "DaVinci/InputType-RDST.py"
+          },
+          {
+            "title": "DaVinci/DV-RawEventJuggler-0_3-to-4_3.py"
+          },
+          {
+            "title": "Persistency/Compression-ZLIB-1.py"
+          }
+        ],
+        "release": "DaVinci.v42r9p2 AppConfig.v3r394 Det/SQLDDDB.v7r10 TMVAWeights.v1r16",
+        "type": "Stripping29r2p1"
+      },
+      {
+        "configuration_files": [
+          {
+            "title": "Merging/DV-Stripping-Merging.py"
+          },
+          {
+            "title": "Persistency/Compression-LZMA-4.py"
+          }
+        ],
+        "release": "DaVinci.v42r9p2 AppConfig.v3r394 Det/SQLDDDB.v7r10",
+        "type": "Stripping29r2p1-Merging"
+      }
+    ]
+  },
+  "publisher": "CERN Open Data Portal",
+  "recid": "24739",
+  "run_period": [
+    "2017"
+  ],
+  "stripping": {
+    "stream": "SEMILEPTONIC",
+    "version": "stripping29r2p1"
+  },
+  "title": "LHCb 2017 Beam6500GeV MagUp SEMILEPTONIC Stream Stripping29r2p1",
+  "title_additional": "",
+  "type": {
+    "primary": "Dataset",
+    "secondary": [
+      "Collision"
+    ]
+  },
+  "usage": {
+    "description": "<p> The Run 1 and 2 data collected by the LHCb detector is available using the LHCb Ntupling Service, while the Run 1 data is additionally available in .DST and .mDST formats. The data obtained from the LHCb Ntupling Service are ROOT ntuples and do not require custom software to analyze. <p> Links are provided to the LHCb Ntupling Service for exploration of available data and the LHCb Open Data Guide for usage instructions.",
+    "links": [
+      {
+        "description": "LHCb Ntupling Service",
+        "url": "https://opendata-lhcb-ntupling-service.app.cern.ch/"
+      },
+      {
+        "description": "LHCb Open Data Guide",
+        "url": "https://lhcb-opendata-guide.web.cern.ch/"
+      }
+    ]
+  }
+}]

--- a/data/records/LHCb_2017_Beam6500GeV_VeloClosed_MagUp_RealData_Reco17_Stripping29r2p2_BHADRONCOMPLETEEVENT_DST.json
+++ b/data/records/LHCb_2017_Beam6500GeV_VeloClosed_MagUp_RealData_Reco17_Stripping29r2p2_BHADRONCOMPLETEEVENT_DST.json
@@ -1,0 +1,201 @@
+[{
+  "abstract": {
+    "description": "Data from proton-proton (pp) collisions collected by the LHCb experiment in the year 2017 of Run2 of the LHC."
+  },
+  "accelerator": "CERN-LHC",
+  "collaboration": {
+    "name": "LHCb collaboration",
+    "recid": "456"
+  },
+  "collections": [
+    "LHCb-Collision-Datasets"
+  ],
+  "collision_information": {
+    "energy": "13TeV",
+    "type": "pp"
+  },
+  "date_created": [
+    "2017"
+  ],
+  "date_published": "2026",
+  "date_reprocessed": "2021",
+  "distribution": {
+    "formats": [
+      "DST"
+    ],
+    "number_events": 327647610,
+    "number_files": 9786,
+    "size": 35813321553124
+  },
+  "experiment": [
+    "LHCb"
+  ],
+  "magnet_polarity": "MagUp",
+  "methodology": {
+    "description": "<p> This dataset was created in several production steps. These steps, software used and the configuration is provided below. </p><p> <strong> Prod ID: &nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;</strong> 142816<p> <strong>Prod type:&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp; </strong> Merge<p> <strong> Parent Prod ID:&nbsp;&nbsp;&nbsp;&nbsp; </strong> 140080<p> <strong> Parent Prod type: </strong> DataStripping<p> <strong> Conditions: </strong><p>dddb-20210215-7<p>cond-20191004-3</strong><p> <strong> List of Trigger Configuration Keys (TCK): </strong> </p> <p><p><strong>TCK &nbsp;&nbsp;&nbsp;&nbsp;&nbsp; Number of Files </strong><p>0x11561707 &nbsp;&nbsp;&nbsp;&nbsp;&nbsp; 987<p>0x11601707 &nbsp;&nbsp;&nbsp;&nbsp;&nbsp; 1366<p>0x11601708 &nbsp;&nbsp;&nbsp;&nbsp;&nbsp; 1325<p>0x114e1703 &nbsp;&nbsp;&nbsp;&nbsp;&nbsp; 24<p>0x11501704 &nbsp;&nbsp;&nbsp;&nbsp;&nbsp; 321<p>0x11501703 &nbsp;&nbsp;&nbsp;&nbsp;&nbsp; 306<p>0x11501705 &nbsp;&nbsp;&nbsp;&nbsp;&nbsp; 1390<p>0x114e1702 &nbsp;&nbsp;&nbsp;&nbsp;&nbsp; 45<p>0x11501706 &nbsp;&nbsp;&nbsp;&nbsp;&nbsp; 282<p>0x11611709 &nbsp;&nbsp;&nbsp;&nbsp;&nbsp; 3740",
+    "steps": [
+      {
+        "configuration_files": [
+          {
+            "title": "DaVinci/DV-Stripping29r2p2-Stripping.py"
+          },
+          {
+            "title": "DaVinci/DataType-2017.py"
+          },
+          {
+            "title": "DaVinci/InputType-RDST.py"
+          },
+          {
+            "title": "DaVinci/DV-RawEventJuggler-0_3-to-4_3.py"
+          },
+          {
+            "title": "Persistency/Compression-ZLIB-1.py"
+          }
+        ],
+        "release": "DaVinci.v42r11p2 AppConfig.v3r404 Det/SQLDDDB.v7r10 TMVAWeights.v1r16",
+        "type": "Stripping29r2p2"
+      },
+      {
+        "configuration_files": [
+          {
+            "title": "Merging/DV-Stripping-Merging.py"
+          },
+          {
+            "title": "Persistency/Compression-LZMA-4.py"
+          }
+        ],
+        "release": "DaVinci.v42r11p2 AppConfig.v3r404 Det/SQLDDDB.v7r10",
+        "type": "Stripping29r2p2-Merging"
+      },
+      {
+        "configuration_files": [
+          {
+            "title": "DaVinci/DV-Stripping29r2p2-Stripping.py"
+          },
+          {
+            "title": "DaVinci/DataType-2017.py"
+          },
+          {
+            "title": "DaVinci/InputType-RDST.py"
+          },
+          {
+            "title": "DaVinci/DV-RawEventJuggler-0_3-to-4_3.py"
+          },
+          {
+            "title": "Persistency/Compression-ZLIB-1.py"
+          }
+        ],
+        "release": "DaVinci.v42r11p2 AppConfig.v3r404 Det/SQLDDDB.v7r10 TMVAWeights.v1r16",
+        "type": "Stripping29r2p2"
+      },
+      {
+        "configuration_files": [
+          {
+            "title": "Merging/DV-Stripping-Merging.py"
+          },
+          {
+            "title": "Persistency/Compression-LZMA-4.py"
+          }
+        ],
+        "release": "DaVinci.v42r11p2 AppConfig.v3r404 Det/SQLDDDB.v7r10",
+        "type": "Stripping29r2p2-Merging"
+      },
+      {
+        "configuration_files": [
+          {
+            "title": "DaVinci/DV-Stripping29r2p2-Stripping.py"
+          },
+          {
+            "title": "DaVinci/DataType-2017.py"
+          },
+          {
+            "title": "DaVinci/InputType-RDST.py"
+          },
+          {
+            "title": "DaVinci/DV-RawEventJuggler-0_3-to-4_3.py"
+          },
+          {
+            "title": "Persistency/Compression-ZLIB-1.py"
+          }
+        ],
+        "release": "DaVinci.v42r11p2 AppConfig.v3r404 Det/SQLDDDB.v7r10 TMVAWeights.v1r16",
+        "type": "Stripping29r2p2"
+      },
+      {
+        "configuration_files": [
+          {
+            "title": "Merging/DV-Stripping-Merging.py"
+          },
+          {
+            "title": "Persistency/Compression-LZMA-4.py"
+          }
+        ],
+        "release": "DaVinci.v42r11p2 AppConfig.v3r404 Det/SQLDDDB.v7r10",
+        "type": "Stripping29r2p2-Merging"
+      },
+      {
+        "configuration_files": [
+          {
+            "title": "DaVinci/DV-Stripping29r2p2-Stripping.py"
+          },
+          {
+            "title": "DaVinci/DataType-2017.py"
+          },
+          {
+            "title": "DaVinci/InputType-RDST.py"
+          },
+          {
+            "title": "DaVinci/DV-RawEventJuggler-0_3-to-4_3.py"
+          },
+          {
+            "title": "Persistency/Compression-ZLIB-1.py"
+          }
+        ],
+        "release": "DaVinci.v42r11p2 AppConfig.v3r404 Det/SQLDDDB.v7r10 TMVAWeights.v1r16",
+        "type": "Stripping29r2p2"
+      },
+      {
+        "configuration_files": [
+          {
+            "title": "Merging/DV-Stripping-Merging.py"
+          },
+          {
+            "title": "Persistency/Compression-LZMA-4.py"
+          }
+        ],
+        "release": "DaVinci.v42r11p2 AppConfig.v3r404 Det/SQLDDDB.v7r10",
+        "type": "Stripping29r2p2-Merging"
+      }
+    ]
+  },
+  "publisher": "CERN Open Data Portal",
+  "recid": "24755",
+  "run_period": [
+    "2017"
+  ],
+  "stripping": {
+    "stream": "BHADRONCOMPLETEEVENT",
+    "version": "stripping29r2p2"
+  },
+  "title": "LHCb 2017 Beam6500GeV MagUp BHADRONCOMPLETEEVENT Stream Stripping29r2p2",
+  "title_additional": "",
+  "type": {
+    "primary": "Dataset",
+    "secondary": [
+      "Collision"
+    ]
+  },
+  "usage": {
+    "description": "<p> The Run 1 and 2 data collected by the LHCb detector is available using the LHCb Ntupling Service, while the Run 1 data is additionally available in .DST and .mDST formats. The data obtained from the LHCb Ntupling Service are ROOT ntuples and do not require custom software to analyze. <p> Links are provided to the LHCb Ntupling Service for exploration of available data and the LHCb Open Data Guide for usage instructions.",
+    "links": [
+      {
+        "description": "LHCb Ntupling Service",
+        "url": "https://opendata-lhcb-ntupling-service.app.cern.ch/"
+      },
+      {
+        "description": "LHCb Open Data Guide",
+        "url": "https://lhcb-opendata-guide.web.cern.ch/"
+      }
+    ]
+  }
+}]

--- a/data/records/LHCb_2017_Beam6500GeV_VeloClosed_MagUp_RealData_Reco17_Stripping29r2p2_BHADRON_MDST.json
+++ b/data/records/LHCb_2017_Beam6500GeV_VeloClosed_MagUp_RealData_Reco17_Stripping29r2p2_BHADRON_MDST.json
@@ -1,0 +1,201 @@
+[{
+  "abstract": {
+    "description": "Data from proton-proton (pp) collisions collected by the LHCb experiment in the year 2017 of Run2 of the LHC."
+  },
+  "accelerator": "CERN-LHC",
+  "collaboration": {
+    "name": "LHCb collaboration",
+    "recid": "456"
+  },
+  "collections": [
+    "LHCb-Collision-Datasets"
+  ],
+  "collision_information": {
+    "energy": "13TeV",
+    "type": "pp"
+  },
+  "date_created": [
+    "2017"
+  ],
+  "date_published": "2026",
+  "date_reprocessed": "2021",
+  "distribution": {
+    "formats": [
+      "MDST"
+    ],
+    "number_events": 571283688,
+    "number_files": 3313,
+    "size": 10828763914711
+  },
+  "experiment": [
+    "LHCb"
+  ],
+  "magnet_polarity": "MagUp",
+  "methodology": {
+    "description": "<p> This dataset was created in several production steps. These steps, software used and the configuration is provided below. </p><p> <strong> Prod ID: &nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;</strong> 142814<p> <strong>Prod type:&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp; </strong> Merge<p> <strong> Parent Prod ID:&nbsp;&nbsp;&nbsp;&nbsp; </strong> 140080<p> <strong> Parent Prod type: </strong> DataStripping<p> <strong> Conditions: </strong><p>dddb-20210215-7<p>cond-20191004-3</strong><p> <strong> List of Trigger Configuration Keys (TCK): </strong> </p> <p><p><strong>TCK &nbsp;&nbsp;&nbsp;&nbsp;&nbsp; Number of Files </strong><p>0x11561707 &nbsp;&nbsp;&nbsp;&nbsp;&nbsp; 359<p>0x11601707 &nbsp;&nbsp;&nbsp;&nbsp;&nbsp; 499<p>0x11601708 &nbsp;&nbsp;&nbsp;&nbsp;&nbsp; 473<p>0x114e1702 &nbsp;&nbsp;&nbsp;&nbsp;&nbsp; 23<p>0x11501705 &nbsp;&nbsp;&nbsp;&nbsp;&nbsp; 446<p>0x114e1703 &nbsp;&nbsp;&nbsp;&nbsp;&nbsp; 13<p>0x11501703 &nbsp;&nbsp;&nbsp;&nbsp;&nbsp; 110<p>0x11501704 &nbsp;&nbsp;&nbsp;&nbsp;&nbsp; 106<p>0x11501706 &nbsp;&nbsp;&nbsp;&nbsp;&nbsp; 96<p>0x11611709 &nbsp;&nbsp;&nbsp;&nbsp;&nbsp; 1188",
+    "steps": [
+      {
+        "configuration_files": [
+          {
+            "title": "DaVinci/DV-Stripping29r2p2-Stripping.py"
+          },
+          {
+            "title": "DaVinci/DataType-2017.py"
+          },
+          {
+            "title": "DaVinci/InputType-RDST.py"
+          },
+          {
+            "title": "DaVinci/DV-RawEventJuggler-0_3-to-4_3.py"
+          },
+          {
+            "title": "Persistency/Compression-ZLIB-1.py"
+          }
+        ],
+        "release": "DaVinci.v42r11p2 AppConfig.v3r404 Det/SQLDDDB.v7r10 TMVAWeights.v1r16",
+        "type": "Stripping29r2p2"
+      },
+      {
+        "configuration_files": [
+          {
+            "title": "Merging/DV-Stripping-Merging.py"
+          },
+          {
+            "title": "Persistency/Compression-LZMA-4.py"
+          }
+        ],
+        "release": "DaVinci.v42r11p2 AppConfig.v3r404 Det/SQLDDDB.v7r10",
+        "type": "Stripping29r2p2-Merging"
+      },
+      {
+        "configuration_files": [
+          {
+            "title": "DaVinci/DV-Stripping29r2p2-Stripping.py"
+          },
+          {
+            "title": "DaVinci/DataType-2017.py"
+          },
+          {
+            "title": "DaVinci/InputType-RDST.py"
+          },
+          {
+            "title": "DaVinci/DV-RawEventJuggler-0_3-to-4_3.py"
+          },
+          {
+            "title": "Persistency/Compression-ZLIB-1.py"
+          }
+        ],
+        "release": "DaVinci.v42r11p2 AppConfig.v3r404 Det/SQLDDDB.v7r10 TMVAWeights.v1r16",
+        "type": "Stripping29r2p2"
+      },
+      {
+        "configuration_files": [
+          {
+            "title": "Merging/DV-Stripping-Merging.py"
+          },
+          {
+            "title": "Persistency/Compression-LZMA-4.py"
+          }
+        ],
+        "release": "DaVinci.v42r11p2 AppConfig.v3r404 Det/SQLDDDB.v7r10",
+        "type": "Stripping29r2p2-Merging"
+      },
+      {
+        "configuration_files": [
+          {
+            "title": "DaVinci/DV-Stripping29r2p2-Stripping.py"
+          },
+          {
+            "title": "DaVinci/DataType-2017.py"
+          },
+          {
+            "title": "DaVinci/InputType-RDST.py"
+          },
+          {
+            "title": "DaVinci/DV-RawEventJuggler-0_3-to-4_3.py"
+          },
+          {
+            "title": "Persistency/Compression-ZLIB-1.py"
+          }
+        ],
+        "release": "DaVinci.v42r11p2 AppConfig.v3r404 Det/SQLDDDB.v7r10 TMVAWeights.v1r16",
+        "type": "Stripping29r2p2"
+      },
+      {
+        "configuration_files": [
+          {
+            "title": "Merging/DV-Stripping-Merging.py"
+          },
+          {
+            "title": "Persistency/Compression-LZMA-4.py"
+          }
+        ],
+        "release": "DaVinci.v42r11p2 AppConfig.v3r404 Det/SQLDDDB.v7r10",
+        "type": "Stripping29r2p2-Merging"
+      },
+      {
+        "configuration_files": [
+          {
+            "title": "DaVinci/DV-Stripping29r2p2-Stripping.py"
+          },
+          {
+            "title": "DaVinci/DataType-2017.py"
+          },
+          {
+            "title": "DaVinci/InputType-RDST.py"
+          },
+          {
+            "title": "DaVinci/DV-RawEventJuggler-0_3-to-4_3.py"
+          },
+          {
+            "title": "Persistency/Compression-ZLIB-1.py"
+          }
+        ],
+        "release": "DaVinci.v42r11p2 AppConfig.v3r404 Det/SQLDDDB.v7r10 TMVAWeights.v1r16",
+        "type": "Stripping29r2p2"
+      },
+      {
+        "configuration_files": [
+          {
+            "title": "Merging/DV-Stripping-Merging.py"
+          },
+          {
+            "title": "Persistency/Compression-LZMA-4.py"
+          }
+        ],
+        "release": "DaVinci.v42r11p2 AppConfig.v3r404 Det/SQLDDDB.v7r10",
+        "type": "Stripping29r2p2-Merging"
+      }
+    ]
+  },
+  "publisher": "CERN Open Data Portal",
+  "recid": "24754",
+  "run_period": [
+    "2017"
+  ],
+  "stripping": {
+    "stream": "BHADRON",
+    "version": "stripping29r2p2"
+  },
+  "title": "LHCb 2017 Beam6500GeV MagUp BHADRON Stream Stripping29r2p2",
+  "title_additional": "",
+  "type": {
+    "primary": "Dataset",
+    "secondary": [
+      "Collision"
+    ]
+  },
+  "usage": {
+    "description": "<p> The Run 1 and 2 data collected by the LHCb detector is available using the LHCb Ntupling Service, while the Run 1 data is additionally available in .DST and .mDST formats. The data obtained from the LHCb Ntupling Service are ROOT ntuples and do not require custom software to analyze. <p> Links are provided to the LHCb Ntupling Service for exploration of available data and the LHCb Open Data Guide for usage instructions.",
+    "links": [
+      {
+        "description": "LHCb Ntupling Service",
+        "url": "https://opendata-lhcb-ntupling-service.app.cern.ch/"
+      },
+      {
+        "description": "LHCb Open Data Guide",
+        "url": "https://lhcb-opendata-guide.web.cern.ch/"
+      }
+    ]
+  }
+}]

--- a/data/records/LHCb_2017_Beam6500GeV_VeloClosed_MagUp_RealData_Reco17_Stripping29r2p2_CHARMCOMPLETEEVENT_DST.json
+++ b/data/records/LHCb_2017_Beam6500GeV_VeloClosed_MagUp_RealData_Reco17_Stripping29r2p2_CHARMCOMPLETEEVENT_DST.json
@@ -1,0 +1,201 @@
+[{
+  "abstract": {
+    "description": "Data from proton-proton (pp) collisions collected by the LHCb experiment in the year 2017 of Run2 of the LHC."
+  },
+  "accelerator": "CERN-LHC",
+  "collaboration": {
+    "name": "LHCb collaboration",
+    "recid": "456"
+  },
+  "collections": [
+    "LHCb-Collision-Datasets"
+  ],
+  "collision_information": {
+    "energy": "13TeV",
+    "type": "pp"
+  },
+  "date_created": [
+    "2017"
+  ],
+  "date_published": "2026",
+  "date_reprocessed": "2021",
+  "distribution": {
+    "formats": [
+      "DST"
+    ],
+    "number_events": 100728191,
+    "number_files": 3137,
+    "size": 8214768661037
+  },
+  "experiment": [
+    "LHCb"
+  ],
+  "magnet_polarity": "MagUp",
+  "methodology": {
+    "description": "<p> This dataset was created in several production steps. These steps, software used and the configuration is provided below. </p><p> <strong> Prod ID: &nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;</strong> 142816<p> <strong>Prod type:&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp; </strong> Merge<p> <strong> Parent Prod ID:&nbsp;&nbsp;&nbsp;&nbsp; </strong> 140080<p> <strong> Parent Prod type: </strong> DataStripping<p> <strong> Conditions: </strong><p>dddb-20210215-7<p>cond-20191004-3</strong><p> <strong> List of Trigger Configuration Keys (TCK): </strong> </p> <p><p><strong>TCK &nbsp;&nbsp;&nbsp;&nbsp;&nbsp; Number of Files </strong><p>0x11561707 &nbsp;&nbsp;&nbsp;&nbsp;&nbsp; 336<p>0x11601707 &nbsp;&nbsp;&nbsp;&nbsp;&nbsp; 464<p>0x11601708 &nbsp;&nbsp;&nbsp;&nbsp;&nbsp; 431<p>0x11501703 &nbsp;&nbsp;&nbsp;&nbsp;&nbsp; 106<p>0x11501705 &nbsp;&nbsp;&nbsp;&nbsp;&nbsp; 427<p>0x11501704 &nbsp;&nbsp;&nbsp;&nbsp;&nbsp; 93<p>0x114e1702 &nbsp;&nbsp;&nbsp;&nbsp;&nbsp; 23<p>0x114e1703 &nbsp;&nbsp;&nbsp;&nbsp;&nbsp; 13<p>0x11501706 &nbsp;&nbsp;&nbsp;&nbsp;&nbsp; 90<p>0x11611709 &nbsp;&nbsp;&nbsp;&nbsp;&nbsp; 1154",
+    "steps": [
+      {
+        "configuration_files": [
+          {
+            "title": "DaVinci/DV-Stripping29r2p2-Stripping.py"
+          },
+          {
+            "title": "DaVinci/DataType-2017.py"
+          },
+          {
+            "title": "DaVinci/InputType-RDST.py"
+          },
+          {
+            "title": "DaVinci/DV-RawEventJuggler-0_3-to-4_3.py"
+          },
+          {
+            "title": "Persistency/Compression-ZLIB-1.py"
+          }
+        ],
+        "release": "DaVinci.v42r11p2 AppConfig.v3r404 Det/SQLDDDB.v7r10 TMVAWeights.v1r16",
+        "type": "Stripping29r2p2"
+      },
+      {
+        "configuration_files": [
+          {
+            "title": "Merging/DV-Stripping-Merging.py"
+          },
+          {
+            "title": "Persistency/Compression-LZMA-4.py"
+          }
+        ],
+        "release": "DaVinci.v42r11p2 AppConfig.v3r404 Det/SQLDDDB.v7r10",
+        "type": "Stripping29r2p2-Merging"
+      },
+      {
+        "configuration_files": [
+          {
+            "title": "DaVinci/DV-Stripping29r2p2-Stripping.py"
+          },
+          {
+            "title": "DaVinci/DataType-2017.py"
+          },
+          {
+            "title": "DaVinci/InputType-RDST.py"
+          },
+          {
+            "title": "DaVinci/DV-RawEventJuggler-0_3-to-4_3.py"
+          },
+          {
+            "title": "Persistency/Compression-ZLIB-1.py"
+          }
+        ],
+        "release": "DaVinci.v42r11p2 AppConfig.v3r404 Det/SQLDDDB.v7r10 TMVAWeights.v1r16",
+        "type": "Stripping29r2p2"
+      },
+      {
+        "configuration_files": [
+          {
+            "title": "Merging/DV-Stripping-Merging.py"
+          },
+          {
+            "title": "Persistency/Compression-LZMA-4.py"
+          }
+        ],
+        "release": "DaVinci.v42r11p2 AppConfig.v3r404 Det/SQLDDDB.v7r10",
+        "type": "Stripping29r2p2-Merging"
+      },
+      {
+        "configuration_files": [
+          {
+            "title": "DaVinci/DV-Stripping29r2p2-Stripping.py"
+          },
+          {
+            "title": "DaVinci/DataType-2017.py"
+          },
+          {
+            "title": "DaVinci/InputType-RDST.py"
+          },
+          {
+            "title": "DaVinci/DV-RawEventJuggler-0_3-to-4_3.py"
+          },
+          {
+            "title": "Persistency/Compression-ZLIB-1.py"
+          }
+        ],
+        "release": "DaVinci.v42r11p2 AppConfig.v3r404 Det/SQLDDDB.v7r10 TMVAWeights.v1r16",
+        "type": "Stripping29r2p2"
+      },
+      {
+        "configuration_files": [
+          {
+            "title": "Merging/DV-Stripping-Merging.py"
+          },
+          {
+            "title": "Persistency/Compression-LZMA-4.py"
+          }
+        ],
+        "release": "DaVinci.v42r11p2 AppConfig.v3r404 Det/SQLDDDB.v7r10",
+        "type": "Stripping29r2p2-Merging"
+      },
+      {
+        "configuration_files": [
+          {
+            "title": "DaVinci/DV-Stripping29r2p2-Stripping.py"
+          },
+          {
+            "title": "DaVinci/DataType-2017.py"
+          },
+          {
+            "title": "DaVinci/InputType-RDST.py"
+          },
+          {
+            "title": "DaVinci/DV-RawEventJuggler-0_3-to-4_3.py"
+          },
+          {
+            "title": "Persistency/Compression-ZLIB-1.py"
+          }
+        ],
+        "release": "DaVinci.v42r11p2 AppConfig.v3r404 Det/SQLDDDB.v7r10 TMVAWeights.v1r16",
+        "type": "Stripping29r2p2"
+      },
+      {
+        "configuration_files": [
+          {
+            "title": "Merging/DV-Stripping-Merging.py"
+          },
+          {
+            "title": "Persistency/Compression-LZMA-4.py"
+          }
+        ],
+        "release": "DaVinci.v42r11p2 AppConfig.v3r404 Det/SQLDDDB.v7r10",
+        "type": "Stripping29r2p2-Merging"
+      }
+    ]
+  },
+  "publisher": "CERN Open Data Portal",
+  "recid": "24757",
+  "run_period": [
+    "2017"
+  ],
+  "stripping": {
+    "stream": "CHARMCOMPLETEEVENT",
+    "version": "stripping29r2p2"
+  },
+  "title": "LHCb 2017 Beam6500GeV MagUp CHARMCOMPLETEEVENT Stream Stripping29r2p2",
+  "title_additional": "",
+  "type": {
+    "primary": "Dataset",
+    "secondary": [
+      "Collision"
+    ]
+  },
+  "usage": {
+    "description": "<p> The Run 1 and 2 data collected by the LHCb detector is available using the LHCb Ntupling Service, while the Run 1 data is additionally available in .DST and .mDST formats. The data obtained from the LHCb Ntupling Service are ROOT ntuples and do not require custom software to analyze. <p> Links are provided to the LHCb Ntupling Service for exploration of available data and the LHCb Open Data Guide for usage instructions.",
+    "links": [
+      {
+        "description": "LHCb Ntupling Service",
+        "url": "https://opendata-lhcb-ntupling-service.app.cern.ch/"
+      },
+      {
+        "description": "LHCb Open Data Guide",
+        "url": "https://lhcb-opendata-guide.web.cern.ch/"
+      }
+    ]
+  }
+}]

--- a/data/records/LHCb_2017_Beam6500GeV_VeloClosed_MagUp_RealData_Reco17_Stripping29r2p2_CHARM_MDST.json
+++ b/data/records/LHCb_2017_Beam6500GeV_VeloClosed_MagUp_RealData_Reco17_Stripping29r2p2_CHARM_MDST.json
@@ -1,0 +1,201 @@
+[{
+  "abstract": {
+    "description": "Data from proton-proton (pp) collisions collected by the LHCb experiment in the year 2017 of Run2 of the LHC."
+  },
+  "accelerator": "CERN-LHC",
+  "collaboration": {
+    "name": "LHCb collaboration",
+    "recid": "456"
+  },
+  "collections": [
+    "LHCb-Collision-Datasets"
+  ],
+  "collision_information": {
+    "energy": "13TeV",
+    "type": "pp"
+  },
+  "date_created": [
+    "2017"
+  ],
+  "date_published": "2026",
+  "date_reprocessed": "2021",
+  "distribution": {
+    "formats": [
+      "MDST"
+    ],
+    "number_events": 978891489,
+    "number_files": 5215,
+    "size": 18895118443379
+  },
+  "experiment": [
+    "LHCb"
+  ],
+  "magnet_polarity": "MagUp",
+  "methodology": {
+    "description": "<p> This dataset was created in several production steps. These steps, software used and the configuration is provided below. </p><p> <strong> Prod ID: &nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;</strong> 141014<p> <strong>Prod type:&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp; </strong> Merge<p> <strong> Parent Prod ID:&nbsp;&nbsp;&nbsp;&nbsp; </strong> 140080<p> <strong> Parent Prod type: </strong> DataStripping<p> <strong> Conditions: </strong><p>dddb-20210215-7<p>cond-20191004-3</strong><p> <strong> List of Trigger Configuration Keys (TCK): </strong> </p> <p><p><strong>TCK &nbsp;&nbsp;&nbsp;&nbsp;&nbsp; Number of Files </strong><p>0x11561707 &nbsp;&nbsp;&nbsp;&nbsp;&nbsp; 549<p>0x11601707 &nbsp;&nbsp;&nbsp;&nbsp;&nbsp; 742<p>0x11601708 &nbsp;&nbsp;&nbsp;&nbsp;&nbsp; 705<p>0x11501704 &nbsp;&nbsp;&nbsp;&nbsp;&nbsp; 172<p>0x11501705 &nbsp;&nbsp;&nbsp;&nbsp;&nbsp; 729<p>0x11501703 &nbsp;&nbsp;&nbsp;&nbsp;&nbsp; 172<p>0x114e1703 &nbsp;&nbsp;&nbsp;&nbsp;&nbsp; 16<p>0x114e1702 &nbsp;&nbsp;&nbsp;&nbsp;&nbsp; 30<p>0x11501706 &nbsp;&nbsp;&nbsp;&nbsp;&nbsp; 148<p>0x11611709 &nbsp;&nbsp;&nbsp;&nbsp;&nbsp; 1952",
+    "steps": [
+      {
+        "configuration_files": [
+          {
+            "title": "DaVinci/DV-Stripping29r2p2-Stripping.py"
+          },
+          {
+            "title": "DaVinci/DataType-2017.py"
+          },
+          {
+            "title": "DaVinci/InputType-RDST.py"
+          },
+          {
+            "title": "DaVinci/DV-RawEventJuggler-0_3-to-4_3.py"
+          },
+          {
+            "title": "Persistency/Compression-ZLIB-1.py"
+          }
+        ],
+        "release": "DaVinci.v42r11p2 AppConfig.v3r404 Det/SQLDDDB.v7r10 TMVAWeights.v1r16",
+        "type": "Stripping29r2p2"
+      },
+      {
+        "configuration_files": [
+          {
+            "title": "Merging/DV-Stripping-Merging.py"
+          },
+          {
+            "title": "Persistency/Compression-LZMA-4.py"
+          }
+        ],
+        "release": "DaVinci.v42r11p2 AppConfig.v3r404 Det/SQLDDDB.v7r10",
+        "type": "Stripping29r2p2-Merging"
+      },
+      {
+        "configuration_files": [
+          {
+            "title": "DaVinci/DV-Stripping29r2p2-Stripping.py"
+          },
+          {
+            "title": "DaVinci/DataType-2017.py"
+          },
+          {
+            "title": "DaVinci/InputType-RDST.py"
+          },
+          {
+            "title": "DaVinci/DV-RawEventJuggler-0_3-to-4_3.py"
+          },
+          {
+            "title": "Persistency/Compression-ZLIB-1.py"
+          }
+        ],
+        "release": "DaVinci.v42r11p2 AppConfig.v3r404 Det/SQLDDDB.v7r10 TMVAWeights.v1r16",
+        "type": "Stripping29r2p2"
+      },
+      {
+        "configuration_files": [
+          {
+            "title": "Merging/DV-Stripping-Merging.py"
+          },
+          {
+            "title": "Persistency/Compression-LZMA-4.py"
+          }
+        ],
+        "release": "DaVinci.v42r11p2 AppConfig.v3r404 Det/SQLDDDB.v7r10",
+        "type": "Stripping29r2p2-Merging"
+      },
+      {
+        "configuration_files": [
+          {
+            "title": "DaVinci/DV-Stripping29r2p2-Stripping.py"
+          },
+          {
+            "title": "DaVinci/DataType-2017.py"
+          },
+          {
+            "title": "DaVinci/InputType-RDST.py"
+          },
+          {
+            "title": "DaVinci/DV-RawEventJuggler-0_3-to-4_3.py"
+          },
+          {
+            "title": "Persistency/Compression-ZLIB-1.py"
+          }
+        ],
+        "release": "DaVinci.v42r11p2 AppConfig.v3r404 Det/SQLDDDB.v7r10 TMVAWeights.v1r16",
+        "type": "Stripping29r2p2"
+      },
+      {
+        "configuration_files": [
+          {
+            "title": "Merging/DV-Stripping-Merging.py"
+          },
+          {
+            "title": "Persistency/Compression-LZMA-4.py"
+          }
+        ],
+        "release": "DaVinci.v42r11p2 AppConfig.v3r404 Det/SQLDDDB.v7r10",
+        "type": "Stripping29r2p2-Merging"
+      },
+      {
+        "configuration_files": [
+          {
+            "title": "DaVinci/DV-Stripping29r2p2-Stripping.py"
+          },
+          {
+            "title": "DaVinci/DataType-2017.py"
+          },
+          {
+            "title": "DaVinci/InputType-RDST.py"
+          },
+          {
+            "title": "DaVinci/DV-RawEventJuggler-0_3-to-4_3.py"
+          },
+          {
+            "title": "Persistency/Compression-ZLIB-1.py"
+          }
+        ],
+        "release": "DaVinci.v42r11p2 AppConfig.v3r404 Det/SQLDDDB.v7r10 TMVAWeights.v1r16",
+        "type": "Stripping29r2p2"
+      },
+      {
+        "configuration_files": [
+          {
+            "title": "Merging/DV-Stripping-Merging.py"
+          },
+          {
+            "title": "Persistency/Compression-LZMA-4.py"
+          }
+        ],
+        "release": "DaVinci.v42r11p2 AppConfig.v3r404 Det/SQLDDDB.v7r10",
+        "type": "Stripping29r2p2-Merging"
+      }
+    ]
+  },
+  "publisher": "CERN Open Data Portal",
+  "recid": "24756",
+  "run_period": [
+    "2017"
+  ],
+  "stripping": {
+    "stream": "CHARM",
+    "version": "stripping29r2p2"
+  },
+  "title": "LHCb 2017 Beam6500GeV MagUp CHARM Stream Stripping29r2p2",
+  "title_additional": "",
+  "type": {
+    "primary": "Dataset",
+    "secondary": [
+      "Collision"
+    ]
+  },
+  "usage": {
+    "description": "<p> The Run 1 and 2 data collected by the LHCb detector is available using the LHCb Ntupling Service, while the Run 1 data is additionally available in .DST and .mDST formats. The data obtained from the LHCb Ntupling Service are ROOT ntuples and do not require custom software to analyze. <p> Links are provided to the LHCb Ntupling Service for exploration of available data and the LHCb Open Data Guide for usage instructions.",
+    "links": [
+      {
+        "description": "LHCb Ntupling Service",
+        "url": "https://opendata-lhcb-ntupling-service.app.cern.ch/"
+      },
+      {
+        "description": "LHCb Open Data Guide",
+        "url": "https://lhcb-opendata-guide.web.cern.ch/"
+      }
+    ]
+  }
+}]

--- a/data/records/LHCb_2017_Beam6500GeV_VeloClosed_MagUp_RealData_Reco17_Stripping29r2p2_DIMUON_DST.json
+++ b/data/records/LHCb_2017_Beam6500GeV_VeloClosed_MagUp_RealData_Reco17_Stripping29r2p2_DIMUON_DST.json
@@ -1,0 +1,201 @@
+[{
+  "abstract": {
+    "description": "Data from proton-proton (pp) collisions collected by the LHCb experiment in the year 2017 of Run2 of the LHC."
+  },
+  "accelerator": "CERN-LHC",
+  "collaboration": {
+    "name": "LHCb collaboration",
+    "recid": "456"
+  },
+  "collections": [
+    "LHCb-Collision-Datasets"
+  ],
+  "collision_information": {
+    "energy": "13TeV",
+    "type": "pp"
+  },
+  "date_created": [
+    "2017"
+  ],
+  "date_published": "2026",
+  "date_reprocessed": "2021",
+  "distribution": {
+    "formats": [
+      "DST"
+    ],
+    "number_events": 169989967,
+    "number_files": 5272,
+    "size": 17650097707942
+  },
+  "experiment": [
+    "LHCb"
+  ],
+  "magnet_polarity": "MagUp",
+  "methodology": {
+    "description": "<p> This dataset was created in several production steps. These steps, software used and the configuration is provided below. </p><p> <strong> Prod ID: &nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;</strong> 142814<p> <strong>Prod type:&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp; </strong> Merge<p> <strong> Parent Prod ID:&nbsp;&nbsp;&nbsp;&nbsp; </strong> 140080<p> <strong> Parent Prod type: </strong> DataStripping<p> <strong> Conditions: </strong><p>dddb-20210215-7<p>cond-20191004-3</strong><p> <strong> List of Trigger Configuration Keys (TCK): </strong> </p> <p><p><strong>TCK &nbsp;&nbsp;&nbsp;&nbsp;&nbsp; Number of Files </strong><p>0x11561707 &nbsp;&nbsp;&nbsp;&nbsp;&nbsp; 555<p>0x11601707 &nbsp;&nbsp;&nbsp;&nbsp;&nbsp; 744<p>0x11601708 &nbsp;&nbsp;&nbsp;&nbsp;&nbsp; 719<p>0x11501705 &nbsp;&nbsp;&nbsp;&nbsp;&nbsp; 772<p>0x11501704 &nbsp;&nbsp;&nbsp;&nbsp;&nbsp; 163<p>0x11501703 &nbsp;&nbsp;&nbsp;&nbsp;&nbsp; 160<p>0x114e1702 &nbsp;&nbsp;&nbsp;&nbsp;&nbsp; 27<p>0x114e1703 &nbsp;&nbsp;&nbsp;&nbsp;&nbsp; 15<p>0x11501706 &nbsp;&nbsp;&nbsp;&nbsp;&nbsp; 156<p>0x11611709 &nbsp;&nbsp;&nbsp;&nbsp;&nbsp; 1961",
+    "steps": [
+      {
+        "configuration_files": [
+          {
+            "title": "DaVinci/DV-Stripping29r2p2-Stripping.py"
+          },
+          {
+            "title": "DaVinci/DataType-2017.py"
+          },
+          {
+            "title": "DaVinci/InputType-RDST.py"
+          },
+          {
+            "title": "DaVinci/DV-RawEventJuggler-0_3-to-4_3.py"
+          },
+          {
+            "title": "Persistency/Compression-ZLIB-1.py"
+          }
+        ],
+        "release": "DaVinci.v42r11p2 AppConfig.v3r404 Det/SQLDDDB.v7r10 TMVAWeights.v1r16",
+        "type": "Stripping29r2p2"
+      },
+      {
+        "configuration_files": [
+          {
+            "title": "Merging/DV-Stripping-Merging.py"
+          },
+          {
+            "title": "Persistency/Compression-LZMA-4.py"
+          }
+        ],
+        "release": "DaVinci.v42r11p2 AppConfig.v3r404 Det/SQLDDDB.v7r10",
+        "type": "Stripping29r2p2-Merging"
+      },
+      {
+        "configuration_files": [
+          {
+            "title": "DaVinci/DV-Stripping29r2p2-Stripping.py"
+          },
+          {
+            "title": "DaVinci/DataType-2017.py"
+          },
+          {
+            "title": "DaVinci/InputType-RDST.py"
+          },
+          {
+            "title": "DaVinci/DV-RawEventJuggler-0_3-to-4_3.py"
+          },
+          {
+            "title": "Persistency/Compression-ZLIB-1.py"
+          }
+        ],
+        "release": "DaVinci.v42r11p2 AppConfig.v3r404 Det/SQLDDDB.v7r10 TMVAWeights.v1r16",
+        "type": "Stripping29r2p2"
+      },
+      {
+        "configuration_files": [
+          {
+            "title": "Merging/DV-Stripping-Merging.py"
+          },
+          {
+            "title": "Persistency/Compression-LZMA-4.py"
+          }
+        ],
+        "release": "DaVinci.v42r11p2 AppConfig.v3r404 Det/SQLDDDB.v7r10",
+        "type": "Stripping29r2p2-Merging"
+      },
+      {
+        "configuration_files": [
+          {
+            "title": "DaVinci/DV-Stripping29r2p2-Stripping.py"
+          },
+          {
+            "title": "DaVinci/DataType-2017.py"
+          },
+          {
+            "title": "DaVinci/InputType-RDST.py"
+          },
+          {
+            "title": "DaVinci/DV-RawEventJuggler-0_3-to-4_3.py"
+          },
+          {
+            "title": "Persistency/Compression-ZLIB-1.py"
+          }
+        ],
+        "release": "DaVinci.v42r11p2 AppConfig.v3r404 Det/SQLDDDB.v7r10 TMVAWeights.v1r16",
+        "type": "Stripping29r2p2"
+      },
+      {
+        "configuration_files": [
+          {
+            "title": "Merging/DV-Stripping-Merging.py"
+          },
+          {
+            "title": "Persistency/Compression-LZMA-4.py"
+          }
+        ],
+        "release": "DaVinci.v42r11p2 AppConfig.v3r404 Det/SQLDDDB.v7r10",
+        "type": "Stripping29r2p2-Merging"
+      },
+      {
+        "configuration_files": [
+          {
+            "title": "DaVinci/DV-Stripping29r2p2-Stripping.py"
+          },
+          {
+            "title": "DaVinci/DataType-2017.py"
+          },
+          {
+            "title": "DaVinci/InputType-RDST.py"
+          },
+          {
+            "title": "DaVinci/DV-RawEventJuggler-0_3-to-4_3.py"
+          },
+          {
+            "title": "Persistency/Compression-ZLIB-1.py"
+          }
+        ],
+        "release": "DaVinci.v42r11p2 AppConfig.v3r404 Det/SQLDDDB.v7r10 TMVAWeights.v1r16",
+        "type": "Stripping29r2p2"
+      },
+      {
+        "configuration_files": [
+          {
+            "title": "Merging/DV-Stripping-Merging.py"
+          },
+          {
+            "title": "Persistency/Compression-LZMA-4.py"
+          }
+        ],
+        "release": "DaVinci.v42r11p2 AppConfig.v3r404 Det/SQLDDDB.v7r10",
+        "type": "Stripping29r2p2-Merging"
+      }
+    ]
+  },
+  "publisher": "CERN Open Data Portal",
+  "recid": "24758",
+  "run_period": [
+    "2017"
+  ],
+  "stripping": {
+    "stream": "DIMUON",
+    "version": "stripping29r2p2"
+  },
+  "title": "LHCb 2017 Beam6500GeV MagUp DIMUON Stream Stripping29r2p2",
+  "title_additional": "",
+  "type": {
+    "primary": "Dataset",
+    "secondary": [
+      "Collision"
+    ]
+  },
+  "usage": {
+    "description": "<p> The Run 1 and 2 data collected by the LHCb detector is available using the LHCb Ntupling Service, while the Run 1 data is additionally available in .DST and .mDST formats. The data obtained from the LHCb Ntupling Service are ROOT ntuples and do not require custom software to analyze. <p> Links are provided to the LHCb Ntupling Service for exploration of available data and the LHCb Open Data Guide for usage instructions.",
+    "links": [
+      {
+        "description": "LHCb Ntupling Service",
+        "url": "https://opendata-lhcb-ntupling-service.app.cern.ch/"
+      },
+      {
+        "description": "LHCb Open Data Guide",
+        "url": "https://lhcb-opendata-guide.web.cern.ch/"
+      }
+    ]
+  }
+}]

--- a/data/records/LHCb_2017_Beam6500GeV_VeloClosed_MagUp_RealData_Reco17_Stripping29r2p2_LEPTONIC_MDST.json
+++ b/data/records/LHCb_2017_Beam6500GeV_VeloClosed_MagUp_RealData_Reco17_Stripping29r2p2_LEPTONIC_MDST.json
@@ -1,0 +1,201 @@
+[{
+  "abstract": {
+    "description": "Data from proton-proton (pp) collisions collected by the LHCb experiment in the year 2017 of Run2 of the LHC."
+  },
+  "accelerator": "CERN-LHC",
+  "collaboration": {
+    "name": "LHCb collaboration",
+    "recid": "456"
+  },
+  "collections": [
+    "LHCb-Collision-Datasets"
+  ],
+  "collision_information": {
+    "energy": "13TeV",
+    "type": "pp"
+  },
+  "date_created": [
+    "2017"
+  ],
+  "date_published": "2026",
+  "date_reprocessed": "2021",
+  "distribution": {
+    "formats": [
+      "MDST"
+    ],
+    "number_events": 1537060856,
+    "number_files": 9806,
+    "size": 39138041255079
+  },
+  "experiment": [
+    "LHCb"
+  ],
+  "magnet_polarity": "MagUp",
+  "methodology": {
+    "description": "<p> This dataset was created in several production steps. These steps, software used and the configuration is provided below. </p><p> <strong> Prod ID: &nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;</strong> 142814<p> <strong>Prod type:&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp; </strong> Merge<p> <strong> Parent Prod ID:&nbsp;&nbsp;&nbsp;&nbsp; </strong> 140080<p> <strong> Parent Prod type: </strong> DataStripping<p> <strong> Conditions: </strong><p>dddb-20210215-7<p>cond-20191004-3</strong><p> <strong> List of Trigger Configuration Keys (TCK): </strong> </p> <p><p><strong>TCK &nbsp;&nbsp;&nbsp;&nbsp;&nbsp; Number of Files </strong><p>0x11561707 &nbsp;&nbsp;&nbsp;&nbsp;&nbsp; 973<p>0x11601707 &nbsp;&nbsp;&nbsp;&nbsp;&nbsp; 1349<p>0x11601708 &nbsp;&nbsp;&nbsp;&nbsp;&nbsp; 1349<p>0x11501703 &nbsp;&nbsp;&nbsp;&nbsp;&nbsp; 291<p>0x11501704 &nbsp;&nbsp;&nbsp;&nbsp;&nbsp; 313<p>0x11501705 &nbsp;&nbsp;&nbsp;&nbsp;&nbsp; 1430<p>0x114e1703 &nbsp;&nbsp;&nbsp;&nbsp;&nbsp; 24<p>0x114e1702 &nbsp;&nbsp;&nbsp;&nbsp;&nbsp; 45<p>0x11501706 &nbsp;&nbsp;&nbsp;&nbsp;&nbsp; 283<p>0x11611709 &nbsp;&nbsp;&nbsp;&nbsp;&nbsp; 3749",
+    "steps": [
+      {
+        "configuration_files": [
+          {
+            "title": "DaVinci/DV-Stripping29r2p2-Stripping.py"
+          },
+          {
+            "title": "DaVinci/DataType-2017.py"
+          },
+          {
+            "title": "DaVinci/InputType-RDST.py"
+          },
+          {
+            "title": "DaVinci/DV-RawEventJuggler-0_3-to-4_3.py"
+          },
+          {
+            "title": "Persistency/Compression-ZLIB-1.py"
+          }
+        ],
+        "release": "DaVinci.v42r11p2 AppConfig.v3r404 Det/SQLDDDB.v7r10 TMVAWeights.v1r16",
+        "type": "Stripping29r2p2"
+      },
+      {
+        "configuration_files": [
+          {
+            "title": "Merging/DV-Stripping-Merging.py"
+          },
+          {
+            "title": "Persistency/Compression-LZMA-4.py"
+          }
+        ],
+        "release": "DaVinci.v42r11p2 AppConfig.v3r404 Det/SQLDDDB.v7r10",
+        "type": "Stripping29r2p2-Merging"
+      },
+      {
+        "configuration_files": [
+          {
+            "title": "DaVinci/DV-Stripping29r2p2-Stripping.py"
+          },
+          {
+            "title": "DaVinci/DataType-2017.py"
+          },
+          {
+            "title": "DaVinci/InputType-RDST.py"
+          },
+          {
+            "title": "DaVinci/DV-RawEventJuggler-0_3-to-4_3.py"
+          },
+          {
+            "title": "Persistency/Compression-ZLIB-1.py"
+          }
+        ],
+        "release": "DaVinci.v42r11p2 AppConfig.v3r404 Det/SQLDDDB.v7r10 TMVAWeights.v1r16",
+        "type": "Stripping29r2p2"
+      },
+      {
+        "configuration_files": [
+          {
+            "title": "Merging/DV-Stripping-Merging.py"
+          },
+          {
+            "title": "Persistency/Compression-LZMA-4.py"
+          }
+        ],
+        "release": "DaVinci.v42r11p2 AppConfig.v3r404 Det/SQLDDDB.v7r10",
+        "type": "Stripping29r2p2-Merging"
+      },
+      {
+        "configuration_files": [
+          {
+            "title": "DaVinci/DV-Stripping29r2p2-Stripping.py"
+          },
+          {
+            "title": "DaVinci/DataType-2017.py"
+          },
+          {
+            "title": "DaVinci/InputType-RDST.py"
+          },
+          {
+            "title": "DaVinci/DV-RawEventJuggler-0_3-to-4_3.py"
+          },
+          {
+            "title": "Persistency/Compression-ZLIB-1.py"
+          }
+        ],
+        "release": "DaVinci.v42r11p2 AppConfig.v3r404 Det/SQLDDDB.v7r10 TMVAWeights.v1r16",
+        "type": "Stripping29r2p2"
+      },
+      {
+        "configuration_files": [
+          {
+            "title": "Merging/DV-Stripping-Merging.py"
+          },
+          {
+            "title": "Persistency/Compression-LZMA-4.py"
+          }
+        ],
+        "release": "DaVinci.v42r11p2 AppConfig.v3r404 Det/SQLDDDB.v7r10",
+        "type": "Stripping29r2p2-Merging"
+      },
+      {
+        "configuration_files": [
+          {
+            "title": "DaVinci/DV-Stripping29r2p2-Stripping.py"
+          },
+          {
+            "title": "DaVinci/DataType-2017.py"
+          },
+          {
+            "title": "DaVinci/InputType-RDST.py"
+          },
+          {
+            "title": "DaVinci/DV-RawEventJuggler-0_3-to-4_3.py"
+          },
+          {
+            "title": "Persistency/Compression-ZLIB-1.py"
+          }
+        ],
+        "release": "DaVinci.v42r11p2 AppConfig.v3r404 Det/SQLDDDB.v7r10 TMVAWeights.v1r16",
+        "type": "Stripping29r2p2"
+      },
+      {
+        "configuration_files": [
+          {
+            "title": "Merging/DV-Stripping-Merging.py"
+          },
+          {
+            "title": "Persistency/Compression-LZMA-4.py"
+          }
+        ],
+        "release": "DaVinci.v42r11p2 AppConfig.v3r404 Det/SQLDDDB.v7r10",
+        "type": "Stripping29r2p2-Merging"
+      }
+    ]
+  },
+  "publisher": "CERN Open Data Portal",
+  "recid": "24751",
+  "run_period": [
+    "2017"
+  ],
+  "stripping": {
+    "stream": "LEPTONIC",
+    "version": "stripping29r2p2"
+  },
+  "title": "LHCb 2017 Beam6500GeV MagUp LEPTONIC Stream Stripping29r2p2",
+  "title_additional": "",
+  "type": {
+    "primary": "Dataset",
+    "secondary": [
+      "Collision"
+    ]
+  },
+  "usage": {
+    "description": "<p> The Run 1 and 2 data collected by the LHCb detector is available using the LHCb Ntupling Service, while the Run 1 data is additionally available in .DST and .mDST formats. The data obtained from the LHCb Ntupling Service are ROOT ntuples and do not require custom software to analyze. <p> Links are provided to the LHCb Ntupling Service for exploration of available data and the LHCb Open Data Guide for usage instructions.",
+    "links": [
+      {
+        "description": "LHCb Ntupling Service",
+        "url": "https://opendata-lhcb-ntupling-service.app.cern.ch/"
+      },
+      {
+        "description": "LHCb Open Data Guide",
+        "url": "https://lhcb-opendata-guide.web.cern.ch/"
+      }
+    ]
+  }
+}]

--- a/data/records/LHCb_2017_Beam6500GeV_VeloClosed_MagUp_RealData_Reco17_Stripping29r2p2_SEMILEPTONIC_DST.json
+++ b/data/records/LHCb_2017_Beam6500GeV_VeloClosed_MagUp_RealData_Reco17_Stripping29r2p2_SEMILEPTONIC_DST.json
@@ -1,0 +1,201 @@
+[{
+  "abstract": {
+    "description": "Data from proton-proton (pp) collisions collected by the LHCb experiment in the year 2017 of Run2 of the LHC."
+  },
+  "accelerator": "CERN-LHC",
+  "collaboration": {
+    "name": "LHCb collaboration",
+    "recid": "456"
+  },
+  "collections": [
+    "LHCb-Collision-Datasets"
+  ],
+  "collision_information": {
+    "energy": "13TeV",
+    "type": "pp"
+  },
+  "date_created": [
+    "2017"
+  ],
+  "date_published": "2026",
+  "date_reprocessed": "2021",
+  "distribution": {
+    "formats": [
+      "DST"
+    ],
+    "number_events": 76578902,
+    "number_files": 3095,
+    "size": 7115517180008
+  },
+  "experiment": [
+    "LHCb"
+  ],
+  "magnet_polarity": "MagUp",
+  "methodology": {
+    "description": "<p> This dataset was created in several production steps. These steps, software used and the configuration is provided below. </p><p> <strong> Prod ID: &nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;</strong> 141014<p> <strong>Prod type:&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp; </strong> Merge<p> <strong> Parent Prod ID:&nbsp;&nbsp;&nbsp;&nbsp; </strong> 140080<p> <strong> Parent Prod type: </strong> DataStripping<p> <strong> Conditions: </strong><p>dddb-20210215-7<p>cond-20191004-3</strong><p> <strong> List of Trigger Configuration Keys (TCK): </strong> </p> <p><p><strong>TCK &nbsp;&nbsp;&nbsp;&nbsp;&nbsp; Number of Files </strong><p>0x11561707 &nbsp;&nbsp;&nbsp;&nbsp;&nbsp; 336<p>0x11601707 &nbsp;&nbsp;&nbsp;&nbsp;&nbsp; 464<p>0x11601708 &nbsp;&nbsp;&nbsp;&nbsp;&nbsp; 414<p>0x11501704 &nbsp;&nbsp;&nbsp;&nbsp;&nbsp; 93<p>0x11501705 &nbsp;&nbsp;&nbsp;&nbsp;&nbsp; 404<p>0x11501703 &nbsp;&nbsp;&nbsp;&nbsp;&nbsp; 106<p>0x114e1702 &nbsp;&nbsp;&nbsp;&nbsp;&nbsp; 23<p>0x11501706 &nbsp;&nbsp;&nbsp;&nbsp;&nbsp; 89<p>0x11611709 &nbsp;&nbsp;&nbsp;&nbsp;&nbsp; 1153<p>0x114e1703 &nbsp;&nbsp;&nbsp;&nbsp;&nbsp; 13",
+    "steps": [
+      {
+        "configuration_files": [
+          {
+            "title": "DaVinci/DV-Stripping29r2p2-Stripping.py"
+          },
+          {
+            "title": "DaVinci/DataType-2017.py"
+          },
+          {
+            "title": "DaVinci/InputType-RDST.py"
+          },
+          {
+            "title": "DaVinci/DV-RawEventJuggler-0_3-to-4_3.py"
+          },
+          {
+            "title": "Persistency/Compression-ZLIB-1.py"
+          }
+        ],
+        "release": "DaVinci.v42r11p2 AppConfig.v3r404 Det/SQLDDDB.v7r10 TMVAWeights.v1r16",
+        "type": "Stripping29r2p2"
+      },
+      {
+        "configuration_files": [
+          {
+            "title": "Merging/DV-Stripping-Merging.py"
+          },
+          {
+            "title": "Persistency/Compression-LZMA-4.py"
+          }
+        ],
+        "release": "DaVinci.v42r11p2 AppConfig.v3r404 Det/SQLDDDB.v7r10",
+        "type": "Stripping29r2p2-Merging"
+      },
+      {
+        "configuration_files": [
+          {
+            "title": "DaVinci/DV-Stripping29r2p2-Stripping.py"
+          },
+          {
+            "title": "DaVinci/DataType-2017.py"
+          },
+          {
+            "title": "DaVinci/InputType-RDST.py"
+          },
+          {
+            "title": "DaVinci/DV-RawEventJuggler-0_3-to-4_3.py"
+          },
+          {
+            "title": "Persistency/Compression-ZLIB-1.py"
+          }
+        ],
+        "release": "DaVinci.v42r11p2 AppConfig.v3r404 Det/SQLDDDB.v7r10 TMVAWeights.v1r16",
+        "type": "Stripping29r2p2"
+      },
+      {
+        "configuration_files": [
+          {
+            "title": "Merging/DV-Stripping-Merging.py"
+          },
+          {
+            "title": "Persistency/Compression-LZMA-4.py"
+          }
+        ],
+        "release": "DaVinci.v42r11p2 AppConfig.v3r404 Det/SQLDDDB.v7r10",
+        "type": "Stripping29r2p2-Merging"
+      },
+      {
+        "configuration_files": [
+          {
+            "title": "DaVinci/DV-Stripping29r2p2-Stripping.py"
+          },
+          {
+            "title": "DaVinci/DataType-2017.py"
+          },
+          {
+            "title": "DaVinci/InputType-RDST.py"
+          },
+          {
+            "title": "DaVinci/DV-RawEventJuggler-0_3-to-4_3.py"
+          },
+          {
+            "title": "Persistency/Compression-ZLIB-1.py"
+          }
+        ],
+        "release": "DaVinci.v42r11p2 AppConfig.v3r404 Det/SQLDDDB.v7r10 TMVAWeights.v1r16",
+        "type": "Stripping29r2p2"
+      },
+      {
+        "configuration_files": [
+          {
+            "title": "Merging/DV-Stripping-Merging.py"
+          },
+          {
+            "title": "Persistency/Compression-LZMA-4.py"
+          }
+        ],
+        "release": "DaVinci.v42r11p2 AppConfig.v3r404 Det/SQLDDDB.v7r10",
+        "type": "Stripping29r2p2-Merging"
+      },
+      {
+        "configuration_files": [
+          {
+            "title": "DaVinci/DV-Stripping29r2p2-Stripping.py"
+          },
+          {
+            "title": "DaVinci/DataType-2017.py"
+          },
+          {
+            "title": "DaVinci/InputType-RDST.py"
+          },
+          {
+            "title": "DaVinci/DV-RawEventJuggler-0_3-to-4_3.py"
+          },
+          {
+            "title": "Persistency/Compression-ZLIB-1.py"
+          }
+        ],
+        "release": "DaVinci.v42r11p2 AppConfig.v3r404 Det/SQLDDDB.v7r10 TMVAWeights.v1r16",
+        "type": "Stripping29r2p2"
+      },
+      {
+        "configuration_files": [
+          {
+            "title": "Merging/DV-Stripping-Merging.py"
+          },
+          {
+            "title": "Persistency/Compression-LZMA-4.py"
+          }
+        ],
+        "release": "DaVinci.v42r11p2 AppConfig.v3r404 Det/SQLDDDB.v7r10",
+        "type": "Stripping29r2p2-Merging"
+      }
+    ]
+  },
+  "publisher": "CERN Open Data Portal",
+  "recid": "24759",
+  "run_period": [
+    "2017"
+  ],
+  "stripping": {
+    "stream": "SEMILEPTONIC",
+    "version": "stripping29r2p2"
+  },
+  "title": "LHCb 2017 Beam6500GeV MagUp SEMILEPTONIC Stream Stripping29r2p2",
+  "title_additional": "",
+  "type": {
+    "primary": "Dataset",
+    "secondary": [
+      "Collision"
+    ]
+  },
+  "usage": {
+    "description": "<p> The Run 1 and 2 data collected by the LHCb detector is available using the LHCb Ntupling Service, while the Run 1 data is additionally available in .DST and .mDST formats. The data obtained from the LHCb Ntupling Service are ROOT ntuples and do not require custom software to analyze. <p> Links are provided to the LHCb Ntupling Service for exploration of available data and the LHCb Open Data Guide for usage instructions.",
+    "links": [
+      {
+        "description": "LHCb Ntupling Service",
+        "url": "https://opendata-lhcb-ntupling-service.app.cern.ch/"
+      },
+      {
+        "description": "LHCb Open Data Guide",
+        "url": "https://lhcb-opendata-guide.web.cern.ch/"
+      }
+    ]
+  }
+}]

--- a/data/records/LHCb_2017_Beam6500GeV_VeloClosed_MagUp_RealData_Reco17_Stripping29r2p3_BHADRONCOMPLETEEVENT_DST.json
+++ b/data/records/LHCb_2017_Beam6500GeV_VeloClosed_MagUp_RealData_Reco17_Stripping29r2p3_BHADRONCOMPLETEEVENT_DST.json
@@ -1,0 +1,234 @@
+[{
+  "abstract": {
+    "description": "Data from proton-proton (pp) collisions collected by the LHCb experiment in the year 2017 of Run2 of the LHC."
+  },
+  "accelerator": "CERN-LHC",
+  "collaboration": {
+    "name": "LHCb collaboration",
+    "recid": "456"
+  },
+  "collections": [
+    "LHCb-Collision-Datasets"
+  ],
+  "collision_information": {
+    "energy": "13TeV",
+    "type": "pp"
+  },
+  "date_created": [
+    "2017"
+  ],
+  "date_published": "2026",
+  "date_reprocessed": "2023",
+  "distribution": {
+    "formats": [
+      "DST"
+    ],
+    "number_events": 480464034,
+    "number_files": 13588,
+    "size": 51339795287572
+  },
+  "experiment": [
+    "LHCb"
+  ],
+  "magnet_polarity": "MagUp",
+  "methodology": {
+    "description": "<p> This dataset was created in several production steps. These steps, software used and the configuration is provided below. </p><p> <strong> Prod ID: &nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;</strong> 206436<p> <strong>Prod type:&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp; </strong> Merge<p> <strong> Parent Prod ID:&nbsp;&nbsp;&nbsp;&nbsp; </strong> 206435<p> <strong> Parent Prod type: </strong> DataStripping<p> <strong> Conditions: </strong><p>dddb-20220927-2017<p>cond-20191004-2</strong><p> <strong> List of Trigger Configuration Keys (TCK): </strong> </p> <p><p><strong>TCK &nbsp;&nbsp;&nbsp;&nbsp;&nbsp; Number of Files </strong><p>0x11501703 &nbsp;&nbsp;&nbsp;&nbsp;&nbsp; 430<p>0x114e1702 &nbsp;&nbsp;&nbsp;&nbsp;&nbsp; 61<p>0x11501704 &nbsp;&nbsp;&nbsp;&nbsp;&nbsp; 458<p>0x11501705 &nbsp;&nbsp;&nbsp;&nbsp;&nbsp; 1965<p>0x114e1703 &nbsp;&nbsp;&nbsp;&nbsp;&nbsp; 37<p>0x11501706 &nbsp;&nbsp;&nbsp;&nbsp;&nbsp; 388<p>0x11611709 &nbsp;&nbsp;&nbsp;&nbsp;&nbsp; 5178<p>0x11601707 &nbsp;&nbsp;&nbsp;&nbsp;&nbsp; 1873<p>0x11561707 &nbsp;&nbsp;&nbsp;&nbsp;&nbsp; 1336<p>0x11601708 &nbsp;&nbsp;&nbsp;&nbsp;&nbsp; 1862",
+    "steps": [
+      {
+        "configuration_files": [
+          {
+            "title": "DaVinci/DV-Stripping29r2p3-Stripping.py"
+          },
+          {
+            "title": "DaVinci/DataType-2017.py"
+          },
+          {
+            "title": "DaVinci/InputType-RDST.py"
+          },
+          {
+            "title": "DaVinci/DV-RawEventJuggler-0_3-to-4_3.py"
+          },
+          {
+            "title": "Persistency/Compression-ZLIB-1.py"
+          }
+        ],
+        "release": "DaVinci.v44r11p6 AppConfig.v3r421 Det/SQLDDDB.v7r12 TMVAWeights.v1r18",
+        "type": "Stripping29r2p3_mu"
+      },
+      {
+        "configuration_files": [
+          {
+            "title": "Merging/DV-Stripping-Merging.py"
+          },
+          {
+            "title": "Persistency/Compression-LZMA-4.py"
+          }
+        ],
+        "release": "DaVinci.v44r11p6 AppConfig.v3r421 Det/SQLDDDB.v7r12 TMVAWeights.v1r18",
+        "type": "Merge_Stripping29r2p3_mu"
+      },
+      {
+        "configuration_files": [
+          {
+            "title": "DaVinci/DV-Stripping29r2p3-Stripping.py"
+          },
+          {
+            "title": "DaVinci/DataType-2017.py"
+          },
+          {
+            "title": "DaVinci/InputType-RDST.py"
+          },
+          {
+            "title": "DaVinci/DV-RawEventJuggler-0_3-to-4_3.py"
+          },
+          {
+            "title": "Persistency/Compression-ZLIB-1.py"
+          }
+        ],
+        "release": "DaVinci.v44r11p6 AppConfig.v3r421 Det/SQLDDDB.v7r12 TMVAWeights.v1r18",
+        "type": "Stripping29r2p3_mu"
+      },
+      {
+        "configuration_files": [
+          {
+            "title": "Merging/DV-Stripping-Merging.py"
+          },
+          {
+            "title": "Persistency/Compression-LZMA-4.py"
+          }
+        ],
+        "release": "DaVinci.v44r11p6 AppConfig.v3r421 Det/SQLDDDB.v7r12 TMVAWeights.v1r18",
+        "type": "Merge_Stripping29r2p3_mu"
+      },
+      {
+        "configuration_files": [
+          {
+            "title": "DaVinci/DV-Stripping29r2p3-Stripping.py"
+          },
+          {
+            "title": "DaVinci/DataType-2017.py"
+          },
+          {
+            "title": "DaVinci/InputType-RDST.py"
+          },
+          {
+            "title": "DaVinci/DV-RawEventJuggler-0_3-to-4_3.py"
+          },
+          {
+            "title": "Persistency/Compression-ZLIB-1.py"
+          }
+        ],
+        "release": "DaVinci.v44r11p6 AppConfig.v3r421 Det/SQLDDDB.v7r12 TMVAWeights.v1r18",
+        "type": "Stripping29r2p3_mu"
+      },
+      {
+        "configuration_files": [
+          {
+            "title": "Merging/DV-Stripping-Merging.py"
+          },
+          {
+            "title": "Persistency/Compression-LZMA-4.py"
+          }
+        ],
+        "release": "DaVinci.v44r11p6 AppConfig.v3r421 Det/SQLDDDB.v7r12 TMVAWeights.v1r18",
+        "type": "Merge_Stripping29r2p3_mu"
+      },
+      {
+        "configuration_files": [
+          {
+            "title": "DaVinci/DV-Stripping29r2p3-Stripping.py"
+          },
+          {
+            "title": "DaVinci/DataType-2017.py"
+          },
+          {
+            "title": "DaVinci/InputType-RDST.py"
+          },
+          {
+            "title": "DaVinci/DV-RawEventJuggler-0_3-to-4_3.py"
+          },
+          {
+            "title": "Persistency/Compression-ZLIB-1.py"
+          }
+        ],
+        "release": "DaVinci.v44r11p6 AppConfig.v3r421 Det/SQLDDDB.v7r12 TMVAWeights.v1r18",
+        "type": "Stripping29r2p3_mu"
+      },
+      {
+        "configuration_files": [
+          {
+            "title": "Merging/DV-Stripping-Merging.py"
+          },
+          {
+            "title": "Persistency/Compression-LZMA-4.py"
+          }
+        ],
+        "release": "DaVinci.v44r11p6 AppConfig.v3r421 Det/SQLDDDB.v7r12 TMVAWeights.v1r18",
+        "type": "Merge_Stripping29r2p3_mu"
+      },
+      {
+        "configuration_files": [
+          {
+            "title": "DaVinci/DV-Stripping29r2p3-Stripping.py"
+          },
+          {
+            "title": "DaVinci/DataType-2017.py"
+          },
+          {
+            "title": "DaVinci/InputType-RDST.py"
+          },
+          {
+            "title": "DaVinci/DV-RawEventJuggler-0_3-to-4_3.py"
+          },
+          {
+            "title": "Persistency/Compression-ZLIB-1.py"
+          }
+        ],
+        "release": "DaVinci.v44r11p6 AppConfig.v3r421 Det/SQLDDDB.v7r12 TMVAWeights.v1r18",
+        "type": "Stripping29r2p3_mu"
+      },
+      {
+        "configuration_files": [
+          {
+            "title": "Merging/DV-Stripping-Merging.py"
+          },
+          {
+            "title": "Persistency/Compression-LZMA-4.py"
+          }
+        ],
+        "release": "DaVinci.v44r11p6 AppConfig.v3r421 Det/SQLDDDB.v7r12 TMVAWeights.v1r18",
+        "type": "Merge_Stripping29r2p3_mu"
+      }
+    ]
+  },
+  "publisher": "CERN Open Data Portal",
+  "recid": "24775",
+  "run_period": [
+    "2017"
+  ],
+  "stripping": {
+    "stream": "BHADRONCOMPLETEEVENT",
+    "version": "stripping29r2p3"
+  },
+  "title": "LHCb 2017 Beam6500GeV MagUp BHADRONCOMPLETEEVENT Stream Stripping29r2p3",
+  "title_additional": "",
+  "type": {
+    "primary": "Dataset",
+    "secondary": [
+      "Collision"
+    ]
+  },
+  "usage": {
+    "description": "<p> The Run 1 and 2 data collected by the LHCb detector is available using the LHCb Ntupling Service, while the Run 1 data is additionally available in .DST and .mDST formats. The data obtained from the LHCb Ntupling Service are ROOT ntuples and do not require custom software to analyze. <p> Links are provided to the LHCb Ntupling Service for exploration of available data and the LHCb Open Data Guide for usage instructions.",
+    "links": [
+      {
+        "description": "LHCb Ntupling Service",
+        "url": "https://opendata-lhcb-ntupling-service.app.cern.ch/"
+      },
+      {
+        "description": "LHCb Open Data Guide",
+        "url": "https://lhcb-opendata-guide.web.cern.ch/"
+      }
+    ]
+  }
+}]

--- a/data/records/LHCb_2017_Beam6500GeV_VeloClosed_MagUp_RealData_Reco17_Stripping29r2p3_BHADRON_MDST.json
+++ b/data/records/LHCb_2017_Beam6500GeV_VeloClosed_MagUp_RealData_Reco17_Stripping29r2p3_BHADRON_MDST.json
@@ -1,0 +1,234 @@
+[{
+  "abstract": {
+    "description": "Data from proton-proton (pp) collisions collected by the LHCb experiment in the year 2017 of Run2 of the LHC."
+  },
+  "accelerator": "CERN-LHC",
+  "collaboration": {
+    "name": "LHCb collaboration",
+    "recid": "456"
+  },
+  "collections": [
+    "LHCb-Collision-Datasets"
+  ],
+  "collision_information": {
+    "energy": "13TeV",
+    "type": "pp"
+  },
+  "date_created": [
+    "2017"
+  ],
+  "date_published": "2026",
+  "date_reprocessed": "2023",
+  "distribution": {
+    "formats": [
+      "MDST"
+    ],
+    "number_events": 1818354011,
+    "number_files": 10155,
+    "size": 35229104213682
+  },
+  "experiment": [
+    "LHCb"
+  ],
+  "magnet_polarity": "MagUp",
+  "methodology": {
+    "description": "<p> This dataset was created in several production steps. These steps, software used and the configuration is provided below. </p><p> <strong> Prod ID: &nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;</strong> 206436<p> <strong>Prod type:&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp; </strong> Merge<p> <strong> Parent Prod ID:&nbsp;&nbsp;&nbsp;&nbsp; </strong> 206435<p> <strong> Parent Prod type: </strong> DataStripping<p> <strong> Conditions: </strong><p>dddb-20220927-2017<p>cond-20191004-2</strong><p> <strong> List of Trigger Configuration Keys (TCK): </strong> </p> <p><p><strong>TCK &nbsp;&nbsp;&nbsp;&nbsp;&nbsp; Number of Files </strong><p>0x11501705 &nbsp;&nbsp;&nbsp;&nbsp;&nbsp; 1429<p>0x11501704 &nbsp;&nbsp;&nbsp;&nbsp;&nbsp; 337<p>0x11501703 &nbsp;&nbsp;&nbsp;&nbsp;&nbsp; 321<p>0x114e1702 &nbsp;&nbsp;&nbsp;&nbsp;&nbsp; 51<p>0x114e1703 &nbsp;&nbsp;&nbsp;&nbsp;&nbsp; 28<p>0x11501706 &nbsp;&nbsp;&nbsp;&nbsp;&nbsp; 282<p>0x11611709 &nbsp;&nbsp;&nbsp;&nbsp;&nbsp; 3921<p>0x11561707 &nbsp;&nbsp;&nbsp;&nbsp;&nbsp; 982<p>0x11601707 &nbsp;&nbsp;&nbsp;&nbsp;&nbsp; 1394<p>0x11601708 &nbsp;&nbsp;&nbsp;&nbsp;&nbsp; 1410",
+    "steps": [
+      {
+        "configuration_files": [
+          {
+            "title": "DaVinci/DV-Stripping29r2p3-Stripping.py"
+          },
+          {
+            "title": "DaVinci/DataType-2017.py"
+          },
+          {
+            "title": "DaVinci/InputType-RDST.py"
+          },
+          {
+            "title": "DaVinci/DV-RawEventJuggler-0_3-to-4_3.py"
+          },
+          {
+            "title": "Persistency/Compression-ZLIB-1.py"
+          }
+        ],
+        "release": "DaVinci.v44r11p6 AppConfig.v3r421 Det/SQLDDDB.v7r12 TMVAWeights.v1r18",
+        "type": "Stripping29r2p3_mu"
+      },
+      {
+        "configuration_files": [
+          {
+            "title": "Merging/DV-Stripping-Merging.py"
+          },
+          {
+            "title": "Persistency/Compression-LZMA-4.py"
+          }
+        ],
+        "release": "DaVinci.v44r11p6 AppConfig.v3r421 Det/SQLDDDB.v7r12 TMVAWeights.v1r18",
+        "type": "Merge_Stripping29r2p3_mu"
+      },
+      {
+        "configuration_files": [
+          {
+            "title": "DaVinci/DV-Stripping29r2p3-Stripping.py"
+          },
+          {
+            "title": "DaVinci/DataType-2017.py"
+          },
+          {
+            "title": "DaVinci/InputType-RDST.py"
+          },
+          {
+            "title": "DaVinci/DV-RawEventJuggler-0_3-to-4_3.py"
+          },
+          {
+            "title": "Persistency/Compression-ZLIB-1.py"
+          }
+        ],
+        "release": "DaVinci.v44r11p6 AppConfig.v3r421 Det/SQLDDDB.v7r12 TMVAWeights.v1r18",
+        "type": "Stripping29r2p3_mu"
+      },
+      {
+        "configuration_files": [
+          {
+            "title": "Merging/DV-Stripping-Merging.py"
+          },
+          {
+            "title": "Persistency/Compression-LZMA-4.py"
+          }
+        ],
+        "release": "DaVinci.v44r11p6 AppConfig.v3r421 Det/SQLDDDB.v7r12 TMVAWeights.v1r18",
+        "type": "Merge_Stripping29r2p3_mu"
+      },
+      {
+        "configuration_files": [
+          {
+            "title": "DaVinci/DV-Stripping29r2p3-Stripping.py"
+          },
+          {
+            "title": "DaVinci/DataType-2017.py"
+          },
+          {
+            "title": "DaVinci/InputType-RDST.py"
+          },
+          {
+            "title": "DaVinci/DV-RawEventJuggler-0_3-to-4_3.py"
+          },
+          {
+            "title": "Persistency/Compression-ZLIB-1.py"
+          }
+        ],
+        "release": "DaVinci.v44r11p6 AppConfig.v3r421 Det/SQLDDDB.v7r12 TMVAWeights.v1r18",
+        "type": "Stripping29r2p3_mu"
+      },
+      {
+        "configuration_files": [
+          {
+            "title": "Merging/DV-Stripping-Merging.py"
+          },
+          {
+            "title": "Persistency/Compression-LZMA-4.py"
+          }
+        ],
+        "release": "DaVinci.v44r11p6 AppConfig.v3r421 Det/SQLDDDB.v7r12 TMVAWeights.v1r18",
+        "type": "Merge_Stripping29r2p3_mu"
+      },
+      {
+        "configuration_files": [
+          {
+            "title": "DaVinci/DV-Stripping29r2p3-Stripping.py"
+          },
+          {
+            "title": "DaVinci/DataType-2017.py"
+          },
+          {
+            "title": "DaVinci/InputType-RDST.py"
+          },
+          {
+            "title": "DaVinci/DV-RawEventJuggler-0_3-to-4_3.py"
+          },
+          {
+            "title": "Persistency/Compression-ZLIB-1.py"
+          }
+        ],
+        "release": "DaVinci.v44r11p6 AppConfig.v3r421 Det/SQLDDDB.v7r12 TMVAWeights.v1r18",
+        "type": "Stripping29r2p3_mu"
+      },
+      {
+        "configuration_files": [
+          {
+            "title": "Merging/DV-Stripping-Merging.py"
+          },
+          {
+            "title": "Persistency/Compression-LZMA-4.py"
+          }
+        ],
+        "release": "DaVinci.v44r11p6 AppConfig.v3r421 Det/SQLDDDB.v7r12 TMVAWeights.v1r18",
+        "type": "Merge_Stripping29r2p3_mu"
+      },
+      {
+        "configuration_files": [
+          {
+            "title": "DaVinci/DV-Stripping29r2p3-Stripping.py"
+          },
+          {
+            "title": "DaVinci/DataType-2017.py"
+          },
+          {
+            "title": "DaVinci/InputType-RDST.py"
+          },
+          {
+            "title": "DaVinci/DV-RawEventJuggler-0_3-to-4_3.py"
+          },
+          {
+            "title": "Persistency/Compression-ZLIB-1.py"
+          }
+        ],
+        "release": "DaVinci.v44r11p6 AppConfig.v3r421 Det/SQLDDDB.v7r12 TMVAWeights.v1r18",
+        "type": "Stripping29r2p3_mu"
+      },
+      {
+        "configuration_files": [
+          {
+            "title": "Merging/DV-Stripping-Merging.py"
+          },
+          {
+            "title": "Persistency/Compression-LZMA-4.py"
+          }
+        ],
+        "release": "DaVinci.v44r11p6 AppConfig.v3r421 Det/SQLDDDB.v7r12 TMVAWeights.v1r18",
+        "type": "Merge_Stripping29r2p3_mu"
+      }
+    ]
+  },
+  "publisher": "CERN Open Data Portal",
+  "recid": "24774",
+  "run_period": [
+    "2017"
+  ],
+  "stripping": {
+    "stream": "BHADRON",
+    "version": "stripping29r2p3"
+  },
+  "title": "LHCb 2017 Beam6500GeV MagUp BHADRON Stream Stripping29r2p3",
+  "title_additional": "",
+  "type": {
+    "primary": "Dataset",
+    "secondary": [
+      "Collision"
+    ]
+  },
+  "usage": {
+    "description": "<p> The Run 1 and 2 data collected by the LHCb detector is available using the LHCb Ntupling Service, while the Run 1 data is additionally available in .DST and .mDST formats. The data obtained from the LHCb Ntupling Service are ROOT ntuples and do not require custom software to analyze. <p> Links are provided to the LHCb Ntupling Service for exploration of available data and the LHCb Open Data Guide for usage instructions.",
+    "links": [
+      {
+        "description": "LHCb Ntupling Service",
+        "url": "https://opendata-lhcb-ntupling-service.app.cern.ch/"
+      },
+      {
+        "description": "LHCb Open Data Guide",
+        "url": "https://lhcb-opendata-guide.web.cern.ch/"
+      }
+    ]
+  }
+}]

--- a/data/records/LHCb_2017_Beam6500GeV_VeloClosed_MagUp_RealData_Reco17_Stripping29r2p3_CHARMCOMPLETEEVENT_DST.json
+++ b/data/records/LHCb_2017_Beam6500GeV_VeloClosed_MagUp_RealData_Reco17_Stripping29r2p3_CHARMCOMPLETEEVENT_DST.json
@@ -1,0 +1,234 @@
+[{
+  "abstract": {
+    "description": "Data from proton-proton (pp) collisions collected by the LHCb experiment in the year 2017 of Run2 of the LHC."
+  },
+  "accelerator": "CERN-LHC",
+  "collaboration": {
+    "name": "LHCb collaboration",
+    "recid": "456"
+  },
+  "collections": [
+    "LHCb-Collision-Datasets"
+  ],
+  "collision_information": {
+    "energy": "13TeV",
+    "type": "pp"
+  },
+  "date_created": [
+    "2017"
+  ],
+  "date_published": "2026",
+  "date_reprocessed": "2023",
+  "distribution": {
+    "formats": [
+      "DST"
+    ],
+    "number_events": 150721721,
+    "number_files": 3987,
+    "size": 11850220191712
+  },
+  "experiment": [
+    "LHCb"
+  ],
+  "magnet_polarity": "MagUp",
+  "methodology": {
+    "description": "<p> This dataset was created in several production steps. These steps, software used and the configuration is provided below. </p><p> <strong> Prod ID: &nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;</strong> 206592<p> <strong>Prod type:&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp; </strong> Merge<p> <strong> Parent Prod ID:&nbsp;&nbsp;&nbsp;&nbsp; </strong> 206435<p> <strong> Parent Prod type: </strong> DataStripping<p> <strong> Conditions: </strong><p>dddb-20220927-2017<p>cond-20191004-2</strong><p> <strong> List of Trigger Configuration Keys (TCK): </strong> </p> <p><p><strong>TCK &nbsp;&nbsp;&nbsp;&nbsp;&nbsp; Number of Files </strong><p>0x11501703 &nbsp;&nbsp;&nbsp;&nbsp;&nbsp; 141<p>0x11501704 &nbsp;&nbsp;&nbsp;&nbsp;&nbsp; 141<p>0x11501705 &nbsp;&nbsp;&nbsp;&nbsp;&nbsp; 558<p>0x114e1703 &nbsp;&nbsp;&nbsp;&nbsp;&nbsp; 16<p>0x114e1702 &nbsp;&nbsp;&nbsp;&nbsp;&nbsp; 24<p>0x11501706 &nbsp;&nbsp;&nbsp;&nbsp;&nbsp; 109<p>0x11611709 &nbsp;&nbsp;&nbsp;&nbsp;&nbsp; 1430<p>0x11601707 &nbsp;&nbsp;&nbsp;&nbsp;&nbsp; 598<p>0x11561707 &nbsp;&nbsp;&nbsp;&nbsp;&nbsp; 397<p>0x11601708 &nbsp;&nbsp;&nbsp;&nbsp;&nbsp; 573",
+    "steps": [
+      {
+        "configuration_files": [
+          {
+            "title": "DaVinci/DV-Stripping29r2p3-Stripping.py"
+          },
+          {
+            "title": "DaVinci/DataType-2017.py"
+          },
+          {
+            "title": "DaVinci/InputType-RDST.py"
+          },
+          {
+            "title": "DaVinci/DV-RawEventJuggler-0_3-to-4_3.py"
+          },
+          {
+            "title": "Persistency/Compression-ZLIB-1.py"
+          }
+        ],
+        "release": "DaVinci.v44r11p6 AppConfig.v3r421 Det/SQLDDDB.v7r12 TMVAWeights.v1r18",
+        "type": "Stripping29r2p3_mu"
+      },
+      {
+        "configuration_files": [
+          {
+            "title": "Merging/DV-Stripping-Merging.py"
+          },
+          {
+            "title": "Persistency/Compression-LZMA-4.py"
+          }
+        ],
+        "release": "DaVinci.v44r11p6 AppConfig.v3r421 Det/SQLDDDB.v7r12 TMVAWeights.v1r18",
+        "type": "Merge_Stripping29r2p3_mu"
+      },
+      {
+        "configuration_files": [
+          {
+            "title": "DaVinci/DV-Stripping29r2p3-Stripping.py"
+          },
+          {
+            "title": "DaVinci/DataType-2017.py"
+          },
+          {
+            "title": "DaVinci/InputType-RDST.py"
+          },
+          {
+            "title": "DaVinci/DV-RawEventJuggler-0_3-to-4_3.py"
+          },
+          {
+            "title": "Persistency/Compression-ZLIB-1.py"
+          }
+        ],
+        "release": "DaVinci.v44r11p6 AppConfig.v3r421 Det/SQLDDDB.v7r12 TMVAWeights.v1r18",
+        "type": "Stripping29r2p3_mu"
+      },
+      {
+        "configuration_files": [
+          {
+            "title": "Merging/DV-Stripping-Merging.py"
+          },
+          {
+            "title": "Persistency/Compression-LZMA-4.py"
+          }
+        ],
+        "release": "DaVinci.v44r11p6 AppConfig.v3r421 Det/SQLDDDB.v7r12 TMVAWeights.v1r18",
+        "type": "Merge_Stripping29r2p3_mu"
+      },
+      {
+        "configuration_files": [
+          {
+            "title": "DaVinci/DV-Stripping29r2p3-Stripping.py"
+          },
+          {
+            "title": "DaVinci/DataType-2017.py"
+          },
+          {
+            "title": "DaVinci/InputType-RDST.py"
+          },
+          {
+            "title": "DaVinci/DV-RawEventJuggler-0_3-to-4_3.py"
+          },
+          {
+            "title": "Persistency/Compression-ZLIB-1.py"
+          }
+        ],
+        "release": "DaVinci.v44r11p6 AppConfig.v3r421 Det/SQLDDDB.v7r12 TMVAWeights.v1r18",
+        "type": "Stripping29r2p3_mu"
+      },
+      {
+        "configuration_files": [
+          {
+            "title": "Merging/DV-Stripping-Merging.py"
+          },
+          {
+            "title": "Persistency/Compression-LZMA-4.py"
+          }
+        ],
+        "release": "DaVinci.v44r11p6 AppConfig.v3r421 Det/SQLDDDB.v7r12 TMVAWeights.v1r18",
+        "type": "Merge_Stripping29r2p3_mu"
+      },
+      {
+        "configuration_files": [
+          {
+            "title": "DaVinci/DV-Stripping29r2p3-Stripping.py"
+          },
+          {
+            "title": "DaVinci/DataType-2017.py"
+          },
+          {
+            "title": "DaVinci/InputType-RDST.py"
+          },
+          {
+            "title": "DaVinci/DV-RawEventJuggler-0_3-to-4_3.py"
+          },
+          {
+            "title": "Persistency/Compression-ZLIB-1.py"
+          }
+        ],
+        "release": "DaVinci.v44r11p6 AppConfig.v3r421 Det/SQLDDDB.v7r12 TMVAWeights.v1r18",
+        "type": "Stripping29r2p3_mu"
+      },
+      {
+        "configuration_files": [
+          {
+            "title": "Merging/DV-Stripping-Merging.py"
+          },
+          {
+            "title": "Persistency/Compression-LZMA-4.py"
+          }
+        ],
+        "release": "DaVinci.v44r11p6 AppConfig.v3r421 Det/SQLDDDB.v7r12 TMVAWeights.v1r18",
+        "type": "Merge_Stripping29r2p3_mu"
+      },
+      {
+        "configuration_files": [
+          {
+            "title": "DaVinci/DV-Stripping29r2p3-Stripping.py"
+          },
+          {
+            "title": "DaVinci/DataType-2017.py"
+          },
+          {
+            "title": "DaVinci/InputType-RDST.py"
+          },
+          {
+            "title": "DaVinci/DV-RawEventJuggler-0_3-to-4_3.py"
+          },
+          {
+            "title": "Persistency/Compression-ZLIB-1.py"
+          }
+        ],
+        "release": "DaVinci.v44r11p6 AppConfig.v3r421 Det/SQLDDDB.v7r12 TMVAWeights.v1r18",
+        "type": "Stripping29r2p3_mu"
+      },
+      {
+        "configuration_files": [
+          {
+            "title": "Merging/DV-Stripping-Merging.py"
+          },
+          {
+            "title": "Persistency/Compression-LZMA-4.py"
+          }
+        ],
+        "release": "DaVinci.v44r11p6 AppConfig.v3r421 Det/SQLDDDB.v7r12 TMVAWeights.v1r18",
+        "type": "Merge_Stripping29r2p3_mu"
+      }
+    ]
+  },
+  "publisher": "CERN Open Data Portal",
+  "recid": "24777",
+  "run_period": [
+    "2017"
+  ],
+  "stripping": {
+    "stream": "CHARMCOMPLETEEVENT",
+    "version": "stripping29r2p3"
+  },
+  "title": "LHCb 2017 Beam6500GeV MagUp CHARMCOMPLETEEVENT Stream Stripping29r2p3",
+  "title_additional": "",
+  "type": {
+    "primary": "Dataset",
+    "secondary": [
+      "Collision"
+    ]
+  },
+  "usage": {
+    "description": "<p> The Run 1 and 2 data collected by the LHCb detector is available using the LHCb Ntupling Service, while the Run 1 data is additionally available in .DST and .mDST formats. The data obtained from the LHCb Ntupling Service are ROOT ntuples and do not require custom software to analyze. <p> Links are provided to the LHCb Ntupling Service for exploration of available data and the LHCb Open Data Guide for usage instructions.",
+    "links": [
+      {
+        "description": "LHCb Ntupling Service",
+        "url": "https://opendata-lhcb-ntupling-service.app.cern.ch/"
+      },
+      {
+        "description": "LHCb Open Data Guide",
+        "url": "https://lhcb-opendata-guide.web.cern.ch/"
+      }
+    ]
+  }
+}]

--- a/data/records/LHCb_2017_Beam6500GeV_VeloClosed_MagUp_RealData_Reco17_Stripping29r2p3_CHARM_MDST.json
+++ b/data/records/LHCb_2017_Beam6500GeV_VeloClosed_MagUp_RealData_Reco17_Stripping29r2p3_CHARM_MDST.json
@@ -1,0 +1,234 @@
+[{
+  "abstract": {
+    "description": "Data from proton-proton (pp) collisions collected by the LHCb experiment in the year 2017 of Run2 of the LHC."
+  },
+  "accelerator": "CERN-LHC",
+  "collaboration": {
+    "name": "LHCb collaboration",
+    "recid": "456"
+  },
+  "collections": [
+    "LHCb-Collision-Datasets"
+  ],
+  "collision_information": {
+    "energy": "13TeV",
+    "type": "pp"
+  },
+  "date_created": [
+    "2017"
+  ],
+  "date_published": "2026",
+  "date_reprocessed": "2023",
+  "distribution": {
+    "formats": [
+      "MDST"
+    ],
+    "number_events": 1983645533,
+    "number_files": 6787,
+    "size": 23097546414509
+  },
+  "experiment": [
+    "LHCb"
+  ],
+  "magnet_polarity": "MagUp",
+  "methodology": {
+    "description": "<p> This dataset was created in several production steps. These steps, software used and the configuration is provided below. </p><p> <strong> Prod ID: &nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;</strong> 206436<p> <strong>Prod type:&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp; </strong> Merge<p> <strong> Parent Prod ID:&nbsp;&nbsp;&nbsp;&nbsp; </strong> 206435<p> <strong> Parent Prod type: </strong> DataStripping<p> <strong> Conditions: </strong><p>dddb-20220927-2017<p>cond-20191004-2</strong><p> <strong> List of Trigger Configuration Keys (TCK): </strong> </p> <p><p><strong>TCK &nbsp;&nbsp;&nbsp;&nbsp;&nbsp; Number of Files </strong><p>0x11501705 &nbsp;&nbsp;&nbsp;&nbsp;&nbsp; 942<p>0x11501704 &nbsp;&nbsp;&nbsp;&nbsp;&nbsp; 227<p>0x11501703 &nbsp;&nbsp;&nbsp;&nbsp;&nbsp; 218<p>0x114e1702 &nbsp;&nbsp;&nbsp;&nbsp;&nbsp; 37<p>0x114e1703 &nbsp;&nbsp;&nbsp;&nbsp;&nbsp; 21<p>0x11501706 &nbsp;&nbsp;&nbsp;&nbsp;&nbsp; 186<p>0x11611709 &nbsp;&nbsp;&nbsp;&nbsp;&nbsp; 2608<p>0x11601707 &nbsp;&nbsp;&nbsp;&nbsp;&nbsp; 931<p>0x11561707 &nbsp;&nbsp;&nbsp;&nbsp;&nbsp; 645<p>0x11601708 &nbsp;&nbsp;&nbsp;&nbsp;&nbsp; 972",
+    "steps": [
+      {
+        "configuration_files": [
+          {
+            "title": "DaVinci/DV-Stripping29r2p3-Stripping.py"
+          },
+          {
+            "title": "DaVinci/DataType-2017.py"
+          },
+          {
+            "title": "DaVinci/InputType-RDST.py"
+          },
+          {
+            "title": "DaVinci/DV-RawEventJuggler-0_3-to-4_3.py"
+          },
+          {
+            "title": "Persistency/Compression-ZLIB-1.py"
+          }
+        ],
+        "release": "DaVinci.v44r11p6 AppConfig.v3r421 Det/SQLDDDB.v7r12 TMVAWeights.v1r18",
+        "type": "Stripping29r2p3_mu"
+      },
+      {
+        "configuration_files": [
+          {
+            "title": "Merging/DV-Stripping-Merging.py"
+          },
+          {
+            "title": "Persistency/Compression-LZMA-4.py"
+          }
+        ],
+        "release": "DaVinci.v44r11p6 AppConfig.v3r421 Det/SQLDDDB.v7r12 TMVAWeights.v1r18",
+        "type": "Merge_Stripping29r2p3_mu"
+      },
+      {
+        "configuration_files": [
+          {
+            "title": "DaVinci/DV-Stripping29r2p3-Stripping.py"
+          },
+          {
+            "title": "DaVinci/DataType-2017.py"
+          },
+          {
+            "title": "DaVinci/InputType-RDST.py"
+          },
+          {
+            "title": "DaVinci/DV-RawEventJuggler-0_3-to-4_3.py"
+          },
+          {
+            "title": "Persistency/Compression-ZLIB-1.py"
+          }
+        ],
+        "release": "DaVinci.v44r11p6 AppConfig.v3r421 Det/SQLDDDB.v7r12 TMVAWeights.v1r18",
+        "type": "Stripping29r2p3_mu"
+      },
+      {
+        "configuration_files": [
+          {
+            "title": "Merging/DV-Stripping-Merging.py"
+          },
+          {
+            "title": "Persistency/Compression-LZMA-4.py"
+          }
+        ],
+        "release": "DaVinci.v44r11p6 AppConfig.v3r421 Det/SQLDDDB.v7r12 TMVAWeights.v1r18",
+        "type": "Merge_Stripping29r2p3_mu"
+      },
+      {
+        "configuration_files": [
+          {
+            "title": "DaVinci/DV-Stripping29r2p3-Stripping.py"
+          },
+          {
+            "title": "DaVinci/DataType-2017.py"
+          },
+          {
+            "title": "DaVinci/InputType-RDST.py"
+          },
+          {
+            "title": "DaVinci/DV-RawEventJuggler-0_3-to-4_3.py"
+          },
+          {
+            "title": "Persistency/Compression-ZLIB-1.py"
+          }
+        ],
+        "release": "DaVinci.v44r11p6 AppConfig.v3r421 Det/SQLDDDB.v7r12 TMVAWeights.v1r18",
+        "type": "Stripping29r2p3_mu"
+      },
+      {
+        "configuration_files": [
+          {
+            "title": "Merging/DV-Stripping-Merging.py"
+          },
+          {
+            "title": "Persistency/Compression-LZMA-4.py"
+          }
+        ],
+        "release": "DaVinci.v44r11p6 AppConfig.v3r421 Det/SQLDDDB.v7r12 TMVAWeights.v1r18",
+        "type": "Merge_Stripping29r2p3_mu"
+      },
+      {
+        "configuration_files": [
+          {
+            "title": "DaVinci/DV-Stripping29r2p3-Stripping.py"
+          },
+          {
+            "title": "DaVinci/DataType-2017.py"
+          },
+          {
+            "title": "DaVinci/InputType-RDST.py"
+          },
+          {
+            "title": "DaVinci/DV-RawEventJuggler-0_3-to-4_3.py"
+          },
+          {
+            "title": "Persistency/Compression-ZLIB-1.py"
+          }
+        ],
+        "release": "DaVinci.v44r11p6 AppConfig.v3r421 Det/SQLDDDB.v7r12 TMVAWeights.v1r18",
+        "type": "Stripping29r2p3_mu"
+      },
+      {
+        "configuration_files": [
+          {
+            "title": "Merging/DV-Stripping-Merging.py"
+          },
+          {
+            "title": "Persistency/Compression-LZMA-4.py"
+          }
+        ],
+        "release": "DaVinci.v44r11p6 AppConfig.v3r421 Det/SQLDDDB.v7r12 TMVAWeights.v1r18",
+        "type": "Merge_Stripping29r2p3_mu"
+      },
+      {
+        "configuration_files": [
+          {
+            "title": "DaVinci/DV-Stripping29r2p3-Stripping.py"
+          },
+          {
+            "title": "DaVinci/DataType-2017.py"
+          },
+          {
+            "title": "DaVinci/InputType-RDST.py"
+          },
+          {
+            "title": "DaVinci/DV-RawEventJuggler-0_3-to-4_3.py"
+          },
+          {
+            "title": "Persistency/Compression-ZLIB-1.py"
+          }
+        ],
+        "release": "DaVinci.v44r11p6 AppConfig.v3r421 Det/SQLDDDB.v7r12 TMVAWeights.v1r18",
+        "type": "Stripping29r2p3_mu"
+      },
+      {
+        "configuration_files": [
+          {
+            "title": "Merging/DV-Stripping-Merging.py"
+          },
+          {
+            "title": "Persistency/Compression-LZMA-4.py"
+          }
+        ],
+        "release": "DaVinci.v44r11p6 AppConfig.v3r421 Det/SQLDDDB.v7r12 TMVAWeights.v1r18",
+        "type": "Merge_Stripping29r2p3_mu"
+      }
+    ]
+  },
+  "publisher": "CERN Open Data Portal",
+  "recid": "24776",
+  "run_period": [
+    "2017"
+  ],
+  "stripping": {
+    "stream": "CHARM",
+    "version": "stripping29r2p3"
+  },
+  "title": "LHCb 2017 Beam6500GeV MagUp CHARM Stream Stripping29r2p3",
+  "title_additional": "",
+  "type": {
+    "primary": "Dataset",
+    "secondary": [
+      "Collision"
+    ]
+  },
+  "usage": {
+    "description": "<p> The Run 1 and 2 data collected by the LHCb detector is available using the LHCb Ntupling Service, while the Run 1 data is additionally available in .DST and .mDST formats. The data obtained from the LHCb Ntupling Service are ROOT ntuples and do not require custom software to analyze. <p> Links are provided to the LHCb Ntupling Service for exploration of available data and the LHCb Open Data Guide for usage instructions.",
+    "links": [
+      {
+        "description": "LHCb Ntupling Service",
+        "url": "https://opendata-lhcb-ntupling-service.app.cern.ch/"
+      },
+      {
+        "description": "LHCb Open Data Guide",
+        "url": "https://lhcb-opendata-guide.web.cern.ch/"
+      }
+    ]
+  }
+}]

--- a/data/records/LHCb_2017_Beam6500GeV_VeloClosed_MagUp_RealData_Reco17_Stripping29r2p3_DIMUON_DST.json
+++ b/data/records/LHCb_2017_Beam6500GeV_VeloClosed_MagUp_RealData_Reco17_Stripping29r2p3_DIMUON_DST.json
@@ -1,0 +1,234 @@
+[{
+  "abstract": {
+    "description": "Data from proton-proton (pp) collisions collected by the LHCb experiment in the year 2017 of Run2 of the LHC."
+  },
+  "accelerator": "CERN-LHC",
+  "collaboration": {
+    "name": "LHCb collaboration",
+    "recid": "456"
+  },
+  "collections": [
+    "LHCb-Collision-Datasets"
+  ],
+  "collision_information": {
+    "energy": "13TeV",
+    "type": "pp"
+  },
+  "date_created": [
+    "2017"
+  ],
+  "date_published": "2026",
+  "date_reprocessed": "2023",
+  "distribution": {
+    "formats": [
+      "DST"
+    ],
+    "number_events": 82218042,
+    "number_files": 3302,
+    "size": 9577921058612
+  },
+  "experiment": [
+    "LHCb"
+  ],
+  "magnet_polarity": "MagUp",
+  "methodology": {
+    "description": "<p> This dataset was created in several production steps. These steps, software used and the configuration is provided below. </p><p> <strong> Prod ID: &nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;</strong> 207029<p> <strong>Prod type:&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp; </strong> Merge<p> <strong> Parent Prod ID:&nbsp;&nbsp;&nbsp;&nbsp; </strong> 206435<p> <strong> Parent Prod type: </strong> DataStripping<p> <strong> Conditions: </strong><p>dddb-20220927-2017<p>cond-20191004-2</strong><p> <strong> List of Trigger Configuration Keys (TCK): </strong> </p> <p><p><strong>TCK &nbsp;&nbsp;&nbsp;&nbsp;&nbsp; Number of Files </strong><p>0x11501704 &nbsp;&nbsp;&nbsp;&nbsp;&nbsp; 115<p>0x11501703 &nbsp;&nbsp;&nbsp;&nbsp;&nbsp; 111<p>0x114e1703 &nbsp;&nbsp;&nbsp;&nbsp;&nbsp; 14<p>0x11501705 &nbsp;&nbsp;&nbsp;&nbsp;&nbsp; 481<p>0x114e1702 &nbsp;&nbsp;&nbsp;&nbsp;&nbsp; 24<p>0x11501706 &nbsp;&nbsp;&nbsp;&nbsp;&nbsp; 92<p>0x11611709 &nbsp;&nbsp;&nbsp;&nbsp;&nbsp; 1163<p>0x11561707 &nbsp;&nbsp;&nbsp;&nbsp;&nbsp; 334<p>0x11601707 &nbsp;&nbsp;&nbsp;&nbsp;&nbsp; 501<p>0x11601708 &nbsp;&nbsp;&nbsp;&nbsp;&nbsp; 467",
+    "steps": [
+      {
+        "configuration_files": [
+          {
+            "title": "DaVinci/DV-Stripping29r2p3-Stripping.py"
+          },
+          {
+            "title": "DaVinci/DataType-2017.py"
+          },
+          {
+            "title": "DaVinci/InputType-RDST.py"
+          },
+          {
+            "title": "DaVinci/DV-RawEventJuggler-0_3-to-4_3.py"
+          },
+          {
+            "title": "Persistency/Compression-ZLIB-1.py"
+          }
+        ],
+        "release": "DaVinci.v44r11p6 AppConfig.v3r421 Det/SQLDDDB.v7r12 TMVAWeights.v1r18",
+        "type": "Stripping29r2p3_mu"
+      },
+      {
+        "configuration_files": [
+          {
+            "title": "Merging/DV-Stripping-Merging.py"
+          },
+          {
+            "title": "Persistency/Compression-LZMA-4.py"
+          }
+        ],
+        "release": "DaVinci.v44r11p6 AppConfig.v3r421 Det/SQLDDDB.v7r12 TMVAWeights.v1r18",
+        "type": "Merge_Stripping29r2p3_mu"
+      },
+      {
+        "configuration_files": [
+          {
+            "title": "DaVinci/DV-Stripping29r2p3-Stripping.py"
+          },
+          {
+            "title": "DaVinci/DataType-2017.py"
+          },
+          {
+            "title": "DaVinci/InputType-RDST.py"
+          },
+          {
+            "title": "DaVinci/DV-RawEventJuggler-0_3-to-4_3.py"
+          },
+          {
+            "title": "Persistency/Compression-ZLIB-1.py"
+          }
+        ],
+        "release": "DaVinci.v44r11p6 AppConfig.v3r421 Det/SQLDDDB.v7r12 TMVAWeights.v1r18",
+        "type": "Stripping29r2p3_mu"
+      },
+      {
+        "configuration_files": [
+          {
+            "title": "Merging/DV-Stripping-Merging.py"
+          },
+          {
+            "title": "Persistency/Compression-LZMA-4.py"
+          }
+        ],
+        "release": "DaVinci.v44r11p6 AppConfig.v3r421 Det/SQLDDDB.v7r12 TMVAWeights.v1r18",
+        "type": "Merge_Stripping29r2p3_mu"
+      },
+      {
+        "configuration_files": [
+          {
+            "title": "DaVinci/DV-Stripping29r2p3-Stripping.py"
+          },
+          {
+            "title": "DaVinci/DataType-2017.py"
+          },
+          {
+            "title": "DaVinci/InputType-RDST.py"
+          },
+          {
+            "title": "DaVinci/DV-RawEventJuggler-0_3-to-4_3.py"
+          },
+          {
+            "title": "Persistency/Compression-ZLIB-1.py"
+          }
+        ],
+        "release": "DaVinci.v44r11p6 AppConfig.v3r421 Det/SQLDDDB.v7r12 TMVAWeights.v1r18",
+        "type": "Stripping29r2p3_mu"
+      },
+      {
+        "configuration_files": [
+          {
+            "title": "Merging/DV-Stripping-Merging.py"
+          },
+          {
+            "title": "Persistency/Compression-LZMA-4.py"
+          }
+        ],
+        "release": "DaVinci.v44r11p6 AppConfig.v3r421 Det/SQLDDDB.v7r12 TMVAWeights.v1r18",
+        "type": "Merge_Stripping29r2p3_mu"
+      },
+      {
+        "configuration_files": [
+          {
+            "title": "DaVinci/DV-Stripping29r2p3-Stripping.py"
+          },
+          {
+            "title": "DaVinci/DataType-2017.py"
+          },
+          {
+            "title": "DaVinci/InputType-RDST.py"
+          },
+          {
+            "title": "DaVinci/DV-RawEventJuggler-0_3-to-4_3.py"
+          },
+          {
+            "title": "Persistency/Compression-ZLIB-1.py"
+          }
+        ],
+        "release": "DaVinci.v44r11p6 AppConfig.v3r421 Det/SQLDDDB.v7r12 TMVAWeights.v1r18",
+        "type": "Stripping29r2p3_mu"
+      },
+      {
+        "configuration_files": [
+          {
+            "title": "Merging/DV-Stripping-Merging.py"
+          },
+          {
+            "title": "Persistency/Compression-LZMA-4.py"
+          }
+        ],
+        "release": "DaVinci.v44r11p6 AppConfig.v3r421 Det/SQLDDDB.v7r12 TMVAWeights.v1r18",
+        "type": "Merge_Stripping29r2p3_mu"
+      },
+      {
+        "configuration_files": [
+          {
+            "title": "DaVinci/DV-Stripping29r2p3-Stripping.py"
+          },
+          {
+            "title": "DaVinci/DataType-2017.py"
+          },
+          {
+            "title": "DaVinci/InputType-RDST.py"
+          },
+          {
+            "title": "DaVinci/DV-RawEventJuggler-0_3-to-4_3.py"
+          },
+          {
+            "title": "Persistency/Compression-ZLIB-1.py"
+          }
+        ],
+        "release": "DaVinci.v44r11p6 AppConfig.v3r421 Det/SQLDDDB.v7r12 TMVAWeights.v1r18",
+        "type": "Stripping29r2p3_mu"
+      },
+      {
+        "configuration_files": [
+          {
+            "title": "Merging/DV-Stripping-Merging.py"
+          },
+          {
+            "title": "Persistency/Compression-LZMA-4.py"
+          }
+        ],
+        "release": "DaVinci.v44r11p6 AppConfig.v3r421 Det/SQLDDDB.v7r12 TMVAWeights.v1r18",
+        "type": "Merge_Stripping29r2p3_mu"
+      }
+    ]
+  },
+  "publisher": "CERN Open Data Portal",
+  "recid": "24778",
+  "run_period": [
+    "2017"
+  ],
+  "stripping": {
+    "stream": "DIMUON",
+    "version": "stripping29r2p3"
+  },
+  "title": "LHCb 2017 Beam6500GeV MagUp DIMUON Stream Stripping29r2p3",
+  "title_additional": "",
+  "type": {
+    "primary": "Dataset",
+    "secondary": [
+      "Collision"
+    ]
+  },
+  "usage": {
+    "description": "<p> The Run 1 and 2 data collected by the LHCb detector is available using the LHCb Ntupling Service, while the Run 1 data is additionally available in .DST and .mDST formats. The data obtained from the LHCb Ntupling Service are ROOT ntuples and do not require custom software to analyze. <p> Links are provided to the LHCb Ntupling Service for exploration of available data and the LHCb Open Data Guide for usage instructions.",
+    "links": [
+      {
+        "description": "LHCb Ntupling Service",
+        "url": "https://opendata-lhcb-ntupling-service.app.cern.ch/"
+      },
+      {
+        "description": "LHCb Open Data Guide",
+        "url": "https://lhcb-opendata-guide.web.cern.ch/"
+      }
+    ]
+  }
+}]

--- a/data/records/LHCb_2017_Beam6500GeV_VeloClosed_MagUp_RealData_Reco17_Stripping29r2p3_EW_DST.json
+++ b/data/records/LHCb_2017_Beam6500GeV_VeloClosed_MagUp_RealData_Reco17_Stripping29r2p3_EW_DST.json
@@ -1,0 +1,234 @@
+[{
+  "abstract": {
+    "description": "Data from proton-proton (pp) collisions collected by the LHCb experiment in the year 2017 of Run2 of the LHC."
+  },
+  "accelerator": "CERN-LHC",
+  "collaboration": {
+    "name": "LHCb collaboration",
+    "recid": "456"
+  },
+  "collections": [
+    "LHCb-Collision-Datasets"
+  ],
+  "collision_information": {
+    "energy": "13TeV",
+    "type": "pp"
+  },
+  "date_created": [
+    "2017"
+  ],
+  "date_published": "2026",
+  "date_reprocessed": "2023",
+  "distribution": {
+    "formats": [
+      "DST"
+    ],
+    "number_events": 65219239,
+    "number_files": 3135,
+    "size": 3983809299780
+  },
+  "experiment": [
+    "LHCb"
+  ],
+  "magnet_polarity": "MagUp",
+  "methodology": {
+    "description": "<p> This dataset was created in several production steps. These steps, software used and the configuration is provided below. </p><p> <strong> Prod ID: &nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;</strong> 206592<p> <strong>Prod type:&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp; </strong> Merge<p> <strong> Parent Prod ID:&nbsp;&nbsp;&nbsp;&nbsp; </strong> 206435<p> <strong> Parent Prod type: </strong> DataStripping<p> <strong> Conditions: </strong><p>dddb-20220927-2017<p>cond-20191004-2</strong><p> <strong> List of Trigger Configuration Keys (TCK): </strong> </p> <p><p><strong>TCK &nbsp;&nbsp;&nbsp;&nbsp;&nbsp; Number of Files </strong><p>0x11501703 &nbsp;&nbsp;&nbsp;&nbsp;&nbsp; 111<p>0x11501705 &nbsp;&nbsp;&nbsp;&nbsp;&nbsp; 422<p>0x114e1702 &nbsp;&nbsp;&nbsp;&nbsp;&nbsp; 24<p>0x11501704 &nbsp;&nbsp;&nbsp;&nbsp;&nbsp; 105<p>0x114e1703 &nbsp;&nbsp;&nbsp;&nbsp;&nbsp; 14<p>0x11501706 &nbsp;&nbsp;&nbsp;&nbsp;&nbsp; 88<p>0x11611709 &nbsp;&nbsp;&nbsp;&nbsp;&nbsp; 1146<p>0x11561707 &nbsp;&nbsp;&nbsp;&nbsp;&nbsp; 322<p>0x11601707 &nbsp;&nbsp;&nbsp;&nbsp;&nbsp; 486<p>0x11601708 &nbsp;&nbsp;&nbsp;&nbsp;&nbsp; 417",
+    "steps": [
+      {
+        "configuration_files": [
+          {
+            "title": "DaVinci/DV-Stripping29r2p3-Stripping.py"
+          },
+          {
+            "title": "DaVinci/DataType-2017.py"
+          },
+          {
+            "title": "DaVinci/InputType-RDST.py"
+          },
+          {
+            "title": "DaVinci/DV-RawEventJuggler-0_3-to-4_3.py"
+          },
+          {
+            "title": "Persistency/Compression-ZLIB-1.py"
+          }
+        ],
+        "release": "DaVinci.v44r11p6 AppConfig.v3r421 Det/SQLDDDB.v7r12 TMVAWeights.v1r18",
+        "type": "Stripping29r2p3_mu"
+      },
+      {
+        "configuration_files": [
+          {
+            "title": "Merging/DV-Stripping-Merging.py"
+          },
+          {
+            "title": "Persistency/Compression-LZMA-4.py"
+          }
+        ],
+        "release": "DaVinci.v44r11p6 AppConfig.v3r421 Det/SQLDDDB.v7r12 TMVAWeights.v1r18",
+        "type": "Merge_Stripping29r2p3_mu"
+      },
+      {
+        "configuration_files": [
+          {
+            "title": "DaVinci/DV-Stripping29r2p3-Stripping.py"
+          },
+          {
+            "title": "DaVinci/DataType-2017.py"
+          },
+          {
+            "title": "DaVinci/InputType-RDST.py"
+          },
+          {
+            "title": "DaVinci/DV-RawEventJuggler-0_3-to-4_3.py"
+          },
+          {
+            "title": "Persistency/Compression-ZLIB-1.py"
+          }
+        ],
+        "release": "DaVinci.v44r11p6 AppConfig.v3r421 Det/SQLDDDB.v7r12 TMVAWeights.v1r18",
+        "type": "Stripping29r2p3_mu"
+      },
+      {
+        "configuration_files": [
+          {
+            "title": "Merging/DV-Stripping-Merging.py"
+          },
+          {
+            "title": "Persistency/Compression-LZMA-4.py"
+          }
+        ],
+        "release": "DaVinci.v44r11p6 AppConfig.v3r421 Det/SQLDDDB.v7r12 TMVAWeights.v1r18",
+        "type": "Merge_Stripping29r2p3_mu"
+      },
+      {
+        "configuration_files": [
+          {
+            "title": "DaVinci/DV-Stripping29r2p3-Stripping.py"
+          },
+          {
+            "title": "DaVinci/DataType-2017.py"
+          },
+          {
+            "title": "DaVinci/InputType-RDST.py"
+          },
+          {
+            "title": "DaVinci/DV-RawEventJuggler-0_3-to-4_3.py"
+          },
+          {
+            "title": "Persistency/Compression-ZLIB-1.py"
+          }
+        ],
+        "release": "DaVinci.v44r11p6 AppConfig.v3r421 Det/SQLDDDB.v7r12 TMVAWeights.v1r18",
+        "type": "Stripping29r2p3_mu"
+      },
+      {
+        "configuration_files": [
+          {
+            "title": "Merging/DV-Stripping-Merging.py"
+          },
+          {
+            "title": "Persistency/Compression-LZMA-4.py"
+          }
+        ],
+        "release": "DaVinci.v44r11p6 AppConfig.v3r421 Det/SQLDDDB.v7r12 TMVAWeights.v1r18",
+        "type": "Merge_Stripping29r2p3_mu"
+      },
+      {
+        "configuration_files": [
+          {
+            "title": "DaVinci/DV-Stripping29r2p3-Stripping.py"
+          },
+          {
+            "title": "DaVinci/DataType-2017.py"
+          },
+          {
+            "title": "DaVinci/InputType-RDST.py"
+          },
+          {
+            "title": "DaVinci/DV-RawEventJuggler-0_3-to-4_3.py"
+          },
+          {
+            "title": "Persistency/Compression-ZLIB-1.py"
+          }
+        ],
+        "release": "DaVinci.v44r11p6 AppConfig.v3r421 Det/SQLDDDB.v7r12 TMVAWeights.v1r18",
+        "type": "Stripping29r2p3_mu"
+      },
+      {
+        "configuration_files": [
+          {
+            "title": "Merging/DV-Stripping-Merging.py"
+          },
+          {
+            "title": "Persistency/Compression-LZMA-4.py"
+          }
+        ],
+        "release": "DaVinci.v44r11p6 AppConfig.v3r421 Det/SQLDDDB.v7r12 TMVAWeights.v1r18",
+        "type": "Merge_Stripping29r2p3_mu"
+      },
+      {
+        "configuration_files": [
+          {
+            "title": "DaVinci/DV-Stripping29r2p3-Stripping.py"
+          },
+          {
+            "title": "DaVinci/DataType-2017.py"
+          },
+          {
+            "title": "DaVinci/InputType-RDST.py"
+          },
+          {
+            "title": "DaVinci/DV-RawEventJuggler-0_3-to-4_3.py"
+          },
+          {
+            "title": "Persistency/Compression-ZLIB-1.py"
+          }
+        ],
+        "release": "DaVinci.v44r11p6 AppConfig.v3r421 Det/SQLDDDB.v7r12 TMVAWeights.v1r18",
+        "type": "Stripping29r2p3_mu"
+      },
+      {
+        "configuration_files": [
+          {
+            "title": "Merging/DV-Stripping-Merging.py"
+          },
+          {
+            "title": "Persistency/Compression-LZMA-4.py"
+          }
+        ],
+        "release": "DaVinci.v44r11p6 AppConfig.v3r421 Det/SQLDDDB.v7r12 TMVAWeights.v1r18",
+        "type": "Merge_Stripping29r2p3_mu"
+      }
+    ]
+  },
+  "publisher": "CERN Open Data Portal",
+  "recid": "24770",
+  "run_period": [
+    "2017"
+  ],
+  "stripping": {
+    "stream": "EW",
+    "version": "stripping29r2p3"
+  },
+  "title": "LHCb 2017 Beam6500GeV MagUp EW Stream Stripping29r2p3",
+  "title_additional": "",
+  "type": {
+    "primary": "Dataset",
+    "secondary": [
+      "Collision"
+    ]
+  },
+  "usage": {
+    "description": "<p> The Run 1 and 2 data collected by the LHCb detector is available using the LHCb Ntupling Service, while the Run 1 data is additionally available in .DST and .mDST formats. The data obtained from the LHCb Ntupling Service are ROOT ntuples and do not require custom software to analyze. <p> Links are provided to the LHCb Ntupling Service for exploration of available data and the LHCb Open Data Guide for usage instructions.",
+    "links": [
+      {
+        "description": "LHCb Ntupling Service",
+        "url": "https://opendata-lhcb-ntupling-service.app.cern.ch/"
+      },
+      {
+        "description": "LHCb Open Data Guide",
+        "url": "https://lhcb-opendata-guide.web.cern.ch/"
+      }
+    ]
+  }
+}]

--- a/data/records/LHCb_2017_Beam6500GeV_VeloClosed_MagUp_RealData_Reco17_Stripping29r2p3_SEMILEPTONIC_DST.json
+++ b/data/records/LHCb_2017_Beam6500GeV_VeloClosed_MagUp_RealData_Reco17_Stripping29r2p3_SEMILEPTONIC_DST.json
@@ -1,0 +1,234 @@
+[{
+  "abstract": {
+    "description": "Data from proton-proton (pp) collisions collected by the LHCb experiment in the year 2017 of Run2 of the LHC."
+  },
+  "accelerator": "CERN-LHC",
+  "collaboration": {
+    "name": "LHCb collaboration",
+    "recid": "456"
+  },
+  "collections": [
+    "LHCb-Collision-Datasets"
+  ],
+  "collision_information": {
+    "energy": "13TeV",
+    "type": "pp"
+  },
+  "date_created": [
+    "2017"
+  ],
+  "date_published": "2026",
+  "date_reprocessed": "2023",
+  "distribution": {
+    "formats": [
+      "DST"
+    ],
+    "number_events": 543501852,
+    "number_files": 10362,
+    "size": 35910152839633
+  },
+  "experiment": [
+    "LHCb"
+  ],
+  "magnet_polarity": "MagUp",
+  "methodology": {
+    "description": "<p> This dataset was created in several production steps. These steps, software used and the configuration is provided below. </p><p> <strong> Prod ID: &nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;</strong> 206592<p> <strong>Prod type:&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp; </strong> Merge<p> <strong> Parent Prod ID:&nbsp;&nbsp;&nbsp;&nbsp; </strong> 206435<p> <strong> Parent Prod type: </strong> DataStripping<p> <strong> Conditions: </strong><p>dddb-20220927-2017<p>cond-20191004-2</strong><p> <strong> List of Trigger Configuration Keys (TCK): </strong> </p> <p><p><strong>TCK &nbsp;&nbsp;&nbsp;&nbsp;&nbsp; Number of Files </strong><p>0x11501703 &nbsp;&nbsp;&nbsp;&nbsp;&nbsp; 340<p>0x11501704 &nbsp;&nbsp;&nbsp;&nbsp;&nbsp; 359<p>0x11501705 &nbsp;&nbsp;&nbsp;&nbsp;&nbsp; 1499<p>0x114e1703 &nbsp;&nbsp;&nbsp;&nbsp;&nbsp; 28<p>0x114e1702 &nbsp;&nbsp;&nbsp;&nbsp;&nbsp; 52<p>0x11501706 &nbsp;&nbsp;&nbsp;&nbsp;&nbsp; 296<p>0x11611709 &nbsp;&nbsp;&nbsp;&nbsp;&nbsp; 3919<p>0x11561707 &nbsp;&nbsp;&nbsp;&nbsp;&nbsp; 1010<p>0x11601707 &nbsp;&nbsp;&nbsp;&nbsp;&nbsp; 1440<p>0x11601708 &nbsp;&nbsp;&nbsp;&nbsp;&nbsp; 1419",
+    "steps": [
+      {
+        "configuration_files": [
+          {
+            "title": "DaVinci/DV-Stripping29r2p3-Stripping.py"
+          },
+          {
+            "title": "DaVinci/DataType-2017.py"
+          },
+          {
+            "title": "DaVinci/InputType-RDST.py"
+          },
+          {
+            "title": "DaVinci/DV-RawEventJuggler-0_3-to-4_3.py"
+          },
+          {
+            "title": "Persistency/Compression-ZLIB-1.py"
+          }
+        ],
+        "release": "DaVinci.v44r11p6 AppConfig.v3r421 Det/SQLDDDB.v7r12 TMVAWeights.v1r18",
+        "type": "Stripping29r2p3_mu"
+      },
+      {
+        "configuration_files": [
+          {
+            "title": "Merging/DV-Stripping-Merging.py"
+          },
+          {
+            "title": "Persistency/Compression-LZMA-4.py"
+          }
+        ],
+        "release": "DaVinci.v44r11p6 AppConfig.v3r421 Det/SQLDDDB.v7r12 TMVAWeights.v1r18",
+        "type": "Merge_Stripping29r2p3_mu"
+      },
+      {
+        "configuration_files": [
+          {
+            "title": "DaVinci/DV-Stripping29r2p3-Stripping.py"
+          },
+          {
+            "title": "DaVinci/DataType-2017.py"
+          },
+          {
+            "title": "DaVinci/InputType-RDST.py"
+          },
+          {
+            "title": "DaVinci/DV-RawEventJuggler-0_3-to-4_3.py"
+          },
+          {
+            "title": "Persistency/Compression-ZLIB-1.py"
+          }
+        ],
+        "release": "DaVinci.v44r11p6 AppConfig.v3r421 Det/SQLDDDB.v7r12 TMVAWeights.v1r18",
+        "type": "Stripping29r2p3_mu"
+      },
+      {
+        "configuration_files": [
+          {
+            "title": "Merging/DV-Stripping-Merging.py"
+          },
+          {
+            "title": "Persistency/Compression-LZMA-4.py"
+          }
+        ],
+        "release": "DaVinci.v44r11p6 AppConfig.v3r421 Det/SQLDDDB.v7r12 TMVAWeights.v1r18",
+        "type": "Merge_Stripping29r2p3_mu"
+      },
+      {
+        "configuration_files": [
+          {
+            "title": "DaVinci/DV-Stripping29r2p3-Stripping.py"
+          },
+          {
+            "title": "DaVinci/DataType-2017.py"
+          },
+          {
+            "title": "DaVinci/InputType-RDST.py"
+          },
+          {
+            "title": "DaVinci/DV-RawEventJuggler-0_3-to-4_3.py"
+          },
+          {
+            "title": "Persistency/Compression-ZLIB-1.py"
+          }
+        ],
+        "release": "DaVinci.v44r11p6 AppConfig.v3r421 Det/SQLDDDB.v7r12 TMVAWeights.v1r18",
+        "type": "Stripping29r2p3_mu"
+      },
+      {
+        "configuration_files": [
+          {
+            "title": "Merging/DV-Stripping-Merging.py"
+          },
+          {
+            "title": "Persistency/Compression-LZMA-4.py"
+          }
+        ],
+        "release": "DaVinci.v44r11p6 AppConfig.v3r421 Det/SQLDDDB.v7r12 TMVAWeights.v1r18",
+        "type": "Merge_Stripping29r2p3_mu"
+      },
+      {
+        "configuration_files": [
+          {
+            "title": "DaVinci/DV-Stripping29r2p3-Stripping.py"
+          },
+          {
+            "title": "DaVinci/DataType-2017.py"
+          },
+          {
+            "title": "DaVinci/InputType-RDST.py"
+          },
+          {
+            "title": "DaVinci/DV-RawEventJuggler-0_3-to-4_3.py"
+          },
+          {
+            "title": "Persistency/Compression-ZLIB-1.py"
+          }
+        ],
+        "release": "DaVinci.v44r11p6 AppConfig.v3r421 Det/SQLDDDB.v7r12 TMVAWeights.v1r18",
+        "type": "Stripping29r2p3_mu"
+      },
+      {
+        "configuration_files": [
+          {
+            "title": "Merging/DV-Stripping-Merging.py"
+          },
+          {
+            "title": "Persistency/Compression-LZMA-4.py"
+          }
+        ],
+        "release": "DaVinci.v44r11p6 AppConfig.v3r421 Det/SQLDDDB.v7r12 TMVAWeights.v1r18",
+        "type": "Merge_Stripping29r2p3_mu"
+      },
+      {
+        "configuration_files": [
+          {
+            "title": "DaVinci/DV-Stripping29r2p3-Stripping.py"
+          },
+          {
+            "title": "DaVinci/DataType-2017.py"
+          },
+          {
+            "title": "DaVinci/InputType-RDST.py"
+          },
+          {
+            "title": "DaVinci/DV-RawEventJuggler-0_3-to-4_3.py"
+          },
+          {
+            "title": "Persistency/Compression-ZLIB-1.py"
+          }
+        ],
+        "release": "DaVinci.v44r11p6 AppConfig.v3r421 Det/SQLDDDB.v7r12 TMVAWeights.v1r18",
+        "type": "Stripping29r2p3_mu"
+      },
+      {
+        "configuration_files": [
+          {
+            "title": "Merging/DV-Stripping-Merging.py"
+          },
+          {
+            "title": "Persistency/Compression-LZMA-4.py"
+          }
+        ],
+        "release": "DaVinci.v44r11p6 AppConfig.v3r421 Det/SQLDDDB.v7r12 TMVAWeights.v1r18",
+        "type": "Merge_Stripping29r2p3_mu"
+      }
+    ]
+  },
+  "publisher": "CERN Open Data Portal",
+  "recid": "24779",
+  "run_period": [
+    "2017"
+  ],
+  "stripping": {
+    "stream": "SEMILEPTONIC",
+    "version": "stripping29r2p3"
+  },
+  "title": "LHCb 2017 Beam6500GeV MagUp SEMILEPTONIC Stream Stripping29r2p3",
+  "title_additional": "",
+  "type": {
+    "primary": "Dataset",
+    "secondary": [
+      "Collision"
+    ]
+  },
+  "usage": {
+    "description": "<p> The Run 1 and 2 data collected by the LHCb detector is available using the LHCb Ntupling Service, while the Run 1 data is additionally available in .DST and .mDST formats. The data obtained from the LHCb Ntupling Service are ROOT ntuples and do not require custom software to analyze. <p> Links are provided to the LHCb Ntupling Service for exploration of available data and the LHCb Open Data Guide for usage instructions.",
+    "links": [
+      {
+        "description": "LHCb Ntupling Service",
+        "url": "https://opendata-lhcb-ntupling-service.app.cern.ch/"
+      },
+      {
+        "description": "LHCb Open Data Guide",
+        "url": "https://lhcb-opendata-guide.web.cern.ch/"
+      }
+    ]
+  }
+}]


### PR DESCRIPTION
This PR adds 122 new records for the run 2 LHCb data available in the ntupling service. There are no dsts included or planned to be added with this release, only metadata. The goal for these records is to provide a DOI to cite for all data available in the ntupling service. I tested to ensure the schema is correct and the records render on the ODP on a local instance. 

There are a few remaining to dos before this can be merged:

- [ ] run 2 author list PR needs to be merged (https://github.com/cernopendata/opendata.cern.ch/pull/3789), and records in this PR need to be updated to point to the author list recids for 2015, 2016, and 2017 separately
- [ ] DOI assignment for each record
- [ ] recid assignment for each record (we do have some control over this from our end, if we have a block of recids we can use, I can regenerate the records with the proper recids). 

cc @tiborsimko, @pietnogga, @MindaugasSarpis