### PR TITLE
fix(records): correct NanoAOD dataset distribution sizes

### DIFF
--- a/data/records/cms-derived-nanoaodrun1.json
+++ b/data/records/cms-derived-nanoaodrun1.json
@@ -31,7 +31,7 @@
       ],
       "number_events": 34926233,
       "number_files": 188,
-      "size": 97825100
+      "size": 100172805636
     },
     "experiment": [
       "CMS"
@@ -138,7 +138,7 @@
       ],
       "number_events": 9771205,
       "number_files": 17,
-      "size": 49740759
+      "size": 50934530071
     },
     "experiment": [
       "CMS"
@@ -245,7 +245,7 @@
       ],
       "number_events": 6423106,
       "number_files": 18,
-      "size": 30978175
+      "size": 31721642985
     },
     "experiment": [
       "CMS"
@@ -352,7 +352,7 @@
       ],
       "number_events": 47187984,
       "number_files": 88,
-      "size": 29466084
+      "size": 30173222209
     },
     "experiment": [
       "CMS"
@@ -459,7 +459,7 @@
       ],
       "number_events": 20850125,
       "number_files": 40,
-      "size": 13460112
+      "size": 13783134556
     },
     "experiment": [
       "CMS"
@@ -566,7 +566,7 @@
       ],
       "number_events": 29583697,
       "number_files": 65,
-      "size": 21183852
+      "size": 21692230079
     },
     "experiment": [
       "CMS"
@@ -673,7 +673,7 @@
       ],
       "number_events": 27856626,
       "number_files": 81,
-      "size": 24110900
+      "size": 24689517847
     },
     "experiment": [
       "CMS"
@@ -780,7 +780,7 @@
       ],
       "number_events": 16341187,
       "number_files": 42,
-      "size": 12596211
+      "size": 12898497608
     },
     "experiment": [
       "CMS"
@@ -887,7 +887,7 @@
       ],
       "number_events": 26718043,
       "number_files": 75,
-      "size": 26723593
+      "size": 27364916758
     },
     "experiment": [
       "CMS"
@@ -994,7 +994,7 @@
       ],
       "number_events": 22677534,
       "number_files": 73,
-      "size": 24284679
+      "size": 24867474311
     },
     "experiment": [
       "CMS"
@@ -1101,7 +1101,7 @@
       ],
       "number_events": 44239644,
       "number_files": 43,
-      "size": 64547332
+      "size": 66096445245
     },
     "experiment": [
       "CMS"
@@ -1208,7 +1208,7 @@
       ],
       "number_events": 35287778,
       "number_files": 35,
-      "size": 52140430
+      "size": 53391782552
     },
     "experiment": [
       "CMS"
@@ -1315,7 +1315,7 @@
       ],
       "number_events": 26277742,
       "number_files": 31,
-      "size": 52902894
+      "size": 54172548524
     },
     "experiment": [
       "CMS"
@@ -1422,7 +1422,7 @@
       ],
       "number_events": 55915322,
       "number_files": 58,
-      "size": 79626551
+      "size": 81537560599
     },
     "experiment": [
       "CMS"
@@ -1529,7 +1529,7 @@
       ],
       "number_events": 37917536,
       "number_files": 39,
-      "size": 67852776
+      "size": 69481222431
     },
     "experiment": [
       "CMS"
@@ -1636,7 +1636,7 @@
       ],
       "number_events": 78757263,
       "number_files": 100,
-      "size": 121509784
+      "size": 124425966746
     },
     "experiment": [
       "CMS"
@@ -1743,7 +1743,7 @@
       ],
       "number_events": 14588696,
       "number_files": 25,
-      "size": 35748992
+      "size": 36606955059
     },
     "experiment": [
       "CMS"
@@ -1850,7 +1850,7 @@
       ],
       "number_events": 22334391,
       "number_files": 35,
-      "size": 48506867
+      "size": 49671016201
     },
     "experiment": [
       "CMS"
@@ -1957,7 +1957,7 @@
       ],
       "number_events": 12069498,
       "number_files": 21,
-      "size": 38545896
+      "size": 39470987979
     },
     "experiment": [
       "CMS"
@@ -2064,7 +2064,7 @@
       ],
       "number_events": 26280382,
       "number_files": 39,
-      "size": 52354586
+      "size": 53611077301
     },
     "experiment": [
       "CMS"
@@ -2171,7 +2171,7 @@
       ],
       "number_events": 15956053,
       "number_files": 25,
-      "size": 49131393
+      "size": 50310534097
     },
     "experiment": [
       "CMS"
@@ -2278,7 +2278,7 @@
       ],
       "number_events": 47134514,
       "number_files": 93,
-      "size": 135693716
+      "size": 138950316897
     },
     "experiment": [
       "CMS"
@@ -2385,7 +2385,7 @@
       ],
       "number_events": 21474287,
       "number_files": 42,
-      "size": 53390189
+      "size": 54671536139
     },
     "experiment": [
       "CMS"
@@ -2492,7 +2492,7 @@
       ],
       "number_events": 26084708,
       "number_files": 57,
-      "size": 79256573
+      "size": 81158700547
     },
     "experiment": [
       "CMS"
@@ -2599,7 +2599,7 @@
       ],
       "number_events": 34025601,
       "number_files": 64,
-      "size": 90182715
+      "size": 92347066206
     },
     "experiment": [
       "CMS"
@@ -2706,7 +2706,7 @@
       ],
       "number_events": 54116119,
       "number_files": 110,
-      "size": 139545513
+      "size": 142894552911
     },
     "experiment": [
       "CMS"
@@ -2813,7 +2813,7 @@
       ],
       "number_events": 62023592,
       "number_files": 133,
-      "size": 152143352
+      "size": 155794725835
     },
     "experiment": [
       "CMS"
@@ -2920,7 +2920,7 @@
       ],
       "number_events": 53446198,
       "number_files": 107,
-      "size": 133394178
+      "size": 136595588725
     },
     "experiment": [
       "CMS"
@@ -3027,7 +3027,7 @@
       ],
       "number_events": 32537541,
       "number_files": 60,
-      "size": 82257438
+      "size": 84231586295
     },
     "experiment": [
       "CMS"
@@ -3134,7 +3134,7 @@
       ],
       "number_events": 35455705,
       "number_files": 74,
-      "size": 105982515
+      "size": 108526059136
     },
     "experiment": [
       "CMS"
@@ -3241,7 +3241,7 @@
       ],
       "number_events": 60197132,
       "number_files": 110,
-      "size": 162710217
+      "size": 166615208887
     },
     "experiment": [
       "CMS"
@@ -3348,7 +3348,7 @@
       ],
       "number_events": 126105289,
       "number_files": 243,
-      "size": 326477179
+      "size": 334312504315
     },
     "experiment": [
       "CMS"
@@ -3455,7 +3455,7 @@
       ],
       "number_events": 98626059,
       "number_files": 194,
-      "size": 242416816
+      "size": 248234725502
     },
     "experiment": [
       "CMS"
@@ -3562,7 +3562,7 @@
       ],
       "number_events": 85731835,
       "number_files": 157,
-      "size": 215970803
+      "size": 221154024702
     },
     "experiment": [
       "CMS"

--- a/data/records/cms-derived-pfnano-2016.json
+++ b/data/records/cms-derived-pfnano-2016.json
@@ -39,7 +39,7 @@
       ],
       "number_events": 100826567,
       "number_files": 468,
-      "size": 1297795768
+      "size": 1328942631099
     },
     "experiment": [
       "CMS"
@@ -142,7 +142,7 @@
       ],
       "number_events": 27536603,
       "number_files": 91,
-      "size": 320657946
+      "size": 328353697999
     },
     "experiment": [
       "CMS"
@@ -245,7 +245,7 @@
       ],
       "number_events": 62080523,
       "number_files": 205,
-      "size": 673570329
+      "size": 689735908846
     },
     "experiment": [
       "CMS"
@@ -348,7 +348,7 @@
       ],
       "number_events": 18289323,
       "number_files": 79,
-      "size": 225286816
+      "size": 230693660395
     },
     "experiment": [
       "CMS"
@@ -452,7 +452,7 @@
       ],
       "number_events": 78216635,
       "number_files": 355,
-      "size": 893878988
+      "size": 915331908674
     },
     "experiment": [
       "CMS"
@@ -566,7 +566,7 @@
       ],
       "number_events": 45235604,
       "number_files": 151,
-      "size": 529653350
+      "size": 542364959597
     },
     "experiment": [
       "CMS"
@@ -669,7 +669,7 @@
       ],
       "number_events": 45367551,
       "number_files": 133,
-      "size": 498873700
+      "size": 510846600043
     },
     "experiment": [
       "CMS"
@@ -772,7 +772,7 @@
       ],
       "number_events": 32367421,
       "number_files": 143,
-      "size": 402556267
+      "size": 412217539571
     },
     "experiment": [
       "CMS"
@@ -876,7 +876,7 @@
       ],
       "number_events": 120517157,
       "number_files": 842,
-      "size": 1486368460
+      "size": 1522040870588
     },
     "experiment": [
       "CMS"
@@ -990,7 +990,7 @@
       ],
       "number_events": 26974131,
       "number_files": 109,
-      "size": 339156181
+      "size": 347295875568
     },
     "experiment": [
       "CMS"
@@ -1093,7 +1093,7 @@
       ],
       "number_events": 35301548,
       "number_files": 127,
-      "size": 379335688
+      "size": 388439681321
     },
     "experiment": [
       "CMS"
@@ -1196,7 +1196,7 @@
       ],
       "number_events": 33854612,
       "number_files": 119,
-      "size": 405546762
+      "size": 415279824811
     },
     "experiment": [
       "CMS"
@@ -1299,7 +1299,7 @@
       ],
       "number_events": 153363109,
       "number_files": 556,
-      "size": 1722259073
+      "size": 1763592998534
     },
     "experiment": [
       "CMS"
@@ -1402,7 +1402,7 @@
       ],
       "number_events": 149916849,
       "number_files": 381,
-      "size": 1658003182
+      "size": 1697795066298
     },
     "experiment": [
       "CMS"
@@ -1505,7 +1505,7 @@
       ],
       "number_events": 33288854,
       "number_files": 122,
-      "size": 378974160
+      "size": 388069469766
     },
     "experiment": [
       "CMS"
@@ -1608,7 +1608,7 @@
       ],
       "number_events": 79578661,
       "number_files": 370,
-      "size": 922922704
+      "size": 945072653657
     },
     "experiment": [
       "CMS"
@@ -1711,7 +1711,7 @@
       ],
       "number_events": 27123616,
       "number_files": 67,
-      "size": 219858693
+      "size": 225135265550
     },
     "experiment": [
       "CMS"


### PR DESCRIPTION
Fixes #3767 

Stored `distribution.size` values were ~1024× too small (TiB→GiB unit slip) in:

- `data/records/cms-derived-pfnano-2016.json` (17 records, from the issue)
- `data/records/cms-derived-nanoaodrun1.json` (34 records, same bug found during verification)

New values are sums of each record's own `root_file_index.json` manifest from EOS. Other fields verified correct and untouched.
