### PR TITLE
fix(records): correct dataset size in bytes for CMS PFNano 2016 records (#3767)

### DIFF
--- a/data/records/cms-derived-pfnano-2016.json
+++ b/data/records/cms-derived-pfnano-2016.json
@@ -39,7 +39,7 @@
       ],
       "number_events": 100826567,
       "number_files": 468,
-      "size": 1297795768
+      "size": 1328942631099
     },
     "experiment": [
       "CMS"
@@ -142,7 +142,7 @@
       ],
       "number_events": 27536603,
       "number_files": 91,
-      "size": 320657946
+      "size": 328353697999
     },
     "experiment": [
       "CMS"
@@ -245,7 +245,7 @@
       ],
       "number_events": 62080523,
       "number_files": 205,
-      "size": 673570329
+      "size": 689735908846
     },
     "experiment": [
       "CMS"
@@ -348,7 +348,7 @@
       ],
       "number_events": 18289323,
       "number_files": 79,
-      "size": 225286816
+      "size": 230693660395
     },
     "experiment": [
       "CMS"
@@ -452,7 +452,7 @@
       ],
       "number_events": 78216635,
       "number_files": 355,
-      "size": 893878988
+      "size": 915331908674
     },
     "experiment": [
       "CMS"
@@ -566,7 +566,7 @@
       ],
       "number_events": 45235604,
       "number_files": 151,
-      "size": 529653350
+      "size": 542364959597
     },
     "experiment": [
       "CMS"
@@ -669,7 +669,7 @@
       ],
       "number_events": 45367551,
       "number_files": 133,
-      "size": 498873700
+      "size": 510846600043
     },
     "experiment": [
       "CMS"
@@ -772,7 +772,7 @@
       ],
       "number_events": 32367421,
       "number_files": 143,
-      "size": 402556267
+      "size": 412217539571
     },
     "experiment": [
       "CMS"
@@ -876,7 +876,7 @@
       ],
       "number_events": 120517157,
       "number_files": 842,
-      "size": 1486368460
+      "size": 1522040870588
     },
     "experiment": [
       "CMS"
@@ -990,7 +990,7 @@
       ],
       "number_events": 26974131,
       "number_files": 109,
-      "size": 339156181
+      "size": 347295875568
     },
     "experiment": [
       "CMS"
@@ -1093,7 +1093,7 @@
       ],
       "number_events": 35301548,
       "number_files": 127,
-      "size": 379335688
+      "size": 388439681321
     },
     "experiment": [
       "CMS"
@@ -1196,7 +1196,7 @@
       ],
       "number_events": 33854612,
       "number_files": 119,
-      "size": 405546762
+      "size": 415279824811
     },
     "experiment": [
       "CMS"
@@ -1299,7 +1299,7 @@
       ],
       "number_events": 153363109,
       "number_files": 556,
-      "size": 1722259073
+      "size": 1763592998534
     },
     "experiment": [
       "CMS"
@@ -1402,7 +1402,7 @@
       ],
       "number_events": 149916849,
       "number_files": 381,
-      "size": 1658003182
+      "size": 1697795066298
     },
     "experiment": [
       "CMS"
@@ -1505,7 +1505,7 @@
       ],
       "number_events": 33288854,
       "number_files": 122,
-      "size": 378974160
+      "size": 388069469766
     },
     "experiment": [
       "CMS"
@@ -1608,7 +1608,7 @@
       ],
       "number_events": 79578661,
       "number_files": 370,
-      "size": 922922704
+      "size": 945072653657
     },
     "experiment": [
       "CMS"
@@ -1711,7 +1711,7 @@
       ],
       "number_events": 27123616,
       "number_files": 67,
-      "size": 219858693
+      "size": 225135265550
     },
     "experiment": [
       "CMS"


### PR DESCRIPTION
Closes #3767

### Summary
The dataset sizes in `data/records/cms-derived-pfnano-2016.json` for the 17 NanoAOD+ParticleFlow records (`31300` through `31316`) were stored in KiB instead of Bytes (~1,024x smaller than actual total size). As a result, Invenio displayed dataset sizes as ~1.4 GiB instead of ~1.4 TiB.

This PR recalculates and sets the exact byte sum from each record's EOS index JSON (`*root_file_index.json`), matching the file sizes and resolving the inconsistency across all 17 records.