### PR TITLE
add records for requests 35, 44, 79

### DIFF
--- a/data/records/lhcb-ntuples-request-35.json
+++ b/data/records/lhcb-ntuples-request-35.json
@@ -1,0 +1,229 @@
+[
+  {
+    "abstract": {
+      "description": "<p>Data from proton-proton (pp) collisions collected by the LHCb experiment filtered to produce ntuples for exploring $B^0 \\to J/\\psi (\\to \\mu^+ \\mu^-) K^- \\pi^+$ and charge-conjugate decays.</p> <p>Ntuples are created using DaVinci version v46r11 and the Analysis Productions batch processing system. Quantities saved to the ntuple are specified during the request phase and detailed in the code configuration files attached below.</p>"
+    },
+    "accelerator": "CERN-LHC",
+    "collaboration": {
+      "name": "LHCb collaboration"
+    },
+    "collections": [
+      "LHCb-Collision-Datasets"
+    ],
+    "date_created": [
+      "2012"
+    ],
+    "date_published": "2026",
+    "date_reprocessed": "2026",
+    "distribution": {
+      "formats": [
+        "py",
+        "yaml"
+      ],
+      "number_files": 3,
+      "size": 2491
+    },
+    "doi": "__REQ35_DOI__",
+    "experiment": [
+      "LHCb"
+    ],
+    "files": [
+      {
+        "checksum": "adler32:4209f928",
+        "size": 737,
+        "uri": "root://eospublic.cern.ch//eos/opendata/lhcb/CollisionNtuples/__REQ35_DOI__/inputs/BtoKpiJpsi/JK.py"
+      },
+      {
+        "checksum": "adler32:e69f5b8c",
+        "size": 1238,
+        "uri": "root://eospublic.cern.ch//eos/opendata/lhcb/CollisionNtuples/__REQ35_DOI__/inputs/BtoKpiJpsi/JK.yaml"
+      },
+      {
+        "checksum": "adler32:8ae29d70",
+        "size": 516,
+        "uri": "root://eospublic.cern.ch//eos/opendata/lhcb/CollisionNtuples/__REQ35_DOI__/inputs/BtoKpiJpsi/info.yaml"
+      }
+    ],
+    "methodology": {
+      "description": "These ntuples were produced from the LHCb Open Data Ntupling Service user request 35. Please see the input configuration files attached below."
+    },
+    "publisher": "CERN Open Data portal",
+    "recid": "__REQ35_PARENT_RECID__",
+    "relations": [
+      {
+        "recid": "__REQ35_2012_DOWN_RECID__",
+        "type": "isParentOf"
+      },
+      {
+        "recid": "__REQ35_2012_UP_RECID__",
+        "type": "isParentOf"
+      }
+    ],
+    "title": "[$B^0 \\to J/\\psi (\\to \\mu^+ \\mu^-) K^- \\pi^+$]CC Ntuples 35",
+    "type": {
+      "primary": "Dataset",
+      "secondary": [
+        "Collision"
+      ]
+    },
+    "usage": {
+      "description": "<p>Ntuples and instructions are provided in the links under Related datasets. They are ready to be downloaded and used for analysis. If these do not suit your needs, you can clone and amend this ntupling request here:</p>",
+      "links": [
+        {
+          "description": "LHCb Open Data Ntupling Service",
+          "url": "https://opendata-lhcb-ntupling-service.app.cern.ch/"
+        },
+        {
+          "description": "LHCb Open Data Ntupling Service Usage Guide",
+          "url": "https://lhcb-opendata-guide.web.cern.ch/ntupling-service/"
+        }
+      ]
+    }
+  },
+  {
+    "abstract": {
+      "description": "<p>Data from proton-proton (pp) collisions collected by the LHCb experiment filtered to produce ntuples for exploring $B^0 \\to J/\\psi (\\to \\mu^+ \\mu^-) K^- \\pi^+$ and charge-conjugate decays.</p>"
+    },
+    "accelerator": "CERN-LHC",
+    "collaboration": {
+      "name": "LHCb collaboration"
+    },
+    "collections": [
+      "LHCb-Collision-Datasets"
+    ],
+    "collision_information": {
+      "energy": "8TeV",
+      "type": "pp"
+    },
+    "date_created": [
+      "2012"
+    ],
+    "date_published": "2026",
+    "date_reprocessed": "2026",
+    "distribution": {
+      "formats": [
+        "root"
+      ],
+      "number_files": 1,
+      "size": 163505172
+    },
+    "experiment": [
+      "LHCb"
+    ],
+    "files": [
+      {
+        "checksum": "adler32:7f547e9f",
+        "size": 163505172,
+        "uri": "root://eospublic.cern.ch//eos/opendata/lhcb/CollisionNtuples/__REQ35_DOI__/outputs/real-production/00370939_00000001_1.dvntuple.root"
+      }
+    ],
+    "magnet_polarity": "MagDown",
+    "methodology": {
+      "description": "<p>These ntuples were produced from the LHCb Open Data Ntupling Service user request 35. Please see the input configuration files <a href=\"/record/__REQ35_PARENT_RECID__\">here</a>.</p>"
+    },
+    "publisher": "CERN Open Data portal",
+    "recid": "__REQ35_2012_DOWN_RECID__",
+    "relations": [
+      {
+        "recid": "__REQ35_PARENT_RECID__",
+        "type": "isChildOf"
+      }
+    ],
+    "run_period": [
+      "2012"
+    ],
+    "stripping": {
+      "stream": "BHADRON",
+      "version": "stripping21"
+    },
+    "title": "[$B^0 \\to J/\\psi (\\to \\mu^+ \\mu^-) K^- \\pi^+$]CC Ntuples 35 -- 2012 Magnet Down",
+    "type": {
+      "primary": "Dataset",
+      "secondary": [
+        "Collision"
+      ]
+    },
+    "usage": {
+      "description": "<p>You can use these ntuples with <a href=\"https://root.cern.ch/\">ROOT</a> data analysis framework. See documentation and examples here:</p>",
+      "links": [
+        {
+          "description": "LHCb Open Data Ntupling Service Usage Guide",
+          "url": "https://lhcb-opendata-guide.web.cern.ch/ntupling-service/"
+        }
+      ]
+    }
+  },
+  {
+    "abstract": {
+      "description": "<p>Data from proton-proton (pp) collisions collected by the LHCb experiment filtered to produce ntuples for exploring $B^0 \\to J/\\psi (\\to \\mu^+ \\mu^-) K^- \\pi^+$ and charge-conjugate decays.</p>"
+    },
+    "accelerator": "CERN-LHC",
+    "collaboration": {
+      "name": "LHCb collaboration"
+    },
+    "collections": [
+      "LHCb-Collision-Datasets"
+    ],
+    "collision_information": {
+      "energy": "8TeV",
+      "type": "pp"
+    },
+    "date_created": [
+      "2012"
+    ],
+    "date_published": "2026",
+    "date_reprocessed": "2026",
+    "distribution": {
+      "formats": [
+        "root"
+      ],
+      "number_files": 1,
+      "size": 160751643
+    },
+    "experiment": [
+      "LHCb"
+    ],
+    "files": [
+      {
+        "checksum": "adler32:1bfc7e1d",
+        "size": 160751643,
+        "uri": "root://eospublic.cern.ch//eos/opendata/lhcb/CollisionNtuples/__REQ35_DOI__/outputs/real-production/00370938_00000001_1.dvntuple.root"
+      }
+    ],
+    "magnet_polarity": "MagUp",
+    "methodology": {
+      "description": "<p>These ntuples were produced from the LHCb Open Data Ntupling Service user request 35. Please see the input configuration files <a href=\"/record/__REQ35_PARENT_RECID__\">here</a>.</p>"
+    },
+    "publisher": "CERN Open Data portal",
+    "recid": "__REQ35_2012_UP_RECID__",
+    "relations": [
+      {
+        "recid": "__REQ35_PARENT_RECID__",
+        "type": "isChildOf"
+      }
+    ],
+    "run_period": [
+      "2012"
+    ],
+    "stripping": {
+      "stream": "BHADRON",
+      "version": "stripping21"
+    },
+    "title": "[$B^0 \\to J/\\psi (\\to \\mu^+ \\mu^-) K^- \\pi^+$]CC Ntuples 35 -- 2012 Magnet Up",
+    "type": {
+      "primary": "Dataset",
+      "secondary": [
+        "Collision"
+      ]
+    },
+    "usage": {
+      "description": "<p>You can use these ntuples with <a href=\"https://root.cern.ch/\">ROOT</a> data analysis framework. See documentation and examples here:</p>",
+      "links": [
+        {
+          "description": "LHCb Open Data Ntupling Service Usage Guide",
+          "url": "https://lhcb-opendata-guide.web.cern.ch/ntupling-service/"
+        }
+      ]
+    }
+  }
+]

--- a/data/records/lhcb-ntuples-request-44.json
+++ b/data/records/lhcb-ntuples-request-44.json
@@ -1,0 +1,864 @@
+[
+  {
+    "abstract": {
+      "description": "<p>Data from proton-proton (pp) collisions collected by the LHCb experiment filtered to produce ntuples for exploring $B^0 \\to \\Lambda_c^+ (\\to p K^- \\pi^+) \\bar{\\Lambda}^0 (\\to \\bar{p} \\pi^+) K^-$ and charge-conjugate decays.</p> <p>Ntuples are created using DaVinci version v46r11 and the Analysis Productions batch processing system. Quantities saved to the ntuple are specified during the request phase and detailed in the code configuration files attached below.</p>"
+    },
+    "accelerator": "CERN-LHC",
+    "collaboration": {
+      "name": "LHCb collaboration"
+    },
+    "collections": [
+      "LHCb-Collision-Datasets"
+    ],
+    "date_created": [
+      "2011",
+      "2012",
+      "2015",
+      "2016",
+      "2017"
+    ],
+    "date_published": "2026",
+    "date_reprocessed": "2026",
+    "distribution": {
+      "formats": [
+        "py",
+        "yaml"
+      ],
+      "number_files": 3,
+      "size": 4320
+    },
+    "doi": "__REQ44_DOI__",
+    "experiment": [
+      "LHCb"
+    ],
+    "files": [
+      {
+        "checksum": "adler32:4a7efeaa",
+        "size": 756,
+        "uri": "root://eospublic.cern.ch//eos/opendata/lhcb/CollisionNtuples/__REQ44_DOI__/inputs/BtoLLcK/LcK.py"
+      },
+      {
+        "checksum": "adler32:6c4f9df9",
+        "size": 1452,
+        "uri": "root://eospublic.cern.ch//eos/opendata/lhcb/CollisionNtuples/__REQ44_DOI__/inputs/BtoLLcK/LcK.yaml"
+      },
+      {
+        "checksum": "adler32:88297538",
+        "size": 2112,
+        "uri": "root://eospublic.cern.ch//eos/opendata/lhcb/CollisionNtuples/__REQ44_DOI__/inputs/BtoLLcK/info.yaml"
+      }
+    ],
+    "methodology": {
+      "description": "These ntuples were produced from the LHCb Open Data Ntupling Service user request 44. Please see the input configuration files attached below."
+    },
+    "publisher": "CERN Open Data portal",
+    "recid": "__REQ44_PARENT_RECID__",
+    "relations": [
+      {
+        "recid": "__REQ44_2011_DOWN_RECID__",
+        "type": "isParentOf"
+      },
+      {
+        "recid": "__REQ44_2011_UP_RECID__",
+        "type": "isParentOf"
+      },
+      {
+        "recid": "__REQ44_2012_DOWN_RECID__",
+        "type": "isParentOf"
+      },
+      {
+        "recid": "__REQ44_2012_UP_RECID__",
+        "type": "isParentOf"
+      },
+      {
+        "recid": "__REQ44_2015_DOWN_RECID__",
+        "type": "isParentOf"
+      },
+      {
+        "recid": "__REQ44_2015_UP_RECID__",
+        "type": "isParentOf"
+      },
+      {
+        "recid": "__REQ44_2016_DOWN_RECID__",
+        "type": "isParentOf"
+      },
+      {
+        "recid": "__REQ44_2016_UP_RECID__",
+        "type": "isParentOf"
+      },
+      {
+        "recid": "__REQ44_2017_DOWN_RECID__",
+        "type": "isParentOf"
+      },
+      {
+        "recid": "__REQ44_2017_UP_RECID__",
+        "type": "isParentOf"
+      }
+    ],
+    "title": "[$B^0 \\to \\Lambda_c^+ (\\to p K^- \\pi^+) \\bar{\\Lambda}^0 (\\to \\bar{p} \\pi^+) K^-$]CC Ntuples 44",
+    "type": {
+      "primary": "Dataset",
+      "secondary": [
+        "Collision"
+      ]
+    },
+    "usage": {
+      "description": "<p>Ntuples and instructions are provided in the links under Related datasets. They are ready to be downloaded and used for analysis. If these do not suit your needs, you can clone and amend this ntupling request here:</p>",
+      "links": [
+        {
+          "description": "LHCb Open Data Ntupling Service",
+          "url": "https://opendata-lhcb-ntupling-service.app.cern.ch/"
+        },
+        {
+          "description": "LHCb Open Data Ntupling Service Usage Guide",
+          "url": "https://lhcb-opendata-guide.web.cern.ch/ntupling-service/"
+        }
+      ]
+    }
+  },
+  {
+    "abstract": {
+      "description": "<p>Data from proton-proton (pp) collisions collected by the LHCb experiment filtered to produce ntuples for exploring $B^0 \\to \\Lambda_c^+ (\\to p K^- \\pi^+) \\bar{\\Lambda}^0 (\\to \\bar{p} \\pi^+) K^-$ and charge-conjugate decays.</p>"
+    },
+    "accelerator": "CERN-LHC",
+    "collaboration": {
+      "name": "LHCb collaboration"
+    },
+    "collections": [
+      "LHCb-Collision-Datasets"
+    ],
+    "collision_information": {
+      "energy": "7TeV",
+      "type": "pp"
+    },
+    "date_created": [
+      "2011"
+    ],
+    "date_published": "2026",
+    "date_reprocessed": "2026",
+    "distribution": {
+      "formats": [
+        "root"
+      ],
+      "number_files": 1,
+      "size": 1702748735
+    },
+    "experiment": [
+      "LHCb"
+    ],
+    "files": [
+      {
+        "checksum": "adler32:7f7d4c62",
+        "size": 1702748735,
+        "uri": "root://eospublic.cern.ch//eos/opendata/lhcb/CollisionNtuples/__REQ44_DOI__/outputs/real-production/00377848_00000001_1.dvntuple.root"
+      }
+    ],
+    "magnet_polarity": "MagDown",
+    "methodology": {
+      "description": "<p>These ntuples were produced from the LHCb Open Data Ntupling Service user request 44. Please see the input configuration files <a href=\"/record/__REQ44_PARENT_RECID__\">here</a>.</p>"
+    },
+    "publisher": "CERN Open Data portal",
+    "recid": "__REQ44_2011_DOWN_RECID__",
+    "relations": [
+      {
+        "recid": "__REQ44_PARENT_RECID__",
+        "type": "isChildOf"
+      }
+    ],
+    "run_period": [
+      "2011"
+    ],
+    "stripping": {
+      "stream": "BHADRON",
+      "version": "stripping21r1"
+    },
+    "title": "[$B^0 \\to \\Lambda_c^+ (\\to p K^- \\pi^+) \\bar{\\Lambda}^0 (\\to \\bar{p} \\pi^+) K^-$]CC Ntuples 44 -- 2011 Magnet Down",
+    "type": {
+      "primary": "Dataset",
+      "secondary": [
+        "Collision"
+      ]
+    },
+    "usage": {
+      "description": "<p>You can use these ntuples with <a href=\"https://root.cern.ch/\">ROOT</a> data analysis framework. See documentation and examples here:</p>",
+      "links": [
+        {
+          "description": "LHCb Open Data Ntupling Service Usage Guide",
+          "url": "https://lhcb-opendata-guide.web.cern.ch/ntupling-service/"
+        }
+      ]
+    }
+  },
+  {
+    "abstract": {
+      "description": "<p>Data from proton-proton (pp) collisions collected by the LHCb experiment filtered to produce ntuples for exploring $B^0 \\to \\Lambda_c^+ (\\to p K^- \\pi^+) \\bar{\\Lambda}^0 (\\to \\bar{p} \\pi^+) K^-$ and charge-conjugate decays.</p>"
+    },
+    "accelerator": "CERN-LHC",
+    "collaboration": {
+      "name": "LHCb collaboration"
+    },
+    "collections": [
+      "LHCb-Collision-Datasets"
+    ],
+    "collision_information": {
+      "energy": "7TeV",
+      "type": "pp"
+    },
+    "date_created": [
+      "2011"
+    ],
+    "date_published": "2026",
+    "date_reprocessed": "2026",
+    "distribution": {
+      "formats": [
+        "root"
+      ],
+      "number_files": 1,
+      "size": 1203962960
+    },
+    "experiment": [
+      "LHCb"
+    ],
+    "files": [
+      {
+        "checksum": "adler32:ff3ca6ff",
+        "size": 1203962960,
+        "uri": "root://eospublic.cern.ch//eos/opendata/lhcb/CollisionNtuples/__REQ44_DOI__/outputs/real-production/00377849_00000001_1.dvntuple.root"
+      }
+    ],
+    "magnet_polarity": "MagUp",
+    "methodology": {
+      "description": "<p>These ntuples were produced from the LHCb Open Data Ntupling Service user request 44. Please see the input configuration files <a href=\"/record/__REQ44_PARENT_RECID__\">here</a>.</p>"
+    },
+    "publisher": "CERN Open Data portal",
+    "recid": "__REQ44_2011_UP_RECID__",
+    "relations": [
+      {
+        "recid": "__REQ44_PARENT_RECID__",
+        "type": "isChildOf"
+      }
+    ],
+    "run_period": [
+      "2011"
+    ],
+    "stripping": {
+      "stream": "BHADRON",
+      "version": "stripping21r1"
+    },
+    "title": "[$B^0 \\to \\Lambda_c^+ (\\to p K^- \\pi^+) \\bar{\\Lambda}^0 (\\to \\bar{p} \\pi^+) K^-$]CC Ntuples 44 -- 2011 Magnet Up",
+    "type": {
+      "primary": "Dataset",
+      "secondary": [
+        "Collision"
+      ]
+    },
+    "usage": {
+      "description": "<p>You can use these ntuples with <a href=\"https://root.cern.ch/\">ROOT</a> data analysis framework. See documentation and examples here:</p>",
+      "links": [
+        {
+          "description": "LHCb Open Data Ntupling Service Usage Guide",
+          "url": "https://lhcb-opendata-guide.web.cern.ch/ntupling-service/"
+        }
+      ]
+    }
+  },
+  {
+    "abstract": {
+      "description": "<p>Data from proton-proton (pp) collisions collected by the LHCb experiment filtered to produce ntuples for exploring $B^0 \\to \\Lambda_c^+ (\\to p K^- \\pi^+) \\bar{\\Lambda}^0 (\\to \\bar{p} \\pi^+) K^-$ and charge-conjugate decays.</p>"
+    },
+    "accelerator": "CERN-LHC",
+    "collaboration": {
+      "name": "LHCb collaboration"
+    },
+    "collections": [
+      "LHCb-Collision-Datasets"
+    ],
+    "collision_information": {
+      "energy": "8TeV",
+      "type": "pp"
+    },
+    "date_created": [
+      "2012"
+    ],
+    "date_published": "2026",
+    "date_reprocessed": "2026",
+    "distribution": {
+      "formats": [
+        "root"
+      ],
+      "number_files": 1,
+      "size": 4384172226
+    },
+    "experiment": [
+      "LHCb"
+    ],
+    "files": [
+      {
+        "checksum": "adler32:ac539ff6",
+        "size": 4384172226,
+        "uri": "root://eospublic.cern.ch//eos/opendata/lhcb/CollisionNtuples/__REQ44_DOI__/outputs/real-production/00377852_00000001_1.dvntuple.root"
+      }
+    ],
+    "magnet_polarity": "MagDown",
+    "methodology": {
+      "description": "<p>These ntuples were produced from the LHCb Open Data Ntupling Service user request 44. Please see the input configuration files <a href=\"/record/__REQ44_PARENT_RECID__\">here</a>.</p>"
+    },
+    "publisher": "CERN Open Data portal",
+    "recid": "__REQ44_2012_DOWN_RECID__",
+    "relations": [
+      {
+        "recid": "__REQ44_PARENT_RECID__",
+        "type": "isChildOf"
+      }
+    ],
+    "run_period": [
+      "2012"
+    ],
+    "stripping": {
+      "stream": "BHADRON",
+      "version": "stripping21"
+    },
+    "title": "[$B^0 \\to \\Lambda_c^+ (\\to p K^- \\pi^+) \\bar{\\Lambda}^0 (\\to \\bar{p} \\pi^+) K^-$]CC Ntuples 44 -- 2012 Magnet Down",
+    "type": {
+      "primary": "Dataset",
+      "secondary": [
+        "Collision"
+      ]
+    },
+    "usage": {
+      "description": "<p>You can use these ntuples with <a href=\"https://root.cern.ch/\">ROOT</a> data analysis framework. See documentation and examples here:</p>",
+      "links": [
+        {
+          "description": "LHCb Open Data Ntupling Service Usage Guide",
+          "url": "https://lhcb-opendata-guide.web.cern.ch/ntupling-service/"
+        }
+      ]
+    }
+  },
+  {
+    "abstract": {
+      "description": "<p>Data from proton-proton (pp) collisions collected by the LHCb experiment filtered to produce ntuples for exploring $B^0 \\to \\Lambda_c^+ (\\to p K^- \\pi^+) \\bar{\\Lambda}^0 (\\to \\bar{p} \\pi^+) K^-$ and charge-conjugate decays.</p>"
+    },
+    "accelerator": "CERN-LHC",
+    "collaboration": {
+      "name": "LHCb collaboration"
+    },
+    "collections": [
+      "LHCb-Collision-Datasets"
+    ],
+    "collision_information": {
+      "energy": "8TeV",
+      "type": "pp"
+    },
+    "date_created": [
+      "2012"
+    ],
+    "date_published": "2026",
+    "date_reprocessed": "2026",
+    "distribution": {
+      "formats": [
+        "root"
+      ],
+      "number_files": 1,
+      "size": 4484982316
+    },
+    "experiment": [
+      "LHCb"
+    ],
+    "files": [
+      {
+        "checksum": "adler32:c004c053",
+        "size": 4484982316,
+        "uri": "root://eospublic.cern.ch//eos/opendata/lhcb/CollisionNtuples/__REQ44_DOI__/outputs/real-production/00377853_00000002_1.dvntuple.root"
+      }
+    ],
+    "magnet_polarity": "MagUp",
+    "methodology": {
+      "description": "<p>These ntuples were produced from the LHCb Open Data Ntupling Service user request 44. Please see the input configuration files <a href=\"/record/__REQ44_PARENT_RECID__\">here</a>.</p>"
+    },
+    "publisher": "CERN Open Data portal",
+    "recid": "__REQ44_2012_UP_RECID__",
+    "relations": [
+      {
+        "recid": "__REQ44_PARENT_RECID__",
+        "type": "isChildOf"
+      }
+    ],
+    "run_period": [
+      "2012"
+    ],
+    "stripping": {
+      "stream": "BHADRON",
+      "version": "stripping21"
+    },
+    "title": "[$B^0 \\to \\Lambda_c^+ (\\to p K^- \\pi^+) \\bar{\\Lambda}^0 (\\to \\bar{p} \\pi^+) K^-$]CC Ntuples 44 -- 2012 Magnet Up",
+    "type": {
+      "primary": "Dataset",
+      "secondary": [
+        "Collision"
+      ]
+    },
+    "usage": {
+      "description": "<p>You can use these ntuples with <a href=\"https://root.cern.ch/\">ROOT</a> data analysis framework. See documentation and examples here:</p>",
+      "links": [
+        {
+          "description": "LHCb Open Data Ntupling Service Usage Guide",
+          "url": "https://lhcb-opendata-guide.web.cern.ch/ntupling-service/"
+        }
+      ]
+    }
+  },
+  {
+    "abstract": {
+      "description": "<p>Data from proton-proton (pp) collisions collected by the LHCb experiment filtered to produce ntuples for exploring $B^0 \\to \\Lambda_c^+ (\\to p K^- \\pi^+) \\bar{\\Lambda}^0 (\\to \\bar{p} \\pi^+) K^-$ and charge-conjugate decays.</p>"
+    },
+    "accelerator": "CERN-LHC",
+    "collaboration": {
+      "name": "LHCb collaboration"
+    },
+    "collections": [
+      "LHCb-Collision-Datasets"
+    ],
+    "collision_information": {
+      "energy": "13TeV",
+      "type": "pp"
+    },
+    "date_created": [
+      "2015"
+    ],
+    "date_published": "2026",
+    "date_reprocessed": "2026",
+    "distribution": {
+      "formats": [
+        "root"
+      ],
+      "number_files": 1,
+      "size": 1151994162
+    },
+    "experiment": [
+      "LHCb"
+    ],
+    "files": [
+      {
+        "checksum": "adler32:fce897da",
+        "size": 1151994162,
+        "uri": "root://eospublic.cern.ch//eos/opendata/lhcb/CollisionNtuples/__REQ44_DOI__/outputs/real-production/00377856_00000001_1.dvntuple.root"
+      }
+    ],
+    "magnet_polarity": "MagDown",
+    "methodology": {
+      "description": "<p>These ntuples were produced from the LHCb Open Data Ntupling Service user request 44. Please see the input configuration files <a href=\"/record/__REQ44_PARENT_RECID__\">here</a>.</p>"
+    },
+    "publisher": "CERN Open Data portal",
+    "recid": "__REQ44_2015_DOWN_RECID__",
+    "relations": [
+      {
+        "recid": "__REQ44_PARENT_RECID__",
+        "type": "isChildOf"
+      }
+    ],
+    "run_period": [
+      "2015"
+    ],
+    "stripping": {
+      "stream": "BHADRON",
+      "version": "stripping24r2"
+    },
+    "title": "[$B^0 \\to \\Lambda_c^+ (\\to p K^- \\pi^+) \\bar{\\Lambda}^0 (\\to \\bar{p} \\pi^+) K^-$]CC Ntuples 44 -- 2015 Magnet Down",
+    "type": {
+      "primary": "Dataset",
+      "secondary": [
+        "Collision"
+      ]
+    },
+    "usage": {
+      "description": "<p>You can use these ntuples with <a href=\"https://root.cern.ch/\">ROOT</a> data analysis framework. See documentation and examples here:</p>",
+      "links": [
+        {
+          "description": "LHCb Open Data Ntupling Service Usage Guide",
+          "url": "https://lhcb-opendata-guide.web.cern.ch/ntupling-service/"
+        }
+      ]
+    }
+  },
+  {
+    "abstract": {
+      "description": "<p>Data from proton-proton (pp) collisions collected by the LHCb experiment filtered to produce ntuples for exploring $B^0 \\to \\Lambda_c^+ (\\to p K^- \\pi^+) \\bar{\\Lambda}^0 (\\to \\bar{p} \\pi^+) K^-$ and charge-conjugate decays.</p>"
+    },
+    "accelerator": "CERN-LHC",
+    "collaboration": {
+      "name": "LHCb collaboration"
+    },
+    "collections": [
+      "LHCb-Collision-Datasets"
+    ],
+    "collision_information": {
+      "energy": "13TeV",
+      "type": "pp"
+    },
+    "date_created": [
+      "2015"
+    ],
+    "date_published": "2026",
+    "date_reprocessed": "2026",
+    "distribution": {
+      "formats": [
+        "root"
+      ],
+      "number_files": 1,
+      "size": 801482156
+    },
+    "experiment": [
+      "LHCb"
+    ],
+    "files": [
+      {
+        "checksum": "adler32:aaf1aaf4",
+        "size": 801482156,
+        "uri": "root://eospublic.cern.ch//eos/opendata/lhcb/CollisionNtuples/__REQ44_DOI__/outputs/real-production/00377857_00000001_1.dvntuple.root"
+      }
+    ],
+    "magnet_polarity": "MagUp",
+    "methodology": {
+      "description": "<p>These ntuples were produced from the LHCb Open Data Ntupling Service user request 44. Please see the input configuration files <a href=\"/record/__REQ44_PARENT_RECID__\">here</a>.</p>"
+    },
+    "publisher": "CERN Open Data portal",
+    "recid": "__REQ44_2015_UP_RECID__",
+    "relations": [
+      {
+        "recid": "__REQ44_PARENT_RECID__",
+        "type": "isChildOf"
+      }
+    ],
+    "run_period": [
+      "2015"
+    ],
+    "stripping": {
+      "stream": "BHADRON",
+      "version": "stripping24r2"
+    },
+    "title": "[$B^0 \\to \\Lambda_c^+ (\\to p K^- \\pi^+) \\bar{\\Lambda}^0 (\\to \\bar{p} \\pi^+) K^-$]CC Ntuples 44 -- 2015 Magnet Up",
+    "type": {
+      "primary": "Dataset",
+      "secondary": [
+        "Collision"
+      ]
+    },
+    "usage": {
+      "description": "<p>You can use these ntuples with <a href=\"https://root.cern.ch/\">ROOT</a> data analysis framework. See documentation and examples here:</p>",
+      "links": [
+        {
+          "description": "LHCb Open Data Ntupling Service Usage Guide",
+          "url": "https://lhcb-opendata-guide.web.cern.ch/ntupling-service/"
+        }
+      ]
+    }
+  },
+  {
+    "abstract": {
+      "description": "<p>Data from proton-proton (pp) collisions collected by the LHCb experiment filtered to produce ntuples for exploring $B^0 \\to \\Lambda_c^+ (\\to p K^- \\pi^+) \\bar{\\Lambda}^0 (\\to \\bar{p} \\pi^+) K^-$ and charge-conjugate decays.</p>"
+    },
+    "accelerator": "CERN-LHC",
+    "collaboration": {
+      "name": "LHCb collaboration"
+    },
+    "collections": [
+      "LHCb-Collision-Datasets"
+    ],
+    "collision_information": {
+      "energy": "13TeV",
+      "type": "pp"
+    },
+    "date_created": [
+      "2016"
+    ],
+    "date_published": "2026",
+    "date_reprocessed": "2026",
+    "distribution": {
+      "formats": [
+        "root"
+      ],
+      "number_files": 2,
+      "size": 7323987457
+    },
+    "experiment": [
+      "LHCb"
+    ],
+    "files": [
+      {
+        "checksum": "adler32:5c7def91",
+        "size": 6355665815,
+        "uri": "root://eospublic.cern.ch//eos/opendata/lhcb/CollisionNtuples/__REQ44_DOI__/outputs/real-production/00377861_00000002_1.dvntuple.root"
+      },
+      {
+        "checksum": "adler32:beb4de83",
+        "size": 968321642,
+        "uri": "root://eospublic.cern.ch//eos/opendata/lhcb/CollisionNtuples/__REQ44_DOI__/outputs/real-production/00377861_00000003_1.dvntuple.root"
+      }
+    ],
+    "magnet_polarity": "MagDown",
+    "methodology": {
+      "description": "<p>These ntuples were produced from the LHCb Open Data Ntupling Service user request 44. Please see the input configuration files <a href=\"/record/__REQ44_PARENT_RECID__\">here</a>.</p>"
+    },
+    "publisher": "CERN Open Data portal",
+    "recid": "__REQ44_2016_DOWN_RECID__",
+    "relations": [
+      {
+        "recid": "__REQ44_PARENT_RECID__",
+        "type": "isChildOf"
+      }
+    ],
+    "run_period": [
+      "2016"
+    ],
+    "stripping": {
+      "stream": "BHADRON",
+      "version": "stripping28r2"
+    },
+    "title": "[$B^0 \\to \\Lambda_c^+ (\\to p K^- \\pi^+) \\bar{\\Lambda}^0 (\\to \\bar{p} \\pi^+) K^-$]CC Ntuples 44 -- 2016 Magnet Down",
+    "type": {
+      "primary": "Dataset",
+      "secondary": [
+        "Collision"
+      ]
+    },
+    "usage": {
+      "description": "<p>You can use these ntuples with <a href=\"https://root.cern.ch/\">ROOT</a> data analysis framework. See documentation and examples here:</p>",
+      "links": [
+        {
+          "description": "LHCb Open Data Ntupling Service Usage Guide",
+          "url": "https://lhcb-opendata-guide.web.cern.ch/ntupling-service/"
+        }
+      ]
+    }
+  },
+  {
+    "abstract": {
+      "description": "<p>Data from proton-proton (pp) collisions collected by the LHCb experiment filtered to produce ntuples for exploring $B^0 \\to \\Lambda_c^+ (\\to p K^- \\pi^+) \\bar{\\Lambda}^0 (\\to \\bar{p} \\pi^+) K^-$ and charge-conjugate decays.</p>"
+    },
+    "accelerator": "CERN-LHC",
+    "collaboration": {
+      "name": "LHCb collaboration"
+    },
+    "collections": [
+      "LHCb-Collision-Datasets"
+    ],
+    "collision_information": {
+      "energy": "13TeV",
+      "type": "pp"
+    },
+    "date_created": [
+      "2016"
+    ],
+    "date_published": "2026",
+    "date_reprocessed": "2026",
+    "distribution": {
+      "formats": [
+        "root"
+      ],
+      "number_files": 2,
+      "size": 6464891936
+    },
+    "experiment": [
+      "LHCb"
+    ],
+    "files": [
+      {
+        "checksum": "adler32:11c8028c",
+        "size": 6361615117,
+        "uri": "root://eospublic.cern.ch//eos/opendata/lhcb/CollisionNtuples/__REQ44_DOI__/outputs/real-production/00377860_00000001_1.dvntuple.root"
+      },
+      {
+        "checksum": "adler32:5eba9bfc",
+        "size": 103276819,
+        "uri": "root://eospublic.cern.ch//eos/opendata/lhcb/CollisionNtuples/__REQ44_DOI__/outputs/real-production/00377860_00000002_1.dvntuple.root"
+      }
+    ],
+    "magnet_polarity": "MagUp",
+    "methodology": {
+      "description": "<p>These ntuples were produced from the LHCb Open Data Ntupling Service user request 44. Please see the input configuration files <a href=\"/record/__REQ44_PARENT_RECID__\">here</a>.</p>"
+    },
+    "publisher": "CERN Open Data portal",
+    "recid": "__REQ44_2016_UP_RECID__",
+    "relations": [
+      {
+        "recid": "__REQ44_PARENT_RECID__",
+        "type": "isChildOf"
+      }
+    ],
+    "run_period": [
+      "2016"
+    ],
+    "stripping": {
+      "stream": "BHADRON",
+      "version": "stripping28r2"
+    },
+    "title": "[$B^0 \\to \\Lambda_c^+ (\\to p K^- \\pi^+) \\bar{\\Lambda}^0 (\\to \\bar{p} \\pi^+) K^-$]CC Ntuples 44 -- 2016 Magnet Up",
+    "type": {
+      "primary": "Dataset",
+      "secondary": [
+        "Collision"
+      ]
+    },
+    "usage": {
+      "description": "<p>You can use these ntuples with <a href=\"https://root.cern.ch/\">ROOT</a> data analysis framework. See documentation and examples here:</p>",
+      "links": [
+        {
+          "description": "LHCb Open Data Ntupling Service Usage Guide",
+          "url": "https://lhcb-opendata-guide.web.cern.ch/ntupling-service/"
+        }
+      ]
+    }
+  },
+  {
+    "abstract": {
+      "description": "<p>Data from proton-proton (pp) collisions collected by the LHCb experiment filtered to produce ntuples for exploring $B^0 \\to \\Lambda_c^+ (\\to p K^- \\pi^+) \\bar{\\Lambda}^0 (\\to \\bar{p} \\pi^+) K^-$ and charge-conjugate decays.</p>"
+    },
+    "accelerator": "CERN-LHC",
+    "collaboration": {
+      "name": "LHCb collaboration"
+    },
+    "collections": [
+      "LHCb-Collision-Datasets"
+    ],
+    "collision_information": {
+      "energy": "13TeV",
+      "type": "pp"
+    },
+    "date_created": [
+      "2017"
+    ],
+    "date_published": "2026",
+    "date_reprocessed": "2026",
+    "distribution": {
+      "formats": [
+        "root"
+      ],
+      "number_files": 2,
+      "size": 6359958239
+    },
+    "experiment": [
+      "LHCb"
+    ],
+    "files": [
+      {
+        "checksum": "adler32:57a5ea4b",
+        "size": 6299773441,
+        "uri": "root://eospublic.cern.ch//eos/opendata/lhcb/CollisionNtuples/__REQ44_DOI__/outputs/real-production/00377864_00000001_1.dvntuple.root"
+      },
+      {
+        "checksum": "adler32:d318f652",
+        "size": 60184798,
+        "uri": "root://eospublic.cern.ch//eos/opendata/lhcb/CollisionNtuples/__REQ44_DOI__/outputs/real-production/00377864_00000002_1.dvntuple.root"
+      }
+    ],
+    "magnet_polarity": "MagDown",
+    "methodology": {
+      "description": "<p>These ntuples were produced from the LHCb Open Data Ntupling Service user request 44. Please see the input configuration files <a href=\"/record/__REQ44_PARENT_RECID__\">here</a>.</p>"
+    },
+    "publisher": "CERN Open Data portal",
+    "recid": "__REQ44_2017_DOWN_RECID__",
+    "relations": [
+      {
+        "recid": "__REQ44_PARENT_RECID__",
+        "type": "isChildOf"
+      }
+    ],
+    "run_period": [
+      "2017"
+    ],
+    "stripping": {
+      "stream": "BHADRON",
+      "version": "stripping29r2"
+    },
+    "title": "[$B^0 \\to \\Lambda_c^+ (\\to p K^- \\pi^+) \\bar{\\Lambda}^0 (\\to \\bar{p} \\pi^+) K^-$]CC Ntuples 44 -- 2017 Magnet Down",
+    "type": {
+      "primary": "Dataset",
+      "secondary": [
+        "Collision"
+      ]
+    },
+    "usage": {
+      "description": "<p>You can use these ntuples with <a href=\"https://root.cern.ch/\">ROOT</a> data analysis framework. See documentation and examples here:</p>",
+      "links": [
+        {
+          "description": "LHCb Open Data Ntupling Service Usage Guide",
+          "url": "https://lhcb-opendata-guide.web.cern.ch/ntupling-service/"
+        }
+      ]
+    }
+  },
+  {
+    "abstract": {
+      "description": "<p>Data from proton-proton (pp) collisions collected by the LHCb experiment filtered to produce ntuples for exploring $B^0 \\to \\Lambda_c^+ (\\to p K^- \\pi^+) \\bar{\\Lambda}^0 (\\to \\bar{p} \\pi^+) K^-$ and charge-conjugate decays.</p>"
+    },
+    "accelerator": "CERN-LHC",
+    "collaboration": {
+      "name": "LHCb collaboration"
+    },
+    "collections": [
+      "LHCb-Collision-Datasets"
+    ],
+    "collision_information": {
+      "energy": "13TeV",
+      "type": "pp"
+    },
+    "date_created": [
+      "2017"
+    ],
+    "date_published": "2026",
+    "date_reprocessed": "2026",
+    "distribution": {
+      "formats": [
+        "root"
+      ],
+      "number_files": 1,
+      "size": 6124915420
+    },
+    "experiment": [
+      "LHCb"
+    ],
+    "files": [
+      {
+        "checksum": "adler32:175f8883",
+        "size": 6124915420,
+        "uri": "root://eospublic.cern.ch//eos/opendata/lhcb/CollisionNtuples/__REQ44_DOI__/outputs/real-production/00377865_00000001_1.dvntuple.root"
+      }
+    ],
+    "magnet_polarity": "MagUp",
+    "methodology": {
+      "description": "<p>These ntuples were produced from the LHCb Open Data Ntupling Service user request 44. Please see the input configuration files <a href=\"/record/__REQ44_PARENT_RECID__\">here</a>.</p>"
+    },
+    "publisher": "CERN Open Data portal",
+    "recid": "__REQ44_2017_UP_RECID__",
+    "relations": [
+      {
+        "recid": "__REQ44_PARENT_RECID__",
+        "type": "isChildOf"
+      }
+    ],
+    "run_period": [
+      "2017"
+    ],
+    "stripping": {
+      "stream": "BHADRON",
+      "version": "stripping29r2"
+    },
+    "title": "[$B^0 \\to \\Lambda_c^+ (\\to p K^- \\pi^+) \\bar{\\Lambda}^0 (\\to \\bar{p} \\pi^+) K^-$]CC Ntuples 44 -- 2017 Magnet Up",
+    "type": {
+      "primary": "Dataset",
+      "secondary": [
+        "Collision"
+      ]
+    },
+    "usage": {
+      "description": "<p>You can use these ntuples with <a href=\"https://root.cern.ch/\">ROOT</a> data analysis framework. See documentation and examples here:</p>",
+      "links": [
+        {
+          "description": "LHCb Open Data Ntupling Service Usage Guide",
+          "url": "https://lhcb-opendata-guide.web.cern.ch/ntupling-service/"
+        }
+      ]
+    }
+  }
+]

--- a/data/records/lhcb-ntuples-request-79.json
+++ b/data/records/lhcb-ntuples-request-79.json
@@ -1,0 +1,849 @@
+[
+  {
+    "abstract": {
+      "description": "<p>Data from proton-proton (pp) collisions collected by the LHCb experiment filtered to produce ntuples for exploring $B^0 \\to \\bar{D}^0 (\\to K^+ \\pi^-) K_S^0 (\\to \\pi^+ \\pi^-) K^+ \\pi^-$ and charge-conjugate decays.</p> <p>Ntuples are created using DaVinci version v46r11 and the Analysis Productions batch processing system. Quantities saved to the ntuple are specified during the request phase and detailed in the code configuration files attached below.</p>"
+    },
+    "accelerator": "CERN-LHC",
+    "collaboration": {
+      "name": "LHCb collaboration"
+    },
+    "collections": [
+      "LHCb-Collision-Datasets"
+    ],
+    "date_created": [
+      "2011",
+      "2012",
+      "2015",
+      "2016",
+      "2017"
+    ],
+    "date_published": "2026",
+    "date_reprocessed": "2026",
+    "distribution": {
+      "formats": [
+        "py",
+        "yaml"
+      ],
+      "number_files": 3,
+      "size": 4264
+    },
+    "doi": "__REQ79_DOI__",
+    "experiment": [
+      "LHCb"
+    ],
+    "files": [
+      {
+        "checksum": "adler32:8002fa4f",
+        "size": 742,
+        "uri": "root://eospublic.cern.ch//eos/opendata/lhcb/CollisionNtuples/__REQ79_DOI__/inputs/B0_D0barKSKpi/DKSpi.py"
+      },
+      {
+        "checksum": "adler32:879685d5",
+        "size": 1390,
+        "uri": "root://eospublic.cern.ch//eos/opendata/lhcb/CollisionNtuples/__REQ79_DOI__/inputs/B0_D0barKSKpi/DKSpi.yaml"
+      },
+      {
+        "checksum": "adler32:cbd97cc2",
+        "size": 2132,
+        "uri": "root://eospublic.cern.ch//eos/opendata/lhcb/CollisionNtuples/__REQ79_DOI__/inputs/B0_D0barKSKpi/info.yaml"
+      }
+    ],
+    "methodology": {
+      "description": "These ntuples were produced from the LHCb Open Data Ntupling Service user request 79. Please see the input configuration files attached below."
+    },
+    "publisher": "CERN Open Data portal",
+    "recid": "__REQ79_PARENT_RECID__",
+    "relations": [
+      {
+        "recid": "__REQ79_2011_DOWN_RECID__",
+        "type": "isParentOf"
+      },
+      {
+        "recid": "__REQ79_2011_UP_RECID__",
+        "type": "isParentOf"
+      },
+      {
+        "recid": "__REQ79_2012_DOWN_RECID__",
+        "type": "isParentOf"
+      },
+      {
+        "recid": "__REQ79_2012_UP_RECID__",
+        "type": "isParentOf"
+      },
+      {
+        "recid": "__REQ79_2015_DOWN_RECID__",
+        "type": "isParentOf"
+      },
+      {
+        "recid": "__REQ79_2015_UP_RECID__",
+        "type": "isParentOf"
+      },
+      {
+        "recid": "__REQ79_2016_DOWN_RECID__",
+        "type": "isParentOf"
+      },
+      {
+        "recid": "__REQ79_2016_UP_RECID__",
+        "type": "isParentOf"
+      },
+      {
+        "recid": "__REQ79_2017_DOWN_RECID__",
+        "type": "isParentOf"
+      },
+      {
+        "recid": "__REQ79_2017_UP_RECID__",
+        "type": "isParentOf"
+      }
+    ],
+    "title": "[$B^0 \\to \\bar{D}^0 (\\to K^+ \\pi^-) K_S^0 (\\to \\pi^+ \\pi^-) K^+ \\pi^-$]CC Ntuples 79",
+    "type": {
+      "primary": "Dataset",
+      "secondary": [
+        "Collision"
+      ]
+    },
+    "usage": {
+      "description": "<p>Ntuples and instructions are provided in the links under Related datasets. They are ready to be downloaded and used for analysis. If these do not suit your needs, you can clone and amend this ntupling request here:</p>",
+      "links": [
+        {
+          "description": "LHCb Open Data Ntupling Service",
+          "url": "https://opendata-lhcb-ntupling-service.app.cern.ch/"
+        },
+        {
+          "description": "LHCb Open Data Ntupling Service Usage Guide",
+          "url": "https://lhcb-opendata-guide.web.cern.ch/ntupling-service/"
+        }
+      ]
+    }
+  },
+  {
+    "abstract": {
+      "description": "<p>Data from proton-proton (pp) collisions collected by the LHCb experiment filtered to produce ntuples for exploring $B^0 \\to \\bar{D}^0 (\\to K^+ \\pi^-) K_S^0 (\\to \\pi^+ \\pi^-) K^+ \\pi^-$ and charge-conjugate decays.</p>"
+    },
+    "accelerator": "CERN-LHC",
+    "collaboration": {
+      "name": "LHCb collaboration"
+    },
+    "collections": [
+      "LHCb-Collision-Datasets"
+    ],
+    "collision_information": {
+      "energy": "7TeV",
+      "type": "pp"
+    },
+    "date_created": [
+      "2011"
+    ],
+    "date_published": "2026",
+    "date_reprocessed": "2026",
+    "distribution": {
+      "formats": [
+        "root"
+      ],
+      "number_files": 1,
+      "size": 11732587
+    },
+    "experiment": [
+      "LHCb"
+    ],
+    "files": [
+      {
+        "checksum": "adler32:0efb21bf",
+        "size": 11732587,
+        "uri": "root://eospublic.cern.ch//eos/opendata/lhcb/CollisionNtuples/__REQ79_DOI__/outputs/real-production/00402316_00000001_1.dvntuple.root"
+      }
+    ],
+    "magnet_polarity": "MagDown",
+    "methodology": {
+      "description": "<p>These ntuples were produced from the LHCb Open Data Ntupling Service user request 79. Please see the input configuration files <a href=\"/record/__REQ79_PARENT_RECID__\">here</a>.</p>"
+    },
+    "publisher": "CERN Open Data portal",
+    "recid": "__REQ79_2011_DOWN_RECID__",
+    "relations": [
+      {
+        "recid": "__REQ79_PARENT_RECID__",
+        "type": "isChildOf"
+      }
+    ],
+    "run_period": [
+      "2011"
+    ],
+    "stripping": {
+      "stream": "BHADRON",
+      "version": "stripping21r1"
+    },
+    "title": "[$B^0 \\to \\bar{D}^0 (\\to K^+ \\pi^-) K_S^0 (\\to \\pi^+ \\pi^-) K^+ \\pi^-$]CC Ntuples 79 -- 2011 Magnet Down",
+    "type": {
+      "primary": "Dataset",
+      "secondary": [
+        "Collision"
+      ]
+    },
+    "usage": {
+      "description": "<p>You can use these ntuples with <a href=\"https://root.cern.ch/\">ROOT</a> data analysis framework. See documentation and examples here:</p>",
+      "links": [
+        {
+          "description": "LHCb Open Data Ntupling Service Usage Guide",
+          "url": "https://lhcb-opendata-guide.web.cern.ch/ntupling-service/"
+        }
+      ]
+    }
+  },
+  {
+    "abstract": {
+      "description": "<p>Data from proton-proton (pp) collisions collected by the LHCb experiment filtered to produce ntuples for exploring $B^0 \\to \\bar{D}^0 (\\to K^+ \\pi^-) K_S^0 (\\to \\pi^+ \\pi^-) K^+ \\pi^-$ and charge-conjugate decays.</p>"
+    },
+    "accelerator": "CERN-LHC",
+    "collaboration": {
+      "name": "LHCb collaboration"
+    },
+    "collections": [
+      "LHCb-Collision-Datasets"
+    ],
+    "collision_information": {
+      "energy": "7TeV",
+      "type": "pp"
+    },
+    "date_created": [
+      "2011"
+    ],
+    "date_published": "2026",
+    "date_reprocessed": "2026",
+    "distribution": {
+      "formats": [
+        "root"
+      ],
+      "number_files": 1,
+      "size": 8252875
+    },
+    "experiment": [
+      "LHCb"
+    ],
+    "files": [
+      {
+        "checksum": "adler32:91b8d708",
+        "size": 8252875,
+        "uri": "root://eospublic.cern.ch//eos/opendata/lhcb/CollisionNtuples/__REQ79_DOI__/outputs/real-production/00402318_00000001_1.dvntuple.root"
+      }
+    ],
+    "magnet_polarity": "MagUp",
+    "methodology": {
+      "description": "<p>These ntuples were produced from the LHCb Open Data Ntupling Service user request 79. Please see the input configuration files <a href=\"/record/__REQ79_PARENT_RECID__\">here</a>.</p>"
+    },
+    "publisher": "CERN Open Data portal",
+    "recid": "__REQ79_2011_UP_RECID__",
+    "relations": [
+      {
+        "recid": "__REQ79_PARENT_RECID__",
+        "type": "isChildOf"
+      }
+    ],
+    "run_period": [
+      "2011"
+    ],
+    "stripping": {
+      "stream": "BHADRON",
+      "version": "stripping21r1"
+    },
+    "title": "[$B^0 \\to \\bar{D}^0 (\\to K^+ \\pi^-) K_S^0 (\\to \\pi^+ \\pi^-) K^+ \\pi^-$]CC Ntuples 79 -- 2011 Magnet Up",
+    "type": {
+      "primary": "Dataset",
+      "secondary": [
+        "Collision"
+      ]
+    },
+    "usage": {
+      "description": "<p>You can use these ntuples with <a href=\"https://root.cern.ch/\">ROOT</a> data analysis framework. See documentation and examples here:</p>",
+      "links": [
+        {
+          "description": "LHCb Open Data Ntupling Service Usage Guide",
+          "url": "https://lhcb-opendata-guide.web.cern.ch/ntupling-service/"
+        }
+      ]
+    }
+  },
+  {
+    "abstract": {
+      "description": "<p>Data from proton-proton (pp) collisions collected by the LHCb experiment filtered to produce ntuples for exploring $B^0 \\to \\bar{D}^0 (\\to K^+ \\pi^-) K_S^0 (\\to \\pi^+ \\pi^-) K^+ \\pi^-$ and charge-conjugate decays.</p>"
+    },
+    "accelerator": "CERN-LHC",
+    "collaboration": {
+      "name": "LHCb collaboration"
+    },
+    "collections": [
+      "LHCb-Collision-Datasets"
+    ],
+    "collision_information": {
+      "energy": "8TeV",
+      "type": "pp"
+    },
+    "date_created": [
+      "2012"
+    ],
+    "date_published": "2026",
+    "date_reprocessed": "2026",
+    "distribution": {
+      "formats": [
+        "root"
+      ],
+      "number_files": 1,
+      "size": 22825116
+    },
+    "experiment": [
+      "LHCb"
+    ],
+    "files": [
+      {
+        "checksum": "adler32:f509ed4e",
+        "size": 22825116,
+        "uri": "root://eospublic.cern.ch//eos/opendata/lhcb/CollisionNtuples/__REQ79_DOI__/outputs/real-production/00402320_00000001_1.dvntuple.root"
+      }
+    ],
+    "magnet_polarity": "MagDown",
+    "methodology": {
+      "description": "<p>These ntuples were produced from the LHCb Open Data Ntupling Service user request 79. Please see the input configuration files <a href=\"/record/__REQ79_PARENT_RECID__\">here</a>.</p>"
+    },
+    "publisher": "CERN Open Data portal",
+    "recid": "__REQ79_2012_DOWN_RECID__",
+    "relations": [
+      {
+        "recid": "__REQ79_PARENT_RECID__",
+        "type": "isChildOf"
+      }
+    ],
+    "run_period": [
+      "2012"
+    ],
+    "stripping": {
+      "stream": "BHADRON",
+      "version": "stripping21"
+    },
+    "title": "[$B^0 \\to \\bar{D}^0 (\\to K^+ \\pi^-) K_S^0 (\\to \\pi^+ \\pi^-) K^+ \\pi^-$]CC Ntuples 79 -- 2012 Magnet Down",
+    "type": {
+      "primary": "Dataset",
+      "secondary": [
+        "Collision"
+      ]
+    },
+    "usage": {
+      "description": "<p>You can use these ntuples with <a href=\"https://root.cern.ch/\">ROOT</a> data analysis framework. See documentation and examples here:</p>",
+      "links": [
+        {
+          "description": "LHCb Open Data Ntupling Service Usage Guide",
+          "url": "https://lhcb-opendata-guide.web.cern.ch/ntupling-service/"
+        }
+      ]
+    }
+  },
+  {
+    "abstract": {
+      "description": "<p>Data from proton-proton (pp) collisions collected by the LHCb experiment filtered to produce ntuples for exploring $B^0 \\to \\bar{D}^0 (\\to K^+ \\pi^-) K_S^0 (\\to \\pi^+ \\pi^-) K^+ \\pi^-$ and charge-conjugate decays.</p>"
+    },
+    "accelerator": "CERN-LHC",
+    "collaboration": {
+      "name": "LHCb collaboration"
+    },
+    "collections": [
+      "LHCb-Collision-Datasets"
+    ],
+    "collision_information": {
+      "energy": "8TeV",
+      "type": "pp"
+    },
+    "date_created": [
+      "2012"
+    ],
+    "date_published": "2026",
+    "date_reprocessed": "2026",
+    "distribution": {
+      "formats": [
+        "root"
+      ],
+      "number_files": 1,
+      "size": 21960332
+    },
+    "experiment": [
+      "LHCb"
+    ],
+    "files": [
+      {
+        "checksum": "adler32:574736aa",
+        "size": 21960332,
+        "uri": "root://eospublic.cern.ch//eos/opendata/lhcb/CollisionNtuples/__REQ79_DOI__/outputs/real-production/00402304_00000001_1.dvntuple.root"
+      }
+    ],
+    "magnet_polarity": "MagUp",
+    "methodology": {
+      "description": "<p>These ntuples were produced from the LHCb Open Data Ntupling Service user request 79. Please see the input configuration files <a href=\"/record/__REQ79_PARENT_RECID__\">here</a>.</p>"
+    },
+    "publisher": "CERN Open Data portal",
+    "recid": "__REQ79_2012_UP_RECID__",
+    "relations": [
+      {
+        "recid": "__REQ79_PARENT_RECID__",
+        "type": "isChildOf"
+      }
+    ],
+    "run_period": [
+      "2012"
+    ],
+    "stripping": {
+      "stream": "BHADRON",
+      "version": "stripping21"
+    },
+    "title": "[$B^0 \\to \\bar{D}^0 (\\to K^+ \\pi^-) K_S^0 (\\to \\pi^+ \\pi^-) K^+ \\pi^-$]CC Ntuples 79 -- 2012 Magnet Up",
+    "type": {
+      "primary": "Dataset",
+      "secondary": [
+        "Collision"
+      ]
+    },
+    "usage": {
+      "description": "<p>You can use these ntuples with <a href=\"https://root.cern.ch/\">ROOT</a> data analysis framework. See documentation and examples here:</p>",
+      "links": [
+        {
+          "description": "LHCb Open Data Ntupling Service Usage Guide",
+          "url": "https://lhcb-opendata-guide.web.cern.ch/ntupling-service/"
+        }
+      ]
+    }
+  },
+  {
+    "abstract": {
+      "description": "<p>Data from proton-proton (pp) collisions collected by the LHCb experiment filtered to produce ntuples for exploring $B^0 \\to \\bar{D}^0 (\\to K^+ \\pi^-) K_S^0 (\\to \\pi^+ \\pi^-) K^+ \\pi^-$ and charge-conjugate decays.</p>"
+    },
+    "accelerator": "CERN-LHC",
+    "collaboration": {
+      "name": "LHCb collaboration"
+    },
+    "collections": [
+      "LHCb-Collision-Datasets"
+    ],
+    "collision_information": {
+      "energy": "13TeV",
+      "type": "pp"
+    },
+    "date_created": [
+      "2015"
+    ],
+    "date_published": "2026",
+    "date_reprocessed": "2026",
+    "distribution": {
+      "formats": [
+        "root"
+      ],
+      "number_files": 1,
+      "size": 8563529
+    },
+    "experiment": [
+      "LHCb"
+    ],
+    "files": [
+      {
+        "checksum": "adler32:2aa5fa06",
+        "size": 8563529,
+        "uri": "root://eospublic.cern.ch//eos/opendata/lhcb/CollisionNtuples/__REQ79_DOI__/outputs/real-production/00402303_00000001_1.dvntuple.root"
+      }
+    ],
+    "magnet_polarity": "MagDown",
+    "methodology": {
+      "description": "<p>These ntuples were produced from the LHCb Open Data Ntupling Service user request 79. Please see the input configuration files <a href=\"/record/__REQ79_PARENT_RECID__\">here</a>.</p>"
+    },
+    "publisher": "CERN Open Data portal",
+    "recid": "__REQ79_2015_DOWN_RECID__",
+    "relations": [
+      {
+        "recid": "__REQ79_PARENT_RECID__",
+        "type": "isChildOf"
+      }
+    ],
+    "run_period": [
+      "2015"
+    ],
+    "stripping": {
+      "stream": "BHADRON",
+      "version": "stripping24r2"
+    },
+    "title": "[$B^0 \\to \\bar{D}^0 (\\to K^+ \\pi^-) K_S^0 (\\to \\pi^+ \\pi^-) K^+ \\pi^-$]CC Ntuples 79 -- 2015 Magnet Down",
+    "type": {
+      "primary": "Dataset",
+      "secondary": [
+        "Collision"
+      ]
+    },
+    "usage": {
+      "description": "<p>You can use these ntuples with <a href=\"https://root.cern.ch/\">ROOT</a> data analysis framework. See documentation and examples here:</p>",
+      "links": [
+        {
+          "description": "LHCb Open Data Ntupling Service Usage Guide",
+          "url": "https://lhcb-opendata-guide.web.cern.ch/ntupling-service/"
+        }
+      ]
+    }
+  },
+  {
+    "abstract": {
+      "description": "<p>Data from proton-proton (pp) collisions collected by the LHCb experiment filtered to produce ntuples for exploring $B^0 \\to \\bar{D}^0 (\\to K^+ \\pi^-) K_S^0 (\\to \\pi^+ \\pi^-) K^+ \\pi^-$ and charge-conjugate decays.</p>"
+    },
+    "accelerator": "CERN-LHC",
+    "collaboration": {
+      "name": "LHCb collaboration"
+    },
+    "collections": [
+      "LHCb-Collision-Datasets"
+    ],
+    "collision_information": {
+      "energy": "13TeV",
+      "type": "pp"
+    },
+    "date_created": [
+      "2015"
+    ],
+    "date_published": "2026",
+    "date_reprocessed": "2026",
+    "distribution": {
+      "formats": [
+        "root"
+      ],
+      "number_files": 1,
+      "size": 6192038
+    },
+    "experiment": [
+      "LHCb"
+    ],
+    "files": [
+      {
+        "checksum": "adler32:29cb1b1c",
+        "size": 6192038,
+        "uri": "root://eospublic.cern.ch//eos/opendata/lhcb/CollisionNtuples/__REQ79_DOI__/outputs/real-production/00402306_00000001_1.dvntuple.root"
+      }
+    ],
+    "magnet_polarity": "MagUp",
+    "methodology": {
+      "description": "<p>These ntuples were produced from the LHCb Open Data Ntupling Service user request 79. Please see the input configuration files <a href=\"/record/__REQ79_PARENT_RECID__\">here</a>.</p>"
+    },
+    "publisher": "CERN Open Data portal",
+    "recid": "__REQ79_2015_UP_RECID__",
+    "relations": [
+      {
+        "recid": "__REQ79_PARENT_RECID__",
+        "type": "isChildOf"
+      }
+    ],
+    "run_period": [
+      "2015"
+    ],
+    "stripping": {
+      "stream": "BHADRON",
+      "version": "stripping24r2"
+    },
+    "title": "[$B^0 \\to \\bar{D}^0 (\\to K^+ \\pi^-) K_S^0 (\\to \\pi^+ \\pi^-) K^+ \\pi^-$]CC Ntuples 79 -- 2015 Magnet Up",
+    "type": {
+      "primary": "Dataset",
+      "secondary": [
+        "Collision"
+      ]
+    },
+    "usage": {
+      "description": "<p>You can use these ntuples with <a href=\"https://root.cern.ch/\">ROOT</a> data analysis framework. See documentation and examples here:</p>",
+      "links": [
+        {
+          "description": "LHCb Open Data Ntupling Service Usage Guide",
+          "url": "https://lhcb-opendata-guide.web.cern.ch/ntupling-service/"
+        }
+      ]
+    }
+  },
+  {
+    "abstract": {
+      "description": "<p>Data from proton-proton (pp) collisions collected by the LHCb experiment filtered to produce ntuples for exploring $B^0 \\to \\bar{D}^0 (\\to K^+ \\pi^-) K_S^0 (\\to \\pi^+ \\pi^-) K^+ \\pi^-$ and charge-conjugate decays.</p>"
+    },
+    "accelerator": "CERN-LHC",
+    "collaboration": {
+      "name": "LHCb collaboration"
+    },
+    "collections": [
+      "LHCb-Collision-Datasets"
+    ],
+    "collision_information": {
+      "energy": "13TeV",
+      "type": "pp"
+    },
+    "date_created": [
+      "2016"
+    ],
+    "date_published": "2026",
+    "date_reprocessed": "2026",
+    "distribution": {
+      "formats": [
+        "root"
+      ],
+      "number_files": 1,
+      "size": 43076020
+    },
+    "experiment": [
+      "LHCb"
+    ],
+    "files": [
+      {
+        "checksum": "adler32:33bc3114",
+        "size": 43076020,
+        "uri": "root://eospublic.cern.ch//eos/opendata/lhcb/CollisionNtuples/__REQ79_DOI__/outputs/real-production/00402308_00000001_1.dvntuple.root"
+      }
+    ],
+    "magnet_polarity": "MagDown",
+    "methodology": {
+      "description": "<p>These ntuples were produced from the LHCb Open Data Ntupling Service user request 79. Please see the input configuration files <a href=\"/record/__REQ79_PARENT_RECID__\">here</a>.</p>"
+    },
+    "publisher": "CERN Open Data portal",
+    "recid": "__REQ79_2016_DOWN_RECID__",
+    "relations": [
+      {
+        "recid": "__REQ79_PARENT_RECID__",
+        "type": "isChildOf"
+      }
+    ],
+    "run_period": [
+      "2016"
+    ],
+    "stripping": {
+      "stream": "BHADRON",
+      "version": "stripping28r2"
+    },
+    "title": "[$B^0 \\to \\bar{D}^0 (\\to K^+ \\pi^-) K_S^0 (\\to \\pi^+ \\pi^-) K^+ \\pi^-$]CC Ntuples 79 -- 2016 Magnet Down",
+    "type": {
+      "primary": "Dataset",
+      "secondary": [
+        "Collision"
+      ]
+    },
+    "usage": {
+      "description": "<p>You can use these ntuples with <a href=\"https://root.cern.ch/\">ROOT</a> data analysis framework. See documentation and examples here:</p>",
+      "links": [
+        {
+          "description": "LHCb Open Data Ntupling Service Usage Guide",
+          "url": "https://lhcb-opendata-guide.web.cern.ch/ntupling-service/"
+        }
+      ]
+    }
+  },
+  {
+    "abstract": {
+      "description": "<p>Data from proton-proton (pp) collisions collected by the LHCb experiment filtered to produce ntuples for exploring $B^0 \\to \\bar{D}^0 (\\to K^+ \\pi^-) K_S^0 (\\to \\pi^+ \\pi^-) K^+ \\pi^-$ and charge-conjugate decays.</p>"
+    },
+    "accelerator": "CERN-LHC",
+    "collaboration": {
+      "name": "LHCb collaboration"
+    },
+    "collections": [
+      "LHCb-Collision-Datasets"
+    ],
+    "collision_information": {
+      "energy": "13TeV",
+      "type": "pp"
+    },
+    "date_created": [
+      "2016"
+    ],
+    "date_published": "2026",
+    "date_reprocessed": "2026",
+    "distribution": {
+      "formats": [
+        "root"
+      ],
+      "number_files": 1,
+      "size": 40354267
+    },
+    "experiment": [
+      "LHCb"
+    ],
+    "files": [
+      {
+        "checksum": "adler32:85e45ee0",
+        "size": 40354267,
+        "uri": "root://eospublic.cern.ch//eos/opendata/lhcb/CollisionNtuples/__REQ79_DOI__/outputs/real-production/00402310_00000001_1.dvntuple.root"
+      }
+    ],
+    "magnet_polarity": "MagUp",
+    "methodology": {
+      "description": "<p>These ntuples were produced from the LHCb Open Data Ntupling Service user request 79. Please see the input configuration files <a href=\"/record/__REQ79_PARENT_RECID__\">here</a>.</p>"
+    },
+    "publisher": "CERN Open Data portal",
+    "recid": "__REQ79_2016_UP_RECID__",
+    "relations": [
+      {
+        "recid": "__REQ79_PARENT_RECID__",
+        "type": "isChildOf"
+      }
+    ],
+    "run_period": [
+      "2016"
+    ],
+    "stripping": {
+      "stream": "BHADRON",
+      "version": "stripping28r2"
+    },
+    "title": "[$B^0 \\to \\bar{D}^0 (\\to K^+ \\pi^-) K_S^0 (\\to \\pi^+ \\pi^-) K^+ \\pi^-$]CC Ntuples 79 -- 2016 Magnet Up",
+    "type": {
+      "primary": "Dataset",
+      "secondary": [
+        "Collision"
+      ]
+    },
+    "usage": {
+      "description": "<p>You can use these ntuples with <a href=\"https://root.cern.ch/\">ROOT</a> data analysis framework. See documentation and examples here:</p>",
+      "links": [
+        {
+          "description": "LHCb Open Data Ntupling Service Usage Guide",
+          "url": "https://lhcb-opendata-guide.web.cern.ch/ntupling-service/"
+        }
+      ]
+    }
+  },
+  {
+    "abstract": {
+      "description": "<p>Data from proton-proton (pp) collisions collected by the LHCb experiment filtered to produce ntuples for exploring $B^0 \\to \\bar{D}^0 (\\to K^+ \\pi^-) K_S^0 (\\to \\pi^+ \\pi^-) K^+ \\pi^-$ and charge-conjugate decays.</p>"
+    },
+    "accelerator": "CERN-LHC",
+    "collaboration": {
+      "name": "LHCb collaboration"
+    },
+    "collections": [
+      "LHCb-Collision-Datasets"
+    ],
+    "collision_information": {
+      "energy": "13TeV",
+      "type": "pp"
+    },
+    "date_created": [
+      "2017"
+    ],
+    "date_published": "2026",
+    "date_reprocessed": "2026",
+    "distribution": {
+      "formats": [
+        "root"
+      ],
+      "number_files": 1,
+      "size": 42541246
+    },
+    "experiment": [
+      "LHCb"
+    ],
+    "files": [
+      {
+        "checksum": "adler32:6dc5ce5f",
+        "size": 42541246,
+        "uri": "root://eospublic.cern.ch//eos/opendata/lhcb/CollisionNtuples/__REQ79_DOI__/outputs/real-production/00402312_00000001_1.dvntuple.root"
+      }
+    ],
+    "magnet_polarity": "MagDown",
+    "methodology": {
+      "description": "<p>These ntuples were produced from the LHCb Open Data Ntupling Service user request 79. Please see the input configuration files <a href=\"/record/__REQ79_PARENT_RECID__\">here</a>.</p>"
+    },
+    "publisher": "CERN Open Data portal",
+    "recid": "__REQ79_2017_DOWN_RECID__",
+    "relations": [
+      {
+        "recid": "__REQ79_PARENT_RECID__",
+        "type": "isChildOf"
+      }
+    ],
+    "run_period": [
+      "2017"
+    ],
+    "stripping": {
+      "stream": "BHADRON",
+      "version": "stripping29r2"
+    },
+    "title": "[$B^0 \\to \\bar{D}^0 (\\to K^+ \\pi^-) K_S^0 (\\to \\pi^+ \\pi^-) K^+ \\pi^-$]CC Ntuples 79 -- 2017 Magnet Down",
+    "type": {
+      "primary": "Dataset",
+      "secondary": [
+        "Collision"
+      ]
+    },
+    "usage": {
+      "description": "<p>You can use these ntuples with <a href=\"https://root.cern.ch/\">ROOT</a> data analysis framework. See documentation and examples here:</p>",
+      "links": [
+        {
+          "description": "LHCb Open Data Ntupling Service Usage Guide",
+          "url": "https://lhcb-opendata-guide.web.cern.ch/ntupling-service/"
+        }
+      ]
+    }
+  },
+  {
+    "abstract": {
+      "description": "<p>Data from proton-proton (pp) collisions collected by the LHCb experiment filtered to produce ntuples for exploring $B^0 \\to \\bar{D}^0 (\\to K^+ \\pi^-) K_S^0 (\\to \\pi^+ \\pi^-) K^+ \\pi^-$ and charge-conjugate decays.</p>"
+    },
+    "accelerator": "CERN-LHC",
+    "collaboration": {
+      "name": "LHCb collaboration"
+    },
+    "collections": [
+      "LHCb-Collision-Datasets"
+    ],
+    "collision_information": {
+      "energy": "13TeV",
+      "type": "pp"
+    },
+    "date_created": [
+      "2017"
+    ],
+    "date_published": "2026",
+    "date_reprocessed": "2026",
+    "distribution": {
+      "formats": [
+        "root"
+      ],
+      "number_files": 1,
+      "size": 41236423
+    },
+    "experiment": [
+      "LHCb"
+    ],
+    "files": [
+      {
+        "checksum": "adler32:260c90bb",
+        "size": 41236423,
+        "uri": "root://eospublic.cern.ch//eos/opendata/lhcb/CollisionNtuples/__REQ79_DOI__/outputs/real-production/00402314_00000001_1.dvntuple.root"
+      }
+    ],
+    "magnet_polarity": "MagUp",
+    "methodology": {
+      "description": "<p>These ntuples were produced from the LHCb Open Data Ntupling Service user request 79. Please see the input configuration files <a href=\"/record/__REQ79_PARENT_RECID__\">here</a>.</p>"
+    },
+    "publisher": "CERN Open Data portal",
+    "recid": "__REQ79_2017_UP_RECID__",
+    "relations": [
+      {
+        "recid": "__REQ79_PARENT_RECID__",
+        "type": "isChildOf"
+      }
+    ],
+    "run_period": [
+      "2017"
+    ],
+    "stripping": {
+      "stream": "BHADRON",
+      "version": "stripping29r2"
+    },
+    "title": "[$B^0 \\to \\bar{D}^0 (\\to K^+ \\pi^-) K_S^0 (\\to \\pi^+ \\pi^-) K^+ \\pi^-$]CC Ntuples 79 -- 2017 Magnet Up",
+    "type": {
+      "primary": "Dataset",
+      "secondary": [
+        "Collision"
+      ]
+    },
+    "usage": {
+      "description": "<p>You can use these ntuples with <a href=\"https://root.cern.ch/\">ROOT</a> data analysis framework. See documentation and examples here:</p>",
+      "links": [
+        {
+          "description": "LHCb Open Data Ntupling Service Usage Guide",
+          "url": "https://lhcb-opendata-guide.web.cern.ch/ntupling-service/"
+        }
+      ]
+    }
+  }
+]


### PR DESCRIPTION
Add records for ntupling service requests 35, 44 and 79 for a planned publication. We have been asked to do this by the open data user. 

Note these records are generated by Sol 5.6, getting its information from the  generated `.filelist.yaml` and the request gitlab. Asked to compare to existing example records. 

Some root file checksums are double checked by me e.g. with

`xrdfs root://eospublic.cern.ch query checksum   /eos/opendata/lhcb/upload/opendata-lhcb-ntupling-service/analysis-productions/merge-requests/6468/outputs/real-production/00402303_00000001_1.dvntuple.root` 

Filenames, sizes etc all look good to me. 

gitlab files checksums might need to be double checked by you @tiborsimko since I don't know how you usually generate them. 


To be done: 

- Add 3 DOIs for the records
- Add RecIds for Request 35  (1 parent, 2 children), 44 (1 parent, 10 children), 79 (1 parent, 10 children) 
- Copy config and root files to new locations