### PR TITLE
ci(scripts): make license checker quiet by default (closes #3716, #3731)

### DIFF
--- a/scripts/check_licenses.py
+++ b/scripts/check_licenses.py
@@ -2,6 +2,7 @@
 
 """Check if license fields are valid in all records."""
 
+import argparse
 import asyncio
 import json
 import logging
@@ -17,16 +18,19 @@ VALID_LICENSE_IDENTIFIERS = [
     "BSD-3-Clause",
 ]
 
-logging.basicConfig(level=logging.INFO, format="[%(levelname)s] %(message)s")
-
 
 async def validate_file(path: pathlib.Path) -> int:
     """Validate a single file."""
     checks = 0
     errors = 0
-    records = await asyncio.get_event_loop().run_in_executor(
-        None, lambda p: json.loads(open(p, "rb").read()), path
-    )
+    try:
+        content = await asyncio.get_event_loop().run_in_executor(
+            None, lambda p: open(p, "rb").read(), path
+        )
+        records = json.loads(content)
+    except Exception as e:
+        logging.error(f"Failed to read or parse JSON file {path.name}: {e}")
+        raise ValueError(1)
 
     for record in records:
         if rec_licenses := record.get("license"):
@@ -34,7 +38,10 @@ async def validate_file(path: pathlib.Path) -> int:
                 attr = rec_licenses["attribution"]
             except KeyError:
                 recid = record.get("recid", "UNSET")
-                message = f"License field set but without attribution in file {path.name} with recid {recid}!"
+                message = (
+                    f"License field set but without attribution in file {path.name} "
+                    f"with recid {recid}!"
+                )
 
                 logging.error(message)
                 errors += 1
@@ -42,7 +49,10 @@ async def validate_file(path: pathlib.Path) -> int:
 
             if attr not in VALID_LICENSE_IDENTIFIERS:
                 recid = record.get("recid", "UNSET")
-                message = f"Invalid license identifier `{attr}` in file {path.name} for recid {recid}! "
+                message = (
+                    f"Invalid license identifier `{attr}` in file {path.name} "
+                    f"for recid {recid}!"
+                )
 
                 logging.error(message)
                 errors += 1
@@ -56,7 +66,7 @@ async def validate_file(path: pathlib.Path) -> int:
     return checks
 
 
-async def check_all_paths():
+async def check_all_paths(verbose: bool = False):
     """Execute checks on all found files."""
     start_time = time.perf_counter()
 
@@ -69,7 +79,10 @@ async def check_all_paths():
     results = await asyncio.gather(*tasks, return_exceptions=True)
 
     finish_time = time.perf_counter() - start_time
-    logging.info(f"Processed {len(all_paths)} files within {finish_time:.2f} seconds.")
+    if verbose:
+        logging.info(
+            f"Processed {len(all_paths)} files within {finish_time:.2f} seconds."
+        )
 
     if any(isinstance(result, Exception) for result in results):
         errors = sum(
@@ -81,21 +94,39 @@ async def check_all_paths():
         )
         logging.error(
             f"Validation completed with {errors} errors!\n"
-            f"\tPlease ensure the licenses are one of the following: {VALID_LICENSE_IDENTIFIERS}.\n"
-            f"\tIf you are using a valid SPDX license string that is not in the above list, "
-            f"please contact `opendata-team@cern.ch`."
+            f"\tPlease ensure the licenses are one of the following: "
+            f"{VALID_LICENSE_IDENTIFIERS}.\n"
+            f"\tIf you are using a valid SPDX license string that is not in the "
+            f"above list, please contact `opendata-team@cern.ch`."
         )
         exit(1)
 
     else:
-        logging.info(f"Successfully validated {sum(results)} records. No errors found.")
+        if verbose:
+            logging.info(
+                f"Successfully validated {sum(results)} records. No errors found."
+            )
 
 
 def main():
     """Test to validate all license fields."""
+    parser = argparse.ArgumentParser(
+        description="Check if license fields are valid in all records."
+    )
+    parser.add_argument(
+        "-v",
+        "--verbose",
+        action="store_true",
+        help="Increase output verbosity to show informational messages.",
+    )
+    args = parser.parse_args()
+
+    log_level = logging.INFO if args.verbose else logging.WARNING
+    logging.basicConfig(level=log_level, format="[%(levelname)s] %(message)s")
+
     loop = asyncio.new_event_loop()
     try:
-        loop.run_until_complete(check_all_paths())
+        loop.run_until_complete(check_all_paths(verbose=args.verbose))
     finally:
         loop.close()
 


### PR DESCRIPTION
### Description
Currently, `scripts/check_licenses.py` outputs hundreds of informational `[INFO] Successfully validated file ...` messages by default, unlike standard linter/checking scripts which are quiet when successful. Furthermore, if a file fails to read or parse (e.g. invalid JSON), the exception was swallowed into a generic validation failure count without logging the offending file.

### Changes
- Configured default log level to `WARNING` so that only errors and warnings are printed by default, adhering to standard CI linter conventions.
- Added `-v` / `--verbose` CLI option to display detailed informational output and statistics when requested.
- Added explicit error logging in `validate_file` when reading/parsing JSON fails, identifying the problematic file name and exception.

Closes #3716.
Closes #3731.