### PR TITLE
docs(lhcb): update DST and MDST usage documentation

### DIFF
--- a/data/records/LHCb_2011_Beam3500GeV_VeloClosed_MagDown_RealData_Reco14_Stripping21r1_BHADRONCOMPLETEEVENT_DST.json
+++ b/data/records/LHCb_2011_Beam3500GeV_VeloClosed_MagDown_RealData_Reco14_Stripping21r1_BHADRONCOMPLETEEVENT_DST.json
@@ -105,15 +105,11 @@
       ]
     },
     "usage": {
-      "description": "<p> The data collected by the LHCb detector is available in .DST and .mDST formats. The data files can be explored using LHCb software but it is best to write the relevant columns to ROOT Tuples or preferred data format. <p> Instructions for exploring a DST and writing out ROOT tuples are available in LHCb Starterkit below. For \"tupling\" jobs, software called DaVinci is mainly used within LHCb, its documentation is also available bellow.",
+      "description": "<p> The data collected by the LHCb detector is available in .DST and .mDST formats. The data files can be explored using LHCb software but it is best to write the relevant columns to ROOT ntuples or a preferred data format. <p> Instructions for exploring a DST and writing out ROOT ntuples are available in the link below. A catalog for exploring the available stripping line selections can be found at the stripping lines index below.",
       "links": [
         {
-          "description": "LHCb StarterKit",
-          "url": "https://lhcb.github.io/starterkit-lessons/first-analysis-steps/minimal-dv-job.html"
-        },
-        {
-          "description": "DaVinci",
-          "url": "http://lhcbdoc.web.cern.ch/lhcbdoc/davinci/"
+          "description": "LHCb Open Data Guide",
+          "url": "https://lhcb-opendata-guide.web.cern.ch/run1-dsts-odp/"
         },
         {
           "description": "Stripping lines index for stripping21r1",

--- a/data/records/LHCb_2011_Beam3500GeV_VeloClosed_MagDown_RealData_Reco14_Stripping21r1_BHADRON_MDST.json
+++ b/data/records/LHCb_2011_Beam3500GeV_VeloClosed_MagDown_RealData_Reco14_Stripping21r1_BHADRON_MDST.json
@@ -105,15 +105,11 @@
       ]
     },
     "usage": {
-      "description": "<p> The data collected by the LHCb detector is available in .DST and .mDST formats. The data files can be explored using LHCb software but it is best to write the relevant columns to ROOT Tuples or preferred data format. <p> Instructions for exploring a DST and writing out ROOT tuples are available in LHCb Starterkit below. For \"tupling\" jobs, software called DaVinci is mainly used within LHCb, its documentation is also available bellow.",
+      "description": "<p> The data collected by the LHCb detector is available in .DST and .mDST formats. The data files can be explored using LHCb software but it is best to write the relevant columns to ROOT ntuples or a preferred data format. <p> Instructions for exploring a DST and writing out ROOT ntuples are available in the link below. A catalog for exploring the available stripping line selections can be found at the stripping lines index below.",
       "links": [
         {
-          "description": "LHCb StarterKit",
-          "url": "https://lhcb.github.io/starterkit-lessons/first-analysis-steps/minimal-dv-job.html"
-        },
-        {
-          "description": "DaVinci",
-          "url": "http://lhcbdoc.web.cern.ch/lhcbdoc/davinci/"
+          "description": "LHCb Open Data Guide",
+          "url": "https://lhcb-opendata-guide.web.cern.ch/run1-dsts-odp/"
         },
         {
           "description": "Stripping lines index for stripping21r1",

--- a/data/records/LHCb_2011_Beam3500GeV_VeloClosed_MagDown_RealData_Reco14_Stripping21r1_CHARMCOMPLETEEVENT_DST.json
+++ b/data/records/LHCb_2011_Beam3500GeV_VeloClosed_MagDown_RealData_Reco14_Stripping21r1_CHARMCOMPLETEEVENT_DST.json
@@ -105,15 +105,11 @@
       ]
     },
     "usage": {
-      "description": "<p> The data collected by the LHCb detector is available in .DST and .mDST formats. The data files can be explored using LHCb software but it is best to write the relevant columns to ROOT Tuples or preferred data format. <p> Instructions for exploring a DST and writing out ROOT tuples are available in LHCb Starterkit below. For \"tupling\" jobs, software called DaVinci is mainly used within LHCb, its documentation is also available bellow.",
+      "description": "<p> The data collected by the LHCb detector is available in .DST and .mDST formats. The data files can be explored using LHCb software but it is best to write the relevant columns to ROOT ntuples or a preferred data format. <p> Instructions for exploring a DST and writing out ROOT ntuples are available in the link below. A catalog for exploring the available stripping line selections can be found at the stripping lines index below.",
       "links": [
         {
-          "description": "LHCb StarterKit",
-          "url": "https://lhcb.github.io/starterkit-lessons/first-analysis-steps/minimal-dv-job.html"
-        },
-        {
-          "description": "DaVinci",
-          "url": "http://lhcbdoc.web.cern.ch/lhcbdoc/davinci/"
+          "description": "LHCb Open Data Guide",
+          "url": "https://lhcb-opendata-guide.web.cern.ch/run1-dsts-odp/"
         },
         {
           "description": "Stripping lines index for stripping21r1",

--- a/data/records/LHCb_2011_Beam3500GeV_VeloClosed_MagDown_RealData_Reco14_Stripping21r1_CHARM_MDST.json
+++ b/data/records/LHCb_2011_Beam3500GeV_VeloClosed_MagDown_RealData_Reco14_Stripping21r1_CHARM_MDST.json
@@ -105,15 +105,11 @@
       ]
     },
     "usage": {
-      "description": "<p> The data collected by the LHCb detector is available in .DST and .mDST formats. The data files can be explored using LHCb software but it is best to write the relevant columns to ROOT Tuples or preferred data format. <p> Instructions for exploring a DST and writing out ROOT tuples are available in LHCb Starterkit below. For \"tupling\" jobs, software called DaVinci is mainly used within LHCb, its documentation is also available bellow.",
+      "description": "<p> The data collected by the LHCb detector is available in .DST and .mDST formats. The data files can be explored using LHCb software but it is best to write the relevant columns to ROOT ntuples or a preferred data format. <p> Instructions for exploring a DST and writing out ROOT ntuples are available in the link below. A catalog for exploring the available stripping line selections can be found at the stripping lines index below.",
       "links": [
         {
-          "description": "LHCb StarterKit",
-          "url": "https://lhcb.github.io/starterkit-lessons/first-analysis-steps/minimal-dv-job.html"
-        },
-        {
-          "description": "DaVinci",
-          "url": "http://lhcbdoc.web.cern.ch/lhcbdoc/davinci/"
+          "description": "LHCb Open Data Guide",
+          "url": "https://lhcb-opendata-guide.web.cern.ch/run1-dsts-odp/"
         },
         {
           "description": "Stripping lines index for stripping21r1",

--- a/data/records/LHCb_2011_Beam3500GeV_VeloClosed_MagDown_RealData_Reco14_Stripping21r1_DIMUON_DST.json
+++ b/data/records/LHCb_2011_Beam3500GeV_VeloClosed_MagDown_RealData_Reco14_Stripping21r1_DIMUON_DST.json
@@ -105,15 +105,11 @@
       ]
     },
     "usage": {
-      "description": "<p> The data collected by the LHCb detector is available in .DST and .mDST formats. The data files can be explored using LHCb software but it is best to write the relevant columns to ROOT Tuples or preferred data format. <p> Instructions for exploring a DST and writing out ROOT tuples are available in LHCb Starterkit below. For \"tupling\" jobs, software called DaVinci is mainly used within LHCb, its documentation is also available bellow.",
+      "description": "<p> The data collected by the LHCb detector is available in .DST and .mDST formats. The data files can be explored using LHCb software but it is best to write the relevant columns to ROOT ntuples or a preferred data format. <p> Instructions for exploring a DST and writing out ROOT ntuples are available in the link below. A catalog for exploring the available stripping line selections can be found at the stripping lines index below.",
       "links": [
         {
-          "description": "LHCb StarterKit",
-          "url": "https://lhcb.github.io/starterkit-lessons/first-analysis-steps/minimal-dv-job.html"
-        },
-        {
-          "description": "DaVinci",
-          "url": "http://lhcbdoc.web.cern.ch/lhcbdoc/davinci/"
+          "description": "LHCb Open Data Guide",
+          "url": "https://lhcb-opendata-guide.web.cern.ch/run1-dsts-odp/"
         },
         {
           "description": "Stripping lines index for stripping21r1",

--- a/data/records/LHCb_2011_Beam3500GeV_VeloClosed_MagDown_RealData_Reco14_Stripping21r1_EW_DST.json
+++ b/data/records/LHCb_2011_Beam3500GeV_VeloClosed_MagDown_RealData_Reco14_Stripping21r1_EW_DST.json
@@ -105,15 +105,11 @@
       ]
     },
     "usage": {
-      "description": "<p> The data collected by the LHCb detector is available in .DST and .mDST formats. The data files can be explored using LHCb software but it is best to write the relevant columns to ROOT Tuples or preferred data format. <p> Instructions for exploring a DST and writing out ROOT tuples are available in LHCb Starterkit below. For \"tupling\" jobs, software called DaVinci is mainly used within LHCb, its documentation is also available below.",
+      "description": "<p> The data collected by the LHCb detector is available in .DST and .mDST formats. The data files can be explored using LHCb software but it is best to write the relevant columns to ROOT ntuples or a preferred data format. <p> Instructions for exploring a DST and writing out ROOT ntuples are available in the link below. A catalog for exploring the available stripping line selections can be found at the stripping lines index below.",
       "links": [
         {
-          "description": "LHCb StarterKit",
-          "url": "https://lhcb.github.io/starterkit-lessons/first-analysis-steps/minimal-dv-job.html"
-        },
-        {
-          "description": "DaVinci",
-          "url": "http://lhcbdoc.web.cern.ch/lhcbdoc/davinci/"
+          "description": "LHCb Open Data Guide",
+          "url": "https://lhcb-opendata-guide.web.cern.ch/run1-dsts-odp/"
         },
         {
           "description": "Stripping lines index for stripping21r1",

--- a/data/records/LHCb_2011_Beam3500GeV_VeloClosed_MagDown_RealData_Reco14_Stripping21r1_LEPTONIC_MDST.json
+++ b/data/records/LHCb_2011_Beam3500GeV_VeloClosed_MagDown_RealData_Reco14_Stripping21r1_LEPTONIC_MDST.json
@@ -105,15 +105,11 @@
       ]
     },
     "usage": {
-      "description": "<p> The data collected by the LHCb detector is available in .DST and .mDST formats. The data files can be explored using LHCb software but it is best to write the relevant columns to ROOT Tuples or preferred data format. <p> Instructions for exploring a DST and writing out ROOT tuples are available in LHCb Starterkit below. For \"tupling\" jobs, software called DaVinci is mainly used within LHCb, its documentation is also available below.",
+      "description": "<p> The data collected by the LHCb detector is available in .DST and .mDST formats. The data files can be explored using LHCb software but it is best to write the relevant columns to ROOT ntuples or a preferred data format. <p> Instructions for exploring a DST and writing out ROOT ntuples are available in the link below. A catalog for exploring the available stripping line selections can be found at the stripping lines index below.",
       "links": [
         {
-          "description": "LHCb StarterKit",
-          "url": "https://lhcb.github.io/starterkit-lessons/first-analysis-steps/minimal-dv-job.html"
-        },
-        {
-          "description": "DaVinci",
-          "url": "http://lhcbdoc.web.cern.ch/lhcbdoc/davinci/"
+          "description": "LHCb Open Data Guide",
+          "url": "https://lhcb-opendata-guide.web.cern.ch/run1-dsts-odp/"
         },
         {
           "description": "Stripping lines index for stripping21r1",

--- a/data/records/LHCb_2011_Beam3500GeV_VeloClosed_MagDown_RealData_Reco14_Stripping21r1_RADIATIVE_DST.json
+++ b/data/records/LHCb_2011_Beam3500GeV_VeloClosed_MagDown_RealData_Reco14_Stripping21r1_RADIATIVE_DST.json
@@ -105,15 +105,11 @@
       ]
     },
     "usage": {
-      "description": "<p> The data collected by the LHCb detector is available in .DST and .mDST formats. The data files can be explored using LHCb software but it is best to write the relevant columns to ROOT Tuples or preferred data format. <p> Instructions for exploring a DST and writing out ROOT tuples are available in LHCb Starterkit below. For \"tupling\" jobs, software called DaVinci is mainly used within LHCb, its documentation is also available below.",
+      "description": "<p> The data collected by the LHCb detector is available in .DST and .mDST formats. The data files can be explored using LHCb software but it is best to write the relevant columns to ROOT ntuples or a preferred data format. <p> Instructions for exploring a DST and writing out ROOT ntuples are available in the link below. A catalog for exploring the available stripping line selections can be found at the stripping lines index below.",
       "links": [
         {
-          "description": "LHCb StarterKit",
-          "url": "https://lhcb.github.io/starterkit-lessons/first-analysis-steps/minimal-dv-job.html"
-        },
-        {
-          "description": "DaVinci",
-          "url": "http://lhcbdoc.web.cern.ch/lhcbdoc/davinci/"
+          "description": "LHCb Open Data Guide",
+          "url": "https://lhcb-opendata-guide.web.cern.ch/run1-dsts-odp/"
         },
         {
           "description": "Stripping lines index for stripping21r1",

--- a/data/records/LHCb_2011_Beam3500GeV_VeloClosed_MagDown_RealData_Reco14_Stripping21r1_SEMILEPTONIC_DST.json
+++ b/data/records/LHCb_2011_Beam3500GeV_VeloClosed_MagDown_RealData_Reco14_Stripping21r1_SEMILEPTONIC_DST.json
@@ -105,15 +105,11 @@
       ]
     },
     "usage": {
-      "description": "<p> The data collected by the LHCb detector is available in .DST and .mDST formats. The data files can be explored using LHCb software but it is best to write the relevant columns to ROOT Tuples or preferred data format. <p> Instructions for exploring a DST and writing out ROOT tuples are available in LHCb Starterkit below. For \"tupling\" jobs, software called DaVinci is mainly used within LHCb, its documentation is also available bellow.",
+      "description": "<p> The data collected by the LHCb detector is available in .DST and .mDST formats. The data files can be explored using LHCb software but it is best to write the relevant columns to ROOT ntuples or a preferred data format. <p> Instructions for exploring a DST and writing out ROOT ntuples are available in the link below. A catalog for exploring the available stripping line selections can be found at the stripping lines index below.",
       "links": [
         {
-          "description": "LHCb StarterKit",
-          "url": "https://lhcb.github.io/starterkit-lessons/first-analysis-steps/minimal-dv-job.html"
-        },
-        {
-          "description": "DaVinci",
-          "url": "http://lhcbdoc.web.cern.ch/lhcbdoc/davinci/"
+          "description": "LHCb Open Data Guide",
+          "url": "https://lhcb-opendata-guide.web.cern.ch/run1-dsts-odp/"
         },
         {
           "description": "Stripping lines index for stripping21r1",

--- a/data/records/LHCb_2011_Beam3500GeV_VeloClosed_MagDown_RealData_Reco14_Stripping21r1p1a_BHADRONCOMPLETEEVENT_DST.json
+++ b/data/records/LHCb_2011_Beam3500GeV_VeloClosed_MagDown_RealData_Reco14_Stripping21r1p1a_BHADRONCOMPLETEEVENT_DST.json
@@ -108,15 +108,11 @@
       ]
     },
     "usage": {
-      "description": "<p> The data collected by the LHCb detector is available in .DST and .mDST formats. The data files can be explored using LHCb software but it is best to write the relevant columns to ROOT Tuples or preferred data format. <p> Instructions for exploring a DST and writing out ROOT tuples are available in LHCb Starterkit below. For \"tupling\" jobs, software called DaVinci is mainly used within LHCb, its documentation is also available bellow.",
+      "description": "<p> The data collected by the LHCb detector is available in .DST and .mDST formats. The data files can be explored using LHCb software but it is best to write the relevant columns to ROOT ntuples or a preferred data format. <p> Instructions for exploring a DST and writing out ROOT ntuples are available in the link below. A catalog for exploring the available stripping line selections can be found at the stripping lines index below.",
       "links": [
         {
-          "description": "LHCb StarterKit",
-          "url": "https://lhcb.github.io/starterkit-lessons/first-analysis-steps/minimal-dv-job.html"
-        },
-        {
-          "description": "DaVinci",
-          "url": "http://lhcbdoc.web.cern.ch/lhcbdoc/davinci/"
+          "description": "LHCb Open Data Guide",
+          "url": "https://lhcb-opendata-guide.web.cern.ch/run1-dsts-odp/"
         },
         {
           "description": "Stripping lines index for stripping21r1p1",

--- a/data/records/LHCb_2011_Beam3500GeV_VeloClosed_MagDown_RealData_Reco14_Stripping21r1p1a_BHADRON_MDST.json
+++ b/data/records/LHCb_2011_Beam3500GeV_VeloClosed_MagDown_RealData_Reco14_Stripping21r1p1a_BHADRON_MDST.json
@@ -108,15 +108,11 @@
       ]
     },
     "usage": {
-      "description": "<p> The data collected by the LHCb detector is available in .DST and .mDST formats. The data files can be explored using LHCb software but it is best to write the relevant columns to ROOT Tuples or preferred data format. <p> Instructions for exploring a DST and writing out ROOT tuples are available in LHCb Starterkit below. For \"tupling\" jobs, software called DaVinci is mainly used within LHCb, its documentation is also available bellow.",
+      "description": "<p> The data collected by the LHCb detector is available in .DST and .mDST formats. The data files can be explored using LHCb software but it is best to write the relevant columns to ROOT ntuples or a preferred data format. <p> Instructions for exploring a DST and writing out ROOT ntuples are available in the link below. A catalog for exploring the available stripping line selections can be found at the stripping lines index below.",
       "links": [
         {
-          "description": "LHCb StarterKit",
-          "url": "https://lhcb.github.io/starterkit-lessons/first-analysis-steps/minimal-dv-job.html"
-        },
-        {
-          "description": "DaVinci",
-          "url": "http://lhcbdoc.web.cern.ch/lhcbdoc/davinci/"
+          "description": "LHCb Open Data Guide",
+          "url": "https://lhcb-opendata-guide.web.cern.ch/run1-dsts-odp/"
         },
         {
           "description": "Stripping lines index for stripping21r1p1",

--- a/data/records/LHCb_2011_Beam3500GeV_VeloClosed_MagDown_RealData_Reco14_Stripping21r1p1a_CHARMCOMPLETEEVENT_DST.json
+++ b/data/records/LHCb_2011_Beam3500GeV_VeloClosed_MagDown_RealData_Reco14_Stripping21r1p1a_CHARMCOMPLETEEVENT_DST.json
@@ -108,15 +108,11 @@
       ]
     },
     "usage": {
-      "description": "<p> The data collected by the LHCb detector is available in .DST and .mDST formats. The data files can be explored using LHCb software but it is best to write the relevant columns to ROOT Tuples or preferred data format. <p> Instructions for exploring a DST and writing out ROOT tuples are available in LHCb Starterkit below. For \"tupling\" jobs, software called DaVinci is mainly used within LHCb, its documentation is also available bellow.",
+      "description": "<p> The data collected by the LHCb detector is available in .DST and .mDST formats. The data files can be explored using LHCb software but it is best to write the relevant columns to ROOT ntuples or a preferred data format. <p> Instructions for exploring a DST and writing out ROOT ntuples are available in the link below. A catalog for exploring the available stripping line selections can be found at the stripping lines index below.",
       "links": [
         {
-          "description": "LHCb StarterKit",
-          "url": "https://lhcb.github.io/starterkit-lessons/first-analysis-steps/minimal-dv-job.html"
-        },
-        {
-          "description": "DaVinci",
-          "url": "http://lhcbdoc.web.cern.ch/lhcbdoc/davinci/"
+          "description": "LHCb Open Data Guide",
+          "url": "https://lhcb-opendata-guide.web.cern.ch/run1-dsts-odp/"
         },
         {
           "description": "Stripping lines index for stripping21r1p1",

--- a/data/records/LHCb_2011_Beam3500GeV_VeloClosed_MagDown_RealData_Reco14_Stripping21r1p1a_CHARM_MDST.json
+++ b/data/records/LHCb_2011_Beam3500GeV_VeloClosed_MagDown_RealData_Reco14_Stripping21r1p1a_CHARM_MDST.json
@@ -108,15 +108,11 @@
       ]
     },
     "usage": {
-      "description": "<p> The data collected by the LHCb detector is available in .DST and .mDST formats. The data files can be explored using LHCb software but it is best to write the relevant columns to ROOT Tuples or preferred data format. <p> Instructions for exploring a DST and writing out ROOT tuples are available in LHCb Starterkit below. For \"tupling\" jobs, software called DaVinci is mainly used within LHCb, its documentation is also available bellow.",
+      "description": "<p> The data collected by the LHCb detector is available in .DST and .mDST formats. The data files can be explored using LHCb software but it is best to write the relevant columns to ROOT ntuples or a preferred data format. <p> Instructions for exploring a DST and writing out ROOT ntuples are available in the link below. A catalog for exploring the available stripping line selections can be found at the stripping lines index below.",
       "links": [
         {
-          "description": "LHCb StarterKit",
-          "url": "https://lhcb.github.io/starterkit-lessons/first-analysis-steps/minimal-dv-job.html"
-        },
-        {
-          "description": "DaVinci",
-          "url": "http://lhcbdoc.web.cern.ch/lhcbdoc/davinci/"
+          "description": "LHCb Open Data Guide",
+          "url": "https://lhcb-opendata-guide.web.cern.ch/run1-dsts-odp/"
         },
         {
           "description": "Stripping lines index for stripping21r1p1",

--- a/data/records/LHCb_2011_Beam3500GeV_VeloClosed_MagDown_RealData_Reco14_Stripping21r1p1a_DIMUON_DST.json
+++ b/data/records/LHCb_2011_Beam3500GeV_VeloClosed_MagDown_RealData_Reco14_Stripping21r1p1a_DIMUON_DST.json
@@ -108,15 +108,11 @@
       ]
     },
     "usage": {
-      "description": "<p> The data collected by the LHCb detector is available in .DST and .mDST formats. The data files can be explored using LHCb software but it is best to write the relevant columns to ROOT Tuples or preferred data format. <p> Instructions for exploring a DST and writing out ROOT tuples are available in LHCb Starterkit below. For \"tupling\" jobs, software called DaVinci is mainly used within LHCb, its documentation is also available bellow.",
+      "description": "<p> The data collected by the LHCb detector is available in .DST and .mDST formats. The data files can be explored using LHCb software but it is best to write the relevant columns to ROOT ntuples or a preferred data format. <p> Instructions for exploring a DST and writing out ROOT ntuples are available in the link below. A catalog for exploring the available stripping line selections can be found at the stripping lines index below.",
       "links": [
         {
-          "description": "LHCb StarterKit",
-          "url": "https://lhcb.github.io/starterkit-lessons/first-analysis-steps/minimal-dv-job.html"
-        },
-        {
-          "description": "DaVinci",
-          "url": "http://lhcbdoc.web.cern.ch/lhcbdoc/davinci/"
+          "description": "LHCb Open Data Guide",
+          "url": "https://lhcb-opendata-guide.web.cern.ch/run1-dsts-odp/"
         },
         {
           "description": "Stripping lines index for stripping21r1p1",

--- a/data/records/LHCb_2011_Beam3500GeV_VeloClosed_MagDown_RealData_Reco14_Stripping21r1p1a_EW_DST.json
+++ b/data/records/LHCb_2011_Beam3500GeV_VeloClosed_MagDown_RealData_Reco14_Stripping21r1p1a_EW_DST.json
@@ -108,15 +108,11 @@
       ]
     },
     "usage": {
-      "description": "<p> The data collected by the LHCb detector is available in .DST and .mDST formats. The data files can be explored using LHCb software but it is best to write the relevant columns to ROOT Tuples or preferred data format. <p> Instructions for exploring a DST and writing out ROOT tuples are available in LHCb Starterkit below. For \"tupling\" jobs, software called DaVinci is mainly used within LHCb, its documentation is also available below.",
+      "description": "<p> The data collected by the LHCb detector is available in .DST and .mDST formats. The data files can be explored using LHCb software but it is best to write the relevant columns to ROOT ntuples or a preferred data format. <p> Instructions for exploring a DST and writing out ROOT ntuples are available in the link below. A catalog for exploring the available stripping line selections can be found at the stripping lines index below.",
       "links": [
         {
-          "description": "LHCb StarterKit",
-          "url": "https://lhcb.github.io/starterkit-lessons/first-analysis-steps/minimal-dv-job.html"
-        },
-        {
-          "description": "DaVinci",
-          "url": "http://lhcbdoc.web.cern.ch/lhcbdoc/davinci/"
+          "description": "LHCb Open Data Guide",
+          "url": "https://lhcb-opendata-guide.web.cern.ch/run1-dsts-odp/"
         },
         {
           "description": "Stripping lines index for stripping21r1p1",

--- a/data/records/LHCb_2011_Beam3500GeV_VeloClosed_MagDown_RealData_Reco14_Stripping21r1p1a_LEPTONIC_MDST.json
+++ b/data/records/LHCb_2011_Beam3500GeV_VeloClosed_MagDown_RealData_Reco14_Stripping21r1p1a_LEPTONIC_MDST.json
@@ -108,15 +108,11 @@
       ]
     },
     "usage": {
-      "description": "<p> The data collected by the LHCb detector is available in .DST and .mDST formats. The data files can be explored using LHCb software but it is best to write the relevant columns to ROOT Tuples or preferred data format. <p> Instructions for exploring a DST and writing out ROOT tuples are available in LHCb Starterkit below. For \"tupling\" jobs, software called DaVinci is mainly used within LHCb, its documentation is also available below.",
+      "description": "<p> The data collected by the LHCb detector is available in .DST and .mDST formats. The data files can be explored using LHCb software but it is best to write the relevant columns to ROOT ntuples or a preferred data format. <p> Instructions for exploring a DST and writing out ROOT ntuples are available in the link below. A catalog for exploring the available stripping line selections can be found at the stripping lines index below.",
       "links": [
         {
-          "description": "LHCb StarterKit",
-          "url": "https://lhcb.github.io/starterkit-lessons/first-analysis-steps/minimal-dv-job.html"
-        },
-        {
-          "description": "DaVinci",
-          "url": "http://lhcbdoc.web.cern.ch/lhcbdoc/davinci/"
+          "description": "LHCb Open Data Guide",
+          "url": "https://lhcb-opendata-guide.web.cern.ch/run1-dsts-odp/"
         },
         {
           "description": "Stripping lines index for stripping21r1p1",

--- a/data/records/LHCb_2011_Beam3500GeV_VeloClosed_MagDown_RealData_Reco14_Stripping21r1p1a_SEMILEPTONIC_DST.json
+++ b/data/records/LHCb_2011_Beam3500GeV_VeloClosed_MagDown_RealData_Reco14_Stripping21r1p1a_SEMILEPTONIC_DST.json
@@ -108,15 +108,11 @@
       ]
     },
     "usage": {
-      "description": "<p> The data collected by the LHCb detector is available in .DST and .mDST formats. The data files can be explored using LHCb software but it is best to write the relevant columns to ROOT Tuples or preferred data format. <p> Instructions for exploring a DST and writing out ROOT tuples are available in LHCb Starterkit below. For \"tupling\" jobs, software called DaVinci is mainly used within LHCb, its documentation is also available bellow.",
+      "description": "<p> The data collected by the LHCb detector is available in .DST and .mDST formats. The data files can be explored using LHCb software but it is best to write the relevant columns to ROOT ntuples or a preferred data format. <p> Instructions for exploring a DST and writing out ROOT ntuples are available in the link below. A catalog for exploring the available stripping line selections can be found at the stripping lines index below.",
       "links": [
         {
-          "description": "LHCb StarterKit",
-          "url": "https://lhcb.github.io/starterkit-lessons/first-analysis-steps/minimal-dv-job.html"
-        },
-        {
-          "description": "DaVinci",
-          "url": "http://lhcbdoc.web.cern.ch/lhcbdoc/davinci/"
+          "description": "LHCb Open Data Guide",
+          "url": "https://lhcb-opendata-guide.web.cern.ch/run1-dsts-odp/"
         },
         {
           "description": "Stripping lines index for stripping21r1p1",

--- a/data/records/LHCb_2011_Beam3500GeV_VeloClosed_MagDown_RealData_Reco14_Stripping21r1p2_BHADRONCOMPLETEEVENT_DST.json
+++ b/data/records/LHCb_2011_Beam3500GeV_VeloClosed_MagDown_RealData_Reco14_Stripping21r1p2_BHADRONCOMPLETEEVENT_DST.json
@@ -108,15 +108,11 @@
       ]
     },
     "usage": {
-      "description": "<p> The data collected by the LHCb detector is available in .DST and .mDST formats. The data files can be explored using LHCb software but it is best to write the relevant columns to ROOT Tuples or preferred data format. <p> Instructions for exploring a DST and writing out ROOT tuples are available in LHCb Starterkit below. For \"tupling\" jobs, software called DaVinci is mainly used within LHCb, its documentation is also available bellow.",
+      "description": "<p> The data collected by the LHCb detector is available in .DST and .mDST formats. The data files can be explored using LHCb software but it is best to write the relevant columns to ROOT ntuples or a preferred data format. <p> Instructions for exploring a DST and writing out ROOT ntuples are available in the link below. A catalog for exploring the available stripping line selections can be found at the stripping lines index below.",
       "links": [
         {
-          "description": "LHCb StarterKit",
-          "url": "https://lhcb.github.io/starterkit-lessons/first-analysis-steps/minimal-dv-job.html"
-        },
-        {
-          "description": "DaVinci",
-          "url": "http://lhcbdoc.web.cern.ch/lhcbdoc/davinci/"
+          "description": "LHCb Open Data Guide",
+          "url": "https://lhcb-opendata-guide.web.cern.ch/run1-dsts-odp/"
         },
         {
           "description": "Stripping lines index for stripping21r1p2",

--- a/data/records/LHCb_2011_Beam3500GeV_VeloClosed_MagDown_RealData_Reco14_Stripping21r1p2_BHADRON_MDST.json
+++ b/data/records/LHCb_2011_Beam3500GeV_VeloClosed_MagDown_RealData_Reco14_Stripping21r1p2_BHADRON_MDST.json
@@ -108,15 +108,11 @@
       ]
     },
     "usage": {
-      "description": "<p> The data collected by the LHCb detector is available in .DST and .mDST formats. The data files can be explored using LHCb software but it is best to write the relevant columns to ROOT Tuples or preferred data format. <p> Instructions for exploring a DST and writing out ROOT tuples are available in LHCb Starterkit below. For \"tupling\" jobs, software called DaVinci is mainly used within LHCb, its documentation is also available bellow.",
+      "description": "<p> The data collected by the LHCb detector is available in .DST and .mDST formats. The data files can be explored using LHCb software but it is best to write the relevant columns to ROOT ntuples or a preferred data format. <p> Instructions for exploring a DST and writing out ROOT ntuples are available in the link below. A catalog for exploring the available stripping line selections can be found at the stripping lines index below.",
       "links": [
         {
-          "description": "LHCb StarterKit",
-          "url": "https://lhcb.github.io/starterkit-lessons/first-analysis-steps/minimal-dv-job.html"
-        },
-        {
-          "description": "DaVinci",
-          "url": "http://lhcbdoc.web.cern.ch/lhcbdoc/davinci/"
+          "description": "LHCb Open Data Guide",
+          "url": "https://lhcb-opendata-guide.web.cern.ch/run1-dsts-odp/"
         },
         {
           "description": "Stripping lines index for stripping21r1p2",

--- a/data/records/LHCb_2011_Beam3500GeV_VeloClosed_MagDown_RealData_Reco14_Stripping21r1p2_CHARMCOMPLETEEVENT_DST.json
+++ b/data/records/LHCb_2011_Beam3500GeV_VeloClosed_MagDown_RealData_Reco14_Stripping21r1p2_CHARMCOMPLETEEVENT_DST.json
@@ -108,15 +108,11 @@
       ]
     },
     "usage": {
-      "description": "<p> The data collected by the LHCb detector is available in .DST and .mDST formats. The data files can be explored using LHCb software but it is best to write the relevant columns to ROOT Tuples or preferred data format. <p> Instructions for exploring a DST and writing out ROOT tuples are available in LHCb Starterkit below. For \"tupling\" jobs, software called DaVinci is mainly used within LHCb, its documentation is also available bellow.",
+      "description": "<p> The data collected by the LHCb detector is available in .DST and .mDST formats. The data files can be explored using LHCb software but it is best to write the relevant columns to ROOT ntuples or a preferred data format. <p> Instructions for exploring a DST and writing out ROOT ntuples are available in the link below. A catalog for exploring the available stripping line selections can be found at the stripping lines index below.",
       "links": [
         {
-          "description": "LHCb StarterKit",
-          "url": "https://lhcb.github.io/starterkit-lessons/first-analysis-steps/minimal-dv-job.html"
-        },
-        {
-          "description": "DaVinci",
-          "url": "http://lhcbdoc.web.cern.ch/lhcbdoc/davinci/"
+          "description": "LHCb Open Data Guide",
+          "url": "https://lhcb-opendata-guide.web.cern.ch/run1-dsts-odp/"
         },
         {
           "description": "Stripping lines index for stripping21r1p2",

--- a/data/records/LHCb_2011_Beam3500GeV_VeloClosed_MagDown_RealData_Reco14_Stripping21r1p2_CHARM_MDST.json
+++ b/data/records/LHCb_2011_Beam3500GeV_VeloClosed_MagDown_RealData_Reco14_Stripping21r1p2_CHARM_MDST.json
@@ -108,15 +108,11 @@
       ]
     },
     "usage": {
-      "description": "<p> The data collected by the LHCb detector is available in .DST and .mDST formats. The data files can be explored using LHCb software but it is best to write the relevant columns to ROOT Tuples or preferred data format. <p> Instructions for exploring a DST and writing out ROOT tuples are available in LHCb Starterkit below. For \"tupling\" jobs, software called DaVinci is mainly used within LHCb, its documentation is also available bellow.",
+      "description": "<p> The data collected by the LHCb detector is available in .DST and .mDST formats. The data files can be explored using LHCb software but it is best to write the relevant columns to ROOT ntuples or a preferred data format. <p> Instructions for exploring a DST and writing out ROOT ntuples are available in the link below. A catalog for exploring the available stripping line selections can be found at the stripping lines index below.",
       "links": [
         {
-          "description": "LHCb StarterKit",
-          "url": "https://lhcb.github.io/starterkit-lessons/first-analysis-steps/minimal-dv-job.html"
-        },
-        {
-          "description": "DaVinci",
-          "url": "http://lhcbdoc.web.cern.ch/lhcbdoc/davinci/"
+          "description": "LHCb Open Data Guide",
+          "url": "https://lhcb-opendata-guide.web.cern.ch/run1-dsts-odp/"
         },
         {
           "description": "Stripping lines index for stripping21r1p2",

--- a/data/records/LHCb_2011_Beam3500GeV_VeloClosed_MagDown_RealData_Reco14_Stripping21r1p2_DIMUON_DST.json
+++ b/data/records/LHCb_2011_Beam3500GeV_VeloClosed_MagDown_RealData_Reco14_Stripping21r1p2_DIMUON_DST.json
@@ -108,15 +108,11 @@
       ]
     },
     "usage": {
-      "description": "<p> The data collected by the LHCb detector is available in .DST and .mDST formats. The data files can be explored using LHCb software but it is best to write the relevant columns to ROOT Tuples or preferred data format. <p> Instructions for exploring a DST and writing out ROOT tuples are available in LHCb Starterkit below. For \"tupling\" jobs, software called DaVinci is mainly used within LHCb, its documentation is also available bellow.",
+      "description": "<p> The data collected by the LHCb detector is available in .DST and .mDST formats. The data files can be explored using LHCb software but it is best to write the relevant columns to ROOT ntuples or a preferred data format. <p> Instructions for exploring a DST and writing out ROOT ntuples are available in the link below. A catalog for exploring the available stripping line selections can be found at the stripping lines index below.",
       "links": [
         {
-          "description": "LHCb StarterKit",
-          "url": "https://lhcb.github.io/starterkit-lessons/first-analysis-steps/minimal-dv-job.html"
-        },
-        {
-          "description": "DaVinci",
-          "url": "http://lhcbdoc.web.cern.ch/lhcbdoc/davinci/"
+          "description": "LHCb Open Data Guide",
+          "url": "https://lhcb-opendata-guide.web.cern.ch/run1-dsts-odp/"
         },
         {
           "description": "Stripping lines index for stripping21r1p2",

--- a/data/records/LHCb_2011_Beam3500GeV_VeloClosed_MagDown_RealData_Reco14_Stripping21r1p2_EW_DST.json
+++ b/data/records/LHCb_2011_Beam3500GeV_VeloClosed_MagDown_RealData_Reco14_Stripping21r1p2_EW_DST.json
@@ -108,15 +108,11 @@
       ]
     },
     "usage": {
-      "description": "<p> The data collected by the LHCb detector is available in .DST and .mDST formats. The data files can be explored using LHCb software but it is best to write the relevant columns to ROOT Tuples or preferred data format. <p> Instructions for exploring a DST and writing out ROOT tuples are available in LHCb Starterkit below. For \"tupling\" jobs, software called DaVinci is mainly used within LHCb, its documentation is also available below.",
+      "description": "<p> The data collected by the LHCb detector is available in .DST and .mDST formats. The data files can be explored using LHCb software but it is best to write the relevant columns to ROOT ntuples or a preferred data format. <p> Instructions for exploring a DST and writing out ROOT ntuples are available in the link below. A catalog for exploring the available stripping line selections can be found at the stripping lines index below.",
       "links": [
         {
-          "description": "LHCb StarterKit",
-          "url": "https://lhcb.github.io/starterkit-lessons/first-analysis-steps/minimal-dv-job.html"
-        },
-        {
-          "description": "DaVinci",
-          "url": "http://lhcbdoc.web.cern.ch/lhcbdoc/davinci/"
+          "description": "LHCb Open Data Guide",
+          "url": "https://lhcb-opendata-guide.web.cern.ch/run1-dsts-odp/"
         },
         {
           "description": "Stripping lines index for stripping21r1p2",

--- a/data/records/LHCb_2011_Beam3500GeV_VeloClosed_MagDown_RealData_Reco14_Stripping21r1p2_LEPTONIC_MDST.json
+++ b/data/records/LHCb_2011_Beam3500GeV_VeloClosed_MagDown_RealData_Reco14_Stripping21r1p2_LEPTONIC_MDST.json
@@ -108,15 +108,11 @@
       ]
     },
     "usage": {
-      "description": "<p> The data collected by the LHCb detector is available in .DST and .mDST formats. The data files can be explored using LHCb software but it is best to write the relevant columns to ROOT Tuples or preferred data format. <p> Instructions for exploring a DST and writing out ROOT tuples are available in LHCb Starterkit below. For \"tupling\" jobs, software called DaVinci is mainly used within LHCb, its documentation is also available below.",
+      "description": "<p> The data collected by the LHCb detector is available in .DST and .mDST formats. The data files can be explored using LHCb software but it is best to write the relevant columns to ROOT ntuples or a preferred data format. <p> Instructions for exploring a DST and writing out ROOT ntuples are available in the link below. A catalog for exploring the available stripping line selections can be found at the stripping lines index below.",
       "links": [
         {
-          "description": "LHCb StarterKit",
-          "url": "https://lhcb.github.io/starterkit-lessons/first-analysis-steps/minimal-dv-job.html"
-        },
-        {
-          "description": "DaVinci",
-          "url": "http://lhcbdoc.web.cern.ch/lhcbdoc/davinci/"
+          "description": "LHCb Open Data Guide",
+          "url": "https://lhcb-opendata-guide.web.cern.ch/run1-dsts-odp/"
         },
         {
           "description": "Stripping lines index for stripping21r1p2",

--- a/data/records/LHCb_2011_Beam3500GeV_VeloClosed_MagDown_RealData_Reco14_Stripping21r1p2_SEMILEPTONIC_DST.json
+++ b/data/records/LHCb_2011_Beam3500GeV_VeloClosed_MagDown_RealData_Reco14_Stripping21r1p2_SEMILEPTONIC_DST.json
@@ -108,15 +108,11 @@
       ]
     },
     "usage": {
-      "description": "<p> The data collected by the LHCb detector is available in .DST and .mDST formats. The data files can be explored using LHCb software but it is best to write the relevant columns to ROOT Tuples or preferred data format. <p> Instructions for exploring a DST and writing out ROOT tuples are available in LHCb Starterkit below. For \"tupling\" jobs, software called DaVinci is mainly used within LHCb, its documentation is also available bellow.",
+      "description": "<p> The data collected by the LHCb detector is available in .DST and .mDST formats. The data files can be explored using LHCb software but it is best to write the relevant columns to ROOT ntuples or a preferred data format. <p> Instructions for exploring a DST and writing out ROOT ntuples are available in the link below. A catalog for exploring the available stripping line selections can be found at the stripping lines index below.",
       "links": [
         {
-          "description": "LHCb StarterKit",
-          "url": "https://lhcb.github.io/starterkit-lessons/first-analysis-steps/minimal-dv-job.html"
-        },
-        {
-          "description": "DaVinci",
-          "url": "http://lhcbdoc.web.cern.ch/lhcbdoc/davinci/"
+          "description": "LHCb Open Data Guide",
+          "url": "https://lhcb-opendata-guide.web.cern.ch/run1-dsts-odp/"
         },
         {
           "description": "Stripping lines index for stripping21r1p2",

--- a/data/records/LHCb_2011_Beam3500GeV_VeloClosed_MagUp_RealData_Reco14_Stripping21r1_BHADRONCOMPLETEEVENT_DST.json
+++ b/data/records/LHCb_2011_Beam3500GeV_VeloClosed_MagUp_RealData_Reco14_Stripping21r1_BHADRONCOMPLETEEVENT_DST.json
@@ -105,15 +105,11 @@
       ]
     },
     "usage": {
-      "description": "<p> The data collected by the LHCb detector is available in .DST and .mDST formats. The data files can be explored using LHCb software but it is best to write the relevant columns to ROOT Tuples or preferred data format. <p> Instructions for exploring a DST and writing out ROOT tuples are available in LHCb Starterkit below. For \"tupling\" jobs, software called DaVinci is mainly used within LHCb, its documentation is also available bellow.",
+      "description": "<p> The data collected by the LHCb detector is available in .DST and .mDST formats. The data files can be explored using LHCb software but it is best to write the relevant columns to ROOT ntuples or a preferred data format. <p> Instructions for exploring a DST and writing out ROOT ntuples are available in the link below. A catalog for exploring the available stripping line selections can be found at the stripping lines index below.",
       "links": [
         {
-          "description": "LHCb StarterKit",
-          "url": "https://lhcb.github.io/starterkit-lessons/first-analysis-steps/minimal-dv-job.html"
-        },
-        {
-          "description": "DaVinci",
-          "url": "http://lhcbdoc.web.cern.ch/lhcbdoc/davinci/"
+          "description": "LHCb Open Data Guide",
+          "url": "https://lhcb-opendata-guide.web.cern.ch/run1-dsts-odp/"
         },
         {
           "description": "Stripping lines index for stripping21r1",

--- a/data/records/LHCb_2011_Beam3500GeV_VeloClosed_MagUp_RealData_Reco14_Stripping21r1_BHADRON_MDST.json
+++ b/data/records/LHCb_2011_Beam3500GeV_VeloClosed_MagUp_RealData_Reco14_Stripping21r1_BHADRON_MDST.json
@@ -105,15 +105,11 @@
       ]
     },
     "usage": {
-      "description": "<p> The data collected by the LHCb detector is available in .DST and .mDST formats. The data files can be explored using LHCb software but it is best to write the relevant columns to ROOT Tuples or preferred data format. <p> Instructions for exploring a DST and writing out ROOT tuples are available in LHCb Starterkit below. For \"tupling\" jobs, software called DaVinci is mainly used within LHCb, its documentation is also available bellow.",
+      "description": "<p> The data collected by the LHCb detector is available in .DST and .mDST formats. The data files can be explored using LHCb software but it is best to write the relevant columns to ROOT ntuples or a preferred data format. <p> Instructions for exploring a DST and writing out ROOT ntuples are available in the link below. A catalog for exploring the available stripping line selections can be found at the stripping lines index below.",
       "links": [
         {
-          "description": "LHCb StarterKit",
-          "url": "https://lhcb.github.io/starterkit-lessons/first-analysis-steps/minimal-dv-job.html"
-        },
-        {
-          "description": "DaVinci",
-          "url": "http://lhcbdoc.web.cern.ch/lhcbdoc/davinci/"
+          "description": "LHCb Open Data Guide",
+          "url": "https://lhcb-opendata-guide.web.cern.ch/run1-dsts-odp/"
         },
         {
           "description": "Stripping lines index for stripping21r1",

--- a/data/records/LHCb_2011_Beam3500GeV_VeloClosed_MagUp_RealData_Reco14_Stripping21r1_CHARMCOMPLETEEVENT_DST.json
+++ b/data/records/LHCb_2011_Beam3500GeV_VeloClosed_MagUp_RealData_Reco14_Stripping21r1_CHARMCOMPLETEEVENT_DST.json
@@ -105,15 +105,11 @@
       ]
     },
     "usage": {
-      "description": "<p> The data collected by the LHCb detector is available in .DST and .mDST formats. The data files can be explored using LHCb software but it is best to write the relevant columns to ROOT Tuples or preferred data format. <p> Instructions for exploring a DST and writing out ROOT tuples are available in LHCb Starterkit below. For \"tupling\" jobs, software called DaVinci is mainly used within LHCb, its documentation is also available bellow.",
+      "description": "<p> The data collected by the LHCb detector is available in .DST and .mDST formats. The data files can be explored using LHCb software but it is best to write the relevant columns to ROOT ntuples or a preferred data format. <p> Instructions for exploring a DST and writing out ROOT ntuples are available in the link below. A catalog for exploring the available stripping line selections can be found at the stripping lines index below.",
       "links": [
         {
-          "description": "LHCb StarterKit",
-          "url": "https://lhcb.github.io/starterkit-lessons/first-analysis-steps/minimal-dv-job.html"
-        },
-        {
-          "description": "DaVinci",
-          "url": "http://lhcbdoc.web.cern.ch/lhcbdoc/davinci/"
+          "description": "LHCb Open Data Guide",
+          "url": "https://lhcb-opendata-guide.web.cern.ch/run1-dsts-odp/"
         },
         {
           "description": "Stripping lines index for stripping21r1",

--- a/data/records/LHCb_2011_Beam3500GeV_VeloClosed_MagUp_RealData_Reco14_Stripping21r1_CHARM_MDST.json
+++ b/data/records/LHCb_2011_Beam3500GeV_VeloClosed_MagUp_RealData_Reco14_Stripping21r1_CHARM_MDST.json
@@ -105,15 +105,11 @@
       ]
     },
     "usage": {
-      "description": "<p> The data collected by the LHCb detector is available in .DST and .mDST formats. The data files can be explored using LHCb software but it is best to write the relevant columns to ROOT Tuples or preferred data format. <p> Instructions for exploring a DST and writing out ROOT tuples are available in LHCb Starterkit below. For \"tupling\" jobs, software called DaVinci is mainly used within LHCb, its documentation is also available bellow.",
+      "description": "<p> The data collected by the LHCb detector is available in .DST and .mDST formats. The data files can be explored using LHCb software but it is best to write the relevant columns to ROOT ntuples or a preferred data format. <p> Instructions for exploring a DST and writing out ROOT ntuples are available in the link below. A catalog for exploring the available stripping line selections can be found at the stripping lines index below.",
       "links": [
         {
-          "description": "LHCb StarterKit",
-          "url": "https://lhcb.github.io/starterkit-lessons/first-analysis-steps/minimal-dv-job.html"
-        },
-        {
-          "description": "DaVinci",
-          "url": "http://lhcbdoc.web.cern.ch/lhcbdoc/davinci/"
+          "description": "LHCb Open Data Guide",
+          "url": "https://lhcb-opendata-guide.web.cern.ch/run1-dsts-odp/"
         },
         {
           "description": "Stripping lines index for stripping21r1",

--- a/data/records/LHCb_2011_Beam3500GeV_VeloClosed_MagUp_RealData_Reco14_Stripping21r1_DIMUON_DST.json
+++ b/data/records/LHCb_2011_Beam3500GeV_VeloClosed_MagUp_RealData_Reco14_Stripping21r1_DIMUON_DST.json
@@ -105,15 +105,11 @@
       ]
     },
     "usage": {
-      "description": "<p> The data collected by the LHCb detector is available in .DST and .mDST formats. The data files can be explored using LHCb software but it is best to write the relevant columns to ROOT Tuples or preferred data format. <p> Instructions for exploring a DST and writing out ROOT tuples are available in LHCb Starterkit below. For \"tupling\" jobs, software called DaVinci is mainly used within LHCb, its documentation is also available bellow.",
+      "description": "<p> The data collected by the LHCb detector is available in .DST and .mDST formats. The data files can be explored using LHCb software but it is best to write the relevant columns to ROOT ntuples or a preferred data format. <p> Instructions for exploring a DST and writing out ROOT ntuples are available in the link below. A catalog for exploring the available stripping line selections can be found at the stripping lines index below.",
       "links": [
         {
-          "description": "LHCb StarterKit",
-          "url": "https://lhcb.github.io/starterkit-lessons/first-analysis-steps/minimal-dv-job.html"
-        },
-        {
-          "description": "DaVinci",
-          "url": "http://lhcbdoc.web.cern.ch/lhcbdoc/davinci/"
+          "description": "LHCb Open Data Guide",
+          "url": "https://lhcb-opendata-guide.web.cern.ch/run1-dsts-odp/"
         },
         {
           "description": "Stripping lines index for stripping21r1",

--- a/data/records/LHCb_2011_Beam3500GeV_VeloClosed_MagUp_RealData_Reco14_Stripping21r1_EW_DST.json
+++ b/data/records/LHCb_2011_Beam3500GeV_VeloClosed_MagUp_RealData_Reco14_Stripping21r1_EW_DST.json
@@ -105,15 +105,11 @@
       ]
     },
     "usage": {
-      "description": "<p> The data collected by the LHCb detector is available in .DST and .mDST formats. The data files can be explored using LHCb software but it is best to write the relevant columns to ROOT Tuples or preferred data format. <p> Instructions for exploring a DST and writing out ROOT tuples are available in LHCb Starterkit below. For \"tupling\" jobs, software called DaVinci is mainly used within LHCb, its documentation is also available below.",
+      "description": "<p> The data collected by the LHCb detector is available in .DST and .mDST formats. The data files can be explored using LHCb software but it is best to write the relevant columns to ROOT ntuples or a preferred data format. <p> Instructions for exploring a DST and writing out ROOT ntuples are available in the link below. A catalog for exploring the available stripping line selections can be found at the stripping lines index below.",
       "links": [
         {
-          "description": "LHCb StarterKit",
-          "url": "https://lhcb.github.io/starterkit-lessons/first-analysis-steps/minimal-dv-job.html"
-        },
-        {
-          "description": "DaVinci",
-          "url": "http://lhcbdoc.web.cern.ch/lhcbdoc/davinci/"
+          "description": "LHCb Open Data Guide",
+          "url": "https://lhcb-opendata-guide.web.cern.ch/run1-dsts-odp/"
         },
         {
           "description": "Stripping lines index for stripping21r1",

--- a/data/records/LHCb_2011_Beam3500GeV_VeloClosed_MagUp_RealData_Reco14_Stripping21r1_LEPTONIC_MDST.json
+++ b/data/records/LHCb_2011_Beam3500GeV_VeloClosed_MagUp_RealData_Reco14_Stripping21r1_LEPTONIC_MDST.json
@@ -105,15 +105,11 @@
       ]
     },
     "usage": {
-      "description": "<p> The data collected by the LHCb detector is available in .DST and .mDST formats. The data files can be explored using LHCb software but it is best to write the relevant columns to ROOT Tuples or preferred data format. <p> Instructions for exploring a DST and writing out ROOT tuples are available in LHCb Starterkit below. For \"tupling\" jobs, software called DaVinci is mainly used within LHCb, its documentation is also available below.",
+      "description": "<p> The data collected by the LHCb detector is available in .DST and .mDST formats. The data files can be explored using LHCb software but it is best to write the relevant columns to ROOT ntuples or a preferred data format. <p> Instructions for exploring a DST and writing out ROOT ntuples are available in the link below. A catalog for exploring the available stripping line selections can be found at the stripping lines index below.",
       "links": [
         {
-          "description": "LHCb StarterKit",
-          "url": "https://lhcb.github.io/starterkit-lessons/first-analysis-steps/minimal-dv-job.html"
-        },
-        {
-          "description": "DaVinci",
-          "url": "http://lhcbdoc.web.cern.ch/lhcbdoc/davinci/"
+          "description": "LHCb Open Data Guide",
+          "url": "https://lhcb-opendata-guide.web.cern.ch/run1-dsts-odp/"
         },
         {
           "description": "Stripping lines index for stripping21r1",

--- a/data/records/LHCb_2011_Beam3500GeV_VeloClosed_MagUp_RealData_Reco14_Stripping21r1_SEMILEPTONIC_DST.json
+++ b/data/records/LHCb_2011_Beam3500GeV_VeloClosed_MagUp_RealData_Reco14_Stripping21r1_SEMILEPTONIC_DST.json
@@ -105,15 +105,11 @@
       ]
     },
     "usage": {
-      "description": "<p> The data collected by the LHCb detector is available in .DST and .mDST formats. The data files can be explored using LHCb software but it is best to write the relevant columns to ROOT Tuples or preferred data format. <p> Instructions for exploring a DST and writing out ROOT tuples are available in LHCb Starterkit below. For \"tupling\" jobs, software called DaVinci is mainly used within LHCb, its documentation is also available bellow.",
+      "description": "<p> The data collected by the LHCb detector is available in .DST and .mDST formats. The data files can be explored using LHCb software but it is best to write the relevant columns to ROOT ntuples or a preferred data format. <p> Instructions for exploring a DST and writing out ROOT ntuples are available in the link below. A catalog for exploring the available stripping line selections can be found at the stripping lines index below.",
       "links": [
         {
-          "description": "LHCb StarterKit",
-          "url": "https://lhcb.github.io/starterkit-lessons/first-analysis-steps/minimal-dv-job.html"
-        },
-        {
-          "description": "DaVinci",
-          "url": "http://lhcbdoc.web.cern.ch/lhcbdoc/davinci/"
+          "description": "LHCb Open Data Guide",
+          "url": "https://lhcb-opendata-guide.web.cern.ch/run1-dsts-odp/"
         },
         {
           "description": "Stripping lines index for stripping21r1",

--- a/data/records/LHCb_2011_Beam3500GeV_VeloClosed_MagUp_RealData_Reco14_Stripping21r1p1a_BHADRONCOMPLETEEVENT_DST.json
+++ b/data/records/LHCb_2011_Beam3500GeV_VeloClosed_MagUp_RealData_Reco14_Stripping21r1p1a_BHADRONCOMPLETEEVENT_DST.json
@@ -108,15 +108,11 @@
       ]
     },
     "usage": {
-      "description": "<p> The data collected by the LHCb detector is available in .DST and .mDST formats. The data files can be explored using LHCb software but it is best to write the relevant columns to ROOT Tuples or preferred data format. <p> Instructions for exploring a DST and writing out ROOT tuples are available in LHCb Starterkit below. For \"tupling\" jobs, software called DaVinci is mainly used within LHCb, its documentation is also available bellow.",
+      "description": "<p> The data collected by the LHCb detector is available in .DST and .mDST formats. The data files can be explored using LHCb software but it is best to write the relevant columns to ROOT ntuples or a preferred data format. <p> Instructions for exploring a DST and writing out ROOT ntuples are available in the link below. A catalog for exploring the available stripping line selections can be found at the stripping lines index below.",
       "links": [
         {
-          "description": "LHCb StarterKit",
-          "url": "https://lhcb.github.io/starterkit-lessons/first-analysis-steps/minimal-dv-job.html"
-        },
-        {
-          "description": "DaVinci",
-          "url": "http://lhcbdoc.web.cern.ch/lhcbdoc/davinci/"
+          "description": "LHCb Open Data Guide",
+          "url": "https://lhcb-opendata-guide.web.cern.ch/run1-dsts-odp/"
         },
         {
           "description": "Stripping lines index for stripping21r1p1",

--- a/data/records/LHCb_2011_Beam3500GeV_VeloClosed_MagUp_RealData_Reco14_Stripping21r1p1a_BHADRON_MDST.json
+++ b/data/records/LHCb_2011_Beam3500GeV_VeloClosed_MagUp_RealData_Reco14_Stripping21r1p1a_BHADRON_MDST.json
@@ -108,15 +108,11 @@
       ]
     },
     "usage": {
-      "description": "<p> The data collected by the LHCb detector is available in .DST and .mDST formats. The data files can be explored using LHCb software but it is best to write the relevant columns to ROOT Tuples or preferred data format. <p> Instructions for exploring a DST and writing out ROOT tuples are available in LHCb Starterkit below. For \"tupling\" jobs, software called DaVinci is mainly used within LHCb, its documentation is also available bellow.",
+      "description": "<p> The data collected by the LHCb detector is available in .DST and .mDST formats. The data files can be explored using LHCb software but it is best to write the relevant columns to ROOT ntuples or a preferred data format. <p> Instructions for exploring a DST and writing out ROOT ntuples are available in the link below. A catalog for exploring the available stripping line selections can be found at the stripping lines index below.",
       "links": [
         {
-          "description": "LHCb StarterKit",
-          "url": "https://lhcb.github.io/starterkit-lessons/first-analysis-steps/minimal-dv-job.html"
-        },
-        {
-          "description": "DaVinci",
-          "url": "http://lhcbdoc.web.cern.ch/lhcbdoc/davinci/"
+          "description": "LHCb Open Data Guide",
+          "url": "https://lhcb-opendata-guide.web.cern.ch/run1-dsts-odp/"
         },
         {
           "description": "Stripping lines index for stripping21r1p1",

--- a/data/records/LHCb_2011_Beam3500GeV_VeloClosed_MagUp_RealData_Reco14_Stripping21r1p1a_CHARMCOMPLETEEVENT_DST.json
+++ b/data/records/LHCb_2011_Beam3500GeV_VeloClosed_MagUp_RealData_Reco14_Stripping21r1p1a_CHARMCOMPLETEEVENT_DST.json
@@ -108,15 +108,11 @@
       ]
     },
     "usage": {
-      "description": "<p> The data collected by the LHCb detector is available in .DST and .mDST formats. The data files can be explored using LHCb software but it is best to write the relevant columns to ROOT Tuples or preferred data format. <p> Instructions for exploring a DST and writing out ROOT tuples are available in LHCb Starterkit below. For \"tupling\" jobs, software called DaVinci is mainly used within LHCb, its documentation is also available bellow.",
+      "description": "<p> The data collected by the LHCb detector is available in .DST and .mDST formats. The data files can be explored using LHCb software but it is best to write the relevant columns to ROOT ntuples or a preferred data format. <p> Instructions for exploring a DST and writing out ROOT ntuples are available in the link below. A catalog for exploring the available stripping line selections can be found at the stripping lines index below.",
       "links": [
         {
-          "description": "LHCb StarterKit",
-          "url": "https://lhcb.github.io/starterkit-lessons/first-analysis-steps/minimal-dv-job.html"
-        },
-        {
-          "description": "DaVinci",
-          "url": "http://lhcbdoc.web.cern.ch/lhcbdoc/davinci/"
+          "description": "LHCb Open Data Guide",
+          "url": "https://lhcb-opendata-guide.web.cern.ch/run1-dsts-odp/"
         },
         {
           "description": "Stripping lines index for stripping21r1p1",

--- a/data/records/LHCb_2011_Beam3500GeV_VeloClosed_MagUp_RealData_Reco14_Stripping21r1p1a_CHARM_MDST.json
+++ b/data/records/LHCb_2011_Beam3500GeV_VeloClosed_MagUp_RealData_Reco14_Stripping21r1p1a_CHARM_MDST.json
@@ -108,15 +108,11 @@
       ]
     },
     "usage": {
-      "description": "<p> The data collected by the LHCb detector is available in .DST and .mDST formats. The data files can be explored using LHCb software but it is best to write the relevant columns to ROOT Tuples or preferred data format. <p> Instructions for exploring a DST and writing out ROOT tuples are available in LHCb Starterkit below. For \"tupling\" jobs, software called DaVinci is mainly used within LHCb, its documentation is also available bellow.",
+      "description": "<p> The data collected by the LHCb detector is available in .DST and .mDST formats. The data files can be explored using LHCb software but it is best to write the relevant columns to ROOT ntuples or a preferred data format. <p> Instructions for exploring a DST and writing out ROOT ntuples are available in the link below. A catalog for exploring the available stripping line selections can be found at the stripping lines index below.",
       "links": [
         {
-          "description": "LHCb StarterKit",
-          "url": "https://lhcb.github.io/starterkit-lessons/first-analysis-steps/minimal-dv-job.html"
-        },
-        {
-          "description": "DaVinci",
-          "url": "http://lhcbdoc.web.cern.ch/lhcbdoc/davinci/"
+          "description": "LHCb Open Data Guide",
+          "url": "https://lhcb-opendata-guide.web.cern.ch/run1-dsts-odp/"
         },
         {
           "description": "Stripping lines index for stripping21r1p1",

--- a/data/records/LHCb_2011_Beam3500GeV_VeloClosed_MagUp_RealData_Reco14_Stripping21r1p1a_DIMUON_DST.json
+++ b/data/records/LHCb_2011_Beam3500GeV_VeloClosed_MagUp_RealData_Reco14_Stripping21r1p1a_DIMUON_DST.json
@@ -108,15 +108,11 @@
       ]
     },
     "usage": {
-      "description": "<p> The data collected by the LHCb detector is available in .DST and .mDST formats. The data files can be explored using LHCb software but it is best to write the relevant columns to ROOT Tuples or preferred data format. <p> Instructions for exploring a DST and writing out ROOT tuples are available in LHCb Starterkit below. For \"tupling\" jobs, software called DaVinci is mainly used within LHCb, its documentation is also available bellow.",
+      "description": "<p> The data collected by the LHCb detector is available in .DST and .mDST formats. The data files can be explored using LHCb software but it is best to write the relevant columns to ROOT ntuples or a preferred data format. <p> Instructions for exploring a DST and writing out ROOT ntuples are available in the link below. A catalog for exploring the available stripping line selections can be found at the stripping lines index below.",
       "links": [
         {
-          "description": "LHCb StarterKit",
-          "url": "https://lhcb.github.io/starterkit-lessons/first-analysis-steps/minimal-dv-job.html"
-        },
-        {
-          "description": "DaVinci",
-          "url": "http://lhcbdoc.web.cern.ch/lhcbdoc/davinci/"
+          "description": "LHCb Open Data Guide",
+          "url": "https://lhcb-opendata-guide.web.cern.ch/run1-dsts-odp/"
         },
         {
           "description": "Stripping lines index for stripping21r1p1",

--- a/data/records/LHCb_2011_Beam3500GeV_VeloClosed_MagUp_RealData_Reco14_Stripping21r1p1a_EW_DST.json
+++ b/data/records/LHCb_2011_Beam3500GeV_VeloClosed_MagUp_RealData_Reco14_Stripping21r1p1a_EW_DST.json
@@ -108,15 +108,11 @@
       ]
     },
     "usage": {
-      "description": "<p> The data collected by the LHCb detector is available in .DST and .mDST formats. The data files can be explored using LHCb software but it is best to write the relevant columns to ROOT Tuples or preferred data format. <p> Instructions for exploring a DST and writing out ROOT tuples are available in LHCb Starterkit below. For \"tupling\" jobs, software called DaVinci is mainly used within LHCb, its documentation is also available below.",
+      "description": "<p> The data collected by the LHCb detector is available in .DST and .mDST formats. The data files can be explored using LHCb software but it is best to write the relevant columns to ROOT ntuples or a preferred data format. <p> Instructions for exploring a DST and writing out ROOT ntuples are available in the link below. A catalog for exploring the available stripping line selections can be found at the stripping lines index below.",
       "links": [
         {
-          "description": "LHCb StarterKit",
-          "url": "https://lhcb.github.io/starterkit-lessons/first-analysis-steps/minimal-dv-job.html"
-        },
-        {
-          "description": "DaVinci",
-          "url": "http://lhcbdoc.web.cern.ch/lhcbdoc/davinci/"
+          "description": "LHCb Open Data Guide",
+          "url": "https://lhcb-opendata-guide.web.cern.ch/run1-dsts-odp/"
         },
         {
           "description": "Stripping lines index for stripping21r1p1",

--- a/data/records/LHCb_2011_Beam3500GeV_VeloClosed_MagUp_RealData_Reco14_Stripping21r1p1a_LEPTONIC_MDST.json
+++ b/data/records/LHCb_2011_Beam3500GeV_VeloClosed_MagUp_RealData_Reco14_Stripping21r1p1a_LEPTONIC_MDST.json
@@ -108,15 +108,11 @@
       ]
     },
     "usage": {
-      "description": "<p> The data collected by the LHCb detector is available in .DST and .mDST formats. The data files can be explored using LHCb software but it is best to write the relevant columns to ROOT Tuples or preferred data format. <p> Instructions for exploring a DST and writing out ROOT tuples are available in LHCb Starterkit below. For \"tupling\" jobs, software called DaVinci is mainly used within LHCb, its documentation is also available below.",
+      "description": "<p> The data collected by the LHCb detector is available in .DST and .mDST formats. The data files can be explored using LHCb software but it is best to write the relevant columns to ROOT ntuples or a preferred data format. <p> Instructions for exploring a DST and writing out ROOT ntuples are available in the link below. A catalog for exploring the available stripping line selections can be found at the stripping lines index below.",
       "links": [
         {
-          "description": "LHCb StarterKit",
-          "url": "https://lhcb.github.io/starterkit-lessons/first-analysis-steps/minimal-dv-job.html"
-        },
-        {
-          "description": "DaVinci",
-          "url": "http://lhcbdoc.web.cern.ch/lhcbdoc/davinci/"
+          "description": "LHCb Open Data Guide",
+          "url": "https://lhcb-opendata-guide.web.cern.ch/run1-dsts-odp/"
         },
         {
           "description": "Stripping lines index for stripping21r1p1",

--- a/data/records/LHCb_2011_Beam3500GeV_VeloClosed_MagUp_RealData_Reco14_Stripping21r1p1a_SEMILEPTONIC_DST.json
+++ b/data/records/LHCb_2011_Beam3500GeV_VeloClosed_MagUp_RealData_Reco14_Stripping21r1p1a_SEMILEPTONIC_DST.json
@@ -108,15 +108,11 @@
       ]
     },
     "usage": {
-      "description": "<p> The data collected by the LHCb detector is available in .DST and .mDST formats. The data files can be explored using LHCb software but it is best to write the relevant columns to ROOT Tuples or preferred data format. <p> Instructions for exploring a DST and writing out ROOT tuples are available in LHCb Starterkit below. For \"tupling\" jobs, software called DaVinci is mainly used within LHCb, its documentation is also available bellow.",
+      "description": "<p> The data collected by the LHCb detector is available in .DST and .mDST formats. The data files can be explored using LHCb software but it is best to write the relevant columns to ROOT ntuples or a preferred data format. <p> Instructions for exploring a DST and writing out ROOT ntuples are available in the link below. A catalog for exploring the available stripping line selections can be found at the stripping lines index below.",
       "links": [
         {
-          "description": "LHCb StarterKit",
-          "url": "https://lhcb.github.io/starterkit-lessons/first-analysis-steps/minimal-dv-job.html"
-        },
-        {
-          "description": "DaVinci",
-          "url": "http://lhcbdoc.web.cern.ch/lhcbdoc/davinci/"
+          "description": "LHCb Open Data Guide",
+          "url": "https://lhcb-opendata-guide.web.cern.ch/run1-dsts-odp/"
         },
         {
           "description": "Stripping lines index for stripping21r1p1",

--- a/data/records/LHCb_2011_Beam3500GeV_VeloClosed_MagUp_RealData_Reco14_Stripping21r1p2_BHADRONCOMPLETEEVENT_DST.json
+++ b/data/records/LHCb_2011_Beam3500GeV_VeloClosed_MagUp_RealData_Reco14_Stripping21r1p2_BHADRONCOMPLETEEVENT_DST.json
@@ -174,15 +174,11 @@
       ]
     },
     "usage": {
-      "description": "<p> The data collected by the LHCb detector is available in .DST and .mDST formats. The data files can be explored using LHCb software but it is best to write the relevant columns to ROOT Tuples or preferred data format. <p> Instructions for exploring a DST and writing out ROOT tuples are available in LHCb Starterkit below. For \"tupling\" jobs, software called DaVinci is mainly used within LHCb, its documentation is also available bellow.",
+      "description": "<p> The data collected by the LHCb detector is available in .DST and .mDST formats. The data files can be explored using LHCb software but it is best to write the relevant columns to ROOT ntuples or a preferred data format. <p> Instructions for exploring a DST and writing out ROOT ntuples are available in the link below. A catalog for exploring the available stripping line selections can be found at the stripping lines index below.",
       "links": [
         {
-          "description": "LHCb StarterKit",
-          "url": "https://lhcb.github.io/starterkit-lessons/first-analysis-steps/minimal-dv-job.html"
-        },
-        {
-          "description": "DaVinci",
-          "url": "http://lhcbdoc.web.cern.ch/lhcbdoc/davinci/"
+          "description": "LHCb Open Data Guide",
+          "url": "https://lhcb-opendata-guide.web.cern.ch/run1-dsts-odp/"
         },
         {
           "description": "Stripping lines index for stripping21r1p2",

--- a/data/records/LHCb_2011_Beam3500GeV_VeloClosed_MagUp_RealData_Reco14_Stripping21r1p2_BHADRON_MDST.json
+++ b/data/records/LHCb_2011_Beam3500GeV_VeloClosed_MagUp_RealData_Reco14_Stripping21r1p2_BHADRON_MDST.json
@@ -174,15 +174,11 @@
       ]
     },
     "usage": {
-      "description": "<p> The data collected by the LHCb detector is available in .DST and .mDST formats. The data files can be explored using LHCb software but it is best to write the relevant columns to ROOT Tuples or preferred data format. <p> Instructions for exploring a DST and writing out ROOT tuples are available in LHCb Starterkit below. For \"tupling\" jobs, software called DaVinci is mainly used within LHCb, its documentation is also available bellow.",
+      "description": "<p> The data collected by the LHCb detector is available in .DST and .mDST formats. The data files can be explored using LHCb software but it is best to write the relevant columns to ROOT ntuples or a preferred data format. <p> Instructions for exploring a DST and writing out ROOT ntuples are available in the link below. A catalog for exploring the available stripping line selections can be found at the stripping lines index below.",
       "links": [
         {
-          "description": "LHCb StarterKit",
-          "url": "https://lhcb.github.io/starterkit-lessons/first-analysis-steps/minimal-dv-job.html"
-        },
-        {
-          "description": "DaVinci",
-          "url": "http://lhcbdoc.web.cern.ch/lhcbdoc/davinci/"
+          "description": "LHCb Open Data Guide",
+          "url": "https://lhcb-opendata-guide.web.cern.ch/run1-dsts-odp/"
         },
         {
           "description": "Stripping lines index for stripping21r1p2",

--- a/data/records/LHCb_2011_Beam3500GeV_VeloClosed_MagUp_RealData_Reco14_Stripping21r1p2_CHARMCOMPLETEEVENT_DST.json
+++ b/data/records/LHCb_2011_Beam3500GeV_VeloClosed_MagUp_RealData_Reco14_Stripping21r1p2_CHARMCOMPLETEEVENT_DST.json
@@ -174,15 +174,11 @@
       ]
     },
     "usage": {
-      "description": "<p> The data collected by the LHCb detector is available in .DST and .mDST formats. The data files can be explored using LHCb software but it is best to write the relevant columns to ROOT Tuples or preferred data format. <p> Instructions for exploring a DST and writing out ROOT tuples are available in LHCb Starterkit below. For \"tupling\" jobs, software called DaVinci is mainly used within LHCb, its documentation is also available bellow.",
+      "description": "<p> The data collected by the LHCb detector is available in .DST and .mDST formats. The data files can be explored using LHCb software but it is best to write the relevant columns to ROOT ntuples or a preferred data format. <p> Instructions for exploring a DST and writing out ROOT ntuples are available in the link below. A catalog for exploring the available stripping line selections can be found at the stripping lines index below.",
       "links": [
         {
-          "description": "LHCb StarterKit",
-          "url": "https://lhcb.github.io/starterkit-lessons/first-analysis-steps/minimal-dv-job.html"
-        },
-        {
-          "description": "DaVinci",
-          "url": "http://lhcbdoc.web.cern.ch/lhcbdoc/davinci/"
+          "description": "LHCb Open Data Guide",
+          "url": "https://lhcb-opendata-guide.web.cern.ch/run1-dsts-odp/"
         },
         {
           "description": "Stripping lines index for stripping21r1p2",

--- a/data/records/LHCb_2011_Beam3500GeV_VeloClosed_MagUp_RealData_Reco14_Stripping21r1p2_CHARM_MDST.json
+++ b/data/records/LHCb_2011_Beam3500GeV_VeloClosed_MagUp_RealData_Reco14_Stripping21r1p2_CHARM_MDST.json
@@ -174,15 +174,11 @@
       ]
     },
     "usage": {
-      "description": "<p> The data collected by the LHCb detector is available in .DST and .mDST formats. The data files can be explored using LHCb software but it is best to write the relevant columns to ROOT Tuples or preferred data format. <p> Instructions for exploring a DST and writing out ROOT tuples are available in LHCb Starterkit below. For \"tupling\" jobs, software called DaVinci is mainly used within LHCb, its documentation is also available bellow.",
+      "description": "<p> The data collected by the LHCb detector is available in .DST and .mDST formats. The data files can be explored using LHCb software but it is best to write the relevant columns to ROOT ntuples or a preferred data format. <p> Instructions for exploring a DST and writing out ROOT ntuples are available in the link below. A catalog for exploring the available stripping line selections can be found at the stripping lines index below.",
       "links": [
         {
-          "description": "LHCb StarterKit",
-          "url": "https://lhcb.github.io/starterkit-lessons/first-analysis-steps/minimal-dv-job.html"
-        },
-        {
-          "description": "DaVinci",
-          "url": "http://lhcbdoc.web.cern.ch/lhcbdoc/davinci/"
+          "description": "LHCb Open Data Guide",
+          "url": "https://lhcb-opendata-guide.web.cern.ch/run1-dsts-odp/"
         },
         {
           "description": "Stripping lines index for stripping21r1p2",

--- a/data/records/LHCb_2011_Beam3500GeV_VeloClosed_MagUp_RealData_Reco14_Stripping21r1p2_DIMUON_DST.json
+++ b/data/records/LHCb_2011_Beam3500GeV_VeloClosed_MagUp_RealData_Reco14_Stripping21r1p2_DIMUON_DST.json
@@ -174,15 +174,11 @@
       ]
     },
     "usage": {
-      "description": "<p> The data collected by the LHCb detector is available in .DST and .mDST formats. The data files can be explored using LHCb software but it is best to write the relevant columns to ROOT Tuples or preferred data format. <p> Instructions for exploring a DST and writing out ROOT tuples are available in LHCb Starterkit below. For \"tupling\" jobs, software called DaVinci is mainly used within LHCb, its documentation is also available bellow.",
+      "description": "<p> The data collected by the LHCb detector is available in .DST and .mDST formats. The data files can be explored using LHCb software but it is best to write the relevant columns to ROOT ntuples or a preferred data format. <p> Instructions for exploring a DST and writing out ROOT ntuples are available in the link below. A catalog for exploring the available stripping line selections can be found at the stripping lines index below.",
       "links": [
         {
-          "description": "LHCb StarterKit",
-          "url": "https://lhcb.github.io/starterkit-lessons/first-analysis-steps/minimal-dv-job.html"
-        },
-        {
-          "description": "DaVinci",
-          "url": "http://lhcbdoc.web.cern.ch/lhcbdoc/davinci/"
+          "description": "LHCb Open Data Guide",
+          "url": "https://lhcb-opendata-guide.web.cern.ch/run1-dsts-odp/"
         },
         {
           "description": "Stripping lines index for stripping21r1p2",

--- a/data/records/LHCb_2011_Beam3500GeV_VeloClosed_MagUp_RealData_Reco14_Stripping21r1p2_EW_DST.json
+++ b/data/records/LHCb_2011_Beam3500GeV_VeloClosed_MagUp_RealData_Reco14_Stripping21r1p2_EW_DST.json
@@ -174,15 +174,11 @@
       ]
     },
     "usage": {
-      "description": "<p> The data collected by the LHCb detector is available in .DST and .mDST formats. The data files can be explored using LHCb software but it is best to write the relevant columns to ROOT Tuples or preferred data format. <p> Instructions for exploring a DST and writing out ROOT tuples are available in LHCb Starterkit below. For \"tupling\" jobs, software called DaVinci is mainly used within LHCb, its documentation is also available below.",
+      "description": "<p> The data collected by the LHCb detector is available in .DST and .mDST formats. The data files can be explored using LHCb software but it is best to write the relevant columns to ROOT ntuples or a preferred data format. <p> Instructions for exploring a DST and writing out ROOT ntuples are available in the link below. A catalog for exploring the available stripping line selections can be found at the stripping lines index below.",
       "links": [
         {
-          "description": "LHCb StarterKit",
-          "url": "https://lhcb.github.io/starterkit-lessons/first-analysis-steps/minimal-dv-job.html"
-        },
-        {
-          "description": "DaVinci",
-          "url": "http://lhcbdoc.web.cern.ch/lhcbdoc/davinci/"
+          "description": "LHCb Open Data Guide",
+          "url": "https://lhcb-opendata-guide.web.cern.ch/run1-dsts-odp/"
         },
         {
           "description": "Stripping lines index for stripping21r1p2",

--- a/data/records/LHCb_2011_Beam3500GeV_VeloClosed_MagUp_RealData_Reco14_Stripping21r1p2_LEPTONIC_MDST.json
+++ b/data/records/LHCb_2011_Beam3500GeV_VeloClosed_MagUp_RealData_Reco14_Stripping21r1p2_LEPTONIC_MDST.json
@@ -174,15 +174,11 @@
       ]
     },
     "usage": {
-      "description": "<p> The data collected by the LHCb detector is available in .DST and .mDST formats. The data files can be explored using LHCb software but it is best to write the relevant columns to ROOT Tuples or preferred data format. <p> Instructions for exploring a DST and writing out ROOT tuples are available in LHCb Starterkit below. For \"tupling\" jobs, software called DaVinci is mainly used within LHCb, its documentation is also available below.",
+      "description": "<p> The data collected by the LHCb detector is available in .DST and .mDST formats. The data files can be explored using LHCb software but it is best to write the relevant columns to ROOT ntuples or a preferred data format. <p> Instructions for exploring a DST and writing out ROOT ntuples are available in the link below. A catalog for exploring the available stripping line selections can be found at the stripping lines index below.",
       "links": [
         {
-          "description": "LHCb StarterKit",
-          "url": "https://lhcb.github.io/starterkit-lessons/first-analysis-steps/minimal-dv-job.html"
-        },
-        {
-          "description": "DaVinci",
-          "url": "http://lhcbdoc.web.cern.ch/lhcbdoc/davinci/"
+          "description": "LHCb Open Data Guide",
+          "url": "https://lhcb-opendata-guide.web.cern.ch/run1-dsts-odp/"
         },
         {
           "description": "Stripping lines index for stripping21r1p2",

--- a/data/records/LHCb_2011_Beam3500GeV_VeloClosed_MagUp_RealData_Reco14_Stripping21r1p2_SEMILEPTONIC_DST.json
+++ b/data/records/LHCb_2011_Beam3500GeV_VeloClosed_MagUp_RealData_Reco14_Stripping21r1p2_SEMILEPTONIC_DST.json
@@ -174,15 +174,11 @@
       ]
     },
     "usage": {
-      "description": "<p> The data collected by the LHCb detector is available in .DST and .mDST formats. The data files can be explored using LHCb software but it is best to write the relevant columns to ROOT Tuples or preferred data format. <p> Instructions for exploring a DST and writing out ROOT tuples are available in LHCb Starterkit below. For \"tupling\" jobs, software called DaVinci is mainly used within LHCb, its documentation is also available bellow.",
+      "description": "<p> The data collected by the LHCb detector is available in .DST and .mDST formats. The data files can be explored using LHCb software but it is best to write the relevant columns to ROOT ntuples or a preferred data format. <p> Instructions for exploring a DST and writing out ROOT ntuples are available in the link below. A catalog for exploring the available stripping line selections can be found at the stripping lines index below.",
       "links": [
         {
-          "description": "LHCb StarterKit",
-          "url": "https://lhcb.github.io/starterkit-lessons/first-analysis-steps/minimal-dv-job.html"
-        },
-        {
-          "description": "DaVinci",
-          "url": "http://lhcbdoc.web.cern.ch/lhcbdoc/davinci/"
+          "description": "LHCb Open Data Guide",
+          "url": "https://lhcb-opendata-guide.web.cern.ch/run1-dsts-odp/"
         },
         {
           "description": "Stripping lines index for stripping21r1p2",

--- a/data/records/LHCb_2012_Beam4000GeV_VeloClosed_MagDown_RealData_Reco14_Stripping21_BHADRONCOMPLETEEVENT_DST.json
+++ b/data/records/LHCb_2012_Beam4000GeV_VeloClosed_MagDown_RealData_Reco14_Stripping21_BHADRONCOMPLETEEVENT_DST.json
@@ -105,15 +105,11 @@
       ]
     },
     "usage": {
-      "description": "<p> The data collected by the LHCb detector is available in .DST and .mDST formats. The data files can be explored using LHCb software but it is best to write the relevant columns to ROOT Tuples or preferred data format. <p> Instructions for exploring a DST and writing out ROOT tuples are available in LHCb Starterkit below. For \"tupling\" jobs, software called DaVinci is mainly used within LHCb, its documentation is also available bellow.",
+      "description": "<p> The data collected by the LHCb detector is available in .DST and .mDST formats. The data files can be explored using LHCb software but it is best to write the relevant columns to ROOT ntuples or a preferred data format. <p> Instructions for exploring a DST and writing out ROOT ntuples are available in the link below. A catalog for exploring the available stripping line selections can be found at the stripping lines index below.",
       "links": [
         {
-          "description": "LHCb StarterKit",
-          "url": "https://lhcb.github.io/starterkit-lessons/first-analysis-steps/minimal-dv-job.html"
-        },
-        {
-          "description": "DaVinci",
-          "url": "http://lhcbdoc.web.cern.ch/lhcbdoc/davinci/"
+          "description": "LHCb Open Data Guide",
+          "url": "https://lhcb-opendata-guide.web.cern.ch/run1-dsts-odp/"
         },
         {
           "description": "Stripping lines index for stripping21",

--- a/data/records/LHCb_2012_Beam4000GeV_VeloClosed_MagDown_RealData_Reco14_Stripping21_BHADRON_MDST.json
+++ b/data/records/LHCb_2012_Beam4000GeV_VeloClosed_MagDown_RealData_Reco14_Stripping21_BHADRON_MDST.json
@@ -105,15 +105,11 @@
       ]
     },
     "usage": {
-      "description": "<p> The data collected by the LHCb detector is available in .DST and .mDST formats. The data files can be explored using LHCb software but it is best to write the relevant columns to ROOT Tuples or preferred data format. <p> Instructions for exploring a DST and writing out ROOT tuples are available in LHCb Starterkit below. For \"tupling\" jobs, software called DaVinci is mainly used within LHCb, its documentation is also available bellow.",
+      "description": "<p> The data collected by the LHCb detector is available in .DST and .mDST formats. The data files can be explored using LHCb software but it is best to write the relevant columns to ROOT ntuples or a preferred data format. <p> Instructions for exploring a DST and writing out ROOT ntuples are available in the link below. A catalog for exploring the available stripping line selections can be found at the stripping lines index below.",
       "links": [
         {
-          "description": "LHCb StarterKit",
-          "url": "https://lhcb.github.io/starterkit-lessons/first-analysis-steps/minimal-dv-job.html"
-        },
-        {
-          "description": "DaVinci",
-          "url": "http://lhcbdoc.web.cern.ch/lhcbdoc/davinci/"
+          "description": "LHCb Open Data Guide",
+          "url": "https://lhcb-opendata-guide.web.cern.ch/run1-dsts-odp/"
         },
         {
           "description": "Stripping lines index for stripping21",

--- a/data/records/LHCb_2012_Beam4000GeV_VeloClosed_MagDown_RealData_Reco14_Stripping21_CHARMCOMPLETEEVENT_DST.json
+++ b/data/records/LHCb_2012_Beam4000GeV_VeloClosed_MagDown_RealData_Reco14_Stripping21_CHARMCOMPLETEEVENT_DST.json
@@ -105,15 +105,11 @@
       ]
     },
     "usage": {
-      "description": "<p> The data collected by the LHCb detector is available in .DST and .mDST formats. The data files can be explored using LHCb software but it is best to write the relevant columns to ROOT Tuples or preferred data format. <p> Instructions for exploring a DST and writing out ROOT tuples are available in LHCb Starterkit below. For \"tupling\" jobs, software called DaVinci is mainly used within LHCb, its documentation is also available bellow.",
+      "description": "<p> The data collected by the LHCb detector is available in .DST and .mDST formats. The data files can be explored using LHCb software but it is best to write the relevant columns to ROOT ntuples or a preferred data format. <p> Instructions for exploring a DST and writing out ROOT ntuples are available in the link below. A catalog for exploring the available stripping line selections can be found at the stripping lines index below.",
       "links": [
         {
-          "description": "LHCb StarterKit",
-          "url": "https://lhcb.github.io/starterkit-lessons/first-analysis-steps/minimal-dv-job.html"
-        },
-        {
-          "description": "DaVinci",
-          "url": "http://lhcbdoc.web.cern.ch/lhcbdoc/davinci/"
+          "description": "LHCb Open Data Guide",
+          "url": "https://lhcb-opendata-guide.web.cern.ch/run1-dsts-odp/"
         },
         {
           "description": "Stripping lines index for stripping21",

--- a/data/records/LHCb_2012_Beam4000GeV_VeloClosed_MagDown_RealData_Reco14_Stripping21_CHARM_MDST.json
+++ b/data/records/LHCb_2012_Beam4000GeV_VeloClosed_MagDown_RealData_Reco14_Stripping21_CHARM_MDST.json
@@ -105,15 +105,11 @@
       ]
     },
     "usage": {
-      "description": "<p> The data collected by the LHCb detector is available in .DST and .mDST formats. The data files can be explored using LHCb software but it is best to write the relevant columns to ROOT Tuples or preferred data format. <p> Instructions for exploring a DST and writing out ROOT tuples are available in LHCb Starterkit below. For \"tupling\" jobs, software called DaVinci is mainly used within LHCb, its documentation is also available bellow.",
+      "description": "<p> The data collected by the LHCb detector is available in .DST and .mDST formats. The data files can be explored using LHCb software but it is best to write the relevant columns to ROOT ntuples or a preferred data format. <p> Instructions for exploring a DST and writing out ROOT ntuples are available in the link below. A catalog for exploring the available stripping line selections can be found at the stripping lines index below.",
       "links": [
         {
-          "description": "LHCb StarterKit",
-          "url": "https://lhcb.github.io/starterkit-lessons/first-analysis-steps/minimal-dv-job.html"
-        },
-        {
-          "description": "DaVinci",
-          "url": "http://lhcbdoc.web.cern.ch/lhcbdoc/davinci/"
+          "description": "LHCb Open Data Guide",
+          "url": "https://lhcb-opendata-guide.web.cern.ch/run1-dsts-odp/"
         },
         {
           "description": "Stripping lines index for stripping21",

--- a/data/records/LHCb_2012_Beam4000GeV_VeloClosed_MagDown_RealData_Reco14_Stripping21_DIMUON_DST.json
+++ b/data/records/LHCb_2012_Beam4000GeV_VeloClosed_MagDown_RealData_Reco14_Stripping21_DIMUON_DST.json
@@ -105,15 +105,11 @@
       ]
     },
     "usage": {
-      "description": "<p> The data collected by the LHCb detector is available in .DST and .mDST formats. The data files can be explored using LHCb software but it is best to write the relevant columns to ROOT Tuples or preferred data format. <p> Instructions for exploring a DST and writing out ROOT tuples are available in LHCb Starterkit below. For \"tupling\" jobs, software called DaVinci is mainly used within LHCb, its documentation is also available bellow.",
+      "description": "<p> The data collected by the LHCb detector is available in .DST and .mDST formats. The data files can be explored using LHCb software but it is best to write the relevant columns to ROOT ntuples or a preferred data format. <p> Instructions for exploring a DST and writing out ROOT ntuples are available in the link below. A catalog for exploring the available stripping line selections can be found at the stripping lines index below.",
       "links": [
         {
-          "description": "LHCb StarterKit",
-          "url": "https://lhcb.github.io/starterkit-lessons/first-analysis-steps/minimal-dv-job.html"
-        },
-        {
-          "description": "DaVinci",
-          "url": "http://lhcbdoc.web.cern.ch/lhcbdoc/davinci/"
+          "description": "LHCb Open Data Guide",
+          "url": "https://lhcb-opendata-guide.web.cern.ch/run1-dsts-odp/"
         },
         {
           "description": "Stripping lines index for stripping21",

--- a/data/records/LHCb_2012_Beam4000GeV_VeloClosed_MagDown_RealData_Reco14_Stripping21_EW_DST.json
+++ b/data/records/LHCb_2012_Beam4000GeV_VeloClosed_MagDown_RealData_Reco14_Stripping21_EW_DST.json
@@ -105,15 +105,11 @@
       ]
     },
     "usage": {
-      "description": "<p> The data collected by the LHCb detector is available in .DST and .mDST formats. The data files can be explored using LHCb software but it is best to write the relevant columns to ROOT Tuples or preferred data format. <p> Instructions for exploring a DST and writing out ROOT tuples are available in LHCb Starterkit below. For \"tupling\" jobs, software called DaVinci is mainly used within LHCb, its documentation is also available below.",
+      "description": "<p> The data collected by the LHCb detector is available in .DST and .mDST formats. The data files can be explored using LHCb software but it is best to write the relevant columns to ROOT ntuples or a preferred data format. <p> Instructions for exploring a DST and writing out ROOT ntuples are available in the link below. A catalog for exploring the available stripping line selections can be found at the stripping lines index below.",
       "links": [
         {
-          "description": "LHCb StarterKit",
-          "url": "https://lhcb.github.io/starterkit-lessons/first-analysis-steps/minimal-dv-job.html"
-        },
-        {
-          "description": "DaVinci",
-          "url": "http://lhcbdoc.web.cern.ch/lhcbdoc/davinci/"
+          "description": "LHCb Open Data Guide",
+          "url": "https://lhcb-opendata-guide.web.cern.ch/run1-dsts-odp/"
         },
         {
           "description": "Stripping lines index for stripping21",

--- a/data/records/LHCb_2012_Beam4000GeV_VeloClosed_MagDown_RealData_Reco14_Stripping21_LEPTONIC_MDST.json
+++ b/data/records/LHCb_2012_Beam4000GeV_VeloClosed_MagDown_RealData_Reco14_Stripping21_LEPTONIC_MDST.json
@@ -105,15 +105,11 @@
       ]
     },
     "usage": {
-      "description": "<p> The data collected by the LHCb detector is available in .DST and .mDST formats. The data files can be explored using LHCb software but it is best to write the relevant columns to ROOT Tuples or preferred data format. <p> Instructions for exploring a DST and writing out ROOT tuples are available in LHCb Starterkit below. For \"tupling\" jobs, software called DaVinci is mainly used within LHCb, its documentation is also available below.",
+      "description": "<p> The data collected by the LHCb detector is available in .DST and .mDST formats. The data files can be explored using LHCb software but it is best to write the relevant columns to ROOT ntuples or a preferred data format. <p> Instructions for exploring a DST and writing out ROOT ntuples are available in the link below. A catalog for exploring the available stripping line selections can be found at the stripping lines index below.",
       "links": [
         {
-          "description": "LHCb StarterKit",
-          "url": "https://lhcb.github.io/starterkit-lessons/first-analysis-steps/minimal-dv-job.html"
-        },
-        {
-          "description": "DaVinci",
-          "url": "http://lhcbdoc.web.cern.ch/lhcbdoc/davinci/"
+          "description": "LHCb Open Data Guide",
+          "url": "https://lhcb-opendata-guide.web.cern.ch/run1-dsts-odp/"
         },
         {
           "description": "Stripping lines index for stripping21",

--- a/data/records/LHCb_2012_Beam4000GeV_VeloClosed_MagDown_RealData_Reco14_Stripping21_RADIATIVE_DST.json
+++ b/data/records/LHCb_2012_Beam4000GeV_VeloClosed_MagDown_RealData_Reco14_Stripping21_RADIATIVE_DST.json
@@ -105,15 +105,11 @@
       ]
     },
     "usage": {
-      "description": "<p> The data collected by the LHCb detector is available in .DST and .mDST formats. The data files can be explored using LHCb software but it is best to write the relevant columns to ROOT Tuples or preferred data format. <p> Instructions for exploring a DST and writing out ROOT tuples are available in LHCb Starterkit below. For \"tupling\" jobs, software called DaVinci is mainly used within LHCb, its documentation is also available below.",
+      "description": "<p> The data collected by the LHCb detector is available in .DST and .mDST formats. The data files can be explored using LHCb software but it is best to write the relevant columns to ROOT ntuples or a preferred data format. <p> Instructions for exploring a DST and writing out ROOT ntuples are available in the link below. A catalog for exploring the available stripping line selections can be found at the stripping lines index below.",
       "links": [
         {
-          "description": "LHCb StarterKit",
-          "url": "https://lhcb.github.io/starterkit-lessons/first-analysis-steps/minimal-dv-job.html"
-        },
-        {
-          "description": "DaVinci",
-          "url": "http://lhcbdoc.web.cern.ch/lhcbdoc/davinci/"
+          "description": "LHCb Open Data Guide",
+          "url": "https://lhcb-opendata-guide.web.cern.ch/run1-dsts-odp/"
         },
         {
           "description": "Stripping lines index for stripping21",

--- a/data/records/LHCb_2012_Beam4000GeV_VeloClosed_MagDown_RealData_Reco14_Stripping21_SEMILEPTONIC_DST.json
+++ b/data/records/LHCb_2012_Beam4000GeV_VeloClosed_MagDown_RealData_Reco14_Stripping21_SEMILEPTONIC_DST.json
@@ -105,15 +105,11 @@
       ]
     },
     "usage": {
-      "description": "<p> The data collected by the LHCb detector is available in .DST and .mDST formats. The data files can be explored using LHCb software but it is best to write the relevant columns to ROOT Tuples or preferred data format. <p> Instructions for exploring a DST and writing out ROOT tuples are available in LHCb Starterkit below. For \"tupling\" jobs, software called DaVinci is mainly used within LHCb, its documentation is also available bellow.",
+      "description": "<p> The data collected by the LHCb detector is available in .DST and .mDST formats. The data files can be explored using LHCb software but it is best to write the relevant columns to ROOT ntuples or a preferred data format. <p> Instructions for exploring a DST and writing out ROOT ntuples are available in the link below. A catalog for exploring the available stripping line selections can be found at the stripping lines index below.",
       "links": [
         {
-          "description": "LHCb StarterKit",
-          "url": "https://lhcb.github.io/starterkit-lessons/first-analysis-steps/minimal-dv-job.html"
-        },
-        {
-          "description": "DaVinci",
-          "url": "http://lhcbdoc.web.cern.ch/lhcbdoc/davinci/"
+          "description": "LHCb Open Data Guide",
+          "url": "https://lhcb-opendata-guide.web.cern.ch/run1-dsts-odp/"
         },
         {
           "description": "Stripping lines index for stripping21",

--- a/data/records/LHCb_2012_Beam4000GeV_VeloClosed_MagDown_RealData_Reco14_Stripping21r0p1a_BHADRONCOMPLETEEVENT_DST.json
+++ b/data/records/LHCb_2012_Beam4000GeV_VeloClosed_MagDown_RealData_Reco14_Stripping21r0p1a_BHADRONCOMPLETEEVENT_DST.json
@@ -108,15 +108,11 @@
       ]
     },
     "usage": {
-      "description": "<p> The data collected by the LHCb detector is available in .DST and .mDST formats. The data files can be explored using LHCb software but it is best to write the relevant columns to ROOT Tuples or preferred data format. <p> Instructions for exploring a DST and writing out ROOT tuples are available in LHCb Starterkit below. For \"tupling\" jobs, software called DaVinci is mainly used within LHCb, its documentation is also available bellow.",
+      "description": "<p> The data collected by the LHCb detector is available in .DST and .mDST formats. The data files can be explored using LHCb software but it is best to write the relevant columns to ROOT ntuples or a preferred data format. <p> Instructions for exploring a DST and writing out ROOT ntuples are available in the link below. A catalog for exploring the available stripping line selections can be found at the stripping lines index below.",
       "links": [
         {
-          "description": "LHCb StarterKit",
-          "url": "https://lhcb.github.io/starterkit-lessons/first-analysis-steps/minimal-dv-job.html"
-        },
-        {
-          "description": "DaVinci",
-          "url": "http://lhcbdoc.web.cern.ch/lhcbdoc/davinci/"
+          "description": "LHCb Open Data Guide",
+          "url": "https://lhcb-opendata-guide.web.cern.ch/run1-dsts-odp/"
         },
         {
           "description": "Stripping lines index for stripping21r0p1",

--- a/data/records/LHCb_2012_Beam4000GeV_VeloClosed_MagDown_RealData_Reco14_Stripping21r0p1a_BHADRON_MDST.json
+++ b/data/records/LHCb_2012_Beam4000GeV_VeloClosed_MagDown_RealData_Reco14_Stripping21r0p1a_BHADRON_MDST.json
@@ -108,15 +108,11 @@
       ]
     },
     "usage": {
-      "description": "<p> The data collected by the LHCb detector is available in .DST and .mDST formats. The data files can be explored using LHCb software but it is best to write the relevant columns to ROOT Tuples or preferred data format. <p> Instructions for exploring a DST and writing out ROOT tuples are available in LHCb Starterkit below. For \"tupling\" jobs, software called DaVinci is mainly used within LHCb, its documentation is also available bellow.",
+      "description": "<p> The data collected by the LHCb detector is available in .DST and .mDST formats. The data files can be explored using LHCb software but it is best to write the relevant columns to ROOT ntuples or a preferred data format. <p> Instructions for exploring a DST and writing out ROOT ntuples are available in the link below. A catalog for exploring the available stripping line selections can be found at the stripping lines index below.",
       "links": [
         {
-          "description": "LHCb StarterKit",
-          "url": "https://lhcb.github.io/starterkit-lessons/first-analysis-steps/minimal-dv-job.html"
-        },
-        {
-          "description": "DaVinci",
-          "url": "http://lhcbdoc.web.cern.ch/lhcbdoc/davinci/"
+          "description": "LHCb Open Data Guide",
+          "url": "https://lhcb-opendata-guide.web.cern.ch/run1-dsts-odp/"
         },
         {
           "description": "Stripping lines index for stripping21r0p1",

--- a/data/records/LHCb_2012_Beam4000GeV_VeloClosed_MagDown_RealData_Reco14_Stripping21r0p1a_CHARMCOMPLETEEVENT_DST.json
+++ b/data/records/LHCb_2012_Beam4000GeV_VeloClosed_MagDown_RealData_Reco14_Stripping21r0p1a_CHARMCOMPLETEEVENT_DST.json
@@ -108,15 +108,11 @@
       ]
     },
     "usage": {
-      "description": "<p> The data collected by the LHCb detector is available in .DST and .mDST formats. The data files can be explored using LHCb software but it is best to write the relevant columns to ROOT Tuples or preferred data format. <p> Instructions for exploring a DST and writing out ROOT tuples are available in LHCb Starterkit below. For \"tupling\" jobs, software called DaVinci is mainly used within LHCb, its documentation is also available bellow.",
+      "description": "<p> The data collected by the LHCb detector is available in .DST and .mDST formats. The data files can be explored using LHCb software but it is best to write the relevant columns to ROOT ntuples or a preferred data format. <p> Instructions for exploring a DST and writing out ROOT ntuples are available in the link below. A catalog for exploring the available stripping line selections can be found at the stripping lines index below.",
       "links": [
         {
-          "description": "LHCb StarterKit",
-          "url": "https://lhcb.github.io/starterkit-lessons/first-analysis-steps/minimal-dv-job.html"
-        },
-        {
-          "description": "DaVinci",
-          "url": "http://lhcbdoc.web.cern.ch/lhcbdoc/davinci/"
+          "description": "LHCb Open Data Guide",
+          "url": "https://lhcb-opendata-guide.web.cern.ch/run1-dsts-odp/"
         },
         {
           "description": "Stripping lines index for stripping21r0p1",

--- a/data/records/LHCb_2012_Beam4000GeV_VeloClosed_MagDown_RealData_Reco14_Stripping21r0p1a_CHARM_MDST.json
+++ b/data/records/LHCb_2012_Beam4000GeV_VeloClosed_MagDown_RealData_Reco14_Stripping21r0p1a_CHARM_MDST.json
@@ -108,15 +108,11 @@
       ]
     },
     "usage": {
-      "description": "<p> The data collected by the LHCb detector is available in .DST and .mDST formats. The data files can be explored using LHCb software but it is best to write the relevant columns to ROOT Tuples or preferred data format. <p> Instructions for exploring a DST and writing out ROOT tuples are available in LHCb Starterkit below. For \"tupling\" jobs, software called DaVinci is mainly used within LHCb, its documentation is also available bellow.",
+      "description": "<p> The data collected by the LHCb detector is available in .DST and .mDST formats. The data files can be explored using LHCb software but it is best to write the relevant columns to ROOT ntuples or a preferred data format. <p> Instructions for exploring a DST and writing out ROOT ntuples are available in the link below. A catalog for exploring the available stripping line selections can be found at the stripping lines index below.",
       "links": [
         {
-          "description": "LHCb StarterKit",
-          "url": "https://lhcb.github.io/starterkit-lessons/first-analysis-steps/minimal-dv-job.html"
-        },
-        {
-          "description": "DaVinci",
-          "url": "http://lhcbdoc.web.cern.ch/lhcbdoc/davinci/"
+          "description": "LHCb Open Data Guide",
+          "url": "https://lhcb-opendata-guide.web.cern.ch/run1-dsts-odp/"
         },
         {
           "description": "Stripping lines index for stripping21r0p1",

--- a/data/records/LHCb_2012_Beam4000GeV_VeloClosed_MagDown_RealData_Reco14_Stripping21r0p1a_DIMUON_DST.json
+++ b/data/records/LHCb_2012_Beam4000GeV_VeloClosed_MagDown_RealData_Reco14_Stripping21r0p1a_DIMUON_DST.json
@@ -108,15 +108,11 @@
       ]
     },
     "usage": {
-      "description": "<p> The data collected by the LHCb detector is available in .DST and .mDST formats. The data files can be explored using LHCb software but it is best to write the relevant columns to ROOT Tuples or preferred data format. <p> Instructions for exploring a DST and writing out ROOT tuples are available in LHCb Starterkit below. For \"tupling\" jobs, software called DaVinci is mainly used within LHCb, its documentation is also available bellow.",
+      "description": "<p> The data collected by the LHCb detector is available in .DST and .mDST formats. The data files can be explored using LHCb software but it is best to write the relevant columns to ROOT ntuples or a preferred data format. <p> Instructions for exploring a DST and writing out ROOT ntuples are available in the link below. A catalog for exploring the available stripping line selections can be found at the stripping lines index below.",
       "links": [
         {
-          "description": "LHCb StarterKit",
-          "url": "https://lhcb.github.io/starterkit-lessons/first-analysis-steps/minimal-dv-job.html"
-        },
-        {
-          "description": "DaVinci",
-          "url": "http://lhcbdoc.web.cern.ch/lhcbdoc/davinci/"
+          "description": "LHCb Open Data Guide",
+          "url": "https://lhcb-opendata-guide.web.cern.ch/run1-dsts-odp/"
         },
         {
           "description": "Stripping lines index for stripping21r0p1",

--- a/data/records/LHCb_2012_Beam4000GeV_VeloClosed_MagDown_RealData_Reco14_Stripping21r0p1a_EW_DST.json
+++ b/data/records/LHCb_2012_Beam4000GeV_VeloClosed_MagDown_RealData_Reco14_Stripping21r0p1a_EW_DST.json
@@ -108,15 +108,11 @@
       ]
     },
     "usage": {
-      "description": "<p> The data collected by the LHCb detector is available in .DST and .mDST formats. The data files can be explored using LHCb software but it is best to write the relevant columns to ROOT Tuples or preferred data format. <p> Instructions for exploring a DST and writing out ROOT tuples are available in LHCb Starterkit below. For \"tupling\" jobs, software called DaVinci is mainly used within LHCb, its documentation is also available below.",
+      "description": "<p> The data collected by the LHCb detector is available in .DST and .mDST formats. The data files can be explored using LHCb software but it is best to write the relevant columns to ROOT ntuples or a preferred data format. <p> Instructions for exploring a DST and writing out ROOT ntuples are available in the link below. A catalog for exploring the available stripping line selections can be found at the stripping lines index below.",
       "links": [
         {
-          "description": "LHCb StarterKit",
-          "url": "https://lhcb.github.io/starterkit-lessons/first-analysis-steps/minimal-dv-job.html"
-        },
-        {
-          "description": "DaVinci",
-          "url": "http://lhcbdoc.web.cern.ch/lhcbdoc/davinci/"
+          "description": "LHCb Open Data Guide",
+          "url": "https://lhcb-opendata-guide.web.cern.ch/run1-dsts-odp/"
         },
         {
           "description": "Stripping lines index for stripping21r0p1",

--- a/data/records/LHCb_2012_Beam4000GeV_VeloClosed_MagDown_RealData_Reco14_Stripping21r0p1a_LEPTONIC_MDST.json
+++ b/data/records/LHCb_2012_Beam4000GeV_VeloClosed_MagDown_RealData_Reco14_Stripping21r0p1a_LEPTONIC_MDST.json
@@ -108,15 +108,11 @@
       ]
     },
     "usage": {
-      "description": "<p> The data collected by the LHCb detector is available in .DST and .mDST formats. The data files can be explored using LHCb software but it is best to write the relevant columns to ROOT Tuples or preferred data format. <p> Instructions for exploring a DST and writing out ROOT tuples are available in LHCb Starterkit below. For \"tupling\" jobs, software called DaVinci is mainly used within LHCb, its documentation is also available below.",
+      "description": "<p> The data collected by the LHCb detector is available in .DST and .mDST formats. The data files can be explored using LHCb software but it is best to write the relevant columns to ROOT ntuples or a preferred data format. <p> Instructions for exploring a DST and writing out ROOT ntuples are available in the link below. A catalog for exploring the available stripping line selections can be found at the stripping lines index below.",
       "links": [
         {
-          "description": "LHCb StarterKit",
-          "url": "https://lhcb.github.io/starterkit-lessons/first-analysis-steps/minimal-dv-job.html"
-        },
-        {
-          "description": "DaVinci",
-          "url": "http://lhcbdoc.web.cern.ch/lhcbdoc/davinci/"
+          "description": "LHCb Open Data Guide",
+          "url": "https://lhcb-opendata-guide.web.cern.ch/run1-dsts-odp/"
         },
         {
           "description": "Stripping lines index for stripping21r0p1",

--- a/data/records/LHCb_2012_Beam4000GeV_VeloClosed_MagDown_RealData_Reco14_Stripping21r0p1a_SEMILEPTONIC_DST.json
+++ b/data/records/LHCb_2012_Beam4000GeV_VeloClosed_MagDown_RealData_Reco14_Stripping21r0p1a_SEMILEPTONIC_DST.json
@@ -108,15 +108,11 @@
       ]
     },
     "usage": {
-      "description": "<p> The data collected by the LHCb detector is available in .DST and .mDST formats. The data files can be explored using LHCb software but it is best to write the relevant columns to ROOT Tuples or preferred data format. <p> Instructions for exploring a DST and writing out ROOT tuples are available in LHCb Starterkit below. For \"tupling\" jobs, software called DaVinci is mainly used within LHCb, its documentation is also available bellow.",
+      "description": "<p> The data collected by the LHCb detector is available in .DST and .mDST formats. The data files can be explored using LHCb software but it is best to write the relevant columns to ROOT ntuples or a preferred data format. <p> Instructions for exploring a DST and writing out ROOT ntuples are available in the link below. A catalog for exploring the available stripping line selections can be found at the stripping lines index below.",
       "links": [
         {
-          "description": "LHCb StarterKit",
-          "url": "https://lhcb.github.io/starterkit-lessons/first-analysis-steps/minimal-dv-job.html"
-        },
-        {
-          "description": "DaVinci",
-          "url": "http://lhcbdoc.web.cern.ch/lhcbdoc/davinci/"
+          "description": "LHCb Open Data Guide",
+          "url": "https://lhcb-opendata-guide.web.cern.ch/run1-dsts-odp/"
         },
         {
           "description": "Stripping lines index for stripping21r0p1",

--- a/data/records/LHCb_2012_Beam4000GeV_VeloClosed_MagDown_RealData_Reco14_Stripping21r0p2_BHADRONCOMPLETEEVENT_DST.json
+++ b/data/records/LHCb_2012_Beam4000GeV_VeloClosed_MagDown_RealData_Reco14_Stripping21r0p2_BHADRONCOMPLETEEVENT_DST.json
@@ -240,15 +240,11 @@
       ]
     },
     "usage": {
-      "description": "<p> The data collected by the LHCb detector is available in .DST and .mDST formats. The data files can be explored using LHCb software but it is best to write the relevant columns to ROOT Tuples or preferred data format. <p> Instructions for exploring a DST and writing out ROOT tuples are available in LHCb Starterkit below. For \"tupling\" jobs, software called DaVinci is mainly used within LHCb, its documentation is also available bellow.",
+      "description": "<p> The data collected by the LHCb detector is available in .DST and .mDST formats. The data files can be explored using LHCb software but it is best to write the relevant columns to ROOT ntuples or a preferred data format. <p> Instructions for exploring a DST and writing out ROOT ntuples are available in the link below. A catalog for exploring the available stripping line selections can be found at the stripping lines index below.",
       "links": [
         {
-          "description": "LHCb StarterKit",
-          "url": "https://lhcb.github.io/starterkit-lessons/first-analysis-steps/minimal-dv-job.html"
-        },
-        {
-          "description": "DaVinci",
-          "url": "http://lhcbdoc.web.cern.ch/lhcbdoc/davinci/"
+          "description": "LHCb Open Data Guide",
+          "url": "https://lhcb-opendata-guide.web.cern.ch/run1-dsts-odp/"
         },
         {
           "description": "Stripping lines index for stripping21r0p2",

--- a/data/records/LHCb_2012_Beam4000GeV_VeloClosed_MagDown_RealData_Reco14_Stripping21r0p2_BHADRON_MDST.json
+++ b/data/records/LHCb_2012_Beam4000GeV_VeloClosed_MagDown_RealData_Reco14_Stripping21r0p2_BHADRON_MDST.json
@@ -240,15 +240,11 @@
       ]
     },
     "usage": {
-      "description": "<p> The data collected by the LHCb detector is available in .DST and .mDST formats. The data files can be explored using LHCb software but it is best to write the relevant columns to ROOT Tuples or preferred data format. <p> Instructions for exploring a DST and writing out ROOT tuples are available in LHCb Starterkit below. For \"tupling\" jobs, software called DaVinci is mainly used within LHCb, its documentation is also available bellow.",
+      "description": "<p> The data collected by the LHCb detector is available in .DST and .mDST formats. The data files can be explored using LHCb software but it is best to write the relevant columns to ROOT ntuples or a preferred data format. <p> Instructions for exploring a DST and writing out ROOT ntuples are available in the link below. A catalog for exploring the available stripping line selections can be found at the stripping lines index below.",
       "links": [
         {
-          "description": "LHCb StarterKit",
-          "url": "https://lhcb.github.io/starterkit-lessons/first-analysis-steps/minimal-dv-job.html"
-        },
-        {
-          "description": "DaVinci",
-          "url": "http://lhcbdoc.web.cern.ch/lhcbdoc/davinci/"
+          "description": "LHCb Open Data Guide",
+          "url": "https://lhcb-opendata-guide.web.cern.ch/run1-dsts-odp/"
         },
         {
           "description": "Stripping lines index for stripping21r0p2",

--- a/data/records/LHCb_2012_Beam4000GeV_VeloClosed_MagDown_RealData_Reco14_Stripping21r0p2_CHARMCOMPLETEEVENT_DST.json
+++ b/data/records/LHCb_2012_Beam4000GeV_VeloClosed_MagDown_RealData_Reco14_Stripping21r0p2_CHARMCOMPLETEEVENT_DST.json
@@ -240,15 +240,11 @@
       ]
     },
     "usage": {
-      "description": "<p> The data collected by the LHCb detector is available in .DST and .mDST formats. The data files can be explored using LHCb software but it is best to write the relevant columns to ROOT Tuples or preferred data format. <p> Instructions for exploring a DST and writing out ROOT tuples are available in LHCb Starterkit below. For \"tupling\" jobs, software called DaVinci is mainly used within LHCb, its documentation is also available bellow.",
+      "description": "<p> The data collected by the LHCb detector is available in .DST and .mDST formats. The data files can be explored using LHCb software but it is best to write the relevant columns to ROOT ntuples or a preferred data format. <p> Instructions for exploring a DST and writing out ROOT ntuples are available in the link below. A catalog for exploring the available stripping line selections can be found at the stripping lines index below.",
       "links": [
         {
-          "description": "LHCb StarterKit",
-          "url": "https://lhcb.github.io/starterkit-lessons/first-analysis-steps/minimal-dv-job.html"
-        },
-        {
-          "description": "DaVinci",
-          "url": "http://lhcbdoc.web.cern.ch/lhcbdoc/davinci/"
+          "description": "LHCb Open Data Guide",
+          "url": "https://lhcb-opendata-guide.web.cern.ch/run1-dsts-odp/"
         },
         {
           "description": "Stripping lines index for stripping21r0p2",

--- a/data/records/LHCb_2012_Beam4000GeV_VeloClosed_MagDown_RealData_Reco14_Stripping21r0p2_CHARM_MDST.json
+++ b/data/records/LHCb_2012_Beam4000GeV_VeloClosed_MagDown_RealData_Reco14_Stripping21r0p2_CHARM_MDST.json
@@ -240,15 +240,11 @@
       ]
     },
     "usage": {
-      "description": "<p> The data collected by the LHCb detector is available in .DST and .mDST formats. The data files can be explored using LHCb software but it is best to write the relevant columns to ROOT Tuples or preferred data format. <p> Instructions for exploring a DST and writing out ROOT tuples are available in LHCb Starterkit below. For \"tupling\" jobs, software called DaVinci is mainly used within LHCb, its documentation is also available bellow.",
+      "description": "<p> The data collected by the LHCb detector is available in .DST and .mDST formats. The data files can be explored using LHCb software but it is best to write the relevant columns to ROOT ntuples or a preferred data format. <p> Instructions for exploring a DST and writing out ROOT ntuples are available in the link below. A catalog for exploring the available stripping line selections can be found at the stripping lines index below.",
       "links": [
         {
-          "description": "LHCb StarterKit",
-          "url": "https://lhcb.github.io/starterkit-lessons/first-analysis-steps/minimal-dv-job.html"
-        },
-        {
-          "description": "DaVinci",
-          "url": "http://lhcbdoc.web.cern.ch/lhcbdoc/davinci/"
+          "description": "LHCb Open Data Guide",
+          "url": "https://lhcb-opendata-guide.web.cern.ch/run1-dsts-odp/"
         },
         {
           "description": "Stripping lines index for stripping21r0p2",

--- a/data/records/LHCb_2012_Beam4000GeV_VeloClosed_MagDown_RealData_Reco14_Stripping21r0p2_DIMUON_DST.json
+++ b/data/records/LHCb_2012_Beam4000GeV_VeloClosed_MagDown_RealData_Reco14_Stripping21r0p2_DIMUON_DST.json
@@ -240,15 +240,11 @@
       ]
     },
     "usage": {
-      "description": "<p> The data collected by the LHCb detector is available in .DST and .mDST formats. The data files can be explored using LHCb software but it is best to write the relevant columns to ROOT Tuples or preferred data format. <p> Instructions for exploring a DST and writing out ROOT tuples are available in LHCb Starterkit below. For \"tupling\" jobs, software called DaVinci is mainly used within LHCb, its documentation is also available bellow.",
+      "description": "<p> The data collected by the LHCb detector is available in .DST and .mDST formats. The data files can be explored using LHCb software but it is best to write the relevant columns to ROOT ntuples or a preferred data format. <p> Instructions for exploring a DST and writing out ROOT ntuples are available in the link below. A catalog for exploring the available stripping line selections can be found at the stripping lines index below.",
       "links": [
         {
-          "description": "LHCb StarterKit",
-          "url": "https://lhcb.github.io/starterkit-lessons/first-analysis-steps/minimal-dv-job.html"
-        },
-        {
-          "description": "DaVinci",
-          "url": "http://lhcbdoc.web.cern.ch/lhcbdoc/davinci/"
+          "description": "LHCb Open Data Guide",
+          "url": "https://lhcb-opendata-guide.web.cern.ch/run1-dsts-odp/"
         },
         {
           "description": "Stripping lines index for stripping21r0p2",

--- a/data/records/LHCb_2012_Beam4000GeV_VeloClosed_MagDown_RealData_Reco14_Stripping21r0p2_EW_DST.json
+++ b/data/records/LHCb_2012_Beam4000GeV_VeloClosed_MagDown_RealData_Reco14_Stripping21r0p2_EW_DST.json
@@ -240,15 +240,11 @@
       ]
     },
     "usage": {
-      "description": "<p> The data collected by the LHCb detector is available in .DST and .mDST formats. The data files can be explored using LHCb software but it is best to write the relevant columns to ROOT Tuples or preferred data format. <p> Instructions for exploring a DST and writing out ROOT tuples are available in LHCb Starterkit below. For \"tupling\" jobs, software called DaVinci is mainly used within LHCb, its documentation is also available below.",
+      "description": "<p> The data collected by the LHCb detector is available in .DST and .mDST formats. The data files can be explored using LHCb software but it is best to write the relevant columns to ROOT ntuples or a preferred data format. <p> Instructions for exploring a DST and writing out ROOT ntuples are available in the link below. A catalog for exploring the available stripping line selections can be found at the stripping lines index below.",
       "links": [
         {
-          "description": "LHCb StarterKit",
-          "url": "https://lhcb.github.io/starterkit-lessons/first-analysis-steps/minimal-dv-job.html"
-        },
-        {
-          "description": "DaVinci",
-          "url": "http://lhcbdoc.web.cern.ch/lhcbdoc/davinci/"
+          "description": "LHCb Open Data Guide",
+          "url": "https://lhcb-opendata-guide.web.cern.ch/run1-dsts-odp/"
         },
         {
           "description": "Stripping lines index for stripping21r0p2",

--- a/data/records/LHCb_2012_Beam4000GeV_VeloClosed_MagDown_RealData_Reco14_Stripping21r0p2_LEPTONIC_MDST.json
+++ b/data/records/LHCb_2012_Beam4000GeV_VeloClosed_MagDown_RealData_Reco14_Stripping21r0p2_LEPTONIC_MDST.json
@@ -240,15 +240,11 @@
       ]
     },
     "usage": {
-      "description": "<p> The data collected by the LHCb detector is available in .DST and .mDST formats. The data files can be explored using LHCb software but it is best to write the relevant columns to ROOT Tuples or preferred data format. <p> Instructions for exploring a DST and writing out ROOT tuples are available in LHCb Starterkit below. For \"tupling\" jobs, software called DaVinci is mainly used within LHCb, its documentation is also available below.",
+      "description": "<p> The data collected by the LHCb detector is available in .DST and .mDST formats. The data files can be explored using LHCb software but it is best to write the relevant columns to ROOT ntuples or a preferred data format. <p> Instructions for exploring a DST and writing out ROOT ntuples are available in the link below. A catalog for exploring the available stripping line selections can be found at the stripping lines index below.",
       "links": [
         {
-          "description": "LHCb StarterKit",
-          "url": "https://lhcb.github.io/starterkit-lessons/first-analysis-steps/minimal-dv-job.html"
-        },
-        {
-          "description": "DaVinci",
-          "url": "http://lhcbdoc.web.cern.ch/lhcbdoc/davinci/"
+          "description": "LHCb Open Data Guide",
+          "url": "https://lhcb-opendata-guide.web.cern.ch/run1-dsts-odp/"
         },
         {
           "description": "Stripping lines index for stripping21r0p2",

--- a/data/records/LHCb_2012_Beam4000GeV_VeloClosed_MagDown_RealData_Reco14_Stripping21r0p2_SEMILEPTONIC_DST.json
+++ b/data/records/LHCb_2012_Beam4000GeV_VeloClosed_MagDown_RealData_Reco14_Stripping21r0p2_SEMILEPTONIC_DST.json
@@ -240,15 +240,11 @@
       ]
     },
     "usage": {
-      "description": "<p> The data collected by the LHCb detector is available in .DST and .mDST formats. The data files can be explored using LHCb software but it is best to write the relevant columns to ROOT Tuples or preferred data format. <p> Instructions for exploring a DST and writing out ROOT tuples are available in LHCb Starterkit below. For \"tupling\" jobs, software called DaVinci is mainly used within LHCb, its documentation is also available bellow.",
+      "description": "<p> The data collected by the LHCb detector is available in .DST and .mDST formats. The data files can be explored using LHCb software but it is best to write the relevant columns to ROOT ntuples or a preferred data format. <p> Instructions for exploring a DST and writing out ROOT ntuples are available in the link below. A catalog for exploring the available stripping line selections can be found at the stripping lines index below.",
       "links": [
         {
-          "description": "LHCb StarterKit",
-          "url": "https://lhcb.github.io/starterkit-lessons/first-analysis-steps/minimal-dv-job.html"
-        },
-        {
-          "description": "DaVinci",
-          "url": "http://lhcbdoc.web.cern.ch/lhcbdoc/davinci/"
+          "description": "LHCb Open Data Guide",
+          "url": "https://lhcb-opendata-guide.web.cern.ch/run1-dsts-odp/"
         },
         {
           "description": "Stripping lines index for stripping21r0p2",

--- a/data/records/LHCb_2012_Beam4000GeV_VeloClosed_MagUp_RealData_Reco14_Stripping21_BHADRONCOMPLETEEVENT_DST.json
+++ b/data/records/LHCb_2012_Beam4000GeV_VeloClosed_MagUp_RealData_Reco14_Stripping21_BHADRONCOMPLETEEVENT_DST.json
@@ -105,15 +105,11 @@
       ]
     },
     "usage": {
-      "description": "<p> The data collected by the LHCb detector is available in .DST and .mDST formats. The data files can be explored using LHCb software but it is best to write the relevant columns to ROOT Tuples or preferred data format. <p> Instructions for exploring a DST and writing out ROOT tuples are available in LHCb Starterkit below. For \"tupling\" jobs, software called DaVinci is mainly used within LHCb, its documentation is also available bellow.",
+      "description": "<p> The data collected by the LHCb detector is available in .DST and .mDST formats. The data files can be explored using LHCb software but it is best to write the relevant columns to ROOT ntuples or a preferred data format. <p> Instructions for exploring a DST and writing out ROOT ntuples are available in the link below. A catalog for exploring the available stripping line selections can be found at the stripping lines index below.",
       "links": [
         {
-          "description": "LHCb StarterKit",
-          "url": "https://lhcb.github.io/starterkit-lessons/first-analysis-steps/minimal-dv-job.html"
-        },
-        {
-          "description": "DaVinci",
-          "url": "http://lhcbdoc.web.cern.ch/lhcbdoc/davinci/"
+          "description": "LHCb Open Data Guide",
+          "url": "https://lhcb-opendata-guide.web.cern.ch/run1-dsts-odp/"
         },
         {
           "description": "Stripping lines index for stripping21",

--- a/data/records/LHCb_2012_Beam4000GeV_VeloClosed_MagUp_RealData_Reco14_Stripping21_BHADRON_MDST.json
+++ b/data/records/LHCb_2012_Beam4000GeV_VeloClosed_MagUp_RealData_Reco14_Stripping21_BHADRON_MDST.json
@@ -105,15 +105,11 @@
       ]
     },
     "usage": {
-      "description": "<p> The data collected by the LHCb detector is available in .DST and .mDST formats. The data files can be explored using LHCb software but it is best to write the relevant columns to ROOT Tuples or preferred data format. <p> Instructions for exploring a DST and writing out ROOT tuples are available in LHCb Starterkit below. For \"tupling\" jobs, software called DaVinci is mainly used within LHCb, its documentation is also available bellow.",
+      "description": "<p> The data collected by the LHCb detector is available in .DST and .mDST formats. The data files can be explored using LHCb software but it is best to write the relevant columns to ROOT ntuples or a preferred data format. <p> Instructions for exploring a DST and writing out ROOT ntuples are available in the link below. A catalog for exploring the available stripping line selections can be found at the stripping lines index below.",
       "links": [
         {
-          "description": "LHCb StarterKit",
-          "url": "https://lhcb.github.io/starterkit-lessons/first-analysis-steps/minimal-dv-job.html"
-        },
-        {
-          "description": "DaVinci",
-          "url": "http://lhcbdoc.web.cern.ch/lhcbdoc/davinci/"
+          "description": "LHCb Open Data Guide",
+          "url": "https://lhcb-opendata-guide.web.cern.ch/run1-dsts-odp/"
         },
         {
           "description": "Stripping lines index for stripping21",

--- a/data/records/LHCb_2012_Beam4000GeV_VeloClosed_MagUp_RealData_Reco14_Stripping21_CHARMCOMPLETEEVENT_DST.json
+++ b/data/records/LHCb_2012_Beam4000GeV_VeloClosed_MagUp_RealData_Reco14_Stripping21_CHARMCOMPLETEEVENT_DST.json
@@ -105,15 +105,11 @@
       ]
     },
     "usage": {
-      "description": "<p> The data collected by the LHCb detector is available in .DST and .mDST formats. The data files can be explored using LHCb software but it is best to write the relevant columns to ROOT Tuples or preferred data format. <p> Instructions for exploring a DST and writing out ROOT tuples are available in LHCb Starterkit below. For \"tupling\" jobs, software called DaVinci is mainly used within LHCb, its documentation is also available bellow.",
+      "description": "<p> The data collected by the LHCb detector is available in .DST and .mDST formats. The data files can be explored using LHCb software but it is best to write the relevant columns to ROOT ntuples or a preferred data format. <p> Instructions for exploring a DST and writing out ROOT ntuples are available in the link below. A catalog for exploring the available stripping line selections can be found at the stripping lines index below.",
       "links": [
         {
-          "description": "LHCb StarterKit",
-          "url": "https://lhcb.github.io/starterkit-lessons/first-analysis-steps/minimal-dv-job.html"
-        },
-        {
-          "description": "DaVinci",
-          "url": "http://lhcbdoc.web.cern.ch/lhcbdoc/davinci/"
+          "description": "LHCb Open Data Guide",
+          "url": "https://lhcb-opendata-guide.web.cern.ch/run1-dsts-odp/"
         },
         {
           "description": "Stripping lines index for stripping21",

--- a/data/records/LHCb_2012_Beam4000GeV_VeloClosed_MagUp_RealData_Reco14_Stripping21_CHARM_MDST.json
+++ b/data/records/LHCb_2012_Beam4000GeV_VeloClosed_MagUp_RealData_Reco14_Stripping21_CHARM_MDST.json
@@ -105,15 +105,11 @@
       ]
     },
     "usage": {
-      "description": "<p> The data collected by the LHCb detector is available in .DST and .mDST formats. The data files can be explored using LHCb software but it is best to write the relevant columns to ROOT Tuples or preferred data format. <p> Instructions for exploring a DST and writing out ROOT tuples are available in LHCb Starterkit below. For \"tupling\" jobs, software called DaVinci is mainly used within LHCb, its documentation is also available bellow.",
+      "description": "<p> The data collected by the LHCb detector is available in .DST and .mDST formats. The data files can be explored using LHCb software but it is best to write the relevant columns to ROOT ntuples or a preferred data format. <p> Instructions for exploring a DST and writing out ROOT ntuples are available in the link below. A catalog for exploring the available stripping line selections can be found at the stripping lines index below.",
       "links": [
         {
-          "description": "LHCb StarterKit",
-          "url": "https://lhcb.github.io/starterkit-lessons/first-analysis-steps/minimal-dv-job.html"
-        },
-        {
-          "description": "DaVinci",
-          "url": "http://lhcbdoc.web.cern.ch/lhcbdoc/davinci/"
+          "description": "LHCb Open Data Guide",
+          "url": "https://lhcb-opendata-guide.web.cern.ch/run1-dsts-odp/"
         },
         {
           "description": "Stripping lines index for stripping21",

--- a/data/records/LHCb_2012_Beam4000GeV_VeloClosed_MagUp_RealData_Reco14_Stripping21_DIMUON_DST.json
+++ b/data/records/LHCb_2012_Beam4000GeV_VeloClosed_MagUp_RealData_Reco14_Stripping21_DIMUON_DST.json
@@ -105,15 +105,11 @@
       ]
     },
     "usage": {
-      "description": "<p> The data collected by the LHCb detector is available in .DST and .mDST formats. The data files can be explored using LHCb software but it is best to write the relevant columns to ROOT Tuples or preferred data format. <p> Instructions for exploring a DST and writing out ROOT tuples are available in LHCb Starterkit below. For \"tupling\" jobs, software called DaVinci is mainly used within LHCb, its documentation is also available bellow.",
+      "description": "<p> The data collected by the LHCb detector is available in .DST and .mDST formats. The data files can be explored using LHCb software but it is best to write the relevant columns to ROOT ntuples or a preferred data format. <p> Instructions for exploring a DST and writing out ROOT ntuples are available in the link below. A catalog for exploring the available stripping line selections can be found at the stripping lines index below.",
       "links": [
         {
-          "description": "LHCb StarterKit",
-          "url": "https://lhcb.github.io/starterkit-lessons/first-analysis-steps/minimal-dv-job.html"
-        },
-        {
-          "description": "DaVinci",
-          "url": "http://lhcbdoc.web.cern.ch/lhcbdoc/davinci/"
+          "description": "LHCb Open Data Guide",
+          "url": "https://lhcb-opendata-guide.web.cern.ch/run1-dsts-odp/"
         },
         {
           "description": "Stripping lines index for stripping21",

--- a/data/records/LHCb_2012_Beam4000GeV_VeloClosed_MagUp_RealData_Reco14_Stripping21_EW_DST.json
+++ b/data/records/LHCb_2012_Beam4000GeV_VeloClosed_MagUp_RealData_Reco14_Stripping21_EW_DST.json
@@ -105,15 +105,11 @@
       ]
     },
     "usage": {
-      "description": "<p> The data collected by the LHCb detector is available in .DST and .mDST formats. The data files can be explored using LHCb software but it is best to write the relevant columns to ROOT Tuples or preferred data format. <p> Instructions for exploring a DST and writing out ROOT tuples are available in LHCb Starterkit below. For \"tupling\" jobs, software called DaVinci is mainly used within LHCb, its documentation is also available below.",
+      "description": "<p> The data collected by the LHCb detector is available in .DST and .mDST formats. The data files can be explored using LHCb software but it is best to write the relevant columns to ROOT ntuples or a preferred data format. <p> Instructions for exploring a DST and writing out ROOT ntuples are available in the link below. A catalog for exploring the available stripping line selections can be found at the stripping lines index below.",
       "links": [
         {
-          "description": "LHCb StarterKit",
-          "url": "https://lhcb.github.io/starterkit-lessons/first-analysis-steps/minimal-dv-job.html"
-        },
-        {
-          "description": "DaVinci",
-          "url": "http://lhcbdoc.web.cern.ch/lhcbdoc/davinci/"
+          "description": "LHCb Open Data Guide",
+          "url": "https://lhcb-opendata-guide.web.cern.ch/run1-dsts-odp/"
         },
         {
           "description": "Stripping lines index for stripping21",

--- a/data/records/LHCb_2012_Beam4000GeV_VeloClosed_MagUp_RealData_Reco14_Stripping21_LEPTONIC_MDST.json
+++ b/data/records/LHCb_2012_Beam4000GeV_VeloClosed_MagUp_RealData_Reco14_Stripping21_LEPTONIC_MDST.json
@@ -105,15 +105,11 @@
       ]
     },
     "usage": {
-      "description": "<p> The data collected by the LHCb detector is available in .DST and .mDST formats. The data files can be explored using LHCb software but it is best to write the relevant columns to ROOT Tuples or preferred data format. <p> Instructions for exploring a DST and writing out ROOT tuples are available in LHCb Starterkit below. For \"tupling\" jobs, software called DaVinci is mainly used within LHCb, its documentation is also available below.",
+      "description": "<p> The data collected by the LHCb detector is available in .DST and .mDST formats. The data files can be explored using LHCb software but it is best to write the relevant columns to ROOT ntuples or a preferred data format. <p> Instructions for exploring a DST and writing out ROOT ntuples are available in the link below. A catalog for exploring the available stripping line selections can be found at the stripping lines index below.",
       "links": [
         {
-          "description": "LHCb StarterKit",
-          "url": "https://lhcb.github.io/starterkit-lessons/first-analysis-steps/minimal-dv-job.html"
-        },
-        {
-          "description": "DaVinci",
-          "url": "http://lhcbdoc.web.cern.ch/lhcbdoc/davinci/"
+          "description": "LHCb Open Data Guide",
+          "url": "https://lhcb-opendata-guide.web.cern.ch/run1-dsts-odp/"
         },
         {
           "description": "Stripping lines index for stripping21",

--- a/data/records/LHCb_2012_Beam4000GeV_VeloClosed_MagUp_RealData_Reco14_Stripping21_RADIATIVE_DST.json
+++ b/data/records/LHCb_2012_Beam4000GeV_VeloClosed_MagUp_RealData_Reco14_Stripping21_RADIATIVE_DST.json
@@ -105,15 +105,11 @@
       ]
     },
     "usage": {
-      "description": "<p> The data collected by the LHCb detector is available in .DST and .mDST formats. The data files can be explored using LHCb software but it is best to write the relevant columns to ROOT Tuples or preferred data format. <p> Instructions for exploring a DST and writing out ROOT tuples are available in LHCb Starterkit below. For \"tupling\" jobs, software called DaVinci is mainly used within LHCb, its documentation is also available below.",
+      "description": "<p> The data collected by the LHCb detector is available in .DST and .mDST formats. The data files can be explored using LHCb software but it is best to write the relevant columns to ROOT ntuples or a preferred data format. <p> Instructions for exploring a DST and writing out ROOT ntuples are available in the link below. A catalog for exploring the available stripping line selections can be found at the stripping lines index below.",
       "links": [
         {
-          "description": "LHCb StarterKit",
-          "url": "https://lhcb.github.io/starterkit-lessons/first-analysis-steps/minimal-dv-job.html"
-        },
-        {
-          "description": "DaVinci",
-          "url": "http://lhcbdoc.web.cern.ch/lhcbdoc/davinci/"
+          "description": "LHCb Open Data Guide",
+          "url": "https://lhcb-opendata-guide.web.cern.ch/run1-dsts-odp/"
         },
         {
           "description": "Stripping lines index for stripping21",

--- a/data/records/LHCb_2012_Beam4000GeV_VeloClosed_MagUp_RealData_Reco14_Stripping21_SEMILEPTONIC_DST.json
+++ b/data/records/LHCb_2012_Beam4000GeV_VeloClosed_MagUp_RealData_Reco14_Stripping21_SEMILEPTONIC_DST.json
@@ -105,15 +105,11 @@
       ]
     },
     "usage": {
-      "description": "<p> The data collected by the LHCb detector is available in .DST and .mDST formats. The data files can be explored using LHCb software but it is best to write the relevant columns to ROOT Tuples or preferred data format. <p> Instructions for exploring a DST and writing out ROOT tuples are available in LHCb Starterkit below. For \"tupling\" jobs, software called DaVinci is mainly used within LHCb, its documentation is also available bellow.",
+      "description": "<p> The data collected by the LHCb detector is available in .DST and .mDST formats. The data files can be explored using LHCb software but it is best to write the relevant columns to ROOT ntuples or a preferred data format. <p> Instructions for exploring a DST and writing out ROOT ntuples are available in the link below. A catalog for exploring the available stripping line selections can be found at the stripping lines index below.",
       "links": [
         {
-          "description": "LHCb StarterKit",
-          "url": "https://lhcb.github.io/starterkit-lessons/first-analysis-steps/minimal-dv-job.html"
-        },
-        {
-          "description": "DaVinci",
-          "url": "http://lhcbdoc.web.cern.ch/lhcbdoc/davinci/"
+          "description": "LHCb Open Data Guide",
+          "url": "https://lhcb-opendata-guide.web.cern.ch/run1-dsts-odp/"
         },
         {
           "description": "Stripping lines index for stripping21",

--- a/data/records/LHCb_2012_Beam4000GeV_VeloClosed_MagUp_RealData_Reco14_Stripping21r0p1a_BHADRONCOMPLETEEVENT_DST.json
+++ b/data/records/LHCb_2012_Beam4000GeV_VeloClosed_MagUp_RealData_Reco14_Stripping21r0p1a_BHADRONCOMPLETEEVENT_DST.json
@@ -108,15 +108,11 @@
       ]
     },
     "usage": {
-      "description": "<p> The data collected by the LHCb detector is available in .DST and .mDST formats. The data files can be explored using LHCb software but it is best to write the relevant columns to ROOT Tuples or preferred data format. <p> Instructions for exploring a DST and writing out ROOT tuples are available in LHCb Starterkit below. For \"tupling\" jobs, software called DaVinci is mainly used within LHCb, its documentation is also available bellow.",
+      "description": "<p> The data collected by the LHCb detector is available in .DST and .mDST formats. The data files can be explored using LHCb software but it is best to write the relevant columns to ROOT ntuples or a preferred data format. <p> Instructions for exploring a DST and writing out ROOT ntuples are available in the link below. A catalog for exploring the available stripping line selections can be found at the stripping lines index below.",
       "links": [
         {
-          "description": "LHCb StarterKit",
-          "url": "https://lhcb.github.io/starterkit-lessons/first-analysis-steps/minimal-dv-job.html"
-        },
-        {
-          "description": "DaVinci",
-          "url": "http://lhcbdoc.web.cern.ch/lhcbdoc/davinci/"
+          "description": "LHCb Open Data Guide",
+          "url": "https://lhcb-opendata-guide.web.cern.ch/run1-dsts-odp/"
         },
         {
           "description": "Stripping lines index for stripping21r0p1",

--- a/data/records/LHCb_2012_Beam4000GeV_VeloClosed_MagUp_RealData_Reco14_Stripping21r0p1a_BHADRON_MDST.json
+++ b/data/records/LHCb_2012_Beam4000GeV_VeloClosed_MagUp_RealData_Reco14_Stripping21r0p1a_BHADRON_MDST.json
@@ -108,15 +108,11 @@
       ]
     },
     "usage": {
-      "description": "<p> The data collected by the LHCb detector is available in .DST and .mDST formats. The data files can be explored using LHCb software but it is best to write the relevant columns to ROOT Tuples or preferred data format. <p> Instructions for exploring a DST and writing out ROOT tuples are available in LHCb Starterkit below. For \"tupling\" jobs, software called DaVinci is mainly used within LHCb, its documentation is also available bellow.",
+      "description": "<p> The data collected by the LHCb detector is available in .DST and .mDST formats. The data files can be explored using LHCb software but it is best to write the relevant columns to ROOT ntuples or a preferred data format. <p> Instructions for exploring a DST and writing out ROOT ntuples are available in the link below. A catalog for exploring the available stripping line selections can be found at the stripping lines index below.",
       "links": [
         {
-          "description": "LHCb StarterKit",
-          "url": "https://lhcb.github.io/starterkit-lessons/first-analysis-steps/minimal-dv-job.html"
-        },
-        {
-          "description": "DaVinci",
-          "url": "http://lhcbdoc.web.cern.ch/lhcbdoc/davinci/"
+          "description": "LHCb Open Data Guide",
+          "url": "https://lhcb-opendata-guide.web.cern.ch/run1-dsts-odp/"
         },
         {
           "description": "Stripping lines index for stripping21r0p1",

--- a/data/records/LHCb_2012_Beam4000GeV_VeloClosed_MagUp_RealData_Reco14_Stripping21r0p1a_CHARMCOMPLETEEVENT_DST.json
+++ b/data/records/LHCb_2012_Beam4000GeV_VeloClosed_MagUp_RealData_Reco14_Stripping21r0p1a_CHARMCOMPLETEEVENT_DST.json
@@ -108,15 +108,11 @@
       ]
     },
     "usage": {
-      "description": "<p> The data collected by the LHCb detector is available in .DST and .mDST formats. The data files can be explored using LHCb software but it is best to write the relevant columns to ROOT Tuples or preferred data format. <p> Instructions for exploring a DST and writing out ROOT tuples are available in LHCb Starterkit below. For \"tupling\" jobs, software called DaVinci is mainly used within LHCb, its documentation is also available bellow.",
+      "description": "<p> The data collected by the LHCb detector is available in .DST and .mDST formats. The data files can be explored using LHCb software but it is best to write the relevant columns to ROOT ntuples or a preferred data format. <p> Instructions for exploring a DST and writing out ROOT ntuples are available in the link below. A catalog for exploring the available stripping line selections can be found at the stripping lines index below.",
       "links": [
         {
-          "description": "LHCb StarterKit",
-          "url": "https://lhcb.github.io/starterkit-lessons/first-analysis-steps/minimal-dv-job.html"
-        },
-        {
-          "description": "DaVinci",
-          "url": "http://lhcbdoc.web.cern.ch/lhcbdoc/davinci/"
+          "description": "LHCb Open Data Guide",
+          "url": "https://lhcb-opendata-guide.web.cern.ch/run1-dsts-odp/"
         },
         {
           "description": "Stripping lines index for stripping21r0p1",

--- a/data/records/LHCb_2012_Beam4000GeV_VeloClosed_MagUp_RealData_Reco14_Stripping21r0p1a_CHARM_MDST.json
+++ b/data/records/LHCb_2012_Beam4000GeV_VeloClosed_MagUp_RealData_Reco14_Stripping21r0p1a_CHARM_MDST.json
@@ -108,15 +108,11 @@
       ]
     },
     "usage": {
-      "description": "<p> The data collected by the LHCb detector is available in .DST and .mDST formats. The data files can be explored using LHCb software but it is best to write the relevant columns to ROOT Tuples or preferred data format. <p> Instructions for exploring a DST and writing out ROOT tuples are available in LHCb Starterkit below. For \"tupling\" jobs, software called DaVinci is mainly used within LHCb, its documentation is also available bellow.",
+      "description": "<p> The data collected by the LHCb detector is available in .DST and .mDST formats. The data files can be explored using LHCb software but it is best to write the relevant columns to ROOT ntuples or a preferred data format. <p> Instructions for exploring a DST and writing out ROOT ntuples are available in the link below. A catalog for exploring the available stripping line selections can be found at the stripping lines index below.",
       "links": [
         {
-          "description": "LHCb StarterKit",
-          "url": "https://lhcb.github.io/starterkit-lessons/first-analysis-steps/minimal-dv-job.html"
-        },
-        {
-          "description": "DaVinci",
-          "url": "http://lhcbdoc.web.cern.ch/lhcbdoc/davinci/"
+          "description": "LHCb Open Data Guide",
+          "url": "https://lhcb-opendata-guide.web.cern.ch/run1-dsts-odp/"
         },
         {
           "description": "Stripping lines index for stripping21r0p1",

--- a/data/records/LHCb_2012_Beam4000GeV_VeloClosed_MagUp_RealData_Reco14_Stripping21r0p1a_DIMUON_DST.json
+++ b/data/records/LHCb_2012_Beam4000GeV_VeloClosed_MagUp_RealData_Reco14_Stripping21r0p1a_DIMUON_DST.json
@@ -108,15 +108,11 @@
       ]
     },
     "usage": {
-      "description": "<p> The data collected by the LHCb detector is available in .DST and .mDST formats. The data files can be explored using LHCb software but it is best to write the relevant columns to ROOT Tuples or preferred data format. <p> Instructions for exploring a DST and writing out ROOT tuples are available in LHCb Starterkit below. For \"tupling\" jobs, software called DaVinci is mainly used within LHCb, its documentation is also available bellow.",
+      "description": "<p> The data collected by the LHCb detector is available in .DST and .mDST formats. The data files can be explored using LHCb software but it is best to write the relevant columns to ROOT ntuples or a preferred data format. <p> Instructions for exploring a DST and writing out ROOT ntuples are available in the link below. A catalog for exploring the available stripping line selections can be found at the stripping lines index below.",
       "links": [
         {
-          "description": "LHCb StarterKit",
-          "url": "https://lhcb.github.io/starterkit-lessons/first-analysis-steps/minimal-dv-job.html"
-        },
-        {
-          "description": "DaVinci",
-          "url": "http://lhcbdoc.web.cern.ch/lhcbdoc/davinci/"
+          "description": "LHCb Open Data Guide",
+          "url": "https://lhcb-opendata-guide.web.cern.ch/run1-dsts-odp/"
         },
         {
           "description": "Stripping lines index for stripping21r0p1",

--- a/data/records/LHCb_2012_Beam4000GeV_VeloClosed_MagUp_RealData_Reco14_Stripping21r0p1a_EW_DST.json
+++ b/data/records/LHCb_2012_Beam4000GeV_VeloClosed_MagUp_RealData_Reco14_Stripping21r0p1a_EW_DST.json
@@ -108,15 +108,11 @@
       ]
     },
     "usage": {
-      "description": "<p> The data collected by the LHCb detector is available in .DST and .mDST formats. The data files can be explored using LHCb software but it is best to write the relevant columns to ROOT Tuples or preferred data format. <p> Instructions for exploring a DST and writing out ROOT tuples are available in LHCb Starterkit below. For \"tupling\" jobs, software called DaVinci is mainly used within LHCb, its documentation is also available below.",
+      "description": "<p> The data collected by the LHCb detector is available in .DST and .mDST formats. The data files can be explored using LHCb software but it is best to write the relevant columns to ROOT ntuples or a preferred data format. <p> Instructions for exploring a DST and writing out ROOT ntuples are available in the link below. A catalog for exploring the available stripping line selections can be found at the stripping lines index below.",
       "links": [
         {
-          "description": "LHCb StarterKit",
-          "url": "https://lhcb.github.io/starterkit-lessons/first-analysis-steps/minimal-dv-job.html"
-        },
-        {
-          "description": "DaVinci",
-          "url": "http://lhcbdoc.web.cern.ch/lhcbdoc/davinci/"
+          "description": "LHCb Open Data Guide",
+          "url": "https://lhcb-opendata-guide.web.cern.ch/run1-dsts-odp/"
         },
         {
           "description": "Stripping lines index for stripping21r0p1",

--- a/data/records/LHCb_2012_Beam4000GeV_VeloClosed_MagUp_RealData_Reco14_Stripping21r0p1a_LEPTONIC_MDST.json
+++ b/data/records/LHCb_2012_Beam4000GeV_VeloClosed_MagUp_RealData_Reco14_Stripping21r0p1a_LEPTONIC_MDST.json
@@ -108,15 +108,11 @@
       ]
     },
     "usage": {
-      "description": "<p> The data collected by the LHCb detector is available in .DST and .mDST formats. The data files can be explored using LHCb software but it is best to write the relevant columns to ROOT Tuples or preferred data format. <p> Instructions for exploring a DST and writing out ROOT tuples are available in LHCb Starterkit below. For \"tupling\" jobs, software called DaVinci is mainly used within LHCb, its documentation is also available below.",
+      "description": "<p> The data collected by the LHCb detector is available in .DST and .mDST formats. The data files can be explored using LHCb software but it is best to write the relevant columns to ROOT ntuples or a preferred data format. <p> Instructions for exploring a DST and writing out ROOT ntuples are available in the link below. A catalog for exploring the available stripping line selections can be found at the stripping lines index below.",
       "links": [
         {
-          "description": "LHCb StarterKit",
-          "url": "https://lhcb.github.io/starterkit-lessons/first-analysis-steps/minimal-dv-job.html"
-        },
-        {
-          "description": "DaVinci",
-          "url": "http://lhcbdoc.web.cern.ch/lhcbdoc/davinci/"
+          "description": "LHCb Open Data Guide",
+          "url": "https://lhcb-opendata-guide.web.cern.ch/run1-dsts-odp/"
         },
         {
           "description": "Stripping lines index for stripping21r0p1",

--- a/data/records/LHCb_2012_Beam4000GeV_VeloClosed_MagUp_RealData_Reco14_Stripping21r0p1a_SEMILEPTONIC_DST.json
+++ b/data/records/LHCb_2012_Beam4000GeV_VeloClosed_MagUp_RealData_Reco14_Stripping21r0p1a_SEMILEPTONIC_DST.json
@@ -108,15 +108,11 @@
       ]
     },
     "usage": {
-      "description": "<p> The data collected by the LHCb detector is available in .DST and .mDST formats. The data files can be explored using LHCb software but it is best to write the relevant columns to ROOT Tuples or preferred data format. <p> Instructions for exploring a DST and writing out ROOT tuples are available in LHCb Starterkit below. For \"tupling\" jobs, software called DaVinci is mainly used within LHCb, its documentation is also available bellow.",
+      "description": "<p> The data collected by the LHCb detector is available in .DST and .mDST formats. The data files can be explored using LHCb software but it is best to write the relevant columns to ROOT ntuples or a preferred data format. <p> Instructions for exploring a DST and writing out ROOT ntuples are available in the link below. A catalog for exploring the available stripping line selections can be found at the stripping lines index below.",
       "links": [
         {
-          "description": "LHCb StarterKit",
-          "url": "https://lhcb.github.io/starterkit-lessons/first-analysis-steps/minimal-dv-job.html"
-        },
-        {
-          "description": "DaVinci",
-          "url": "http://lhcbdoc.web.cern.ch/lhcbdoc/davinci/"
+          "description": "LHCb Open Data Guide",
+          "url": "https://lhcb-opendata-guide.web.cern.ch/run1-dsts-odp/"
         },
         {
           "description": "Stripping lines index for stripping21r0p1",

--- a/data/records/LHCb_2012_Beam4000GeV_VeloClosed_MagUp_RealData_Reco14_Stripping21r0p2_BHADRONCOMPLETEEVENT_DST.json
+++ b/data/records/LHCb_2012_Beam4000GeV_VeloClosed_MagUp_RealData_Reco14_Stripping21r0p2_BHADRONCOMPLETEEVENT_DST.json
@@ -141,15 +141,11 @@
       ]
     },
     "usage": {
-      "description": "<p> The data collected by the LHCb detector is available in .DST and .mDST formats. The data files can be explored using LHCb software but it is best to write the relevant columns to ROOT Tuples or preferred data format. <p> Instructions for exploring a DST and writing out ROOT tuples are available in LHCb Starterkit below. For \"tupling\" jobs, software called DaVinci is mainly used within LHCb, its documentation is also available bellow.",
+      "description": "<p> The data collected by the LHCb detector is available in .DST and .mDST formats. The data files can be explored using LHCb software but it is best to write the relevant columns to ROOT ntuples or a preferred data format. <p> Instructions for exploring a DST and writing out ROOT ntuples are available in the link below. A catalog for exploring the available stripping line selections can be found at the stripping lines index below.",
       "links": [
         {
-          "description": "LHCb StarterKit",
-          "url": "https://lhcb.github.io/starterkit-lessons/first-analysis-steps/minimal-dv-job.html"
-        },
-        {
-          "description": "DaVinci",
-          "url": "http://lhcbdoc.web.cern.ch/lhcbdoc/davinci/"
+          "description": "LHCb Open Data Guide",
+          "url": "https://lhcb-opendata-guide.web.cern.ch/run1-dsts-odp/"
         },
         {
           "description": "Stripping lines index for stripping21r0p2",

--- a/data/records/LHCb_2012_Beam4000GeV_VeloClosed_MagUp_RealData_Reco14_Stripping21r0p2_BHADRON_MDST.json
+++ b/data/records/LHCb_2012_Beam4000GeV_VeloClosed_MagUp_RealData_Reco14_Stripping21r0p2_BHADRON_MDST.json
@@ -141,15 +141,11 @@
       ]
     },
     "usage": {
-      "description": "<p> The data collected by the LHCb detector is available in .DST and .mDST formats. The data files can be explored using LHCb software but it is best to write the relevant columns to ROOT Tuples or preferred data format. <p> Instructions for exploring a DST and writing out ROOT tuples are available in LHCb Starterkit below. For \"tupling\" jobs, software called DaVinci is mainly used within LHCb, its documentation is also available bellow.",
+      "description": "<p> The data collected by the LHCb detector is available in .DST and .mDST formats. The data files can be explored using LHCb software but it is best to write the relevant columns to ROOT ntuples or a preferred data format. <p> Instructions for exploring a DST and writing out ROOT ntuples are available in the link below. A catalog for exploring the available stripping line selections can be found at the stripping lines index below.",
       "links": [
         {
-          "description": "LHCb StarterKit",
-          "url": "https://lhcb.github.io/starterkit-lessons/first-analysis-steps/minimal-dv-job.html"
-        },
-        {
-          "description": "DaVinci",
-          "url": "http://lhcbdoc.web.cern.ch/lhcbdoc/davinci/"
+          "description": "LHCb Open Data Guide",
+          "url": "https://lhcb-opendata-guide.web.cern.ch/run1-dsts-odp/"
         },
         {
           "description": "Stripping lines index for stripping21r0p2",

--- a/data/records/LHCb_2012_Beam4000GeV_VeloClosed_MagUp_RealData_Reco14_Stripping21r0p2_CHARMCOMPLETEEVENT_DST.json
+++ b/data/records/LHCb_2012_Beam4000GeV_VeloClosed_MagUp_RealData_Reco14_Stripping21r0p2_CHARMCOMPLETEEVENT_DST.json
@@ -141,15 +141,11 @@
       ]
     },
     "usage": {
-      "description": "<p> The data collected by the LHCb detector is available in .DST and .mDST formats. The data files can be explored using LHCb software but it is best to write the relevant columns to ROOT Tuples or preferred data format. <p> Instructions for exploring a DST and writing out ROOT tuples are available in LHCb Starterkit below. For \"tupling\" jobs, software called DaVinci is mainly used within LHCb, its documentation is also available bellow.",
+      "description": "<p> The data collected by the LHCb detector is available in .DST and .mDST formats. The data files can be explored using LHCb software but it is best to write the relevant columns to ROOT ntuples or a preferred data format. <p> Instructions for exploring a DST and writing out ROOT ntuples are available in the link below. A catalog for exploring the available stripping line selections can be found at the stripping lines index below.",
       "links": [
         {
-          "description": "LHCb StarterKit",
-          "url": "https://lhcb.github.io/starterkit-lessons/first-analysis-steps/minimal-dv-job.html"
-        },
-        {
-          "description": "DaVinci",
-          "url": "http://lhcbdoc.web.cern.ch/lhcbdoc/davinci/"
+          "description": "LHCb Open Data Guide",
+          "url": "https://lhcb-opendata-guide.web.cern.ch/run1-dsts-odp/"
         },
         {
           "description": "Stripping lines index for stripping21r0p2",

--- a/data/records/LHCb_2012_Beam4000GeV_VeloClosed_MagUp_RealData_Reco14_Stripping21r0p2_CHARM_MDST.json
+++ b/data/records/LHCb_2012_Beam4000GeV_VeloClosed_MagUp_RealData_Reco14_Stripping21r0p2_CHARM_MDST.json
@@ -141,15 +141,11 @@
       ]
     },
     "usage": {
-      "description": "<p> The data collected by the LHCb detector is available in .DST and .mDST formats. The data files can be explored using LHCb software but it is best to write the relevant columns to ROOT Tuples or preferred data format. <p> Instructions for exploring a DST and writing out ROOT tuples are available in LHCb Starterkit below. For \"tupling\" jobs, software called DaVinci is mainly used within LHCb, its documentation is also available bellow.",
+      "description": "<p> The data collected by the LHCb detector is available in .DST and .mDST formats. The data files can be explored using LHCb software but it is best to write the relevant columns to ROOT ntuples or a preferred data format. <p> Instructions for exploring a DST and writing out ROOT ntuples are available in the link below. A catalog for exploring the available stripping line selections can be found at the stripping lines index below.",
       "links": [
         {
-          "description": "LHCb StarterKit",
-          "url": "https://lhcb.github.io/starterkit-lessons/first-analysis-steps/minimal-dv-job.html"
-        },
-        {
-          "description": "DaVinci",
-          "url": "http://lhcbdoc.web.cern.ch/lhcbdoc/davinci/"
+          "description": "LHCb Open Data Guide",
+          "url": "https://lhcb-opendata-guide.web.cern.ch/run1-dsts-odp/"
         },
         {
           "description": "Stripping lines index for stripping21r0p2",

--- a/data/records/LHCb_2012_Beam4000GeV_VeloClosed_MagUp_RealData_Reco14_Stripping21r0p2_DIMUON_DST.json
+++ b/data/records/LHCb_2012_Beam4000GeV_VeloClosed_MagUp_RealData_Reco14_Stripping21r0p2_DIMUON_DST.json
@@ -141,15 +141,11 @@
       ]
     },
     "usage": {
-      "description": "<p> The data collected by the LHCb detector is available in .DST and .mDST formats. The data files can be explored using LHCb software but it is best to write the relevant columns to ROOT Tuples or preferred data format. <p> Instructions for exploring a DST and writing out ROOT tuples are available in LHCb Starterkit below. For \"tupling\" jobs, software called DaVinci is mainly used within LHCb, its documentation is also available bellow.",
+      "description": "<p> The data collected by the LHCb detector is available in .DST and .mDST formats. The data files can be explored using LHCb software but it is best to write the relevant columns to ROOT ntuples or a preferred data format. <p> Instructions for exploring a DST and writing out ROOT ntuples are available in the link below. A catalog for exploring the available stripping line selections can be found at the stripping lines index below.",
       "links": [
         {
-          "description": "LHCb StarterKit",
-          "url": "https://lhcb.github.io/starterkit-lessons/first-analysis-steps/minimal-dv-job.html"
-        },
-        {
-          "description": "DaVinci",
-          "url": "http://lhcbdoc.web.cern.ch/lhcbdoc/davinci/"
+          "description": "LHCb Open Data Guide",
+          "url": "https://lhcb-opendata-guide.web.cern.ch/run1-dsts-odp/"
         },
         {
           "description": "Stripping lines index for stripping21r0p2",

--- a/data/records/LHCb_2012_Beam4000GeV_VeloClosed_MagUp_RealData_Reco14_Stripping21r0p2_EW_DST.json
+++ b/data/records/LHCb_2012_Beam4000GeV_VeloClosed_MagUp_RealData_Reco14_Stripping21r0p2_EW_DST.json
@@ -141,15 +141,11 @@
       ]
     },
     "usage": {
-      "description": "<p> The data collected by the LHCb detector is available in .DST and .mDST formats. The data files can be explored using LHCb software but it is best to write the relevant columns to ROOT Tuples or preferred data format. <p> Instructions for exploring a DST and writing out ROOT tuples are available in LHCb Starterkit below. For \"tupling\" jobs, software called DaVinci is mainly used within LHCb, its documentation is also available below.",
+      "description": "<p> The data collected by the LHCb detector is available in .DST and .mDST formats. The data files can be explored using LHCb software but it is best to write the relevant columns to ROOT ntuples or a preferred data format. <p> Instructions for exploring a DST and writing out ROOT ntuples are available in the link below. A catalog for exploring the available stripping line selections can be found at the stripping lines index below.",
       "links": [
         {
-          "description": "LHCb StarterKit",
-          "url": "https://lhcb.github.io/starterkit-lessons/first-analysis-steps/minimal-dv-job.html"
-        },
-        {
-          "description": "DaVinci",
-          "url": "http://lhcbdoc.web.cern.ch/lhcbdoc/davinci/"
+          "description": "LHCb Open Data Guide",
+          "url": "https://lhcb-opendata-guide.web.cern.ch/run1-dsts-odp/"
         },
         {
           "description": "Stripping lines index for stripping21r0p2",

--- a/data/records/LHCb_2012_Beam4000GeV_VeloClosed_MagUp_RealData_Reco14_Stripping21r0p2_LEPTONIC_MDST.json
+++ b/data/records/LHCb_2012_Beam4000GeV_VeloClosed_MagUp_RealData_Reco14_Stripping21r0p2_LEPTONIC_MDST.json
@@ -141,15 +141,11 @@
       ]
     },
     "usage": {
-      "description": "<p> The data collected by the LHCb detector is available in .DST and .mDST formats. The data files can be explored using LHCb software but it is best to write the relevant columns to ROOT Tuples or preferred data format. <p> Instructions for exploring a DST and writing out ROOT tuples are available in LHCb Starterkit below. For \"tupling\" jobs, software called DaVinci is mainly used within LHCb, its documentation is also available below.",
+      "description": "<p> The data collected by the LHCb detector is available in .DST and .mDST formats. The data files can be explored using LHCb software but it is best to write the relevant columns to ROOT ntuples or a preferred data format. <p> Instructions for exploring a DST and writing out ROOT ntuples are available in the link below. A catalog for exploring the available stripping line selections can be found at the stripping lines index below.",
       "links": [
         {
-          "description": "LHCb StarterKit",
-          "url": "https://lhcb.github.io/starterkit-lessons/first-analysis-steps/minimal-dv-job.html"
-        },
-        {
-          "description": "DaVinci",
-          "url": "http://lhcbdoc.web.cern.ch/lhcbdoc/davinci/"
+          "description": "LHCb Open Data Guide",
+          "url": "https://lhcb-opendata-guide.web.cern.ch/run1-dsts-odp/"
         },
         {
           "description": "Stripping lines index for stripping21r0p2",

--- a/data/records/LHCb_2012_Beam4000GeV_VeloClosed_MagUp_RealData_Reco14_Stripping21r0p2_SEMILEPTONIC_DST.json
+++ b/data/records/LHCb_2012_Beam4000GeV_VeloClosed_MagUp_RealData_Reco14_Stripping21r0p2_SEMILEPTONIC_DST.json
@@ -141,15 +141,11 @@
       ]
     },
     "usage": {
-      "description": "<p> The data collected by the LHCb detector is available in .DST and .mDST formats. The data files can be explored using LHCb software but it is best to write the relevant columns to ROOT Tuples or preferred data format. <p> Instructions for exploring a DST and writing out ROOT tuples are available in LHCb Starterkit below. For \"tupling\" jobs, software called DaVinci is mainly used within LHCb, its documentation is also available bellow.",
+      "description": "<p> The data collected by the LHCb detector is available in .DST and .mDST formats. The data files can be explored using LHCb software but it is best to write the relevant columns to ROOT ntuples or a preferred data format. <p> Instructions for exploring a DST and writing out ROOT ntuples are available in the link below. A catalog for exploring the available stripping line selections can be found at the stripping lines index below.",
       "links": [
         {
-          "description": "LHCb StarterKit",
-          "url": "https://lhcb.github.io/starterkit-lessons/first-analysis-steps/minimal-dv-job.html"
-        },
-        {
-          "description": "DaVinci",
-          "url": "http://lhcbdoc.web.cern.ch/lhcbdoc/davinci/"
+          "description": "LHCb Open Data Guide",
+          "url": "https://lhcb-opendata-guide.web.cern.ch/run1-dsts-odp/"
         },
         {
           "description": "Stripping lines index for stripping21r0p2",


### PR DESCRIPTION
Updates the usage instructions and links for all 99 LHCb Run 1 DST and MDST collision records:
- Points instructions to the [LHCb Open Data Guide](https://lhcb-opendata-guide.web.cern.ch/run1-dsts-odp/)
- Replaces obsolete StarterKit and DaVinci links
- Preserves the record-specific stripping line catalog index

Closes #3736