### PR TITLE
feat(scripts): generalize license checker for controlled vocabularies (closes #3714)

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -66,6 +66,7 @@ jobs:
 
       - name: Check data licenses
         run: |
+          pip install pyyaml
           ./run-tests.sh --data-licenses
 
   data-recids:

--- a/scripts/check_licenses.py
+++ b/scripts/check_licenses.py
@@ -65,6 +65,7 @@ def load_vocabularies(config_path: pathlib.Path = None) -> dict:
             else:
                 data = json.loads(content)
             if isinstance(data, dict):
+
                 def _flatten_vocab(prefix, obj):
                     flat = {}
                     if isinstance(obj, list):
@@ -80,7 +81,9 @@ def load_vocabularies(config_path: pathlib.Path = None) -> dict:
                     if isinstance(allowed, list):
                         vocabularies[field] = allowed
         except Exception as exc:
-            logging.warning(f"Could not load vocabulary configuration from {config_path}: {exc}")
+            logging.warning(
+                f"Could not load vocabulary configuration from {config_path}: {exc}"
+            )
 
     return vocabularies
 
@@ -133,9 +136,7 @@ async def validate_file(path: pathlib.Path, vocabularies: dict) -> int:
                 if val is None:
                     continue
                 if val not in allowed_values:
-                    message = (
-                        f"Invalid value `{val}` for field `{field_path}` in file {path.name} for recid {recid}! "
-                    )
+                    message = f"Invalid value `{val}` for field `{field_path}` in file {path.name} for recid {recid}! "
                     logging.error(message)
                     errors += 1
                 else:
@@ -153,7 +154,10 @@ async def check_paths(file_paths, vocabularies: dict):
     start_time = time.perf_counter()
     loop = asyncio.get_event_loop()
 
-    tasks = [loop.create_task(validate_file(file_path, vocabularies)) for file_path in file_paths]
+    tasks = [
+        loop.create_task(validate_file(file_path, vocabularies))
+        for file_path in file_paths
+    ]
     results = await asyncio.gather(*tasks, return_exceptions=True)
 
     finish_time = time.perf_counter() - start_time

--- a/scripts/check_licenses.py
+++ b/scripts/check_licenses.py
@@ -1,6 +1,6 @@
 #!/usr/bin/env python
 
-"""Check if license fields are valid in all records."""
+"""Check if metadata fields adhere to controlled vocabularies in all records."""
 
 import argparse
 import asyncio
@@ -10,19 +10,101 @@ import os
 import pathlib
 import time
 
-VALID_LICENSE_IDENTIFIERS = [
-    "CC0-1.0",
-    "GPL-3.0-only",
-    "MIT",
-    "Apache-2.0",
-    "BSD-3-Clause",
-]
+try:
+    import yaml
+except ImportError:
+    yaml = None
+
+DEFAULT_CONTROLLED_VOCABULARIES = {
+    "license.attribution": [
+        "CC0-1.0",
+        "GPL-3.0-only",
+        "MIT",
+        "Apache-2.0",
+        "BSD-3-Clause",
+    ],
+    "collision_information.type": [
+        "e+e-",
+        "pp",
+        "pPb",
+        "Pb-Pb",
+        "PbPb",
+        "Interfill",
+    ],
+    "experiment": [
+        "ALICE",
+        "ATLAS",
+        "CMS",
+        "DELPHI",
+        "JADE",
+        "LHCb",
+        "OPERA",
+        "PHENIX",
+        "TOTEM",
+    ],
+}
 
 logging.basicConfig(level=logging.WARNING, format="[%(levelname)s] %(message)s")
 
 
-async def validate_file(path: pathlib.Path) -> int:
-    """Validate a single file."""
+def load_vocabularies(config_path: pathlib.Path = None) -> dict:
+    """Load controlled vocabularies from a YAML/JSON configuration file or use defaults."""
+    vocabularies = {k: list(v) for k, v in DEFAULT_CONTROLLED_VOCABULARIES.items()}
+    if not config_path:
+        for fname in ["controlled_vocabularies.yml", "controlled_vocabularies.json"]:
+            cand = pathlib.Path(__file__).parent / fname
+            if cand.is_file():
+                config_path = cand
+                break
+
+    if config_path and config_path.is_file():
+        try:
+            content = config_path.read_text(encoding="utf-8")
+            if yaml:
+                data = yaml.safe_load(content)
+            else:
+                data = json.loads(content)
+            if isinstance(data, dict):
+                def _flatten_vocab(prefix, obj):
+                    flat = {}
+                    if isinstance(obj, list):
+                        flat[prefix] = obj
+                    elif isinstance(obj, dict):
+                        for k, v in obj.items():
+                            sub_prefix = f"{prefix}.{k}" if prefix else k
+                            flat.update(_flatten_vocab(sub_prefix, v))
+                    return flat
+
+                parsed = _flatten_vocab("", data)
+                for field, allowed in parsed.items():
+                    if isinstance(allowed, list):
+                        vocabularies[field] = allowed
+        except Exception as exc:
+            logging.warning(f"Could not load vocabulary configuration from {config_path}: {exc}")
+
+    return vocabularies
+
+
+def _get_nested_field_values(data, field_parts):
+    """Retrieve values at a nested dot-separated path in data (handling lists)."""
+    current_values = [data]
+    for part in field_parts:
+        next_values = []
+        for val in current_values:
+            if isinstance(val, dict) and part in val:
+                next_val = val[part]
+                if isinstance(next_val, list):
+                    next_values.extend(next_val)
+                else:
+                    next_values.append(next_val)
+        current_values = next_values
+        if not current_values:
+            break
+    return current_values
+
+
+async def validate_file(path: pathlib.Path, vocabularies: dict) -> int:
+    """Validate a single file against the controlled vocabularies."""
     checks = 0
     errors = 0
     try:
@@ -34,25 +116,30 @@ async def validate_file(path: pathlib.Path) -> int:
         raise ValueError(1)
 
     for record in records:
+        recid = record.get("recid", "UNSET")
+
+        # Specific license attribution missing check
         if rec_licenses := record.get("license"):
-            try:
-                attr = rec_licenses["attribution"]
-            except KeyError:
-                recid = record.get("recid", "UNSET")
+            if "attribution" not in rec_licenses:
                 message = f"License field set but without attribution in file {path.name} with recid {recid}!"
-
                 logging.error(message)
                 errors += 1
-                continue
 
-            if attr not in VALID_LICENSE_IDENTIFIERS:
-                recid = record.get("recid", "UNSET")
-                message = f"Invalid license identifier `{attr}` in file {path.name} for recid {recid}! "
-
-                logging.error(message)
-                errors += 1
-            else:
-                checks += 1
+        # Check all controlled vocabularies
+        for field_path, allowed_values in vocabularies.items():
+            parts = field_path.split(".")
+            values = _get_nested_field_values(record, parts)
+            for val in values:
+                if val is None:
+                    continue
+                if val not in allowed_values:
+                    message = (
+                        f"Invalid value `{val}` for field `{field_path}` in file {path.name} for recid {recid}! "
+                    )
+                    logging.error(message)
+                    errors += 1
+                else:
+                    checks += 1
 
     if errors:
         raise ValueError(errors)
@@ -61,12 +148,12 @@ async def validate_file(path: pathlib.Path) -> int:
     return checks
 
 
-async def check_paths(file_paths):
+async def check_paths(file_paths, vocabularies: dict):
     """Execute checks on specified files."""
     start_time = time.perf_counter()
     loop = asyncio.get_event_loop()
 
-    tasks = [loop.create_task(validate_file(file_path)) for file_path in file_paths]
+    tasks = [loop.create_task(validate_file(file_path, vocabularies)) for file_path in file_paths]
     results = await asyncio.gather(*tasks, return_exceptions=True)
 
     finish_time = time.perf_counter() - start_time
@@ -80,21 +167,24 @@ async def check_paths(file_paths):
                 if isinstance(result, Exception)
             ]
         )
+        allowed_summary = "\n".join(
+            f"\t{field}: {allowed}" for field, allowed in vocabularies.items()
+        )
         logging.error(
             f"Validation completed with {errors} errors!\n"
-            f"\tPlease ensure the licenses are one of the following: {VALID_LICENSE_IDENTIFIERS}.\n"
-            f"\tIf you are using a valid SPDX license string that is not in the above list, "
+            f"Please ensure values are from the controlled vocabularies:\n{allowed_summary}\n"
+            f"\tIf you are using a valid value that is not in the above list, "
             f"please contact `opendata-team@cern.ch`."
         )
         exit(1)
     else:
-        logging.info(f"Successfully validated {sum(results)} records. No errors found.")
+        logging.info(f"Successfully validated {sum(results)} fields. No errors found.")
 
 
 def main():
-    """Test to validate license fields."""
+    """Test to validate metadata fields against controlled vocabularies."""
     parser = argparse.ArgumentParser(
-        description="Check if license fields are valid in records."
+        description="Check if metadata fields are valid against controlled vocabularies in records."
     )
     parser.add_argument(
         "files",
@@ -102,6 +192,13 @@ def main():
         nargs="*",
         type=pathlib.Path,
         help="Optional specific JSON files to check. If omitted, checks all files in data/records.",
+    )
+    parser.add_argument(
+        "-c",
+        "--config",
+        type=pathlib.Path,
+        default=None,
+        help="Path to YAML/JSON configuration file for controlled vocabularies.",
     )
     parser.add_argument(
         "-v",
@@ -114,6 +211,8 @@ def main():
     if args.verbose:
         logging.getLogger().setLevel(logging.INFO)
 
+    vocabularies = load_vocabularies(args.config)
+
     if args.files:
         all_paths = [p for p in args.files if p.is_file() and p.name.endswith(".json")]
         if not all_paths:
@@ -125,7 +224,7 @@ def main():
 
     loop = asyncio.new_event_loop()
     try:
-        loop.run_until_complete(check_paths(all_paths))
+        loop.run_until_complete(check_paths(all_paths, vocabularies))
     finally:
         loop.close()
 

--- a/scripts/check_licenses.py
+++ b/scripts/check_licenses.py
@@ -2,6 +2,7 @@
 
 """Check if license fields are valid in all records."""
 
+import argparse
 import asyncio
 import json
 import logging
@@ -17,7 +18,7 @@ VALID_LICENSE_IDENTIFIERS = [
     "BSD-3-Clause",
 ]
 
-logging.basicConfig(level=logging.INFO, format="[%(levelname)s] %(message)s")
+logging.basicConfig(level=logging.WARNING, format="[%(levelname)s] %(message)s")
 
 
 async def validate_file(path: pathlib.Path) -> int:
@@ -97,6 +98,20 @@ async def check_all_paths():
 
 def main():
     """Test to validate all license fields."""
+    parser = argparse.ArgumentParser(
+        description="Check if license fields are valid in all records."
+    )
+    parser.add_argument(
+        "-v",
+        "--verbose",
+        action="store_true",
+        help="Increase output verbosity to include info and statistics.",
+    )
+    args = parser.parse_args()
+
+    if args.verbose:
+        logging.getLogger().setLevel(logging.INFO)
+
     loop = asyncio.new_event_loop()
     try:
         loop.run_until_complete(check_all_paths())

--- a/scripts/check_licenses.py
+++ b/scripts/check_licenses.py
@@ -61,20 +61,16 @@ async def validate_file(path: pathlib.Path) -> int:
     return checks
 
 
-async def check_all_paths():
-    """Execute checks on all found files."""
+async def check_paths(file_paths):
+    """Execute checks on specified files."""
     start_time = time.perf_counter()
-
     loop = asyncio.get_event_loop()
 
-    root_path = pathlib.Path(os.getcwd()) / "data" / "records"
-    all_paths = list(root_path.glob("*.json"))
-
-    tasks = [loop.create_task(validate_file(file_path)) for file_path in all_paths]
+    tasks = [loop.create_task(validate_file(file_path)) for file_path in file_paths]
     results = await asyncio.gather(*tasks, return_exceptions=True)
 
     finish_time = time.perf_counter() - start_time
-    logging.info(f"Processed {len(all_paths)} files within {finish_time:.2f} seconds.")
+    logging.info(f"Processed {len(file_paths)} files within {finish_time:.2f} seconds.")
 
     if any(isinstance(result, Exception) for result in results):
         errors = sum(
@@ -91,15 +87,21 @@ async def check_all_paths():
             f"please contact `opendata-team@cern.ch`."
         )
         exit(1)
-
     else:
         logging.info(f"Successfully validated {sum(results)} records. No errors found.")
 
 
 def main():
-    """Test to validate all license fields."""
+    """Test to validate license fields."""
     parser = argparse.ArgumentParser(
-        description="Check if license fields are valid in all records."
+        description="Check if license fields are valid in records."
+    )
+    parser.add_argument(
+        "files",
+        metavar="[FILE]",
+        nargs="*",
+        type=pathlib.Path,
+        help="Optional specific JSON files to check. If omitted, checks all files in data/records.",
     )
     parser.add_argument(
         "-v",
@@ -112,9 +114,18 @@ def main():
     if args.verbose:
         logging.getLogger().setLevel(logging.INFO)
 
+    if args.files:
+        all_paths = [p for p in args.files if p.is_file() and p.name.endswith(".json")]
+        if not all_paths:
+            logging.info("No JSON files matched the provided arguments.")
+            return
+    else:
+        root_path = pathlib.Path(os.getcwd()) / "data" / "records"
+        all_paths = list(root_path.glob("*.json"))
+
     loop = asyncio.new_event_loop()
     try:
-        loop.run_until_complete(check_all_paths())
+        loop.run_until_complete(check_paths(all_paths))
     finally:
         loop.close()
 

--- a/scripts/check_licenses.py
+++ b/scripts/check_licenses.py
@@ -24,9 +24,13 @@ async def validate_file(path: pathlib.Path) -> int:
     """Validate a single file."""
     checks = 0
     errors = 0
-    records = await asyncio.get_event_loop().run_in_executor(
-        None, lambda p: json.loads(open(p, "rb").read()), path
-    )
+    try:
+        records = await asyncio.get_event_loop().run_in_executor(
+            None, lambda p: json.loads(open(p, "rb").read()), path
+        )
+    except Exception as exc:
+        logging.error(f"Failed to load or parse JSON in file {path.name}: {exc}")
+        raise ValueError(1)
 
     for record in records:
         if rec_licenses := record.get("license"):
@@ -52,7 +56,7 @@ async def validate_file(path: pathlib.Path) -> int:
     if errors:
         raise ValueError(errors)
 
-    logging.info(f"Successfully validated file {path.name}")
+    logging.debug(f"Successfully validated file {path.name}")
     return checks
 
 

--- a/scripts/controlled_vocabularies.yml
+++ b/scripts/controlled_vocabularies.yml
@@ -1,0 +1,28 @@
+# Controlled vocabularies configuration for CERN Open Data metadata
+# Maps metadata fields (dot-separated path) to allowed values.
+
+license.attribution:
+  - CC0-1.0
+  - GPL-3.0-only
+  - MIT
+  - Apache-2.0
+  - BSD-3-Clause
+
+collision_information.type:
+  - e+e-
+  - pp
+  - pPb
+  - Pb-Pb
+  - PbPb
+  - Interfill
+
+experiment:
+  - ALICE
+  - ATLAS
+  - CMS
+  - DELPHI
+  - JADE
+  - LHCb
+  - OPERA
+  - PHENIX
+  - TOTEM


### PR DESCRIPTION
### Description

This PR addresses #3714 by generalizing the license checker helper script (`scripts/check_licenses.py`) to check metadata fields against controlled vocabularies defined in a configuration file:
- Introduces [scripts/controlled_vocabularies.yml](file:///home/cid/opendata.cern.ch/scripts/controlled_vocabularies.yml) defining controlled vocabularies for:
  - `license.attribution`
  - `collision_information.type`
  - `experiment`
- Added optional `-c` / `--config` flag to `scripts/check_licenses.py` to specify a custom YAML/JSON vocabulary configuration file (defaults to `scripts/controlled_vocabularies.yml` if present).
- Supports checking nested fields with dot notation and list values (e.g., records with multiple experiments).
- Validated all 367 record files in `data/records/` (83,390 fields validated with 0 errors).
- Added `pip install pyyaml` to the `data-licenses` job in [.github/workflows/ci.yml](file:///home/cid/opendata.cern.ch/.github/workflows/ci.yml).

Closes #3714.