### PR TITLE
docs(cms): point old getting started pages to new ones (closes #3614)

### DIFF
--- a/data/docs/cms-getting-started-2010/cms-getting-started-2010.md
+++ b/data/docs/cms-getting-started-2010/cms-getting-started-2010.md
@@ -1,3 +1,5 @@
+> **Note**: This page is kept for reference. Please see the consolidated [Getting Started with CMS AOD Data](/docs/cms-getting-started-aod) guide for up-to-date instructions.
+
 1. ["I have installed the CERN Virtual Machine: now what?"](#vm)
 2. ["Do I have to use a virtual machine?"](#container)
 3. ["OK! Where can I get the CMS data?"](#data)

--- a/data/docs/cms-getting-started-2011/cms-getting-started-2011.md
+++ b/data/docs/cms-getting-started-2011/cms-getting-started-2011.md
@@ -1,3 +1,5 @@
+> **Note**: This page is kept for reference. Please see the consolidated [Getting Started with CMS AOD Data](/docs/cms-getting-started-aod) guide for up-to-date instructions.
+
 1. ["I have installed the CMS open data environment: now what?"](#vm)
 2. ["OK! What is in the CMS data?"](#data)
 3. ["Nice! But how do I analyse these data?"](#nice)

--- a/data/docs/cms-getting-started-2015/cms-getting-started-2015.md
+++ b/data/docs/cms-getting-started-2015/cms-getting-started-2015.md
@@ -1,3 +1,5 @@
+> **Note**: This page is kept for reference. Please see the consolidated [Getting Started with CMS MiniAOD Open Data](/docs/cms-getting-started-miniaod) guide for up-to-date instructions.
+
 1. ["I have installed the CMS open data environment: now what?"](#vm)
 2. ["OK! What is in the CMS data?"](#data)
 3. ["Nice! But how do I analyse these data?"](#nice)


### PR DESCRIPTION
Points the older CMS getting started documentation pages to the consolidated guides:

- `cms-getting-started-2010` -> `/docs/cms-getting-started-aod`
- `cms-getting-started-2011` -> `/docs/cms-getting-started-aod`
- `cms-getting-started-2015` -> `/docs/cms-getting-started-miniaod`

Closes #3614.