### PR TITLE
fix(records): fix HLT config links in trigger paths (closes #3647)

### DIFF
--- a/data/records/cms-hlt-trigger-paths-2012.json
+++ b/data/records/cms-hlt-trigger-paths-2012.json
@@ -1248,7 +1248,7 @@
   },
   {
     "abstract": {
-      "description": " <p>High-Level Trigger path information HLT_CentralPFJet80_CaloMET50_dPhi1_PFMHT80_HBHENoiseFiltered (MET dataset).</p><blockquote><p>first seen online on run 190456 (<a href=\"/record/6123\">/cdaq/physics/Run2012/5e33/v4.4/HLT/V5</a>)</p><p>last  seen online on run 193621 (<a href=\"/record/6109\"><a href=\"/record/6125\">/cdaq/physics/Run2012/5e33/v4.16/HLT/V2</a>1</a>)</p><p>V3: (runs 190456 - 190738) seeded by: L1_ETM36 OR L1_ETM40</p><p>V4: (runs 190782 - 191411) seeded by: L1_ETM36 OR L1_ETM40</p><p>V5: (runs 191691 - 193621) seeded by: L1_ETM36 OR L1_ETM40</p></blockquote><p>See also the full list of triggers for CMS 2012 open data:<a href=\"/record/1701\">Trigger information for 2012 CMS open data</a></p>"
+      "description": " <p>High-Level Trigger path information HLT_CentralPFJet80_CaloMET50_dPhi1_PFMHT80_HBHENoiseFiltered (MET dataset).</p><blockquote><p>first seen online on run 190456 (<a href=\"/record/6123\">/cdaq/physics/Run2012/5e33/v4.4/HLT/V5</a>)</p><p>last  seen online on run 193621 (<a href=\"/record/6109\">/cdaq/physics/Run2012/5e33/v4.16/HLT/V21</a>)</p><p>V3: (runs 190456 - 190738) seeded by: L1_ETM36 OR L1_ETM40</p><p>V4: (runs 190782 - 191411) seeded by: L1_ETM36 OR L1_ETM40</p><p>V5: (runs 191691 - 193621) seeded by: L1_ETM36 OR L1_ETM40</p></blockquote><p>See also the full list of triggers for CMS 2012 open data:<a href=\"/record/1701\">Trigger information for 2012 CMS open data</a></p>"
     },
     "accelerator": "CERN-LHC",
     "collaboration": {
@@ -1683,7 +1683,7 @@
   },
   {
     "abstract": {
-      "description": " <p>High-Level Trigger path information HLT_DiCentralJet20_BTagIP_MET65_HBHENoiseFiltered_dPhi1 (MET dataset).</p><blockquote><p>first seen online on run 190456 (<a href=\"/record/6123\">/cdaq/physics/Run2012/5e33/v4.4/HLT/V5</a>)</p><p>last  seen online on run 193621 (<a href=\"/record/6109\"><a href=\"/record/6125\">/cdaq/physics/Run2012/5e33/v4.16/HLT/V2</a>1</a>)</p><p>V3: (runs 190456 - 190738) seeded by: L1_ETM36 OR L1_ETM40</p><p>V4: (runs 190782 - 193621) seeded by: L1_ETM36 OR L1_ETM40</p></blockquote><p>See also the full list of triggers for CMS 2012 open data:<a href=\"/record/1701\">Trigger information for 2012 CMS open data</a></p>"
+      "description": " <p>High-Level Trigger path information HLT_DiCentralJet20_BTagIP_MET65_HBHENoiseFiltered_dPhi1 (MET dataset).</p><blockquote><p>first seen online on run 190456 (<a href=\"/record/6123\">/cdaq/physics/Run2012/5e33/v4.4/HLT/V5</a>)</p><p>last  seen online on run 193621 (<a href=\"/record/6109\">/cdaq/physics/Run2012/5e33/v4.16/HLT/V21</a>)</p><p>V3: (runs 190456 - 190738) seeded by: L1_ETM36 OR L1_ETM40</p><p>V4: (runs 190782 - 193621) seeded by: L1_ETM36 OR L1_ETM40</p></blockquote><p>See also the full list of triggers for CMS 2012 open data:<a href=\"/record/1701\">Trigger information for 2012 CMS open data</a></p>"
     },
     "accelerator": "CERN-LHC",
     "collaboration": {
@@ -1712,7 +1712,7 @@
   },
   {
     "abstract": {
-      "description": " <p>High-Level Trigger path information HLT_DiCentralJet20_CaloMET65_BTagCSV07_PFMHT80 (MET dataset).</p><blockquote><p>first seen online on run 190456 (<a href=\"/record/6123\">/cdaq/physics/Run2012/5e33/v4.4/HLT/V5</a>)</p><p>last  seen online on run 193621 (<a href=\"/record/6109\"><a href=\"/record/6125\">/cdaq/physics/Run2012/5e33/v4.16/HLT/V2</a>1</a>)</p><p>V2: (runs 190456 - 190738) seeded by: L1_ETM36 OR L1_ETM40</p><p>V3: (runs 190782 - 191411) seeded by: L1_ETM36 OR L1_ETM40</p><p>V4: (runs 191691 - 193621) seeded by: L1_ETM36 OR L1_ETM40</p></blockquote><p>See also the full list of triggers for CMS 2012 open data:<a href=\"/record/1701\">Trigger information for 2012 CMS open data</a></p>"
+      "description": " <p>High-Level Trigger path information HLT_DiCentralJet20_CaloMET65_BTagCSV07_PFMHT80 (MET dataset).</p><blockquote><p>first seen online on run 190456 (<a href=\"/record/6123\">/cdaq/physics/Run2012/5e33/v4.4/HLT/V5</a>)</p><p>last  seen online on run 193621 (<a href=\"/record/6109\">/cdaq/physics/Run2012/5e33/v4.16/HLT/V21</a>)</p><p>V2: (runs 190456 - 190738) seeded by: L1_ETM36 OR L1_ETM40</p><p>V3: (runs 190782 - 191411) seeded by: L1_ETM36 OR L1_ETM40</p><p>V4: (runs 191691 - 193621) seeded by: L1_ETM36 OR L1_ETM40</p></blockquote><p>See also the full list of triggers for CMS 2012 open data:<a href=\"/record/1701\">Trigger information for 2012 CMS open data</a></p>"
     },
     "accelerator": "CERN-LHC",
     "collaboration": {
@@ -1770,7 +1770,7 @@
   },
   {
     "abstract": {
-      "description": " <p>High-Level Trigger path information HLT_DiCentralPFJet30_CaloMET50_dPhi1_PFMHT80_HBHENoiseFiltered (MET dataset).</p><blockquote><p>first seen online on run 190456 (<a href=\"/record/6123\">/cdaq/physics/Run2012/5e33/v4.4/HLT/V5</a>)</p><p>last  seen online on run 193621 (<a href=\"/record/6109\"><a href=\"/record/6125\">/cdaq/physics/Run2012/5e33/v4.16/HLT/V2</a>1</a>)</p><p>V3: (runs 190456 - 190738) seeded by: L1_ETM36 OR L1_ETM40</p><p>V4: (runs 190782 - 191411) seeded by: L1_ETM36 OR L1_ETM40</p><p>V5: (runs 191691 - 193621) seeded by: L1_ETM36 OR L1_ETM40</p></blockquote><p>See also the full list of triggers for CMS 2012 open data:<a href=\"/record/1701\">Trigger information for 2012 CMS open data</a></p>"
+      "description": " <p>High-Level Trigger path information HLT_DiCentralPFJet30_CaloMET50_dPhi1_PFMHT80_HBHENoiseFiltered (MET dataset).</p><blockquote><p>first seen online on run 190456 (<a href=\"/record/6123\">/cdaq/physics/Run2012/5e33/v4.4/HLT/V5</a>)</p><p>last  seen online on run 193621 (<a href=\"/record/6109\">/cdaq/physics/Run2012/5e33/v4.16/HLT/V21</a>)</p><p>V3: (runs 190456 - 190738) seeded by: L1_ETM36 OR L1_ETM40</p><p>V4: (runs 190782 - 191411) seeded by: L1_ETM36 OR L1_ETM40</p><p>V5: (runs 191691 - 193621) seeded by: L1_ETM36 OR L1_ETM40</p></blockquote><p>See also the full list of triggers for CMS 2012 open data:<a href=\"/record/1701\">Trigger information for 2012 CMS open data</a></p>"
     },
     "accelerator": "CERN-LHC",
     "collaboration": {
@@ -1857,7 +1857,7 @@
   },
   {
     "abstract": {
-      "description": " <p>High-Level Trigger path information HLT_DiCentralPFJet30_PFMHT80 (MET dataset).</p><blockquote><p>first seen online on run 190456 (<a href=\"/record/6123\">/cdaq/physics/Run2012/5e33/v4.4/HLT/V5</a>)</p><p>last  seen online on run 193621 (<a href=\"/record/6109\"><a href=\"/record/6125\">/cdaq/physics/Run2012/5e33/v4.16/HLT/V2</a>1</a>)</p><p>V5: (runs 190456 - 190738) seeded by: L1_ETM36 OR L1_ETM40</p><p>V6: (runs 190782 - 191411) seeded by: L1_ETM36 OR L1_ETM40</p><p>V7: (runs 191691 - 193621) seeded by: L1_ETM36 OR L1_ETM40</p></blockquote><p>See also the full list of triggers for CMS 2012 open data:<a href=\"/record/1701\">Trigger information for 2012 CMS open data</a></p>"
+      "description": " <p>High-Level Trigger path information HLT_DiCentralPFJet30_PFMHT80 (MET dataset).</p><blockquote><p>first seen online on run 190456 (<a href=\"/record/6123\">/cdaq/physics/Run2012/5e33/v4.4/HLT/V5</a>)</p><p>last  seen online on run 193621 (<a href=\"/record/6109\">/cdaq/physics/Run2012/5e33/v4.16/HLT/V21</a>)</p><p>V5: (runs 190456 - 190738) seeded by: L1_ETM36 OR L1_ETM40</p><p>V6: (runs 190782 - 191411) seeded by: L1_ETM36 OR L1_ETM40</p><p>V7: (runs 191691 - 193621) seeded by: L1_ETM36 OR L1_ETM40</p></blockquote><p>See also the full list of triggers for CMS 2012 open data:<a href=\"/record/1701\">Trigger information for 2012 CMS open data</a></p>"
     },
     "accelerator": "CERN-LHC",
     "collaboration": {
@@ -2089,7 +2089,7 @@
   },
   {
     "abstract": {
-      "description": " <p>High-Level Trigger path information HLT_DiJet40Eta2p6_BTagIP3D (MultiJet dataset).</p><blockquote><p>first seen online on run 190456 (<a href=\"/record/6123\">/cdaq/physics/Run2012/5e33/v4.4/HLT/V5</a>)</p><p>last  seen online on run 193621 (<a href=\"/record/6109\"><a href=\"/record/6125\">/cdaq/physics/Run2012/5e33/v4.16/HLT/V2</a>1</a>)</p><p>V2: (runs 190456 - 190738) seeded by: L1_DoubleJetC36</p><p>V3: (runs 190782 - 193621) seeded by: L1_DoubleJetC36</p></blockquote><p>See also the full list of triggers for CMS 2012 open data:<a href=\"/record/1701\">Trigger information for 2012 CMS open data</a></p>"
+      "description": " <p>High-Level Trigger path information HLT_DiJet40Eta2p6_BTagIP3D (MultiJet dataset).</p><blockquote><p>first seen online on run 190456 (<a href=\"/record/6123\">/cdaq/physics/Run2012/5e33/v4.4/HLT/V5</a>)</p><p>last  seen online on run 193621 (<a href=\"/record/6109\">/cdaq/physics/Run2012/5e33/v4.16/HLT/V21</a>)</p><p>V2: (runs 190456 - 190738) seeded by: L1_DoubleJetC36</p><p>V3: (runs 190782 - 193621) seeded by: L1_DoubleJetC36</p></blockquote><p>See also the full list of triggers for CMS 2012 open data:<a href=\"/record/1701\">Trigger information for 2012 CMS open data</a></p>"
     },
     "accelerator": "CERN-LHC",
     "collaboration": {
@@ -2176,7 +2176,7 @@
   },
   {
     "abstract": {
-      "description": " <p>High-Level Trigger path information HLT_DiJet80Eta2p6_BTagIP3DLoose (MultiJet dataset).</p><blockquote><p>first seen online on run 190456 (<a href=\"/record/6123\">/cdaq/physics/Run2012/5e33/v4.4/HLT/V5</a>)</p><p>last  seen online on run 193621 (<a href=\"/record/6109\"><a href=\"/record/6125\">/cdaq/physics/Run2012/5e33/v4.16/HLT/V2</a>1</a>)</p><p>V2: (runs 190456 - 190738) seeded by: L1_DoubleJetC36</p><p>V3: (runs 190782 - 193621) seeded by: L1_DoubleJetC36</p></blockquote><p>See also the full list of triggers for CMS 2012 open data:<a href=\"/record/1701\">Trigger information for 2012 CMS open data</a></p>"
+      "description": " <p>High-Level Trigger path information HLT_DiJet80Eta2p6_BTagIP3DLoose (MultiJet dataset).</p><blockquote><p>first seen online on run 190456 (<a href=\"/record/6123\">/cdaq/physics/Run2012/5e33/v4.4/HLT/V5</a>)</p><p>last  seen online on run 193621 (<a href=\"/record/6109\">/cdaq/physics/Run2012/5e33/v4.16/HLT/V21</a>)</p><p>V2: (runs 190456 - 190738) seeded by: L1_DoubleJetC36</p><p>V3: (runs 190782 - 193621) seeded by: L1_DoubleJetC36</p></blockquote><p>See also the full list of triggers for CMS 2012 open data:<a href=\"/record/1701\">Trigger information for 2012 CMS open data</a></p>"
     },
     "accelerator": "CERN-LHC",
     "collaboration": {
@@ -3539,7 +3539,7 @@
   },
   {
     "abstract": {
-      "description": " <p>High-Level Trigger path information HLT_DoubleMediumIsoPFTau25_Trk5_eta2p1_Jet30 (Tau dataset).</p><blockquote><p>first seen online on run 190456 (<a href=\"/record/6123\">/cdaq/physics/Run2012/5e33/v4.4/HLT/V5</a>)</p><p>last  seen online on run 193621 (<a href=\"/record/6109\"><a href=\"/record/6125\">/cdaq/physics/Run2012/5e33/v4.16/HLT/V2</a>1</a>)</p><p>V2: (runs 190456 - 190738) seeded by: L1_DoubleTauJet44er OR L1_DoubleJetC64</p><p>V3: (runs 190782 - 191411) seeded by: L1_DoubleTauJet44er OR L1_DoubleJetC64</p><p>V4: (runs 191691 - 193621) seeded by: L1_DoubleTauJet44er OR L1_DoubleJetC64</p></blockquote><p>See also the full list of triggers for CMS 2012 open data:<a href=\"/record/1701\">Trigger information for 2012 CMS open data</a></p>"
+      "description": " <p>High-Level Trigger path information HLT_DoubleMediumIsoPFTau25_Trk5_eta2p1_Jet30 (Tau dataset).</p><blockquote><p>first seen online on run 190456 (<a href=\"/record/6123\">/cdaq/physics/Run2012/5e33/v4.4/HLT/V5</a>)</p><p>last  seen online on run 193621 (<a href=\"/record/6109\">/cdaq/physics/Run2012/5e33/v4.16/HLT/V21</a>)</p><p>V2: (runs 190456 - 190738) seeded by: L1_DoubleTauJet44er OR L1_DoubleJetC64</p><p>V3: (runs 190782 - 191411) seeded by: L1_DoubleTauJet44er OR L1_DoubleJetC64</p><p>V4: (runs 191691 - 193621) seeded by: L1_DoubleTauJet44er OR L1_DoubleJetC64</p></blockquote><p>See also the full list of triggers for CMS 2012 open data:<a href=\"/record/1701\">Trigger information for 2012 CMS open data</a></p>"
     },
     "accelerator": "CERN-LHC",
     "collaboration": {
@@ -4496,7 +4496,7 @@
   },
   {
     "abstract": {
-      "description": " <p>High-Level Trigger path information HLT_DoublePhoton43_HEVT (Photon dataset).</p><blockquote><p>first seen online on run 190456 (<a href=\"/record/6123\">/cdaq/physics/Run2012/5e33/v4.4/HLT/V5</a>)</p><p>last  seen online on run 193621 (<a href=\"/record/6109\"><a href=\"/record/6125\">/cdaq/physics/Run2012/5e33/v4.16/HLT/V2</a>1</a>)</p><p>V5: (runs 190456 - 190738) seeded by: L1_SingleEG20 OR L1_SingleEG22</p><p>V6: (runs 190782 - 191411) seeded by: L1_SingleEG20 OR L1_SingleEG22</p><p>V7: (runs 191691 - 193621) seeded by: L1_SingleEG20 OR L1_SingleEG22</p></blockquote><p>See also the full list of triggers for CMS 2012 open data:<a href=\"/record/1701\">Trigger information for 2012 CMS open data</a></p>"
+      "description": " <p>High-Level Trigger path information HLT_DoublePhoton43_HEVT (Photon dataset).</p><blockquote><p>first seen online on run 190456 (<a href=\"/record/6123\">/cdaq/physics/Run2012/5e33/v4.4/HLT/V5</a>)</p><p>last  seen online on run 193621 (<a href=\"/record/6109\">/cdaq/physics/Run2012/5e33/v4.16/HLT/V21</a>)</p><p>V5: (runs 190456 - 190738) seeded by: L1_SingleEG20 OR L1_SingleEG22</p><p>V6: (runs 190782 - 191411) seeded by: L1_SingleEG20 OR L1_SingleEG22</p><p>V7: (runs 191691 - 193621) seeded by: L1_SingleEG20 OR L1_SingleEG22</p></blockquote><p>See also the full list of triggers for CMS 2012 open data:<a href=\"/record/1701\">Trigger information for 2012 CMS open data</a></p>"
     },
     "accelerator": "CERN-LHC",
     "collaboration": {
@@ -4844,7 +4844,7 @@
   },
   {
     "abstract": {
-      "description": " <p>High-Level Trigger path information HLT_EightJet35 (MultiJet dataset).</p><blockquote><p>first seen online on run 190456 (<a href=\"/record/6123\">/cdaq/physics/Run2012/5e33/v4.4/HLT/V5</a>)</p><p>last  seen online on run 193621 (<a href=\"/record/6109\"><a href=\"/record/6125\">/cdaq/physics/Run2012/5e33/v4.16/HLT/V2</a>1</a>)</p><p>V1: (runs 190456 - 190738) seeded by: L1_HTT150 OR L1_HTT175</p><p>V2: (runs 190782 - 193621) seeded by: L1_HTT150 OR L1_HTT175</p></blockquote><p>See also the full list of triggers for CMS 2012 open data:<a href=\"/record/1701\">Trigger information for 2012 CMS open data</a></p>"
+      "description": " <p>High-Level Trigger path information HLT_EightJet35 (MultiJet dataset).</p><blockquote><p>first seen online on run 190456 (<a href=\"/record/6123\">/cdaq/physics/Run2012/5e33/v4.4/HLT/V5</a>)</p><p>last  seen online on run 193621 (<a href=\"/record/6109\">/cdaq/physics/Run2012/5e33/v4.16/HLT/V21</a>)</p><p>V1: (runs 190456 - 190738) seeded by: L1_HTT150 OR L1_HTT175</p><p>V2: (runs 190782 - 193621) seeded by: L1_HTT150 OR L1_HTT175</p></blockquote><p>See also the full list of triggers for CMS 2012 open data:<a href=\"/record/1701\">Trigger information for 2012 CMS open data</a></p>"
     },
     "accelerator": "CERN-LHC",
     "collaboration": {
@@ -4902,7 +4902,7 @@
   },
   {
     "abstract": {
-      "description": " <p>High-Level Trigger path information HLT_EightJet40 (MultiJet dataset).</p><blockquote><p>first seen online on run 190456 (<a href=\"/record/6123\">/cdaq/physics/Run2012/5e33/v4.4/HLT/V5</a>)</p><p>last  seen online on run 193621 (<a href=\"/record/6109\"><a href=\"/record/6125\">/cdaq/physics/Run2012/5e33/v4.16/HLT/V2</a>1</a>)</p><p>V1: (runs 190456 - 190738) seeded by: L1_HTT150 OR L1_HTT175</p><p>V2: (runs 190782 - 193621) seeded by: L1_HTT150 OR L1_HTT175</p></blockquote><p>See also the full list of triggers for CMS 2012 open data:<a href=\"/record/1701\">Trigger information for 2012 CMS open data</a></p>"
+      "description": " <p>High-Level Trigger path information HLT_EightJet40 (MultiJet dataset).</p><blockquote><p>first seen online on run 190456 (<a href=\"/record/6123\">/cdaq/physics/Run2012/5e33/v4.4/HLT/V5</a>)</p><p>last  seen online on run 193621 (<a href=\"/record/6109\">/cdaq/physics/Run2012/5e33/v4.16/HLT/V21</a>)</p><p>V1: (runs 190456 - 190738) seeded by: L1_HTT150 OR L1_HTT175</p><p>V2: (runs 190782 - 193621) seeded by: L1_HTT150 OR L1_HTT175</p></blockquote><p>See also the full list of triggers for CMS 2012 open data:<a href=\"/record/1701\">Trigger information for 2012 CMS open data</a></p>"
     },
     "accelerator": "CERN-LHC",
     "collaboration": {
@@ -4931,7 +4931,7 @@
   },
   {
     "abstract": {
-      "description": " <p>High-Level Trigger path information HLT_Ele100_CaloIdVT_TrkIdT (SingleElectron dataset).</p><blockquote><p>first seen online on run 190456 (<a href=\"/record/6123\">/cdaq/physics/Run2012/5e33/v4.4/HLT/V5</a>)</p><p>last  seen online on run 193621 (<a href=\"/record/6109\"><a href=\"/record/6125\">/cdaq/physics/Run2012/5e33/v4.16/HLT/V2</a>1</a>)</p><p>V8: (runs 190456 - 190738) seeded by: L1_SingleEG20 OR L1_SingleEG22</p><p>V9: (runs 190782 - 191411) seeded by: L1_SingleEG20 OR L1_SingleEG22</p><p>V10: (runs 191691 - 193621) seeded by: L1_SingleEG20 OR L1_SingleEG22</p></blockquote><p>See also the full list of triggers for CMS 2012 open data:<a href=\"/record/1701\">Trigger information for 2012 CMS open data</a></p>"
+      "description": " <p>High-Level Trigger path information HLT_Ele100_CaloIdVT_TrkIdT (SingleElectron dataset).</p><blockquote><p>first seen online on run 190456 (<a href=\"/record/6123\">/cdaq/physics/Run2012/5e33/v4.4/HLT/V5</a>)</p><p>last  seen online on run 193621 (<a href=\"/record/6109\">/cdaq/physics/Run2012/5e33/v4.16/HLT/V21</a>)</p><p>V8: (runs 190456 - 190738) seeded by: L1_SingleEG20 OR L1_SingleEG22</p><p>V9: (runs 190782 - 191411) seeded by: L1_SingleEG20 OR L1_SingleEG22</p><p>V10: (runs 191691 - 193621) seeded by: L1_SingleEG20 OR L1_SingleEG22</p></blockquote><p>See also the full list of triggers for CMS 2012 open data:<a href=\"/record/1701\">Trigger information for 2012 CMS open data</a></p>"
     },
     "accelerator": "CERN-LHC",
     "collaboration": {
@@ -4960,7 +4960,7 @@
   },
   {
     "abstract": {
-      "description": " <p>High-Level Trigger path information HLT_Ele12_CaloIdL_CaloIsoVL_TrkIdVL_TrkIsoVL_DoubleCentralJet65 (ElectronHad dataset).</p><blockquote><p>first seen online on run 190456 (<a href=\"/record/6123\">/cdaq/physics/Run2012/5e33/v4.4/HLT/V5</a>)</p><p>last  seen online on run 193621 (<a href=\"/record/6109\"><a href=\"/record/6125\">/cdaq/physics/Run2012/5e33/v4.16/HLT/V2</a>1</a>)</p><p>V3: (runs 190456 - 190738) seeded by: L1_DoubleJetC64 OR L1_DoubleJetC56 OR L1_DoubleJetC52</p><p>V4: (runs 190782 - 191411) seeded by: L1_DoubleJetC64 OR L1_DoubleJetC56 OR L1_DoubleJetC52</p><p>V5: (runs 191691 - 193621) seeded by: L1_DoubleJetC64 OR L1_DoubleJetC56 OR L1_DoubleJetC52</p></blockquote><p>See also the full list of triggers for CMS 2012 open data:<a href=\"/record/1701\">Trigger information for 2012 CMS open data</a></p>"
+      "description": " <p>High-Level Trigger path information HLT_Ele12_CaloIdL_CaloIsoVL_TrkIdVL_TrkIsoVL_DoubleCentralJet65 (ElectronHad dataset).</p><blockquote><p>first seen online on run 190456 (<a href=\"/record/6123\">/cdaq/physics/Run2012/5e33/v4.4/HLT/V5</a>)</p><p>last  seen online on run 193621 (<a href=\"/record/6109\">/cdaq/physics/Run2012/5e33/v4.16/HLT/V21</a>)</p><p>V3: (runs 190456 - 190738) seeded by: L1_DoubleJetC64 OR L1_DoubleJetC56 OR L1_DoubleJetC52</p><p>V4: (runs 190782 - 191411) seeded by: L1_DoubleJetC64 OR L1_DoubleJetC56 OR L1_DoubleJetC52</p><p>V5: (runs 191691 - 193621) seeded by: L1_DoubleJetC64 OR L1_DoubleJetC56 OR L1_DoubleJetC52</p></blockquote><p>See also the full list of triggers for CMS 2012 open data:<a href=\"/record/1701\">Trigger information for 2012 CMS open data</a></p>"
     },
     "accelerator": "CERN-LHC",
     "collaboration": {
@@ -4989,7 +4989,7 @@
   },
   {
     "abstract": {
-      "description": " <p>High-Level Trigger path information HLT_Ele12_CaloIdL_CaloIsoVL_TrkIdVL_TrkIsoVL_RsqMR30_Rsq0p04_MR200 (ElectronHad dataset).</p><blockquote><p>first seen online on run 190456 (<a href=\"/record/6123\">/cdaq/physics/Run2012/5e33/v4.4/HLT/V5</a>)</p><p>last  seen online on run 193621 (<a href=\"/record/6109\"><a href=\"/record/6125\">/cdaq/physics/Run2012/5e33/v4.16/HLT/V2</a>1</a>)</p><p>V3: (runs 190456 - 190738) seeded by: L1_DoubleJetC64 OR L1_DoubleJetC56 OR L1_DoubleJetC52</p><p>V4: (runs 190782 - 191411) seeded by: L1_DoubleJetC64 OR L1_DoubleJetC56 OR L1_DoubleJetC52</p><p>V5: (runs 191691 - 193621) seeded by: L1_DoubleJetC64 OR L1_DoubleJetC56 OR L1_DoubleJetC52</p></blockquote><p>See also the full list of triggers for CMS 2012 open data:<a href=\"/record/1701\">Trigger information for 2012 CMS open data</a></p>"
+      "description": " <p>High-Level Trigger path information HLT_Ele12_CaloIdL_CaloIsoVL_TrkIdVL_TrkIsoVL_RsqMR30_Rsq0p04_MR200 (ElectronHad dataset).</p><blockquote><p>first seen online on run 190456 (<a href=\"/record/6123\">/cdaq/physics/Run2012/5e33/v4.4/HLT/V5</a>)</p><p>last  seen online on run 193621 (<a href=\"/record/6109\">/cdaq/physics/Run2012/5e33/v4.16/HLT/V21</a>)</p><p>V3: (runs 190456 - 190738) seeded by: L1_DoubleJetC64 OR L1_DoubleJetC56 OR L1_DoubleJetC52</p><p>V4: (runs 190782 - 191411) seeded by: L1_DoubleJetC64 OR L1_DoubleJetC56 OR L1_DoubleJetC52</p><p>V5: (runs 191691 - 193621) seeded by: L1_DoubleJetC64 OR L1_DoubleJetC56 OR L1_DoubleJetC52</p></blockquote><p>See also the full list of triggers for CMS 2012 open data:<a href=\"/record/1701\">Trigger information for 2012 CMS open data</a></p>"
     },
     "accelerator": "CERN-LHC",
     "collaboration": {
@@ -5018,7 +5018,7 @@
   },
   {
     "abstract": {
-      "description": " <p>High-Level Trigger path information HLT_Ele12_CaloIdL_CaloIsoVL_TrkIdVL_TrkIsoVL_RsqMR40_Rsq0p04_MR200 (ElectronHad dataset).</p><blockquote><p>first seen online on run 190456 (<a href=\"/record/6123\">/cdaq/physics/Run2012/5e33/v4.4/HLT/V5</a>)</p><p>last  seen online on run 193621 (<a href=\"/record/6109\"><a href=\"/record/6125\">/cdaq/physics/Run2012/5e33/v4.16/HLT/V2</a>1</a>)</p><p>V3: (runs 190456 - 190738) seeded by: L1_DoubleJetC64 OR L1_DoubleJetC56 OR L1_DoubleJetC52</p><p>V4: (runs 190782 - 191411) seeded by: L1_DoubleJetC64 OR L1_DoubleJetC56 OR L1_DoubleJetC52</p><p>V5: (runs 191691 - 193621) seeded by: L1_DoubleJetC64 OR L1_DoubleJetC56 OR L1_DoubleJetC52</p></blockquote><p>See also the full list of triggers for CMS 2012 open data:<a href=\"/record/1701\">Trigger information for 2012 CMS open data</a></p>"
+      "description": " <p>High-Level Trigger path information HLT_Ele12_CaloIdL_CaloIsoVL_TrkIdVL_TrkIsoVL_RsqMR40_Rsq0p04_MR200 (ElectronHad dataset).</p><blockquote><p>first seen online on run 190456 (<a href=\"/record/6123\">/cdaq/physics/Run2012/5e33/v4.4/HLT/V5</a>)</p><p>last  seen online on run 193621 (<a href=\"/record/6109\">/cdaq/physics/Run2012/5e33/v4.16/HLT/V21</a>)</p><p>V3: (runs 190456 - 190738) seeded by: L1_DoubleJetC64 OR L1_DoubleJetC56 OR L1_DoubleJetC52</p><p>V4: (runs 190782 - 191411) seeded by: L1_DoubleJetC64 OR L1_DoubleJetC56 OR L1_DoubleJetC52</p><p>V5: (runs 191691 - 193621) seeded by: L1_DoubleJetC64 OR L1_DoubleJetC56 OR L1_DoubleJetC52</p></blockquote><p>See also the full list of triggers for CMS 2012 open data:<a href=\"/record/1701\">Trigger information for 2012 CMS open data</a></p>"
     },
     "accelerator": "CERN-LHC",
     "collaboration": {
@@ -5047,7 +5047,7 @@
   },
   {
     "abstract": {
-      "description": " <p>High-Level Trigger path information HLT_Ele12_CaloIdL_CaloIsoVL_TrkIdVL_TrkIsoVL_RsqMR45_Rsq0p04_MR200 (ElectronHad dataset).</p><blockquote><p>first seen online on run 190456 (<a href=\"/record/6123\">/cdaq/physics/Run2012/5e33/v4.4/HLT/V5</a>)</p><p>last  seen online on run 193621 (<a href=\"/record/6109\"><a href=\"/record/6125\">/cdaq/physics/Run2012/5e33/v4.16/HLT/V2</a>1</a>)</p><p>V2: (runs 190456 - 190738) seeded by: L1_DoubleJetC64 OR L1_DoubleJetC56 OR L1_DoubleJetC52</p><p>V3: (runs 190782 - 191411) seeded by: L1_DoubleJetC64 OR L1_DoubleJetC56 OR L1_DoubleJetC52</p><p>V4: (runs 191691 - 193621) seeded by: L1_DoubleJetC64 OR L1_DoubleJetC56 OR L1_DoubleJetC52</p></blockquote><p>See also the full list of triggers for CMS 2012 open data:<a href=\"/record/1701\">Trigger information for 2012 CMS open data</a></p>"
+      "description": " <p>High-Level Trigger path information HLT_Ele12_CaloIdL_CaloIsoVL_TrkIdVL_TrkIsoVL_RsqMR45_Rsq0p04_MR200 (ElectronHad dataset).</p><blockquote><p>first seen online on run 190456 (<a href=\"/record/6123\">/cdaq/physics/Run2012/5e33/v4.4/HLT/V5</a>)</p><p>last  seen online on run 193621 (<a href=\"/record/6109\">/cdaq/physics/Run2012/5e33/v4.16/HLT/V21</a>)</p><p>V2: (runs 190456 - 190738) seeded by: L1_DoubleJetC64 OR L1_DoubleJetC56 OR L1_DoubleJetC52</p><p>V3: (runs 190782 - 191411) seeded by: L1_DoubleJetC64 OR L1_DoubleJetC56 OR L1_DoubleJetC52</p><p>V4: (runs 191691 - 193621) seeded by: L1_DoubleJetC64 OR L1_DoubleJetC56 OR L1_DoubleJetC52</p></blockquote><p>See also the full list of triggers for CMS 2012 open data:<a href=\"/record/1701\">Trigger information for 2012 CMS open data</a></p>"
     },
     "accelerator": "CERN-LHC",
     "collaboration": {
@@ -5424,7 +5424,7 @@
   },
   {
     "abstract": {
-      "description": " <p>High-Level Trigger path information HLT_Ele20_CaloIdVT_CaloIsoRhoT_TrkIdT_TrkIsoT (TauPlusX dataset).</p><blockquote><p>first seen online on run 190456 (<a href=\"/record/6123\">/cdaq/physics/Run2012/5e33/v4.4/HLT/V5</a>)</p><p>last  seen online on run 193621 (<a href=\"/record/6109\"><a href=\"/record/6125\">/cdaq/physics/Run2012/5e33/v4.16/HLT/V2</a>1</a>)</p><p>V3: (runs 190456 - 190738) seeded by: L1_SingleEG18er</p><p>V4: (runs 190782 - 191411) seeded by: L1_SingleEG18er</p><p>V5: (runs 191691 - 193621) seeded by: L1_SingleEG18er</p></blockquote><p>See also the full list of triggers for CMS 2012 open data:<a href=\"/record/1701\">Trigger information for 2012 CMS open data</a></p>"
+      "description": " <p>High-Level Trigger path information HLT_Ele20_CaloIdVT_CaloIsoRhoT_TrkIdT_TrkIsoT (TauPlusX dataset).</p><blockquote><p>first seen online on run 190456 (<a href=\"/record/6123\">/cdaq/physics/Run2012/5e33/v4.4/HLT/V5</a>)</p><p>last  seen online on run 193621 (<a href=\"/record/6109\">/cdaq/physics/Run2012/5e33/v4.16/HLT/V21</a>)</p><p>V3: (runs 190456 - 190738) seeded by: L1_SingleEG18er</p><p>V4: (runs 190782 - 191411) seeded by: L1_SingleEG18er</p><p>V5: (runs 191691 - 193621) seeded by: L1_SingleEG18er</p></blockquote><p>See also the full list of triggers for CMS 2012 open data:<a href=\"/record/1701\">Trigger information for 2012 CMS open data</a></p>"
     },
     "accelerator": "CERN-LHC",
     "collaboration": {
@@ -5453,7 +5453,7 @@
   },
   {
     "abstract": {
-      "description": " <p>High-Level Trigger path information HLT_Ele20_CaloIdVT_CaloIsoRhoT_TrkIdT_TrkIsoT_LooseIsoPFTau20 (TauPlusX dataset).</p><blockquote><p>first seen online on run 190456 (<a href=\"/record/6123\">/cdaq/physics/Run2012/5e33/v4.4/HLT/V5</a>)</p><p>last  seen online on run 193621 (<a href=\"/record/6109\"><a href=\"/record/6125\">/cdaq/physics/Run2012/5e33/v4.16/HLT/V2</a>1</a>)</p><p>V4: (runs 190456 - 190738) seeded by: L1_SingleIsoEG18er OR L1_SingleEG20</p><p>V5: (runs 190782 - 191411) seeded by: L1_SingleIsoEG18er OR L1_SingleEG20</p><p>V6: (runs 191691 - 193621) seeded by: L1_SingleIsoEG18er OR L1_SingleEG20</p></blockquote><p>See also the full list of triggers for CMS 2012 open data:<a href=\"/record/1701\">Trigger information for 2012 CMS open data</a></p>"
+      "description": " <p>High-Level Trigger path information HLT_Ele20_CaloIdVT_CaloIsoRhoT_TrkIdT_TrkIsoT_LooseIsoPFTau20 (TauPlusX dataset).</p><blockquote><p>first seen online on run 190456 (<a href=\"/record/6123\">/cdaq/physics/Run2012/5e33/v4.4/HLT/V5</a>)</p><p>last  seen online on run 193621 (<a href=\"/record/6109\">/cdaq/physics/Run2012/5e33/v4.16/HLT/V21</a>)</p><p>V4: (runs 190456 - 190738) seeded by: L1_SingleIsoEG18er OR L1_SingleEG20</p><p>V5: (runs 190782 - 191411) seeded by: L1_SingleIsoEG18er OR L1_SingleEG20</p><p>V6: (runs 191691 - 193621) seeded by: L1_SingleIsoEG18er OR L1_SingleEG20</p></blockquote><p>See also the full list of triggers for CMS 2012 open data:<a href=\"/record/1701\">Trigger information for 2012 CMS open data</a></p>"
     },
     "accelerator": "CERN-LHC",
     "collaboration": {
@@ -5482,7 +5482,7 @@
   },
   {
     "abstract": {
-      "description": " <p>High-Level Trigger path information HLT_Ele20_CaloIdVT_CaloIsoRhoT_TrkIdT_TrkIsoT_LooseIsoPFTau20L1Jet (TauPlusX dataset).</p><blockquote><p>first seen online on run 190456 (<a href=\"/record/6123\">/cdaq/physics/Run2012/5e33/v4.4/HLT/V5</a>)</p><p>last  seen online on run 193621 (<a href=\"/record/6109\"><a href=\"/record/6125\">/cdaq/physics/Run2012/5e33/v4.16/HLT/V2</a>1</a>)</p><p>V4: (runs 190456 - 190738) seeded by: L1_EG18er_JetC_Cen28_Tau20_dPhi1 OR L1_IsoEG18er_JetC_Cen32_Tau24_dPhi1</p><p>V5: (runs 190782 - 191411) seeded by: L1_EG18er_JetC_Cen28_Tau20_dPhi1 OR L1_IsoEG18er_JetC_Cen32_Tau24_dPhi1</p><p>V6: (runs 191691 - 193621) seeded by: L1_EG18er_JetC_Cen28_Tau20_dPhi1 OR L1_IsoEG18er_JetC_Cen32_Tau24_dPhi1</p></blockquote><p>See also the full list of triggers for CMS 2012 open data:<a href=\"/record/1701\">Trigger information for 2012 CMS open data</a></p>"
+      "description": " <p>High-Level Trigger path information HLT_Ele20_CaloIdVT_CaloIsoRhoT_TrkIdT_TrkIsoT_LooseIsoPFTau20L1Jet (TauPlusX dataset).</p><blockquote><p>first seen online on run 190456 (<a href=\"/record/6123\">/cdaq/physics/Run2012/5e33/v4.4/HLT/V5</a>)</p><p>last  seen online on run 193621 (<a href=\"/record/6109\">/cdaq/physics/Run2012/5e33/v4.16/HLT/V21</a>)</p><p>V4: (runs 190456 - 190738) seeded by: L1_EG18er_JetC_Cen28_Tau20_dPhi1 OR L1_IsoEG18er_JetC_Cen32_Tau24_dPhi1</p><p>V5: (runs 190782 - 191411) seeded by: L1_EG18er_JetC_Cen28_Tau20_dPhi1 OR L1_IsoEG18er_JetC_Cen32_Tau24_dPhi1</p><p>V6: (runs 191691 - 193621) seeded by: L1_EG18er_JetC_Cen28_Tau20_dPhi1 OR L1_IsoEG18er_JetC_Cen32_Tau24_dPhi1</p></blockquote><p>See also the full list of triggers for CMS 2012 open data:<a href=\"/record/1701\">Trigger information for 2012 CMS open data</a></p>"
     },
     "accelerator": "CERN-LHC",
     "collaboration": {
@@ -5511,7 +5511,7 @@
   },
   {
     "abstract": {
-      "description": " <p>High-Level Trigger path information HLT_Ele20_CaloIdVT_CaloIsoRhoT_TrkIdT_TrkIsoT_LooseIsoPFTau22L1Jet (TauPlusX dataset).</p><blockquote><p>first seen online on run 190456 (<a href=\"/record/6123\">/cdaq/physics/Run2012/5e33/v4.4/HLT/V5</a>)</p><p>last  seen online on run 193621 (<a href=\"/record/6109\"><a href=\"/record/6125\">/cdaq/physics/Run2012/5e33/v4.16/HLT/V2</a>1</a>)</p><p>V3: (runs 190456 - 190738) seeded by: L1_EG18er_JetC_Cen36_Tau28_dPhi1 OR L1_IsoEG18er_JetC_Cen36_Tau28_dPhi1</p><p>V4: (runs 190782 - 191411) seeded by: L1_EG18er_JetC_Cen36_Tau28_dPhi1 OR L1_IsoEG18er_JetC_Cen36_Tau28_dPhi1</p><p>V5: (runs 191691 - 193621) seeded by: L1_EG18er_JetC_Cen36_Tau28_dPhi1 OR L1_IsoEG18er_JetC_Cen36_Tau28_dPhi1</p></blockquote><p>See also the full list of triggers for CMS 2012 open data:<a href=\"/record/1701\">Trigger information for 2012 CMS open data</a></p>"
+      "description": " <p>High-Level Trigger path information HLT_Ele20_CaloIdVT_CaloIsoRhoT_TrkIdT_TrkIsoT_LooseIsoPFTau22L1Jet (TauPlusX dataset).</p><blockquote><p>first seen online on run 190456 (<a href=\"/record/6123\">/cdaq/physics/Run2012/5e33/v4.4/HLT/V5</a>)</p><p>last  seen online on run 193621 (<a href=\"/record/6109\">/cdaq/physics/Run2012/5e33/v4.16/HLT/V21</a>)</p><p>V3: (runs 190456 - 190738) seeded by: L1_EG18er_JetC_Cen36_Tau28_dPhi1 OR L1_IsoEG18er_JetC_Cen36_Tau28_dPhi1</p><p>V4: (runs 190782 - 191411) seeded by: L1_EG18er_JetC_Cen36_Tau28_dPhi1 OR L1_IsoEG18er_JetC_Cen36_Tau28_dPhi1</p><p>V5: (runs 191691 - 193621) seeded by: L1_EG18er_JetC_Cen36_Tau28_dPhi1 OR L1_IsoEG18er_JetC_Cen36_Tau28_dPhi1</p></blockquote><p>See also the full list of triggers for CMS 2012 open data:<a href=\"/record/1701\">Trigger information for 2012 CMS open data</a></p>"
     },
     "accelerator": "CERN-LHC",
     "collaboration": {
@@ -5569,7 +5569,7 @@
   },
   {
     "abstract": {
-      "description": " <p>High-Level Trigger path information HLT_Ele20_CaloIdVT_TrkIdT_LooseIsoPFTau20 (TauPlusX dataset).</p><blockquote><p>first seen online on run 190456 (<a href=\"/record/6123\">/cdaq/physics/Run2012/5e33/v4.4/HLT/V5</a>)</p><p>last  seen online on run 193621 (<a href=\"/record/6109\"><a href=\"/record/6125\">/cdaq/physics/Run2012/5e33/v4.16/HLT/V2</a>1</a>)</p><p>V4: (runs 190456 - 190738) seeded by: L1_SingleEG18er</p><p>V5: (runs 190782 - 191411) seeded by: L1_SingleEG18er</p><p>V6: (runs 191691 - 193621) seeded by: L1_SingleEG18er</p></blockquote><p>See also the full list of triggers for CMS 2012 open data:<a href=\"/record/1701\">Trigger information for 2012 CMS open data</a></p>"
+      "description": " <p>High-Level Trigger path information HLT_Ele20_CaloIdVT_TrkIdT_LooseIsoPFTau20 (TauPlusX dataset).</p><blockquote><p>first seen online on run 190456 (<a href=\"/record/6123\">/cdaq/physics/Run2012/5e33/v4.4/HLT/V5</a>)</p><p>last  seen online on run 193621 (<a href=\"/record/6109\">/cdaq/physics/Run2012/5e33/v4.16/HLT/V21</a>)</p><p>V4: (runs 190456 - 190738) seeded by: L1_SingleEG18er</p><p>V5: (runs 190782 - 191411) seeded by: L1_SingleEG18er</p><p>V6: (runs 191691 - 193621) seeded by: L1_SingleEG18er</p></blockquote><p>See also the full list of triggers for CMS 2012 open data:<a href=\"/record/1701\">Trigger information for 2012 CMS open data</a></p>"
     },
     "accelerator": "CERN-LHC",
     "collaboration": {
@@ -5627,7 +5627,7 @@
   },
   {
     "abstract": {
-      "description": " <p>High-Level Trigger path information HLT_Ele22_CaloIdVT_CaloIsoRhoT_TrkIdT_TrkIsoT_LooseIsoPFTau20 (TauPlusX dataset).</p><blockquote><p>first seen online on run 190456 (<a href=\"/record/6123\">/cdaq/physics/Run2012/5e33/v4.4/HLT/V5</a>)</p><p>last  seen online on run 193621 (<a href=\"/record/6109\"><a href=\"/record/6125\">/cdaq/physics/Run2012/5e33/v4.16/HLT/V2</a>1</a>)</p><p>V3: (runs 190456 - 190738) seeded by: L1_SingleIsoEG20er OR L1_SingleEG22</p><p>V4: (runs 190782 - 191411) seeded by: L1_SingleIsoEG20er OR L1_SingleEG22</p><p>V5: (runs 191691 - 193621) seeded by: L1_SingleIsoEG20er OR L1_SingleEG22</p></blockquote><p>See also the full list of triggers for CMS 2012 open data:<a href=\"/record/1701\">Trigger information for 2012 CMS open data</a></p>"
+      "description": " <p>High-Level Trigger path information HLT_Ele22_CaloIdVT_CaloIsoRhoT_TrkIdT_TrkIsoT_LooseIsoPFTau20 (TauPlusX dataset).</p><blockquote><p>first seen online on run 190456 (<a href=\"/record/6123\">/cdaq/physics/Run2012/5e33/v4.4/HLT/V5</a>)</p><p>last  seen online on run 193621 (<a href=\"/record/6109\">/cdaq/physics/Run2012/5e33/v4.16/HLT/V21</a>)</p><p>V3: (runs 190456 - 190738) seeded by: L1_SingleIsoEG20er OR L1_SingleEG22</p><p>V4: (runs 190782 - 191411) seeded by: L1_SingleIsoEG20er OR L1_SingleEG22</p><p>V5: (runs 191691 - 193621) seeded by: L1_SingleIsoEG20er OR L1_SingleEG22</p></blockquote><p>See also the full list of triggers for CMS 2012 open data:<a href=\"/record/1701\">Trigger information for 2012 CMS open data</a></p>"
     },
     "accelerator": "CERN-LHC",
     "collaboration": {
@@ -5917,7 +5917,7 @@
   },
   {
     "abstract": {
-      "description": " <p>High-Level Trigger path information HLT_Ele25_CaloIdVT_CaloIsoT_TrkIdT_TrkIsoT_CentralPFJet30 (ElectronHad dataset).</p><blockquote><p>first seen online on run 190456 (<a href=\"/record/6123\">/cdaq/physics/Run2012/5e33/v4.4/HLT/V5</a>)</p><p>last  seen online on run 193621 (<a href=\"/record/6109\"><a href=\"/record/6125\">/cdaq/physics/Run2012/5e33/v4.16/HLT/V2</a>1</a>)</p><p>V8: (runs 190456 - 190738) seeded by: L1_SingleEG20 OR L1_SingleEG22</p><p>V9: (runs 190782 - 191411) seeded by: L1_SingleEG20 OR L1_SingleEG22</p><p>V10: (runs 191691 - 193621) seeded by: L1_SingleEG20 OR L1_SingleEG22</p></blockquote><p>See also the full list of triggers for CMS 2012 open data:<a href=\"/record/1701\">Trigger information for 2012 CMS open data</a></p>"
+      "description": " <p>High-Level Trigger path information HLT_Ele25_CaloIdVT_CaloIsoT_TrkIdT_TrkIsoT_CentralPFJet30 (ElectronHad dataset).</p><blockquote><p>first seen online on run 190456 (<a href=\"/record/6123\">/cdaq/physics/Run2012/5e33/v4.4/HLT/V5</a>)</p><p>last  seen online on run 193621 (<a href=\"/record/6109\">/cdaq/physics/Run2012/5e33/v4.16/HLT/V21</a>)</p><p>V8: (runs 190456 - 190738) seeded by: L1_SingleEG20 OR L1_SingleEG22</p><p>V9: (runs 190782 - 191411) seeded by: L1_SingleEG20 OR L1_SingleEG22</p><p>V10: (runs 191691 - 193621) seeded by: L1_SingleEG20 OR L1_SingleEG22</p></blockquote><p>See also the full list of triggers for CMS 2012 open data:<a href=\"/record/1701\">Trigger information for 2012 CMS open data</a></p>"
     },
     "accelerator": "CERN-LHC",
     "collaboration": {
@@ -5946,7 +5946,7 @@
   },
   {
     "abstract": {
-      "description": " <p>High-Level Trigger path information HLT_Ele25_CaloIdVT_CaloIsoT_TrkIdT_TrkIsoT_CentralPFJet30_BTagIPIter (ElectronHad dataset).</p><blockquote><p>first seen online on run 190456 (<a href=\"/record/6123\">/cdaq/physics/Run2012/5e33/v4.4/HLT/V5</a>)</p><p>last  seen online on run 193621 (<a href=\"/record/6109\"><a href=\"/record/6125\">/cdaq/physics/Run2012/5e33/v4.16/HLT/V2</a>1</a>)</p><p>V4: (runs 190456 - 190738) seeded by: L1_SingleEG20 OR L1_SingleEG22</p><p>V5: (runs 190782 - 191411) seeded by: L1_SingleEG20 OR L1_SingleEG22</p><p>V6: (runs 191691 - 193621) seeded by: L1_SingleEG20 OR L1_SingleEG22</p></blockquote><p>See also the full list of triggers for CMS 2012 open data:<a href=\"/record/1701\">Trigger information for 2012 CMS open data</a></p>"
+      "description": " <p>High-Level Trigger path information HLT_Ele25_CaloIdVT_CaloIsoT_TrkIdT_TrkIsoT_CentralPFJet30_BTagIPIter (ElectronHad dataset).</p><blockquote><p>first seen online on run 190456 (<a href=\"/record/6123\">/cdaq/physics/Run2012/5e33/v4.4/HLT/V5</a>)</p><p>last  seen online on run 193621 (<a href=\"/record/6109\">/cdaq/physics/Run2012/5e33/v4.16/HLT/V21</a>)</p><p>V4: (runs 190456 - 190738) seeded by: L1_SingleEG20 OR L1_SingleEG22</p><p>V5: (runs 190782 - 191411) seeded by: L1_SingleEG20 OR L1_SingleEG22</p><p>V6: (runs 191691 - 193621) seeded by: L1_SingleEG20 OR L1_SingleEG22</p></blockquote><p>See also the full list of triggers for CMS 2012 open data:<a href=\"/record/1701\">Trigger information for 2012 CMS open data</a></p>"
     },
     "accelerator": "CERN-LHC",
     "collaboration": {
@@ -6033,7 +6033,7 @@
   },
   {
     "abstract": {
-      "description": " <p>High-Level Trigger path information HLT_Ele25_CaloIdVT_CaloIsoT_TrkIdT_TrkIsoT_DiCentralPFJet30 (ElectronHad dataset).</p><blockquote><p>first seen online on run 190456 (<a href=\"/record/6123\">/cdaq/physics/Run2012/5e33/v4.4/HLT/V5</a>)</p><p>last  seen online on run 193621 (<a href=\"/record/6109\"><a href=\"/record/6125\">/cdaq/physics/Run2012/5e33/v4.16/HLT/V2</a>1</a>)</p><p>V8: (runs 190456 - 190738) seeded by: L1_SingleEG20 OR L1_SingleEG22</p><p>V9: (runs 190782 - 191411) seeded by: L1_SingleEG20 OR L1_SingleEG22</p><p>V10: (runs 191691 - 193621) seeded by: L1_SingleEG20 OR L1_SingleEG22</p></blockquote><p>See also the full list of triggers for CMS 2012 open data:<a href=\"/record/1701\">Trigger information for 2012 CMS open data</a></p>"
+      "description": " <p>High-Level Trigger path information HLT_Ele25_CaloIdVT_CaloIsoT_TrkIdT_TrkIsoT_DiCentralPFJet30 (ElectronHad dataset).</p><blockquote><p>first seen online on run 190456 (<a href=\"/record/6123\">/cdaq/physics/Run2012/5e33/v4.4/HLT/V5</a>)</p><p>last  seen online on run 193621 (<a href=\"/record/6109\">/cdaq/physics/Run2012/5e33/v4.16/HLT/V21</a>)</p><p>V8: (runs 190456 - 190738) seeded by: L1_SingleEG20 OR L1_SingleEG22</p><p>V9: (runs 190782 - 191411) seeded by: L1_SingleEG20 OR L1_SingleEG22</p><p>V10: (runs 191691 - 193621) seeded by: L1_SingleEG20 OR L1_SingleEG22</p></blockquote><p>See also the full list of triggers for CMS 2012 open data:<a href=\"/record/1701\">Trigger information for 2012 CMS open data</a></p>"
     },
     "accelerator": "CERN-LHC",
     "collaboration": {
@@ -6091,7 +6091,7 @@
   },
   {
     "abstract": {
-      "description": " <p>High-Level Trigger path information HLT_Ele25_CaloIdVT_CaloIsoT_TrkIdT_TrkIsoT_TriCentralPFJet30 (ElectronHad dataset).</p><blockquote><p>first seen online on run 190456 (<a href=\"/record/6123\">/cdaq/physics/Run2012/5e33/v4.4/HLT/V5</a>)</p><p>last  seen online on run 193621 (<a href=\"/record/6109\"><a href=\"/record/6125\">/cdaq/physics/Run2012/5e33/v4.16/HLT/V2</a>1</a>)</p><p>V8: (runs 190456 - 190738) seeded by: L1_SingleEG20 OR L1_SingleEG22</p><p>V9: (runs 190782 - 191411) seeded by: L1_SingleEG20 OR L1_SingleEG22</p><p>V10: (runs 191691 - 193621) seeded by: L1_SingleEG20 OR L1_SingleEG22</p></blockquote><p>See also the full list of triggers for CMS 2012 open data:<a href=\"/record/1701\">Trigger information for 2012 CMS open data</a></p>"
+      "description": " <p>High-Level Trigger path information HLT_Ele25_CaloIdVT_CaloIsoT_TrkIdT_TrkIsoT_TriCentralPFJet30 (ElectronHad dataset).</p><blockquote><p>first seen online on run 190456 (<a href=\"/record/6123\">/cdaq/physics/Run2012/5e33/v4.4/HLT/V5</a>)</p><p>last  seen online on run 193621 (<a href=\"/record/6109\">/cdaq/physics/Run2012/5e33/v4.16/HLT/V21</a>)</p><p>V8: (runs 190456 - 190738) seeded by: L1_SingleEG20 OR L1_SingleEG22</p><p>V9: (runs 190782 - 191411) seeded by: L1_SingleEG20 OR L1_SingleEG22</p><p>V10: (runs 191691 - 193621) seeded by: L1_SingleEG20 OR L1_SingleEG22</p></blockquote><p>See also the full list of triggers for CMS 2012 open data:<a href=\"/record/1701\">Trigger information for 2012 CMS open data</a></p>"
     },
     "accelerator": "CERN-LHC",
     "collaboration": {
@@ -6120,7 +6120,7 @@
   },
   {
     "abstract": {
-      "description": " <p>High-Level Trigger path information HLT_Ele25_CaloIdVT_CaloIsoT_TrkIdT_TrkIsoT_TriCentralPFJet50_40_30 (ElectronHad dataset).</p><blockquote><p>first seen online on run 190456 (<a href=\"/record/6123\">/cdaq/physics/Run2012/5e33/v4.4/HLT/V5</a>)</p><p>last  seen online on run 193621 (<a href=\"/record/6109\"><a href=\"/record/6125\">/cdaq/physics/Run2012/5e33/v4.16/HLT/V2</a>1</a>)</p><p>V3: (runs 190456 - 190738) seeded by: L1_SingleEG20 OR L1_SingleEG22</p><p>V4: (runs 190782 - 191411) seeded by: L1_SingleEG20 OR L1_SingleEG22</p><p>V5: (runs 191691 - 193621) seeded by: L1_SingleEG20 OR L1_SingleEG22</p></blockquote><p>See also the full list of triggers for CMS 2012 open data:<a href=\"/record/1701\">Trigger information for 2012 CMS open data</a></p>"
+      "description": " <p>High-Level Trigger path information HLT_Ele25_CaloIdVT_CaloIsoT_TrkIdT_TrkIsoT_TriCentralPFJet50_40_30 (ElectronHad dataset).</p><blockquote><p>first seen online on run 190456 (<a href=\"/record/6123\">/cdaq/physics/Run2012/5e33/v4.4/HLT/V5</a>)</p><p>last  seen online on run 193621 (<a href=\"/record/6109\">/cdaq/physics/Run2012/5e33/v4.16/HLT/V21</a>)</p><p>V3: (runs 190456 - 190738) seeded by: L1_SingleEG20 OR L1_SingleEG22</p><p>V4: (runs 190782 - 191411) seeded by: L1_SingleEG20 OR L1_SingleEG22</p><p>V5: (runs 191691 - 193621) seeded by: L1_SingleEG20 OR L1_SingleEG22</p></blockquote><p>See also the full list of triggers for CMS 2012 open data:<a href=\"/record/1701\">Trigger information for 2012 CMS open data</a></p>"
     },
     "accelerator": "CERN-LHC",
     "collaboration": {
@@ -6352,7 +6352,7 @@
   },
   {
     "abstract": {
-      "description": " <p>High-Level Trigger path information HLT_Ele25_CaloIdVT_TrkIdT_TriCentralPFJet30 (ElectronHad dataset).</p><blockquote><p>first seen online on run 190456 (<a href=\"/record/6123\">/cdaq/physics/Run2012/5e33/v4.4/HLT/V5</a>)</p><p>last  seen online on run 193621 (<a href=\"/record/6109\"><a href=\"/record/6125\">/cdaq/physics/Run2012/5e33/v4.16/HLT/V2</a>1</a>)</p><p>V8: (runs 190456 - 190738) seeded by: L1_SingleEG20 OR L1_SingleEG22</p><p>V9: (runs 190782 - 191411) seeded by: L1_SingleEG20 OR L1_SingleEG22</p><p>V10: (runs 191691 - 193621) seeded by: L1_SingleEG20 OR L1_SingleEG22</p></blockquote><p>See also the full list of triggers for CMS 2012 open data:<a href=\"/record/1701\">Trigger information for 2012 CMS open data</a></p>"
+      "description": " <p>High-Level Trigger path information HLT_Ele25_CaloIdVT_TrkIdT_TriCentralPFJet30 (ElectronHad dataset).</p><blockquote><p>first seen online on run 190456 (<a href=\"/record/6123\">/cdaq/physics/Run2012/5e33/v4.4/HLT/V5</a>)</p><p>last  seen online on run 193621 (<a href=\"/record/6109\">/cdaq/physics/Run2012/5e33/v4.16/HLT/V21</a>)</p><p>V8: (runs 190456 - 190738) seeded by: L1_SingleEG20 OR L1_SingleEG22</p><p>V9: (runs 190782 - 191411) seeded by: L1_SingleEG20 OR L1_SingleEG22</p><p>V10: (runs 191691 - 193621) seeded by: L1_SingleEG20 OR L1_SingleEG22</p></blockquote><p>See also the full list of triggers for CMS 2012 open data:<a href=\"/record/1701\">Trigger information for 2012 CMS open data</a></p>"
     },
     "accelerator": "CERN-LHC",
     "collaboration": {
@@ -6381,7 +6381,7 @@
   },
   {
     "abstract": {
-      "description": " <p>High-Level Trigger path information HLT_Ele25_CaloIdVT_TrkIdT_TriCentralPFJet50_40_30 (ElectronHad dataset).</p><blockquote><p>first seen online on run 190456 (<a href=\"/record/6123\">/cdaq/physics/Run2012/5e33/v4.4/HLT/V5</a>)</p><p>last  seen online on run 193621 (<a href=\"/record/6109\"><a href=\"/record/6125\">/cdaq/physics/Run2012/5e33/v4.16/HLT/V2</a>1</a>)</p><p>V3: (runs 190456 - 190738) seeded by: L1_SingleEG20 OR L1_SingleEG22</p><p>V4: (runs 190782 - 191411) seeded by: L1_SingleEG20 OR L1_SingleEG22</p><p>V5: (runs 191691 - 193621) seeded by: L1_SingleEG20 OR L1_SingleEG22</p></blockquote><p>See also the full list of triggers for CMS 2012 open data:<a href=\"/record/1701\">Trigger information for 2012 CMS open data</a></p>"
+      "description": " <p>High-Level Trigger path information HLT_Ele25_CaloIdVT_TrkIdT_TriCentralPFJet50_40_30 (ElectronHad dataset).</p><blockquote><p>first seen online on run 190456 (<a href=\"/record/6123\">/cdaq/physics/Run2012/5e33/v4.4/HLT/V5</a>)</p><p>last  seen online on run 193621 (<a href=\"/record/6109\">/cdaq/physics/Run2012/5e33/v4.16/HLT/V21</a>)</p><p>V3: (runs 190456 - 190738) seeded by: L1_SingleEG20 OR L1_SingleEG22</p><p>V4: (runs 190782 - 191411) seeded by: L1_SingleEG20 OR L1_SingleEG22</p><p>V5: (runs 191691 - 193621) seeded by: L1_SingleEG20 OR L1_SingleEG22</p></blockquote><p>See also the full list of triggers for CMS 2012 open data:<a href=\"/record/1701\">Trigger information for 2012 CMS open data</a></p>"
     },
     "accelerator": "CERN-LHC",
     "collaboration": {
@@ -6613,7 +6613,7 @@
   },
   {
     "abstract": {
-      "description": " <p>High-Level Trigger path information HLT_Ele27_WP80_CentralPFJet30_CentralPFJet25 (ElectronHad dataset).</p><blockquote><p>first seen online on run 190456 (<a href=\"/record/6123\">/cdaq/physics/Run2012/5e33/v4.4/HLT/V5</a>)</p><p>last  seen online on run 193621 (<a href=\"/record/6109\"><a href=\"/record/6125\">/cdaq/physics/Run2012/5e33/v4.16/HLT/V2</a>1</a>)</p><p>V4: (runs 190456 - 190738) seeded by: L1_SingleEG20 OR L1_SingleEG22</p><p>V5: (runs 190782 - 191411) seeded by: L1_SingleEG20 OR L1_SingleEG22</p><p>V6: (runs 191691 - 193621) seeded by: L1_SingleEG20 OR L1_SingleEG22</p></blockquote><p>See also the full list of triggers for CMS 2012 open data:<a href=\"/record/1701\">Trigger information for 2012 CMS open data</a></p>"
+      "description": " <p>High-Level Trigger path information HLT_Ele27_WP80_CentralPFJet30_CentralPFJet25 (ElectronHad dataset).</p><blockquote><p>first seen online on run 190456 (<a href=\"/record/6123\">/cdaq/physics/Run2012/5e33/v4.4/HLT/V5</a>)</p><p>last  seen online on run 193621 (<a href=\"/record/6109\">/cdaq/physics/Run2012/5e33/v4.16/HLT/V21</a>)</p><p>V4: (runs 190456 - 190738) seeded by: L1_SingleEG20 OR L1_SingleEG22</p><p>V5: (runs 190782 - 191411) seeded by: L1_SingleEG20 OR L1_SingleEG22</p><p>V6: (runs 191691 - 193621) seeded by: L1_SingleEG20 OR L1_SingleEG22</p></blockquote><p>See also the full list of triggers for CMS 2012 open data:<a href=\"/record/1701\">Trigger information for 2012 CMS open data</a></p>"
     },
     "accelerator": "CERN-LHC",
     "collaboration": {
@@ -6642,7 +6642,7 @@
   },
   {
     "abstract": {
-      "description": " <p>High-Level Trigger path information HLT_Ele27_WP80_CentralPFJet30_CentralPFJet25_PFMET20 (ElectronHad dataset).</p><blockquote><p>first seen online on run 190456 (<a href=\"/record/6123\">/cdaq/physics/Run2012/5e33/v4.4/HLT/V5</a>)</p><p>last  seen online on run 193621 (<a href=\"/record/6109\"><a href=\"/record/6125\">/cdaq/physics/Run2012/5e33/v4.16/HLT/V2</a>1</a>)</p><p>V2: (runs 190456 - 190738) seeded by: L1_SingleEG20 OR L1_SingleEG22</p><p>V3: (runs 190782 - 191411) seeded by: L1_SingleEG20 OR L1_SingleEG22</p><p>V4: (runs 191691 - 193621) seeded by: L1_SingleEG20 OR L1_SingleEG22</p></blockquote><p>See also the full list of triggers for CMS 2012 open data:<a href=\"/record/1701\">Trigger information for 2012 CMS open data</a></p>"
+      "description": " <p>High-Level Trigger path information HLT_Ele27_WP80_CentralPFJet30_CentralPFJet25_PFMET20 (ElectronHad dataset).</p><blockquote><p>first seen online on run 190456 (<a href=\"/record/6123\">/cdaq/physics/Run2012/5e33/v4.4/HLT/V5</a>)</p><p>last  seen online on run 193621 (<a href=\"/record/6109\">/cdaq/physics/Run2012/5e33/v4.16/HLT/V21</a>)</p><p>V2: (runs 190456 - 190738) seeded by: L1_SingleEG20 OR L1_SingleEG22</p><p>V3: (runs 190782 - 191411) seeded by: L1_SingleEG20 OR L1_SingleEG22</p><p>V4: (runs 191691 - 193621) seeded by: L1_SingleEG20 OR L1_SingleEG22</p></blockquote><p>See also the full list of triggers for CMS 2012 open data:<a href=\"/record/1701\">Trigger information for 2012 CMS open data</a></p>"
     },
     "accelerator": "CERN-LHC",
     "collaboration": {
@@ -6700,7 +6700,7 @@
   },
   {
     "abstract": {
-      "description": " <p>High-Level Trigger path information HLT_Ele27_WP80_PFJet30_PFJet25_Deta3 (ElectronHad dataset).</p><blockquote><p>first seen online on run 190456 (<a href=\"/record/6123\">/cdaq/physics/Run2012/5e33/v4.4/HLT/V5</a>)</p><p>last  seen online on run 193621 (<a href=\"/record/6109\"><a href=\"/record/6125\">/cdaq/physics/Run2012/5e33/v4.16/HLT/V2</a>1</a>)</p><p>V4: (runs 190456 - 190738) seeded by: L1_SingleEG20 OR L1_SingleEG22</p><p>V5: (runs 190782 - 191411) seeded by: L1_SingleEG20 OR L1_SingleEG22</p><p>V6: (runs 191691 - 193621) seeded by: L1_SingleEG20 OR L1_SingleEG22</p></blockquote><p>See also the full list of triggers for CMS 2012 open data:<a href=\"/record/1701\">Trigger information for 2012 CMS open data</a></p>"
+      "description": " <p>High-Level Trigger path information HLT_Ele27_WP80_PFJet30_PFJet25_Deta3 (ElectronHad dataset).</p><blockquote><p>first seen online on run 190456 (<a href=\"/record/6123\">/cdaq/physics/Run2012/5e33/v4.4/HLT/V5</a>)</p><p>last  seen online on run 193621 (<a href=\"/record/6109\">/cdaq/physics/Run2012/5e33/v4.16/HLT/V21</a>)</p><p>V4: (runs 190456 - 190738) seeded by: L1_SingleEG20 OR L1_SingleEG22</p><p>V5: (runs 190782 - 191411) seeded by: L1_SingleEG20 OR L1_SingleEG22</p><p>V6: (runs 191691 - 193621) seeded by: L1_SingleEG20 OR L1_SingleEG22</p></blockquote><p>See also the full list of triggers for CMS 2012 open data:<a href=\"/record/1701\">Trigger information for 2012 CMS open data</a></p>"
     },
     "accelerator": "CERN-LHC",
     "collaboration": {
@@ -7135,7 +7135,7 @@
   },
   {
     "abstract": {
-      "description": " <p>High-Level Trigger path information HLT_Ele65_CaloIdVT_TrkIdT (SingleElectron dataset).</p><blockquote><p>first seen online on run 190456 (<a href=\"/record/6123\">/cdaq/physics/Run2012/5e33/v4.4/HLT/V5</a>)</p><p>last  seen online on run 193621 (<a href=\"/record/6109\"><a href=\"/record/6125\">/cdaq/physics/Run2012/5e33/v4.16/HLT/V2</a>1</a>)</p><p>V11: (runs 190456 - 190738) seeded by: L1_SingleEG20 OR L1_SingleEG22</p><p>V12: (runs 190782 - 191411) seeded by: L1_SingleEG20 OR L1_SingleEG22</p><p>V13: (runs 191691 - 193621) seeded by: L1_SingleEG20 OR L1_SingleEG22</p></blockquote><p>See also the full list of triggers for CMS 2012 open data:<a href=\"/record/1701\">Trigger information for 2012 CMS open data</a></p>"
+      "description": " <p>High-Level Trigger path information HLT_Ele65_CaloIdVT_TrkIdT (SingleElectron dataset).</p><blockquote><p>first seen online on run 190456 (<a href=\"/record/6123\">/cdaq/physics/Run2012/5e33/v4.4/HLT/V5</a>)</p><p>last  seen online on run 193621 (<a href=\"/record/6109\">/cdaq/physics/Run2012/5e33/v4.16/HLT/V21</a>)</p><p>V11: (runs 190456 - 190738) seeded by: L1_SingleEG20 OR L1_SingleEG22</p><p>V12: (runs 190782 - 191411) seeded by: L1_SingleEG20 OR L1_SingleEG22</p><p>V13: (runs 191691 - 193621) seeded by: L1_SingleEG20 OR L1_SingleEG22</p></blockquote><p>See also the full list of triggers for CMS 2012 open data:<a href=\"/record/1701\">Trigger information for 2012 CMS open data</a></p>"
     },
     "accelerator": "CERN-LHC",
     "collaboration": {
@@ -7193,7 +7193,7 @@
   },
   {
     "abstract": {
-      "description": " <p>High-Level Trigger path information HLT_Ele80_CaloIdVT_TrkIdT (SingleElectron dataset).</p><blockquote><p>first seen online on run 190456 (<a href=\"/record/6123\">/cdaq/physics/Run2012/5e33/v4.4/HLT/V5</a>)</p><p>last  seen online on run 193621 (<a href=\"/record/6109\"><a href=\"/record/6125\">/cdaq/physics/Run2012/5e33/v4.16/HLT/V2</a>1</a>)</p><p>V8: (runs 190456 - 190738) seeded by: L1_SingleEG20 OR L1_SingleEG22</p><p>V9: (runs 190782 - 191411) seeded by: L1_SingleEG20 OR L1_SingleEG22</p><p>V10: (runs 191691 - 193621) seeded by: L1_SingleEG20 OR L1_SingleEG22</p></blockquote><p>See also the full list of triggers for CMS 2012 open data:<a href=\"/record/1701\">Trigger information for 2012 CMS open data</a></p>"
+      "description": " <p>High-Level Trigger path information HLT_Ele80_CaloIdVT_TrkIdT (SingleElectron dataset).</p><blockquote><p>first seen online on run 190456 (<a href=\"/record/6123\">/cdaq/physics/Run2012/5e33/v4.4/HLT/V5</a>)</p><p>last  seen online on run 193621 (<a href=\"/record/6109\">/cdaq/physics/Run2012/5e33/v4.16/HLT/V21</a>)</p><p>V8: (runs 190456 - 190738) seeded by: L1_SingleEG20 OR L1_SingleEG22</p><p>V9: (runs 190782 - 191411) seeded by: L1_SingleEG20 OR L1_SingleEG22</p><p>V10: (runs 191691 - 193621) seeded by: L1_SingleEG20 OR L1_SingleEG22</p></blockquote><p>See also the full list of triggers for CMS 2012 open data:<a href=\"/record/1701\">Trigger information for 2012 CMS open data</a></p>"
     },
     "accelerator": "CERN-LHC",
     "collaboration": {
@@ -7802,7 +7802,7 @@
   },
   {
     "abstract": {
-      "description": " <p>High-Level Trigger path information HLT_HT250_DoubleDisplacedPFJet60 (HT dataset).</p><blockquote><p>first seen online on run 190456 (<a href=\"/record/6123\">/cdaq/physics/Run2012/5e33/v4.4/HLT/V5</a>)</p><p>last  seen online on run 193621 (<a href=\"/record/6109\"><a href=\"/record/6125\">/cdaq/physics/Run2012/5e33/v4.16/HLT/V2</a>1</a>)</p><p>V2: (runs 190456 - 190738) seeded by: L1_HTT150</p><p>V3: (runs 190782 - 191411) seeded by: L1_HTT150</p><p>V4: (runs 191691 - 193621) seeded by: L1_HTT150</p></blockquote><p>See also the full list of triggers for CMS 2012 open data:<a href=\"/record/1701\">Trigger information for 2012 CMS open data</a></p>"
+      "description": " <p>High-Level Trigger path information HLT_HT250_DoubleDisplacedPFJet60 (HT dataset).</p><blockquote><p>first seen online on run 190456 (<a href=\"/record/6123\">/cdaq/physics/Run2012/5e33/v4.4/HLT/V5</a>)</p><p>last  seen online on run 193621 (<a href=\"/record/6109\">/cdaq/physics/Run2012/5e33/v4.16/HLT/V21</a>)</p><p>V2: (runs 190456 - 190738) seeded by: L1_HTT150</p><p>V3: (runs 190782 - 191411) seeded by: L1_HTT150</p><p>V4: (runs 191691 - 193621) seeded by: L1_HTT150</p></blockquote><p>See also the full list of triggers for CMS 2012 open data:<a href=\"/record/1701\">Trigger information for 2012 CMS open data</a></p>"
     },
     "accelerator": "CERN-LHC",
     "collaboration": {
@@ -7831,7 +7831,7 @@
   },
   {
     "abstract": {
-      "description": " <p>High-Level Trigger path information HLT_HT250_DoubleDisplacedPFJet60_ChgFraction10 (HT dataset).</p><blockquote><p>first seen online on run 190456 (<a href=\"/record/6123\">/cdaq/physics/Run2012/5e33/v4.4/HLT/V5</a>)</p><p>last  seen online on run 193621 (<a href=\"/record/6109\"><a href=\"/record/6125\">/cdaq/physics/Run2012/5e33/v4.16/HLT/V2</a>1</a>)</p><p>V2: (runs 190456 - 190738) seeded by: L1_HTT150</p><p>V3: (runs 190782 - 191411) seeded by: L1_HTT150</p><p>V4: (runs 191691 - 193621) seeded by: L1_HTT150</p></blockquote><p>See also the full list of triggers for CMS 2012 open data:<a href=\"/record/1701\">Trigger information for 2012 CMS open data</a></p>"
+      "description": " <p>High-Level Trigger path information HLT_HT250_DoubleDisplacedPFJet60_ChgFraction10 (HT dataset).</p><blockquote><p>first seen online on run 190456 (<a href=\"/record/6123\">/cdaq/physics/Run2012/5e33/v4.4/HLT/V5</a>)</p><p>last  seen online on run 193621 (<a href=\"/record/6109\">/cdaq/physics/Run2012/5e33/v4.16/HLT/V21</a>)</p><p>V2: (runs 190456 - 190738) seeded by: L1_HTT150</p><p>V3: (runs 190782 - 191411) seeded by: L1_HTT150</p><p>V4: (runs 191691 - 193621) seeded by: L1_HTT150</p></blockquote><p>See also the full list of triggers for CMS 2012 open data:<a href=\"/record/1701\">Trigger information for 2012 CMS open data</a></p>"
     },
     "accelerator": "CERN-LHC",
     "collaboration": {
@@ -7860,7 +7860,7 @@
   },
   {
     "abstract": {
-      "description": " <p>High-Level Trigger path information HLT_HT250_SingleDisplacedPFJet60 (HT dataset).</p><blockquote><p>first seen online on run 190456 (<a href=\"/record/6123\">/cdaq/physics/Run2012/5e33/v4.4/HLT/V5</a>)</p><p>last  seen online on run 193621 (<a href=\"/record/6109\"><a href=\"/record/6125\">/cdaq/physics/Run2012/5e33/v4.16/HLT/V2</a>1</a>)</p><p>V2: (runs 190456 - 190738) seeded by: L1_HTT150</p><p>V3: (runs 190782 - 191411) seeded by: L1_HTT150</p><p>V4: (runs 191691 - 193621) seeded by: L1_HTT150</p></blockquote><p>See also the full list of triggers for CMS 2012 open data:<a href=\"/record/1701\">Trigger information for 2012 CMS open data</a></p>"
+      "description": " <p>High-Level Trigger path information HLT_HT250_SingleDisplacedPFJet60 (HT dataset).</p><blockquote><p>first seen online on run 190456 (<a href=\"/record/6123\">/cdaq/physics/Run2012/5e33/v4.4/HLT/V5</a>)</p><p>last  seen online on run 193621 (<a href=\"/record/6109\">/cdaq/physics/Run2012/5e33/v4.16/HLT/V21</a>)</p><p>V2: (runs 190456 - 190738) seeded by: L1_HTT150</p><p>V3: (runs 190782 - 191411) seeded by: L1_HTT150</p><p>V4: (runs 191691 - 193621) seeded by: L1_HTT150</p></blockquote><p>See also the full list of triggers for CMS 2012 open data:<a href=\"/record/1701\">Trigger information for 2012 CMS open data</a></p>"
     },
     "accelerator": "CERN-LHC",
     "collaboration": {
@@ -7889,7 +7889,7 @@
   },
   {
     "abstract": {
-      "description": " <p>High-Level Trigger path information HLT_HT250_SingleDisplacedPFJet60_ChgFraction10 (HT dataset).</p><blockquote><p>first seen online on run 190456 (<a href=\"/record/6123\">/cdaq/physics/Run2012/5e33/v4.4/HLT/V5</a>)</p><p>last  seen online on run 193621 (<a href=\"/record/6109\"><a href=\"/record/6125\">/cdaq/physics/Run2012/5e33/v4.16/HLT/V2</a>1</a>)</p><p>V2: (runs 190456 - 190738) seeded by: L1_HTT150</p><p>V3: (runs 190782 - 191411) seeded by: L1_HTT150</p><p>V4: (runs 191691 - 193621) seeded by: L1_HTT150</p></blockquote><p>See also the full list of triggers for CMS 2012 open data:<a href=\"/record/1701\">Trigger information for 2012 CMS open data</a></p>"
+      "description": " <p>High-Level Trigger path information HLT_HT250_SingleDisplacedPFJet60_ChgFraction10 (HT dataset).</p><blockquote><p>first seen online on run 190456 (<a href=\"/record/6123\">/cdaq/physics/Run2012/5e33/v4.4/HLT/V5</a>)</p><p>last  seen online on run 193621 (<a href=\"/record/6109\">/cdaq/physics/Run2012/5e33/v4.16/HLT/V21</a>)</p><p>V2: (runs 190456 - 190738) seeded by: L1_HTT150</p><p>V3: (runs 190782 - 191411) seeded by: L1_HTT150</p><p>V4: (runs 191691 - 193621) seeded by: L1_HTT150</p></blockquote><p>See also the full list of triggers for CMS 2012 open data:<a href=\"/record/1701\">Trigger information for 2012 CMS open data</a></p>"
     },
     "accelerator": "CERN-LHC",
     "collaboration": {
@@ -9223,7 +9223,7 @@
   },
   {
     "abstract": {
-      "description": " <p>High-Level Trigger path information HLT_IsoMu18_eta2p1_LooseIsoPFTau20 (TauPlusX dataset).</p><blockquote><p>first seen online on run 190456 (<a href=\"/record/6123\">/cdaq/physics/Run2012/5e33/v4.4/HLT/V5</a>)</p><p>last  seen online on run 193621 (<a href=\"/record/6109\"><a href=\"/record/6125\">/cdaq/physics/Run2012/5e33/v4.16/HLT/V2</a>1</a>)</p><p>V4: (runs 190456 - 190738) seeded by: L1_SingleMu16er</p><p>V5: (runs 190782 - 191411) seeded by: L1_SingleMu16er</p><p>V6: (runs 191691 - 193621) seeded by: L1_SingleMu16er</p></blockquote><p>See also the full list of triggers for CMS 2012 open data:<a href=\"/record/1701\">Trigger information for 2012 CMS open data</a></p>"
+      "description": " <p>High-Level Trigger path information HLT_IsoMu18_eta2p1_LooseIsoPFTau20 (TauPlusX dataset).</p><blockquote><p>first seen online on run 190456 (<a href=\"/record/6123\">/cdaq/physics/Run2012/5e33/v4.4/HLT/V5</a>)</p><p>last  seen online on run 193621 (<a href=\"/record/6109\">/cdaq/physics/Run2012/5e33/v4.16/HLT/V21</a>)</p><p>V4: (runs 190456 - 190738) seeded by: L1_SingleMu16er</p><p>V5: (runs 190782 - 191411) seeded by: L1_SingleMu16er</p><p>V6: (runs 191691 - 193621) seeded by: L1_SingleMu16er</p></blockquote><p>See also the full list of triggers for CMS 2012 open data:<a href=\"/record/1701\">Trigger information for 2012 CMS open data</a></p>"
     },
     "accelerator": "CERN-LHC",
     "collaboration": {
@@ -9397,7 +9397,7 @@
   },
   {
     "abstract": {
-      "description": " <p>High-Level Trigger path information HLT_IsoMu20_eta2p1_CentralPFJet30 (MuHad dataset).</p><blockquote><p>first seen online on run 190456 (<a href=\"/record/6123\">/cdaq/physics/Run2012/5e33/v4.4/HLT/V5</a>)</p><p>last  seen online on run 193621 (<a href=\"/record/6109\"><a href=\"/record/6125\">/cdaq/physics/Run2012/5e33/v4.16/HLT/V2</a>1</a>)</p><p>V2: (runs 190456 - 190738) seeded by: L1_SingleMu16er</p><p>V3: (runs 190782 - 191411) seeded by: L1_SingleMu16er</p><p>V4: (runs 191691 - 193621) seeded by: L1_SingleMu16er</p></blockquote><p>See also the full list of triggers for CMS 2012 open data:<a href=\"/record/1701\">Trigger information for 2012 CMS open data</a></p>"
+      "description": " <p>High-Level Trigger path information HLT_IsoMu20_eta2p1_CentralPFJet30 (MuHad dataset).</p><blockquote><p>first seen online on run 190456 (<a href=\"/record/6123\">/cdaq/physics/Run2012/5e33/v4.4/HLT/V5</a>)</p><p>last  seen online on run 193621 (<a href=\"/record/6109\">/cdaq/physics/Run2012/5e33/v4.16/HLT/V21</a>)</p><p>V2: (runs 190456 - 190738) seeded by: L1_SingleMu16er</p><p>V3: (runs 190782 - 191411) seeded by: L1_SingleMu16er</p><p>V4: (runs 191691 - 193621) seeded by: L1_SingleMu16er</p></blockquote><p>See also the full list of triggers for CMS 2012 open data:<a href=\"/record/1701\">Trigger information for 2012 CMS open data</a></p>"
     },
     "accelerator": "CERN-LHC",
     "collaboration": {
@@ -9426,7 +9426,7 @@
   },
   {
     "abstract": {
-      "description": " <p>High-Level Trigger path information HLT_IsoMu20_eta2p1_CentralPFJet30_BTagIPIter (MuHad dataset).</p><blockquote><p>first seen online on run 190456 (<a href=\"/record/6123\">/cdaq/physics/Run2012/5e33/v4.4/HLT/V5</a>)</p><p>last  seen online on run 193621 (<a href=\"/record/6109\"><a href=\"/record/6125\">/cdaq/physics/Run2012/5e33/v4.16/HLT/V2</a>1</a>)</p><p>V2: (runs 190456 - 190738) seeded by: L1_SingleMu16er</p><p>V3: (runs 190782 - 191411) seeded by: L1_SingleMu16er</p><p>V4: (runs 191691 - 193621) seeded by: L1_SingleMu16er</p></blockquote><p>See also the full list of triggers for CMS 2012 open data:<a href=\"/record/1701\">Trigger information for 2012 CMS open data</a></p>"
+      "description": " <p>High-Level Trigger path information HLT_IsoMu20_eta2p1_CentralPFJet30_BTagIPIter (MuHad dataset).</p><blockquote><p>first seen online on run 190456 (<a href=\"/record/6123\">/cdaq/physics/Run2012/5e33/v4.4/HLT/V5</a>)</p><p>last  seen online on run 193621 (<a href=\"/record/6109\">/cdaq/physics/Run2012/5e33/v4.16/HLT/V21</a>)</p><p>V2: (runs 190456 - 190738) seeded by: L1_SingleMu16er</p><p>V3: (runs 190782 - 191411) seeded by: L1_SingleMu16er</p><p>V4: (runs 191691 - 193621) seeded by: L1_SingleMu16er</p></blockquote><p>See also the full list of triggers for CMS 2012 open data:<a href=\"/record/1701\">Trigger information for 2012 CMS open data</a></p>"
     },
     "accelerator": "CERN-LHC",
     "collaboration": {
@@ -9484,7 +9484,7 @@
   },
   {
     "abstract": {
-      "description": " <p>High-Level Trigger path information HLT_IsoMu20_eta2p1_CentralPFNoPUJet30 (MuHad dataset).</p><blockquote><p>first seen online on run 190456 (<a href=\"/record/6123\">/cdaq/physics/Run2012/5e33/v4.4/HLT/V5</a>)</p><p>last  seen online on run 193621 (<a href=\"/record/6109\"><a href=\"/record/6125\">/cdaq/physics/Run2012/5e33/v4.16/HLT/V2</a>1</a>)</p><p>V2: (runs 190456 - 190738) seeded by: L1_SingleMu16er</p><p>V3: (runs 190782 - 191411) seeded by: L1_SingleMu16er</p><p>V4: (runs 191691 - 193621) seeded by: L1_SingleMu16er</p></blockquote><p>See also the full list of triggers for CMS 2012 open data:<a href=\"/record/1701\">Trigger information for 2012 CMS open data</a></p>"
+      "description": " <p>High-Level Trigger path information HLT_IsoMu20_eta2p1_CentralPFNoPUJet30 (MuHad dataset).</p><blockquote><p>first seen online on run 190456 (<a href=\"/record/6123\">/cdaq/physics/Run2012/5e33/v4.4/HLT/V5</a>)</p><p>last  seen online on run 193621 (<a href=\"/record/6109\">/cdaq/physics/Run2012/5e33/v4.16/HLT/V21</a>)</p><p>V2: (runs 190456 - 190738) seeded by: L1_SingleMu16er</p><p>V3: (runs 190782 - 191411) seeded by: L1_SingleMu16er</p><p>V4: (runs 191691 - 193621) seeded by: L1_SingleMu16er</p></blockquote><p>See also the full list of triggers for CMS 2012 open data:<a href=\"/record/1701\">Trigger information for 2012 CMS open data</a></p>"
     },
     "accelerator": "CERN-LHC",
     "collaboration": {
@@ -9513,7 +9513,7 @@
   },
   {
     "abstract": {
-      "description": " <p>High-Level Trigger path information HLT_IsoMu20_eta2p1_CentralPFNoPUJet30_BTagIPIter (MuHad dataset).</p><blockquote><p>first seen online on run 190456 (<a href=\"/record/6123\">/cdaq/physics/Run2012/5e33/v4.4/HLT/V5</a>)</p><p>last  seen online on run 193621 (<a href=\"/record/6109\"><a href=\"/record/6125\">/cdaq/physics/Run2012/5e33/v4.16/HLT/V2</a>1</a>)</p><p>V2: (runs 190456 - 190738) seeded by: L1_SingleMu16er</p><p>V3: (runs 190782 - 191411) seeded by: L1_SingleMu16er</p><p>V4: (runs 191691 - 193621) seeded by: L1_SingleMu16er</p></blockquote><p>See also the full list of triggers for CMS 2012 open data:<a href=\"/record/1701\">Trigger information for 2012 CMS open data</a></p>"
+      "description": " <p>High-Level Trigger path information HLT_IsoMu20_eta2p1_CentralPFNoPUJet30_BTagIPIter (MuHad dataset).</p><blockquote><p>first seen online on run 190456 (<a href=\"/record/6123\">/cdaq/physics/Run2012/5e33/v4.4/HLT/V5</a>)</p><p>last  seen online on run 193621 (<a href=\"/record/6109\">/cdaq/physics/Run2012/5e33/v4.16/HLT/V21</a>)</p><p>V2: (runs 190456 - 190738) seeded by: L1_SingleMu16er</p><p>V3: (runs 190782 - 191411) seeded by: L1_SingleMu16er</p><p>V4: (runs 191691 - 193621) seeded by: L1_SingleMu16er</p></blockquote><p>See also the full list of triggers for CMS 2012 open data:<a href=\"/record/1701\">Trigger information for 2012 CMS open data</a></p>"
     },
     "accelerator": "CERN-LHC",
     "collaboration": {
@@ -9542,7 +9542,7 @@
   },
   {
     "abstract": {
-      "description": " <p>High-Level Trigger path information HLT_IsoMu20_eta2p1_DiCentralPFJet30 (MuHad dataset).</p><blockquote><p>first seen online on run 190456 (<a href=\"/record/6123\">/cdaq/physics/Run2012/5e33/v4.4/HLT/V5</a>)</p><p>last  seen online on run 193621 (<a href=\"/record/6109\"><a href=\"/record/6125\">/cdaq/physics/Run2012/5e33/v4.16/HLT/V2</a>1</a>)</p><p>V2: (runs 190456 - 190738) seeded by: L1_SingleMu16er</p><p>V3: (runs 190782 - 191411) seeded by: L1_SingleMu16er</p><p>V4: (runs 191691 - 193621) seeded by: L1_SingleMu16er</p></blockquote><p>See also the full list of triggers for CMS 2012 open data:<a href=\"/record/1701\">Trigger information for 2012 CMS open data</a></p>"
+      "description": " <p>High-Level Trigger path information HLT_IsoMu20_eta2p1_DiCentralPFJet30 (MuHad dataset).</p><blockquote><p>first seen online on run 190456 (<a href=\"/record/6123\">/cdaq/physics/Run2012/5e33/v4.4/HLT/V5</a>)</p><p>last  seen online on run 193621 (<a href=\"/record/6109\">/cdaq/physics/Run2012/5e33/v4.16/HLT/V21</a>)</p><p>V2: (runs 190456 - 190738) seeded by: L1_SingleMu16er</p><p>V3: (runs 190782 - 191411) seeded by: L1_SingleMu16er</p><p>V4: (runs 191691 - 193621) seeded by: L1_SingleMu16er</p></blockquote><p>See also the full list of triggers for CMS 2012 open data:<a href=\"/record/1701\">Trigger information for 2012 CMS open data</a></p>"
     },
     "accelerator": "CERN-LHC",
     "collaboration": {
@@ -9571,7 +9571,7 @@
   },
   {
     "abstract": {
-      "description": " <p>High-Level Trigger path information HLT_IsoMu20_eta2p1_DiCentralPFNoPUJet30 (MuHad dataset).</p><blockquote><p>first seen online on run 190456 (<a href=\"/record/6123\">/cdaq/physics/Run2012/5e33/v4.4/HLT/V5</a>)</p><p>last  seen online on run 193621 (<a href=\"/record/6109\"><a href=\"/record/6125\">/cdaq/physics/Run2012/5e33/v4.16/HLT/V2</a>1</a>)</p><p>V2: (runs 190456 - 190738) seeded by: L1_SingleMu16er</p><p>V3: (runs 190782 - 191411) seeded by: L1_SingleMu16er</p><p>V4: (runs 191691 - 193621) seeded by: L1_SingleMu16er</p></blockquote><p>See also the full list of triggers for CMS 2012 open data:<a href=\"/record/1701\">Trigger information for 2012 CMS open data</a></p>"
+      "description": " <p>High-Level Trigger path information HLT_IsoMu20_eta2p1_DiCentralPFNoPUJet30 (MuHad dataset).</p><blockquote><p>first seen online on run 190456 (<a href=\"/record/6123\">/cdaq/physics/Run2012/5e33/v4.4/HLT/V5</a>)</p><p>last  seen online on run 193621 (<a href=\"/record/6109\">/cdaq/physics/Run2012/5e33/v4.16/HLT/V21</a>)</p><p>V2: (runs 190456 - 190738) seeded by: L1_SingleMu16er</p><p>V3: (runs 190782 - 191411) seeded by: L1_SingleMu16er</p><p>V4: (runs 191691 - 193621) seeded by: L1_SingleMu16er</p></blockquote><p>See also the full list of triggers for CMS 2012 open data:<a href=\"/record/1701\">Trigger information for 2012 CMS open data</a></p>"
     },
     "accelerator": "CERN-LHC",
     "collaboration": {
@@ -9600,7 +9600,7 @@
   },
   {
     "abstract": {
-      "description": " <p>High-Level Trigger path information HLT_IsoMu20_eta2p1_LooseIsoPFTau20 (TauPlusX dataset).</p><blockquote><p>first seen online on run 190456 (<a href=\"/record/6123\">/cdaq/physics/Run2012/5e33/v4.4/HLT/V5</a>)</p><p>last  seen online on run 193621 (<a href=\"/record/6109\"><a href=\"/record/6125\">/cdaq/physics/Run2012/5e33/v4.16/HLT/V2</a>1</a>)</p><p>V3: (runs 190456 - 190738) seeded by: L1_SingleMu18er OR L1_SingleMu20er</p><p>V4: (runs 190782 - 191411) seeded by: L1_SingleMu18er OR L1_SingleMu20er</p><p>V5: (runs 191691 - 193621) seeded by: L1_SingleMu18er OR L1_SingleMu20er</p></blockquote><p>See also the full list of triggers for CMS 2012 open data:<a href=\"/record/1701\">Trigger information for 2012 CMS open data</a></p>"
+      "description": " <p>High-Level Trigger path information HLT_IsoMu20_eta2p1_LooseIsoPFTau20 (TauPlusX dataset).</p><blockquote><p>first seen online on run 190456 (<a href=\"/record/6123\">/cdaq/physics/Run2012/5e33/v4.4/HLT/V5</a>)</p><p>last  seen online on run 193621 (<a href=\"/record/6109\">/cdaq/physics/Run2012/5e33/v4.16/HLT/V21</a>)</p><p>V3: (runs 190456 - 190738) seeded by: L1_SingleMu18er OR L1_SingleMu20er</p><p>V4: (runs 190782 - 191411) seeded by: L1_SingleMu18er OR L1_SingleMu20er</p><p>V5: (runs 191691 - 193621) seeded by: L1_SingleMu18er OR L1_SingleMu20er</p></blockquote><p>See also the full list of triggers for CMS 2012 open data:<a href=\"/record/1701\">Trigger information for 2012 CMS open data</a></p>"
     },
     "accelerator": "CERN-LHC",
     "collaboration": {
@@ -9629,7 +9629,7 @@
   },
   {
     "abstract": {
-      "description": " <p>High-Level Trigger path information HLT_IsoMu20_eta2p1_TriCentralPFJet30 (MuHad dataset).</p><blockquote><p>first seen online on run 190456 (<a href=\"/record/6123\">/cdaq/physics/Run2012/5e33/v4.4/HLT/V5</a>)</p><p>last  seen online on run 193621 (<a href=\"/record/6109\"><a href=\"/record/6125\">/cdaq/physics/Run2012/5e33/v4.16/HLT/V2</a>1</a>)</p><p>V2: (runs 190456 - 190738) seeded by: L1_SingleMu16er</p><p>V3: (runs 190782 - 191411) seeded by: L1_SingleMu16er</p><p>V4: (runs 191691 - 193621) seeded by: L1_SingleMu16er</p></blockquote><p>See also the full list of triggers for CMS 2012 open data:<a href=\"/record/1701\">Trigger information for 2012 CMS open data</a></p>"
+      "description": " <p>High-Level Trigger path information HLT_IsoMu20_eta2p1_TriCentralPFJet30 (MuHad dataset).</p><blockquote><p>first seen online on run 190456 (<a href=\"/record/6123\">/cdaq/physics/Run2012/5e33/v4.4/HLT/V5</a>)</p><p>last  seen online on run 193621 (<a href=\"/record/6109\">/cdaq/physics/Run2012/5e33/v4.16/HLT/V21</a>)</p><p>V2: (runs 190456 - 190738) seeded by: L1_SingleMu16er</p><p>V3: (runs 190782 - 191411) seeded by: L1_SingleMu16er</p><p>V4: (runs 191691 - 193621) seeded by: L1_SingleMu16er</p></blockquote><p>See also the full list of triggers for CMS 2012 open data:<a href=\"/record/1701\">Trigger information for 2012 CMS open data</a></p>"
     },
     "accelerator": "CERN-LHC",
     "collaboration": {
@@ -9658,7 +9658,7 @@
   },
   {
     "abstract": {
-      "description": " <p>High-Level Trigger path information HLT_IsoMu20_eta2p1_TriCentralPFJet50_40_30 (MuHad dataset).</p><blockquote><p>first seen online on run 190456 (<a href=\"/record/6123\">/cdaq/physics/Run2012/5e33/v4.4/HLT/V5</a>)</p><p>last  seen online on run 193621 (<a href=\"/record/6109\"><a href=\"/record/6125\">/cdaq/physics/Run2012/5e33/v4.16/HLT/V2</a>1</a>)</p><p>V2: (runs 190456 - 190738) seeded by: L1_SingleMu16er</p><p>V3: (runs 190782 - 191411) seeded by: L1_SingleMu16er</p><p>V4: (runs 191691 - 193621) seeded by: L1_SingleMu16er</p></blockquote><p>See also the full list of triggers for CMS 2012 open data:<a href=\"/record/1701\">Trigger information for 2012 CMS open data</a></p>"
+      "description": " <p>High-Level Trigger path information HLT_IsoMu20_eta2p1_TriCentralPFJet50_40_30 (MuHad dataset).</p><blockquote><p>first seen online on run 190456 (<a href=\"/record/6123\">/cdaq/physics/Run2012/5e33/v4.4/HLT/V5</a>)</p><p>last  seen online on run 193621 (<a href=\"/record/6109\">/cdaq/physics/Run2012/5e33/v4.16/HLT/V21</a>)</p><p>V2: (runs 190456 - 190738) seeded by: L1_SingleMu16er</p><p>V3: (runs 190782 - 191411) seeded by: L1_SingleMu16er</p><p>V4: (runs 191691 - 193621) seeded by: L1_SingleMu16er</p></blockquote><p>See also the full list of triggers for CMS 2012 open data:<a href=\"/record/1701\">Trigger information for 2012 CMS open data</a></p>"
     },
     "accelerator": "CERN-LHC",
     "collaboration": {
@@ -9687,7 +9687,7 @@
   },
   {
     "abstract": {
-      "description": " <p>High-Level Trigger path information HLT_IsoMu20_eta2p1_TriCentralPFNoPUJet30 (MuHad dataset).</p><blockquote><p>first seen online on run 190456 (<a href=\"/record/6123\">/cdaq/physics/Run2012/5e33/v4.4/HLT/V5</a>)</p><p>last  seen online on run 193621 (<a href=\"/record/6109\"><a href=\"/record/6125\">/cdaq/physics/Run2012/5e33/v4.16/HLT/V2</a>1</a>)</p><p>V2: (runs 190456 - 190738) seeded by: L1_SingleMu16er</p><p>V3: (runs 190782 - 191411) seeded by: L1_SingleMu16er</p><p>V4: (runs 191691 - 193621) seeded by: L1_SingleMu16er</p></blockquote><p>See also the full list of triggers for CMS 2012 open data:<a href=\"/record/1701\">Trigger information for 2012 CMS open data</a></p>"
+      "description": " <p>High-Level Trigger path information HLT_IsoMu20_eta2p1_TriCentralPFNoPUJet30 (MuHad dataset).</p><blockquote><p>first seen online on run 190456 (<a href=\"/record/6123\">/cdaq/physics/Run2012/5e33/v4.4/HLT/V5</a>)</p><p>last  seen online on run 193621 (<a href=\"/record/6109\">/cdaq/physics/Run2012/5e33/v4.16/HLT/V21</a>)</p><p>V2: (runs 190456 - 190738) seeded by: L1_SingleMu16er</p><p>V3: (runs 190782 - 191411) seeded by: L1_SingleMu16er</p><p>V4: (runs 191691 - 193621) seeded by: L1_SingleMu16er</p></blockquote><p>See also the full list of triggers for CMS 2012 open data:<a href=\"/record/1701\">Trigger information for 2012 CMS open data</a></p>"
     },
     "accelerator": "CERN-LHC",
     "collaboration": {
@@ -9716,7 +9716,7 @@
   },
   {
     "abstract": {
-      "description": " <p>High-Level Trigger path information HLT_IsoMu20_eta2p1_TriCentralPFNoPUJet50_40_30 (MuHad dataset).</p><blockquote><p>first seen online on run 190456 (<a href=\"/record/6123\">/cdaq/physics/Run2012/5e33/v4.4/HLT/V5</a>)</p><p>last  seen online on run 193621 (<a href=\"/record/6109\"><a href=\"/record/6125\">/cdaq/physics/Run2012/5e33/v4.16/HLT/V2</a>1</a>)</p><p>V2: (runs 190456 - 190738) seeded by: L1_SingleMu16er</p><p>V3: (runs 190782 - 191411) seeded by: L1_SingleMu16er</p><p>V4: (runs 191691 - 193621) seeded by: L1_SingleMu16er</p></blockquote><p>See also the full list of triggers for CMS 2012 open data:<a href=\"/record/1701\">Trigger information for 2012 CMS open data</a></p>"
+      "description": " <p>High-Level Trigger path information HLT_IsoMu20_eta2p1_TriCentralPFNoPUJet50_40_30 (MuHad dataset).</p><blockquote><p>first seen online on run 190456 (<a href=\"/record/6123\">/cdaq/physics/Run2012/5e33/v4.4/HLT/V5</a>)</p><p>last  seen online on run 193621 (<a href=\"/record/6109\">/cdaq/physics/Run2012/5e33/v4.16/HLT/V21</a>)</p><p>V2: (runs 190456 - 190738) seeded by: L1_SingleMu16er</p><p>V3: (runs 190782 - 191411) seeded by: L1_SingleMu16er</p><p>V4: (runs 191691 - 193621) seeded by: L1_SingleMu16er</p></blockquote><p>See also the full list of triggers for CMS 2012 open data:<a href=\"/record/1701\">Trigger information for 2012 CMS open data</a></p>"
     },
     "accelerator": "CERN-LHC",
     "collaboration": {
@@ -9919,7 +9919,7 @@
   },
   {
     "abstract": {
-      "description": " <p>High-Level Trigger path information HLT_IsoMu24_eta2p1_CentralPFJet30_CentralPFJet25 (MuHad dataset).</p><blockquote><p>first seen online on run 190456 (<a href=\"/record/6123\">/cdaq/physics/Run2012/5e33/v4.4/HLT/V5</a>)</p><p>last  seen online on run 193621 (<a href=\"/record/6109\"><a href=\"/record/6125\">/cdaq/physics/Run2012/5e33/v4.16/HLT/V2</a>1</a>)</p><p>V3: (runs 190456 - 190738) seeded by: L1_SingleMu16er</p><p>V4: (runs 190782 - 191411) seeded by: L1_SingleMu16er</p><p>V5: (runs 191691 - 193621) seeded by: L1_SingleMu16er</p></blockquote><p>See also the full list of triggers for CMS 2012 open data:<a href=\"/record/1701\">Trigger information for 2012 CMS open data</a></p>"
+      "description": " <p>High-Level Trigger path information HLT_IsoMu24_eta2p1_CentralPFJet30_CentralPFJet25 (MuHad dataset).</p><blockquote><p>first seen online on run 190456 (<a href=\"/record/6123\">/cdaq/physics/Run2012/5e33/v4.4/HLT/V5</a>)</p><p>last  seen online on run 193621 (<a href=\"/record/6109\">/cdaq/physics/Run2012/5e33/v4.16/HLT/V21</a>)</p><p>V3: (runs 190456 - 190738) seeded by: L1_SingleMu16er</p><p>V4: (runs 190782 - 191411) seeded by: L1_SingleMu16er</p><p>V5: (runs 191691 - 193621) seeded by: L1_SingleMu16er</p></blockquote><p>See also the full list of triggers for CMS 2012 open data:<a href=\"/record/1701\">Trigger information for 2012 CMS open data</a></p>"
     },
     "accelerator": "CERN-LHC",
     "collaboration": {
@@ -9948,7 +9948,7 @@
   },
   {
     "abstract": {
-      "description": " <p>High-Level Trigger path information HLT_IsoMu24_eta2p1_CentralPFJet30_CentralPFJet25_PFMET20 (MuHad dataset).</p><blockquote><p>first seen online on run 190456 (<a href=\"/record/6123\">/cdaq/physics/Run2012/5e33/v4.4/HLT/V5</a>)</p><p>last  seen online on run 193621 (<a href=\"/record/6109\"><a href=\"/record/6125\">/cdaq/physics/Run2012/5e33/v4.16/HLT/V2</a>1</a>)</p><p>V2: (runs 190456 - 190738) seeded by: L1_SingleMu16er</p><p>V3: (runs 190782 - 191411) seeded by: L1_SingleMu16er</p><p>V4: (runs 191691 - 193621) seeded by: L1_SingleMu16er</p></blockquote><p>See also the full list of triggers for CMS 2012 open data:<a href=\"/record/1701\">Trigger information for 2012 CMS open data</a></p>"
+      "description": " <p>High-Level Trigger path information HLT_IsoMu24_eta2p1_CentralPFJet30_CentralPFJet25_PFMET20 (MuHad dataset).</p><blockquote><p>first seen online on run 190456 (<a href=\"/record/6123\">/cdaq/physics/Run2012/5e33/v4.4/HLT/V5</a>)</p><p>last  seen online on run 193621 (<a href=\"/record/6109\">/cdaq/physics/Run2012/5e33/v4.16/HLT/V21</a>)</p><p>V2: (runs 190456 - 190738) seeded by: L1_SingleMu16er</p><p>V3: (runs 190782 - 191411) seeded by: L1_SingleMu16er</p><p>V4: (runs 191691 - 193621) seeded by: L1_SingleMu16er</p></blockquote><p>See also the full list of triggers for CMS 2012 open data:<a href=\"/record/1701\">Trigger information for 2012 CMS open data</a></p>"
     },
     "accelerator": "CERN-LHC",
     "collaboration": {
@@ -9977,7 +9977,7 @@
   },
   {
     "abstract": {
-      "description": " <p>High-Level Trigger path information HLT_IsoMu24_eta2p1_PFJet30_PFJet25_Deta3 (MuHad dataset).</p><blockquote><p>first seen online on run 190456 (<a href=\"/record/6123\">/cdaq/physics/Run2012/5e33/v4.4/HLT/V5</a>)</p><p>last  seen online on run 193621 (<a href=\"/record/6109\"><a href=\"/record/6125\">/cdaq/physics/Run2012/5e33/v4.16/HLT/V2</a>1</a>)</p><p>V3: (runs 190456 - 190738) seeded by: L1_SingleMu16er</p><p>V4: (runs 190782 - 191411) seeded by: L1_SingleMu16er</p><p>V5: (runs 191691 - 193621) seeded by: L1_SingleMu16er</p></blockquote><p>See also the full list of triggers for CMS 2012 open data:<a href=\"/record/1701\">Trigger information for 2012 CMS open data</a></p>"
+      "description": " <p>High-Level Trigger path information HLT_IsoMu24_eta2p1_PFJet30_PFJet25_Deta3 (MuHad dataset).</p><blockquote><p>first seen online on run 190456 (<a href=\"/record/6123\">/cdaq/physics/Run2012/5e33/v4.4/HLT/V5</a>)</p><p>last  seen online on run 193621 (<a href=\"/record/6109\">/cdaq/physics/Run2012/5e33/v4.16/HLT/V21</a>)</p><p>V3: (runs 190456 - 190738) seeded by: L1_SingleMu16er</p><p>V4: (runs 190782 - 191411) seeded by: L1_SingleMu16er</p><p>V5: (runs 191691 - 193621) seeded by: L1_SingleMu16er</p></blockquote><p>See also the full list of triggers for CMS 2012 open data:<a href=\"/record/1701\">Trigger information for 2012 CMS open data</a></p>"
     },
     "accelerator": "CERN-LHC",
     "collaboration": {
@@ -10267,7 +10267,7 @@
   },
   {
     "abstract": {
-      "description": " <p>High-Level Trigger path information HLT_Jet160Eta2p4_Jet120Eta2p4_DiBTagIP3DLoose (MultiJet dataset).</p><blockquote><p>first seen online on run 190456 (<a href=\"/record/6123\">/cdaq/physics/Run2012/5e33/v4.4/HLT/V5</a>)</p><p>last  seen online on run 193621 (<a href=\"/record/6109\"><a href=\"/record/6125\">/cdaq/physics/Run2012/5e33/v4.16/HLT/V2</a>1</a>)</p><p>V2: (runs 190456 - 190738) seeded by: L1_SingleJet128</p><p>V3: (runs 190782 - 193621) seeded by: L1_SingleJet128</p></blockquote><p>See also the full list of triggers for CMS 2012 open data:<a href=\"/record/1701\">Trigger information for 2012 CMS open data</a></p>"
+      "description": " <p>High-Level Trigger path information HLT_Jet160Eta2p4_Jet120Eta2p4_DiBTagIP3DLoose (MultiJet dataset).</p><blockquote><p>first seen online on run 190456 (<a href=\"/record/6123\">/cdaq/physics/Run2012/5e33/v4.4/HLT/V5</a>)</p><p>last  seen online on run 193621 (<a href=\"/record/6109\">/cdaq/physics/Run2012/5e33/v4.16/HLT/V21</a>)</p><p>V2: (runs 190456 - 190738) seeded by: L1_SingleJet128</p><p>V3: (runs 190782 - 193621) seeded by: L1_SingleJet128</p></blockquote><p>See also the full list of triggers for CMS 2012 open data:<a href=\"/record/1701\">Trigger information for 2012 CMS open data</a></p>"
     },
     "accelerator": "CERN-LHC",
     "collaboration": {
@@ -10383,7 +10383,7 @@
   },
   {
     "abstract": {
-      "description": " <p>High-Level Trigger path information HLT_Jet60Eta1p7_Jet53Eta1p7_DiBTagIP3D (MultiJet dataset).</p><blockquote><p>first seen online on run 190456 (<a href=\"/record/6123\">/cdaq/physics/Run2012/5e33/v4.4/HLT/V5</a>)</p><p>last  seen online on run 193621 (<a href=\"/record/6109\"><a href=\"/record/6125\">/cdaq/physics/Run2012/5e33/v4.16/HLT/V2</a>1</a>)</p><p>V2: (runs 190456 - 190738) seeded by: L1_DoubleJetC44_Eta1p74_WdEta4</p><p>V3: (runs 190782 - 193621) seeded by: L1_DoubleJetC44_Eta1p74_WdEta4</p></blockquote><p>See also the full list of triggers for CMS 2012 open data:<a href=\"/record/1701\">Trigger information for 2012 CMS open data</a></p>"
+      "description": " <p>High-Level Trigger path information HLT_Jet60Eta1p7_Jet53Eta1p7_DiBTagIP3D (MultiJet dataset).</p><blockquote><p>first seen online on run 190456 (<a href=\"/record/6123\">/cdaq/physics/Run2012/5e33/v4.4/HLT/V5</a>)</p><p>last  seen online on run 193621 (<a href=\"/record/6109\">/cdaq/physics/Run2012/5e33/v4.16/HLT/V21</a>)</p><p>V2: (runs 190456 - 190738) seeded by: L1_DoubleJetC44_Eta1p74_WdEta4</p><p>V3: (runs 190782 - 193621) seeded by: L1_DoubleJetC44_Eta1p74_WdEta4</p></blockquote><p>See also the full list of triggers for CMS 2012 open data:<a href=\"/record/1701\">Trigger information for 2012 CMS open data</a></p>"
     },
     "accelerator": "CERN-LHC",
     "collaboration": {
@@ -10441,7 +10441,7 @@
   },
   {
     "abstract": {
-      "description": " <p>High-Level Trigger path information HLT_Jet80Eta1p7_Jet70Eta1p7_DiBTagIP3D (MultiJet dataset).</p><blockquote><p>first seen online on run 190456 (<a href=\"/record/6123\">/cdaq/physics/Run2012/5e33/v4.4/HLT/V5</a>)</p><p>last  seen online on run 193621 (<a href=\"/record/6109\"><a href=\"/record/6125\">/cdaq/physics/Run2012/5e33/v4.16/HLT/V2</a>1</a>)</p><p>V2: (runs 190456 - 190738) seeded by: L1_DoubleJetC56_Eta1p74_WdEta4</p><p>V3: (runs 190782 - 193621) seeded by: L1_DoubleJetC56_Eta1p74_WdEta4</p></blockquote><p>See also the full list of triggers for CMS 2012 open data:<a href=\"/record/1701\">Trigger information for 2012 CMS open data</a></p>"
+      "description": " <p>High-Level Trigger path information HLT_Jet80Eta1p7_Jet70Eta1p7_DiBTagIP3D (MultiJet dataset).</p><blockquote><p>first seen online on run 190456 (<a href=\"/record/6123\">/cdaq/physics/Run2012/5e33/v4.4/HLT/V5</a>)</p><p>last  seen online on run 193621 (<a href=\"/record/6109\">/cdaq/physics/Run2012/5e33/v4.16/HLT/V21</a>)</p><p>V2: (runs 190456 - 190738) seeded by: L1_DoubleJetC56_Eta1p74_WdEta4</p><p>V3: (runs 190782 - 193621) seeded by: L1_DoubleJetC56_Eta1p74_WdEta4</p></blockquote><p>See also the full list of triggers for CMS 2012 open data:<a href=\"/record/1701\">Trigger information for 2012 CMS open data</a></p>"
     },
     "accelerator": "CERN-LHC",
     "collaboration": {
@@ -12123,7 +12123,7 @@
   },
   {
     "abstract": {
-      "description": " <p>High-Level Trigger path information HLT_L2Mu70_eta2p1_PFMET65 (SingleMu dataset).</p><blockquote><p>first seen online on run 190456 (<a href=\"/record/6123\">/cdaq/physics/Run2012/5e33/v4.4/HLT/V5</a>)</p><p>last  seen online on run 193621 (<a href=\"/record/6109\"><a href=\"/record/6125\">/cdaq/physics/Run2012/5e33/v4.16/HLT/V2</a>1</a>)</p><p>V2: (runs 190456 - 190738) seeded by: L1_SingleMu16er</p><p>V3: (runs 190782 - 191411) seeded by: L1_SingleMu16er</p><p>V4: (runs 191691 - 193621) seeded by: L1_SingleMu16er</p></blockquote><p>See also the full list of triggers for CMS 2012 open data:<a href=\"/record/1701\">Trigger information for 2012 CMS open data</a></p>"
+      "description": " <p>High-Level Trigger path information HLT_L2Mu70_eta2p1_PFMET65 (SingleMu dataset).</p><blockquote><p>first seen online on run 190456 (<a href=\"/record/6123\">/cdaq/physics/Run2012/5e33/v4.4/HLT/V5</a>)</p><p>last  seen online on run 193621 (<a href=\"/record/6109\">/cdaq/physics/Run2012/5e33/v4.16/HLT/V21</a>)</p><p>V2: (runs 190456 - 190738) seeded by: L1_SingleMu16er</p><p>V3: (runs 190782 - 191411) seeded by: L1_SingleMu16er</p><p>V4: (runs 191691 - 193621) seeded by: L1_SingleMu16er</p></blockquote><p>See also the full list of triggers for CMS 2012 open data:<a href=\"/record/1701\">Trigger information for 2012 CMS open data</a></p>"
     },
     "accelerator": "CERN-LHC",
     "collaboration": {
@@ -12152,7 +12152,7 @@
   },
   {
     "abstract": {
-      "description": " <p>High-Level Trigger path information HLT_L2Mu80_eta2p1_PFMET70 (SingleMu dataset).</p><blockquote><p>first seen online on run 190456 (<a href=\"/record/6123\">/cdaq/physics/Run2012/5e33/v4.4/HLT/V5</a>)</p><p>last  seen online on run 193621 (<a href=\"/record/6109\"><a href=\"/record/6125\">/cdaq/physics/Run2012/5e33/v4.16/HLT/V2</a>1</a>)</p><p>V2: (runs 190456 - 190738) seeded by: L1_SingleMu16er</p><p>V3: (runs 190782 - 191411) seeded by: L1_SingleMu16er</p><p>V4: (runs 191691 - 193621) seeded by: L1_SingleMu16er</p></blockquote><p>See also the full list of triggers for CMS 2012 open data:<a href=\"/record/1701\">Trigger information for 2012 CMS open data</a></p>"
+      "description": " <p>High-Level Trigger path information HLT_L2Mu80_eta2p1_PFMET70 (SingleMu dataset).</p><blockquote><p>first seen online on run 190456 (<a href=\"/record/6123\">/cdaq/physics/Run2012/5e33/v4.4/HLT/V5</a>)</p><p>last  seen online on run 193621 (<a href=\"/record/6109\">/cdaq/physics/Run2012/5e33/v4.16/HLT/V21</a>)</p><p>V2: (runs 190456 - 190738) seeded by: L1_SingleMu16er</p><p>V3: (runs 190782 - 191411) seeded by: L1_SingleMu16er</p><p>V4: (runs 191691 - 193621) seeded by: L1_SingleMu16er</p></blockquote><p>See also the full list of triggers for CMS 2012 open data:<a href=\"/record/1701\">Trigger information for 2012 CMS open data</a></p>"
     },
     "accelerator": "CERN-LHC",
     "collaboration": {
@@ -12819,7 +12819,7 @@
   },
   {
     "abstract": {
-      "description": " <p>High-Level Trigger path information HLT_Mu12_DoubleCentralJet65 (MuHad dataset).</p><blockquote><p>first seen online on run 190456 (<a href=\"/record/6123\">/cdaq/physics/Run2012/5e33/v4.4/HLT/V5</a>)</p><p>last  seen online on run 193621 (<a href=\"/record/6109\"><a href=\"/record/6125\">/cdaq/physics/Run2012/5e33/v4.16/HLT/V2</a>1</a>)</p><p>V3: (runs 190456 - 190738) seeded by: (L1_DoubleJetC64 OR L1_DoubleJetC56 OR L1_DoubleJetC52) AND (L1_SingleMuOpen)</p><p>V4: (runs 190782 - 193621) seeded by: (L1_DoubleJetC64 OR L1_DoubleJetC56 OR L1_DoubleJetC52) AND (L1_SingleMuOpen)</p></blockquote><p>See also the full list of triggers for CMS 2012 open data:<a href=\"/record/1701\">Trigger information for 2012 CMS open data</a></p>"
+      "description": " <p>High-Level Trigger path information HLT_Mu12_DoubleCentralJet65 (MuHad dataset).</p><blockquote><p>first seen online on run 190456 (<a href=\"/record/6123\">/cdaq/physics/Run2012/5e33/v4.4/HLT/V5</a>)</p><p>last  seen online on run 193621 (<a href=\"/record/6109\">/cdaq/physics/Run2012/5e33/v4.16/HLT/V21</a>)</p><p>V3: (runs 190456 - 190738) seeded by: (L1_DoubleJetC64 OR L1_DoubleJetC56 OR L1_DoubleJetC52) AND (L1_SingleMuOpen)</p><p>V4: (runs 190782 - 193621) seeded by: (L1_DoubleJetC64 OR L1_DoubleJetC56 OR L1_DoubleJetC52) AND (L1_SingleMuOpen)</p></blockquote><p>See also the full list of triggers for CMS 2012 open data:<a href=\"/record/1701\">Trigger information for 2012 CMS open data</a></p>"
     },
     "accelerator": "CERN-LHC",
     "collaboration": {
@@ -12848,7 +12848,7 @@
   },
   {
     "abstract": {
-      "description": " <p>High-Level Trigger path information HLT_Mu12_RsqMR30_Rsq0p04_MR200 (MuHad dataset).</p><blockquote><p>first seen online on run 190456 (<a href=\"/record/6123\">/cdaq/physics/Run2012/5e33/v4.4/HLT/V5</a>)</p><p>last  seen online on run 193621 (<a href=\"/record/6109\"><a href=\"/record/6125\">/cdaq/physics/Run2012/5e33/v4.16/HLT/V2</a>1</a>)</p><p>V3: (runs 190456 - 190738) seeded by: (L1_DoubleJetC64 OR L1_DoubleJetC56 OR L1_DoubleJetC52) AND (L1_SingleMuOpen)</p><p>V4: (runs 190782 - 193621) seeded by: (L1_DoubleJetC64 OR L1_DoubleJetC56 OR L1_DoubleJetC52) AND (L1_SingleMuOpen)</p></blockquote><p>See also the full list of triggers for CMS 2012 open data:<a href=\"/record/1701\">Trigger information for 2012 CMS open data</a></p>"
+      "description": " <p>High-Level Trigger path information HLT_Mu12_RsqMR30_Rsq0p04_MR200 (MuHad dataset).</p><blockquote><p>first seen online on run 190456 (<a href=\"/record/6123\">/cdaq/physics/Run2012/5e33/v4.4/HLT/V5</a>)</p><p>last  seen online on run 193621 (<a href=\"/record/6109\">/cdaq/physics/Run2012/5e33/v4.16/HLT/V21</a>)</p><p>V3: (runs 190456 - 190738) seeded by: (L1_DoubleJetC64 OR L1_DoubleJetC56 OR L1_DoubleJetC52) AND (L1_SingleMuOpen)</p><p>V4: (runs 190782 - 193621) seeded by: (L1_DoubleJetC64 OR L1_DoubleJetC56 OR L1_DoubleJetC52) AND (L1_SingleMuOpen)</p></blockquote><p>See also the full list of triggers for CMS 2012 open data:<a href=\"/record/1701\">Trigger information for 2012 CMS open data</a></p>"
     },
     "accelerator": "CERN-LHC",
     "collaboration": {
@@ -12877,7 +12877,7 @@
   },
   {
     "abstract": {
-      "description": " <p>High-Level Trigger path information HLT_Mu12_RsqMR40_Rsq0p04_MR200 (MuHad dataset).</p><blockquote><p>first seen online on run 190456 (<a href=\"/record/6123\">/cdaq/physics/Run2012/5e33/v4.4/HLT/V5</a>)</p><p>last  seen online on run 193621 (<a href=\"/record/6109\"><a href=\"/record/6125\">/cdaq/physics/Run2012/5e33/v4.16/HLT/V2</a>1</a>)</p><p>V3: (runs 190456 - 190738) seeded by: (L1_DoubleJetC64 OR L1_DoubleJetC56 OR L1_DoubleJetC52) AND (L1_SingleMuOpen)</p><p>V4: (runs 190782 - 193621) seeded by: (L1_DoubleJetC64 OR L1_DoubleJetC56 OR L1_DoubleJetC52) AND (L1_SingleMuOpen)</p></blockquote><p>See also the full list of triggers for CMS 2012 open data:<a href=\"/record/1701\">Trigger information for 2012 CMS open data</a></p>"
+      "description": " <p>High-Level Trigger path information HLT_Mu12_RsqMR40_Rsq0p04_MR200 (MuHad dataset).</p><blockquote><p>first seen online on run 190456 (<a href=\"/record/6123\">/cdaq/physics/Run2012/5e33/v4.4/HLT/V5</a>)</p><p>last  seen online on run 193621 (<a href=\"/record/6109\">/cdaq/physics/Run2012/5e33/v4.16/HLT/V21</a>)</p><p>V3: (runs 190456 - 190738) seeded by: (L1_DoubleJetC64 OR L1_DoubleJetC56 OR L1_DoubleJetC52) AND (L1_SingleMuOpen)</p><p>V4: (runs 190782 - 193621) seeded by: (L1_DoubleJetC64 OR L1_DoubleJetC56 OR L1_DoubleJetC52) AND (L1_SingleMuOpen)</p></blockquote><p>See also the full list of triggers for CMS 2012 open data:<a href=\"/record/1701\">Trigger information for 2012 CMS open data</a></p>"
     },
     "accelerator": "CERN-LHC",
     "collaboration": {
@@ -12906,7 +12906,7 @@
   },
   {
     "abstract": {
-      "description": " <p>High-Level Trigger path information HLT_Mu12_RsqMR45_Rsq0p04_MR200 (MuHad dataset).</p><blockquote><p>first seen online on run 190456 (<a href=\"/record/6123\">/cdaq/physics/Run2012/5e33/v4.4/HLT/V5</a>)</p><p>last  seen online on run 193621 (<a href=\"/record/6109\"><a href=\"/record/6125\">/cdaq/physics/Run2012/5e33/v4.16/HLT/V2</a>1</a>)</p><p>V2: (runs 190456 - 190738) seeded by: (L1_DoubleJetC64 OR L1_DoubleJetC56 OR L1_DoubleJetC52) AND (L1_SingleMuOpen)</p><p>V3: (runs 190782 - 193621) seeded by: (L1_DoubleJetC64 OR L1_DoubleJetC56 OR L1_DoubleJetC52) AND (L1_SingleMuOpen)</p></blockquote><p>See also the full list of triggers for CMS 2012 open data:<a href=\"/record/1701\">Trigger information for 2012 CMS open data</a></p>"
+      "description": " <p>High-Level Trigger path information HLT_Mu12_RsqMR45_Rsq0p04_MR200 (MuHad dataset).</p><blockquote><p>first seen online on run 190456 (<a href=\"/record/6123\">/cdaq/physics/Run2012/5e33/v4.4/HLT/V5</a>)</p><p>last  seen online on run 193621 (<a href=\"/record/6109\">/cdaq/physics/Run2012/5e33/v4.16/HLT/V21</a>)</p><p>V2: (runs 190456 - 190738) seeded by: (L1_DoubleJetC64 OR L1_DoubleJetC56 OR L1_DoubleJetC52) AND (L1_SingleMuOpen)</p><p>V3: (runs 190782 - 193621) seeded by: (L1_DoubleJetC64 OR L1_DoubleJetC56 OR L1_DoubleJetC52) AND (L1_SingleMuOpen)</p></blockquote><p>See also the full list of triggers for CMS 2012 open data:<a href=\"/record/1701\">Trigger information for 2012 CMS open data</a></p>"
     },
     "accelerator": "CERN-LHC",
     "collaboration": {
@@ -13834,7 +13834,7 @@
   },
   {
     "abstract": {
-      "description": " <p>High-Level Trigger path information HLT_Mu18_eta2p1_LooseIsoPFTau20 (TauPlusX dataset).</p><blockquote><p>first seen online on run 190456 (<a href=\"/record/6123\">/cdaq/physics/Run2012/5e33/v4.4/HLT/V5</a>)</p><p>last  seen online on run 193621 (<a href=\"/record/6109\"><a href=\"/record/6125\">/cdaq/physics/Run2012/5e33/v4.16/HLT/V2</a>1</a>)</p><p>V4: (runs 190456 - 190738) seeded by: L1_SingleMu16er</p><p>V5: (runs 190782 - 191411) seeded by: L1_SingleMu16er</p><p>V6: (runs 191691 - 193621) seeded by: L1_SingleMu16er</p></blockquote><p>See also the full list of triggers for CMS 2012 open data:<a href=\"/record/1701\">Trigger information for 2012 CMS open data</a></p>"
+      "description": " <p>High-Level Trigger path information HLT_Mu18_eta2p1_LooseIsoPFTau20 (TauPlusX dataset).</p><blockquote><p>first seen online on run 190456 (<a href=\"/record/6123\">/cdaq/physics/Run2012/5e33/v4.4/HLT/V5</a>)</p><p>last  seen online on run 193621 (<a href=\"/record/6109\">/cdaq/physics/Run2012/5e33/v4.16/HLT/V21</a>)</p><p>V4: (runs 190456 - 190738) seeded by: L1_SingleMu16er</p><p>V5: (runs 190782 - 191411) seeded by: L1_SingleMu16er</p><p>V6: (runs 191691 - 193621) seeded by: L1_SingleMu16er</p></blockquote><p>See also the full list of triggers for CMS 2012 open data:<a href=\"/record/1701\">Trigger information for 2012 CMS open data</a></p>"
     },
     "accelerator": "CERN-LHC",
     "collaboration": {
@@ -13863,7 +13863,7 @@
   },
   {
     "abstract": {
-      "description": " <p>High-Level Trigger path information HLT_Mu20_eta2p1_CentralPFJet30_BTagIPIter (MuHad dataset).</p><blockquote><p>first seen online on run 190456 (<a href=\"/record/6123\">/cdaq/physics/Run2012/5e33/v4.4/HLT/V5</a>)</p><p>last  seen online on run 193621 (<a href=\"/record/6109\"><a href=\"/record/6125\">/cdaq/physics/Run2012/5e33/v4.16/HLT/V2</a>1</a>)</p><p>V3: (runs 190456 - 190738) seeded by: L1_SingleMu16er</p><p>V4: (runs 190782 - 191411) seeded by: L1_SingleMu16er</p><p>V5: (runs 191691 - 193621) seeded by: L1_SingleMu16er</p></blockquote><p>See also the full list of triggers for CMS 2012 open data:<a href=\"/record/1701\">Trigger information for 2012 CMS open data</a></p>"
+      "description": " <p>High-Level Trigger path information HLT_Mu20_eta2p1_CentralPFJet30_BTagIPIter (MuHad dataset).</p><blockquote><p>first seen online on run 190456 (<a href=\"/record/6123\">/cdaq/physics/Run2012/5e33/v4.4/HLT/V5</a>)</p><p>last  seen online on run 193621 (<a href=\"/record/6109\">/cdaq/physics/Run2012/5e33/v4.16/HLT/V21</a>)</p><p>V3: (runs 190456 - 190738) seeded by: L1_SingleMu16er</p><p>V4: (runs 190782 - 191411) seeded by: L1_SingleMu16er</p><p>V5: (runs 191691 - 193621) seeded by: L1_SingleMu16er</p></blockquote><p>See also the full list of triggers for CMS 2012 open data:<a href=\"/record/1701\">Trigger information for 2012 CMS open data</a></p>"
     },
     "accelerator": "CERN-LHC",
     "collaboration": {
@@ -13892,7 +13892,7 @@
   },
   {
     "abstract": {
-      "description": " <p>High-Level Trigger path information HLT_Mu20_eta2p1_CentralPFNoPUJet30_BTagIPIter (MuHad dataset).</p><blockquote><p>first seen online on run 190456 (<a href=\"/record/6123\">/cdaq/physics/Run2012/5e33/v4.4/HLT/V5</a>)</p><p>last  seen online on run 193621 (<a href=\"/record/6109\"><a href=\"/record/6125\">/cdaq/physics/Run2012/5e33/v4.16/HLT/V2</a>1</a>)</p><p>V2: (runs 190456 - 190738) seeded by: L1_SingleMu16er</p><p>V3: (runs 190782 - 191411) seeded by: L1_SingleMu16er</p><p>V4: (runs 191691 - 193621) seeded by: L1_SingleMu16er</p></blockquote><p>See also the full list of triggers for CMS 2012 open data:<a href=\"/record/1701\">Trigger information for 2012 CMS open data</a></p>"
+      "description": " <p>High-Level Trigger path information HLT_Mu20_eta2p1_CentralPFNoPUJet30_BTagIPIter (MuHad dataset).</p><blockquote><p>first seen online on run 190456 (<a href=\"/record/6123\">/cdaq/physics/Run2012/5e33/v4.4/HLT/V5</a>)</p><p>last  seen online on run 193621 (<a href=\"/record/6109\">/cdaq/physics/Run2012/5e33/v4.16/HLT/V21</a>)</p><p>V2: (runs 190456 - 190738) seeded by: L1_SingleMu16er</p><p>V3: (runs 190782 - 191411) seeded by: L1_SingleMu16er</p><p>V4: (runs 191691 - 193621) seeded by: L1_SingleMu16er</p></blockquote><p>See also the full list of triggers for CMS 2012 open data:<a href=\"/record/1701\">Trigger information for 2012 CMS open data</a></p>"
     },
     "accelerator": "CERN-LHC",
     "collaboration": {
@@ -13921,7 +13921,7 @@
   },
   {
     "abstract": {
-      "description": " <p>High-Level Trigger path information HLT_Mu20_eta2p1_TriCentralPFJet30 (MuHad dataset).</p><blockquote><p>first seen online on run 190456 (<a href=\"/record/6123\">/cdaq/physics/Run2012/5e33/v4.4/HLT/V5</a>)</p><p>last  seen online on run 193621 (<a href=\"/record/6109\"><a href=\"/record/6125\">/cdaq/physics/Run2012/5e33/v4.16/HLT/V2</a>1</a>)</p><p>V3: (runs 190456 - 190738) seeded by: L1_SingleMu16er</p><p>V4: (runs 190782 - 191411) seeded by: L1_SingleMu16er</p><p>V5: (runs 191691 - 193621) seeded by: L1_SingleMu16er</p></blockquote><p>See also the full list of triggers for CMS 2012 open data:<a href=\"/record/1701\">Trigger information for 2012 CMS open data</a></p>"
+      "description": " <p>High-Level Trigger path information HLT_Mu20_eta2p1_TriCentralPFJet30 (MuHad dataset).</p><blockquote><p>first seen online on run 190456 (<a href=\"/record/6123\">/cdaq/physics/Run2012/5e33/v4.4/HLT/V5</a>)</p><p>last  seen online on run 193621 (<a href=\"/record/6109\">/cdaq/physics/Run2012/5e33/v4.16/HLT/V21</a>)</p><p>V3: (runs 190456 - 190738) seeded by: L1_SingleMu16er</p><p>V4: (runs 190782 - 191411) seeded by: L1_SingleMu16er</p><p>V5: (runs 191691 - 193621) seeded by: L1_SingleMu16er</p></blockquote><p>See also the full list of triggers for CMS 2012 open data:<a href=\"/record/1701\">Trigger information for 2012 CMS open data</a></p>"
     },
     "accelerator": "CERN-LHC",
     "collaboration": {
@@ -13950,7 +13950,7 @@
   },
   {
     "abstract": {
-      "description": " <p>High-Level Trigger path information HLT_Mu20_eta2p1_TriCentralPFJet50_40_30 (MuHad dataset).</p><blockquote><p>first seen online on run 190456 (<a href=\"/record/6123\">/cdaq/physics/Run2012/5e33/v4.4/HLT/V5</a>)</p><p>last  seen online on run 193621 (<a href=\"/record/6109\"><a href=\"/record/6125\">/cdaq/physics/Run2012/5e33/v4.16/HLT/V2</a>1</a>)</p><p>V2: (runs 190456 - 190738) seeded by: L1_SingleMu16er</p><p>V3: (runs 190782 - 191411) seeded by: L1_SingleMu16er</p><p>V4: (runs 191691 - 193621) seeded by: L1_SingleMu16er</p></blockquote><p>See also the full list of triggers for CMS 2012 open data:<a href=\"/record/1701\">Trigger information for 2012 CMS open data</a></p>"
+      "description": " <p>High-Level Trigger path information HLT_Mu20_eta2p1_TriCentralPFJet50_40_30 (MuHad dataset).</p><blockquote><p>first seen online on run 190456 (<a href=\"/record/6123\">/cdaq/physics/Run2012/5e33/v4.4/HLT/V5</a>)</p><p>last  seen online on run 193621 (<a href=\"/record/6109\">/cdaq/physics/Run2012/5e33/v4.16/HLT/V21</a>)</p><p>V2: (runs 190456 - 190738) seeded by: L1_SingleMu16er</p><p>V3: (runs 190782 - 191411) seeded by: L1_SingleMu16er</p><p>V4: (runs 191691 - 193621) seeded by: L1_SingleMu16er</p></blockquote><p>See also the full list of triggers for CMS 2012 open data:<a href=\"/record/1701\">Trigger information for 2012 CMS open data</a></p>"
     },
     "accelerator": "CERN-LHC",
     "collaboration": {
@@ -13979,7 +13979,7 @@
   },
   {
     "abstract": {
-      "description": " <p>High-Level Trigger path information HLT_Mu20_eta2p1_TriCentralPFNoPUJet30 (MuHad dataset).</p><blockquote><p>first seen online on run 190456 (<a href=\"/record/6123\">/cdaq/physics/Run2012/5e33/v4.4/HLT/V5</a>)</p><p>last  seen online on run 193621 (<a href=\"/record/6109\"><a href=\"/record/6125\">/cdaq/physics/Run2012/5e33/v4.16/HLT/V2</a>1</a>)</p><p>V2: (runs 190456 - 190738) seeded by: L1_SingleMu16er</p><p>V3: (runs 190782 - 191411) seeded by: L1_SingleMu16er</p><p>V4: (runs 191691 - 193621) seeded by: L1_SingleMu16er</p></blockquote><p>See also the full list of triggers for CMS 2012 open data:<a href=\"/record/1701\">Trigger information for 2012 CMS open data</a></p>"
+      "description": " <p>High-Level Trigger path information HLT_Mu20_eta2p1_TriCentralPFNoPUJet30 (MuHad dataset).</p><blockquote><p>first seen online on run 190456 (<a href=\"/record/6123\">/cdaq/physics/Run2012/5e33/v4.4/HLT/V5</a>)</p><p>last  seen online on run 193621 (<a href=\"/record/6109\">/cdaq/physics/Run2012/5e33/v4.16/HLT/V21</a>)</p><p>V2: (runs 190456 - 190738) seeded by: L1_SingleMu16er</p><p>V3: (runs 190782 - 191411) seeded by: L1_SingleMu16er</p><p>V4: (runs 191691 - 193621) seeded by: L1_SingleMu16er</p></blockquote><p>See also the full list of triggers for CMS 2012 open data:<a href=\"/record/1701\">Trigger information for 2012 CMS open data</a></p>"
     },
     "accelerator": "CERN-LHC",
     "collaboration": {
@@ -14008,7 +14008,7 @@
   },
   {
     "abstract": {
-      "description": " <p>High-Level Trigger path information HLT_Mu20_eta2p1_TriCentralPFNoPUJet50_40_30 (MuHad dataset).</p><blockquote><p>first seen online on run 190456 (<a href=\"/record/6123\">/cdaq/physics/Run2012/5e33/v4.4/HLT/V5</a>)</p><p>last  seen online on run 193621 (<a href=\"/record/6109\"><a href=\"/record/6125\">/cdaq/physics/Run2012/5e33/v4.16/HLT/V2</a>1</a>)</p><p>V2: (runs 190456 - 190738) seeded by: L1_SingleMu16er</p><p>V3: (runs 190782 - 191411) seeded by: L1_SingleMu16er</p><p>V4: (runs 191691 - 193621) seeded by: L1_SingleMu16er</p></blockquote><p>See also the full list of triggers for CMS 2012 open data:<a href=\"/record/1701\">Trigger information for 2012 CMS open data</a></p>"
+      "description": " <p>High-Level Trigger path information HLT_Mu20_eta2p1_TriCentralPFNoPUJet50_40_30 (MuHad dataset).</p><blockquote><p>first seen online on run 190456 (<a href=\"/record/6123\">/cdaq/physics/Run2012/5e33/v4.4/HLT/V5</a>)</p><p>last  seen online on run 193621 (<a href=\"/record/6109\">/cdaq/physics/Run2012/5e33/v4.16/HLT/V21</a>)</p><p>V2: (runs 190456 - 190738) seeded by: L1_SingleMu16er</p><p>V3: (runs 190782 - 191411) seeded by: L1_SingleMu16er</p><p>V4: (runs 191691 - 193621) seeded by: L1_SingleMu16er</p></blockquote><p>See also the full list of triggers for CMS 2012 open data:<a href=\"/record/1701\">Trigger information for 2012 CMS open data</a></p>"
     },
     "accelerator": "CERN-LHC",
     "collaboration": {
@@ -14240,7 +14240,7 @@
   },
   {
     "abstract": {
-      "description": " <p>High-Level Trigger path information HLT_Mu24_eta2p1_CentralPFJet30_CentralPFJet25 (MuHad dataset).</p><blockquote><p>first seen online on run 190456 (<a href=\"/record/6123\">/cdaq/physics/Run2012/5e33/v4.4/HLT/V5</a>)</p><p>last  seen online on run 193621 (<a href=\"/record/6109\"><a href=\"/record/6125\">/cdaq/physics/Run2012/5e33/v4.16/HLT/V2</a>1</a>)</p><p>V3: (runs 190456 - 190738) seeded by: L1_SingleMu16er</p><p>V4: (runs 190782 - 191411) seeded by: L1_SingleMu16er</p><p>V5: (runs 191691 - 193621) seeded by: L1_SingleMu16er</p></blockquote><p>See also the full list of triggers for CMS 2012 open data:<a href=\"/record/1701\">Trigger information for 2012 CMS open data</a></p>"
+      "description": " <p>High-Level Trigger path information HLT_Mu24_eta2p1_CentralPFJet30_CentralPFJet25 (MuHad dataset).</p><blockquote><p>first seen online on run 190456 (<a href=\"/record/6123\">/cdaq/physics/Run2012/5e33/v4.4/HLT/V5</a>)</p><p>last  seen online on run 193621 (<a href=\"/record/6109\">/cdaq/physics/Run2012/5e33/v4.16/HLT/V21</a>)</p><p>V3: (runs 190456 - 190738) seeded by: L1_SingleMu16er</p><p>V4: (runs 190782 - 191411) seeded by: L1_SingleMu16er</p><p>V5: (runs 191691 - 193621) seeded by: L1_SingleMu16er</p></blockquote><p>See also the full list of triggers for CMS 2012 open data:<a href=\"/record/1701\">Trigger information for 2012 CMS open data</a></p>"
     },
     "accelerator": "CERN-LHC",
     "collaboration": {
@@ -14269,7 +14269,7 @@
   },
   {
     "abstract": {
-      "description": " <p>High-Level Trigger path information HLT_Mu24_eta2p1_PFJet30_PFJet25_Deta3 (MuHad dataset).</p><blockquote><p>first seen online on run 190456 (<a href=\"/record/6123\">/cdaq/physics/Run2012/5e33/v4.4/HLT/V5</a>)</p><p>last  seen online on run 193621 (<a href=\"/record/6109\"><a href=\"/record/6125\">/cdaq/physics/Run2012/5e33/v4.16/HLT/V2</a>1</a>)</p><p>V3: (runs 190456 - 190738) seeded by: L1_SingleMu16er</p><p>V4: (runs 190782 - 191411) seeded by: L1_SingleMu16er</p><p>V5: (runs 191691 - 193621) seeded by: L1_SingleMu16er</p></blockquote><p>See also the full list of triggers for CMS 2012 open data:<a href=\"/record/1701\">Trigger information for 2012 CMS open data</a></p>"
+      "description": " <p>High-Level Trigger path information HLT_Mu24_eta2p1_PFJet30_PFJet25_Deta3 (MuHad dataset).</p><blockquote><p>first seen online on run 190456 (<a href=\"/record/6123\">/cdaq/physics/Run2012/5e33/v4.4/HLT/V5</a>)</p><p>last  seen online on run 193621 (<a href=\"/record/6109\">/cdaq/physics/Run2012/5e33/v4.16/HLT/V21</a>)</p><p>V3: (runs 190456 - 190738) seeded by: L1_SingleMu16er</p><p>V4: (runs 190782 - 191411) seeded by: L1_SingleMu16er</p><p>V5: (runs 191691 - 193621) seeded by: L1_SingleMu16er</p></blockquote><p>See also the full list of triggers for CMS 2012 open data:<a href=\"/record/1701\">Trigger information for 2012 CMS open data</a></p>"
     },
     "accelerator": "CERN-LHC",
     "collaboration": {
@@ -14414,7 +14414,7 @@
   },
   {
     "abstract": {
-      "description": " <p>High-Level Trigger path information HLT_Mu40_FJHT200 (MuHad dataset).</p><blockquote><p>first seen online on run 190456 (<a href=\"/record/6123\">/cdaq/physics/Run2012/5e33/v4.4/HLT/V5</a>)</p><p>last  seen online on run 193621 (<a href=\"/record/6109\"><a href=\"/record/6125\">/cdaq/physics/Run2012/5e33/v4.16/HLT/V2</a>1</a>)</p><p>V3: (runs 190456 - 190738) seeded by: L1_Mu0_HTT100 OR L1_Mu4_HTT125</p><p>V4: (runs 190782 - 193621) seeded by: L1_Mu0_HTT100 OR L1_Mu4_HTT125</p></blockquote><p>See also the full list of triggers for CMS 2012 open data:<a href=\"/record/1701\">Trigger information for 2012 CMS open data</a></p>"
+      "description": " <p>High-Level Trigger path information HLT_Mu40_FJHT200 (MuHad dataset).</p><blockquote><p>first seen online on run 190456 (<a href=\"/record/6123\">/cdaq/physics/Run2012/5e33/v4.4/HLT/V5</a>)</p><p>last  seen online on run 193621 (<a href=\"/record/6109\">/cdaq/physics/Run2012/5e33/v4.16/HLT/V21</a>)</p><p>V3: (runs 190456 - 190738) seeded by: L1_Mu0_HTT100 OR L1_Mu4_HTT125</p><p>V4: (runs 190782 - 193621) seeded by: L1_Mu0_HTT100 OR L1_Mu4_HTT125</p></blockquote><p>See also the full list of triggers for CMS 2012 open data:<a href=\"/record/1701\">Trigger information for 2012 CMS open data</a></p>"
     },
     "accelerator": "CERN-LHC",
     "collaboration": {
@@ -17662,7 +17662,7 @@
   },
   {
     "abstract": {
-      "description": " <p>High-Level Trigger path information HLT_Photon250_NoHE (Photon dataset).</p><blockquote><p>first seen online on run 190456 (<a href=\"/record/6123\">/cdaq/physics/Run2012/5e33/v4.4/HLT/V5</a>)</p><p>last  seen online on run 193621 (<a href=\"/record/6109\"><a href=\"/record/6125\">/cdaq/physics/Run2012/5e33/v4.16/HLT/V2</a>1</a>)</p><p>V1: (runs 190456 - 190738) seeded by: L1_SingleEG30</p><p>V2: (runs 190782 - 191411) seeded by: L1_SingleEG30</p><p>V3: (runs 191691 - 193621) seeded by: L1_SingleEG30</p></blockquote><p>See also the full list of triggers for CMS 2012 open data:<a href=\"/record/1701\">Trigger information for 2012 CMS open data</a></p>"
+      "description": " <p>High-Level Trigger path information HLT_Photon250_NoHE (Photon dataset).</p><blockquote><p>first seen online on run 190456 (<a href=\"/record/6123\">/cdaq/physics/Run2012/5e33/v4.4/HLT/V5</a>)</p><p>last  seen online on run 193621 (<a href=\"/record/6109\">/cdaq/physics/Run2012/5e33/v4.16/HLT/V21</a>)</p><p>V1: (runs 190456 - 190738) seeded by: L1_SingleEG30</p><p>V2: (runs 190782 - 191411) seeded by: L1_SingleEG30</p><p>V3: (runs 191691 - 193621) seeded by: L1_SingleEG30</p></blockquote><p>See also the full list of triggers for CMS 2012 open data:<a href=\"/record/1701\">Trigger information for 2012 CMS open data</a></p>"
     },
     "accelerator": "CERN-LHC",
     "collaboration": {
@@ -18561,7 +18561,7 @@
   },
   {
     "abstract": {
-      "description": " <p>High-Level Trigger path information HLT_Photon60_CaloIdL_FJHT300 (PhotonHad dataset).</p><blockquote><p>first seen online on run 190456 (<a href=\"/record/6123\">/cdaq/physics/Run2012/5e33/v4.4/HLT/V5</a>)</p><p>last  seen online on run 193621 (<a href=\"/record/6109\"><a href=\"/record/6125\">/cdaq/physics/Run2012/5e33/v4.16/HLT/V2</a>1</a>)</p><p>V1: (runs 190456 - 190738) seeded by: L1_SingleEG24</p><p>V2: (runs 190782 - 191411) seeded by: L1_SingleEG24</p><p>V3: (runs 191691 - 193621) seeded by: L1_SingleEG24</p></blockquote><p>See also the full list of triggers for CMS 2012 open data:<a href=\"/record/1701\">Trigger information for 2012 CMS open data</a></p>"
+      "description": " <p>High-Level Trigger path information HLT_Photon60_CaloIdL_FJHT300 (PhotonHad dataset).</p><blockquote><p>first seen online on run 190456 (<a href=\"/record/6123\">/cdaq/physics/Run2012/5e33/v4.4/HLT/V5</a>)</p><p>last  seen online on run 193621 (<a href=\"/record/6109\">/cdaq/physics/Run2012/5e33/v4.16/HLT/V21</a>)</p><p>V1: (runs 190456 - 190738) seeded by: L1_SingleEG24</p><p>V2: (runs 190782 - 191411) seeded by: L1_SingleEG24</p><p>V3: (runs 191691 - 193621) seeded by: L1_SingleEG24</p></blockquote><p>See also the full list of triggers for CMS 2012 open data:<a href=\"/record/1701\">Trigger information for 2012 CMS open data</a></p>"
     },
     "accelerator": "CERN-LHC",
     "collaboration": {
@@ -18880,7 +18880,7 @@
   },
   {
     "abstract": {
-      "description": " <p>High-Level Trigger path information HLT_Photon90EBOnly_CaloIdVL_IsoL_TriPFJet25 (PhotonHad dataset).</p><blockquote><p>first seen online on run 190456 (<a href=\"/record/6123\">/cdaq/physics/Run2012/5e33/v4.4/HLT/V5</a>)</p><p>last  seen online on run 193621 (<a href=\"/record/6109\"><a href=\"/record/6125\">/cdaq/physics/Run2012/5e33/v4.16/HLT/V2</a>1</a>)</p><p>V10: (runs 190456 - 190738) seeded by: L1_SingleEG20 OR L1_SingleEG22</p><p>V11: (runs 190782 - 191411) seeded by: L1_SingleEG20 OR L1_SingleEG22</p><p>V12: (runs 191691 - 193621) seeded by: L1_SingleEG20 OR L1_SingleEG22</p></blockquote><p>See also the full list of triggers for CMS 2012 open data:<a href=\"/record/1701\">Trigger information for 2012 CMS open data</a></p>"
+      "description": " <p>High-Level Trigger path information HLT_Photon90EBOnly_CaloIdVL_IsoL_TriPFJet25 (PhotonHad dataset).</p><blockquote><p>first seen online on run 190456 (<a href=\"/record/6123\">/cdaq/physics/Run2012/5e33/v4.4/HLT/V5</a>)</p><p>last  seen online on run 193621 (<a href=\"/record/6109\">/cdaq/physics/Run2012/5e33/v4.16/HLT/V21</a>)</p><p>V10: (runs 190456 - 190738) seeded by: L1_SingleEG20 OR L1_SingleEG22</p><p>V11: (runs 190782 - 191411) seeded by: L1_SingleEG20 OR L1_SingleEG22</p><p>V12: (runs 191691 - 193621) seeded by: L1_SingleEG20 OR L1_SingleEG22</p></blockquote><p>See also the full list of triggers for CMS 2012 open data:<a href=\"/record/1701\">Trigger information for 2012 CMS open data</a></p>"
     },
     "accelerator": "CERN-LHC",
     "collaboration": {
@@ -18909,7 +18909,7 @@
   },
   {
     "abstract": {
-      "description": " <p>High-Level Trigger path information HLT_Photon90EBOnly_CaloIdVL_IsoL_TriPFJet30 (PhotonHad dataset).</p><blockquote><p>first seen online on run 190456 (<a href=\"/record/6123\">/cdaq/physics/Run2012/5e33/v4.4/HLT/V5</a>)</p><p>last  seen online on run 193621 (<a href=\"/record/6109\"><a href=\"/record/6125\">/cdaq/physics/Run2012/5e33/v4.16/HLT/V2</a>1</a>)</p><p>V10: (runs 190456 - 190738) seeded by: L1_SingleEG20 OR L1_SingleEG22</p><p>V11: (runs 190782 - 191411) seeded by: L1_SingleEG20 OR L1_SingleEG22</p><p>V12: (runs 191691 - 193621) seeded by: L1_SingleEG20 OR L1_SingleEG22</p></blockquote><p>See also the full list of triggers for CMS 2012 open data:<a href=\"/record/1701\">Trigger information for 2012 CMS open data</a></p>"
+      "description": " <p>High-Level Trigger path information HLT_Photon90EBOnly_CaloIdVL_IsoL_TriPFJet30 (PhotonHad dataset).</p><blockquote><p>first seen online on run 190456 (<a href=\"/record/6123\">/cdaq/physics/Run2012/5e33/v4.4/HLT/V5</a>)</p><p>last  seen online on run 193621 (<a href=\"/record/6109\">/cdaq/physics/Run2012/5e33/v4.16/HLT/V21</a>)</p><p>V10: (runs 190456 - 190738) seeded by: L1_SingleEG20 OR L1_SingleEG22</p><p>V11: (runs 190782 - 191411) seeded by: L1_SingleEG20 OR L1_SingleEG22</p><p>V12: (runs 191691 - 193621) seeded by: L1_SingleEG20 OR L1_SingleEG22</p></blockquote><p>See also the full list of triggers for CMS 2012 open data:<a href=\"/record/1701\">Trigger information for 2012 CMS open data</a></p>"
     },
     "accelerator": "CERN-LHC",
     "collaboration": {
@@ -19924,7 +19924,7 @@
   },
   {
     "abstract": {
-      "description": " <p>High-Level Trigger path information HLT_RelIso1p0Mu17 (SingleMu dataset).</p><blockquote><p>first seen online on run 190456 (<a href=\"/record/6123\">/cdaq/physics/Run2012/5e33/v4.4/HLT/V5</a>)</p><p>last  seen online on run 193621 (<a href=\"/record/6109\"><a href=\"/record/6125\">/cdaq/physics/Run2012/5e33/v4.16/HLT/V2</a>1</a>)</p><p>V2: (runs 190456 - 190738) seeded by: L1_SingleMu3</p><p>V3: (runs 190782 - 193621) seeded by: L1_SingleMu12</p></blockquote><p>See also the full list of triggers for CMS 2012 open data:<a href=\"/record/1701\">Trigger information for 2012 CMS open data</a></p>"
+      "description": " <p>High-Level Trigger path information HLT_RelIso1p0Mu17 (SingleMu dataset).</p><blockquote><p>first seen online on run 190456 (<a href=\"/record/6123\">/cdaq/physics/Run2012/5e33/v4.4/HLT/V5</a>)</p><p>last  seen online on run 193621 (<a href=\"/record/6109\">/cdaq/physics/Run2012/5e33/v4.16/HLT/V21</a>)</p><p>V2: (runs 190456 - 190738) seeded by: L1_SingleMu3</p><p>V3: (runs 190782 - 193621) seeded by: L1_SingleMu12</p></blockquote><p>See also the full list of triggers for CMS 2012 open data:<a href=\"/record/1701\">Trigger information for 2012 CMS open data</a></p>"
     },
     "accelerator": "CERN-LHC",
     "collaboration": {

--- a/data/records/cms-hlt-trigger-paths-2015.json
+++ b/data/records/cms-hlt-trigger-paths-2015.json
@@ -21309,7 +21309,7 @@
   },
   {
     "abstract": {
-      "description": " <p>High-Level Trigger path information HLT_L1Tech57_CASTOR_HighJet.</p><blockquote><p>first seen online on run 247981 (<a href=\"/record/22506\">/cdaq/physics/firstCollisions15/v8.0/HLT/V2</a>)</p><p>last  seen online on run 251250 (<a href=\"/record/22514\">/cdaq/special/HLTPhysics/v1.0/HLT/V1</a>2)</p><p>V1: (runs 247981 - 251250)</p></blockquote><p>See also the full list of triggers for CMS 2015 open data: <a href=\"/record/23900\">Trigger information for CMS 2015 open data</a></p>"
+      "description": " <p>High-Level Trigger path information HLT_L1Tech57_CASTOR_HighJet.</p><blockquote><p>first seen online on run 247981 (<a href=\"/record/22506\">/cdaq/physics/firstCollisions15/v8.0/HLT/V2</a>)</p><p>last  seen online on run 251250 (<a href=\"/record/22515\">/cdaq/special/HLTPhysics/v1.0/HLT/V12</a>)</p><p>V1: (runs 247981 - 251250)</p></blockquote><p>See also the full list of triggers for CMS 2015 open data: <a href=\"/record/23900\">Trigger information for CMS 2015 open data</a></p>"
     },
     "accelerator": "CERN-LHC",
     "collaboration": {
@@ -21337,7 +21337,7 @@
   },
   {
     "abstract": {
-      "description": " <p>High-Level Trigger path information HLT_L1Tech58_CASTOR_MediumJet.</p><blockquote><p>first seen online on run 247981 (<a href=\"/record/22506\">/cdaq/physics/firstCollisions15/v8.0/HLT/V2</a>)</p><p>last  seen online on run 251250 (<a href=\"/record/22514\">/cdaq/special/HLTPhysics/v1.0/HLT/V1</a>2)</p><p>V1: (runs 247981 - 251250)</p></blockquote><p>See also the full list of triggers for CMS 2015 open data: <a href=\"/record/23900\">Trigger information for CMS 2015 open data</a></p>"
+      "description": " <p>High-Level Trigger path information HLT_L1Tech58_CASTOR_MediumJet.</p><blockquote><p>first seen online on run 247981 (<a href=\"/record/22506\">/cdaq/physics/firstCollisions15/v8.0/HLT/V2</a>)</p><p>last  seen online on run 251250 (<a href=\"/record/22515\">/cdaq/special/HLTPhysics/v1.0/HLT/V12</a>)</p><p>V1: (runs 247981 - 251250)</p></blockquote><p>See also the full list of triggers for CMS 2015 open data: <a href=\"/record/23900\">Trigger information for CMS 2015 open data</a></p>"
     },
     "accelerator": "CERN-LHC",
     "collaboration": {
@@ -21393,7 +21393,7 @@
   },
   {
     "abstract": {
-      "description": " <p>High-Level Trigger path information HLT_L1Tech59_CASTOR_HaloMuon.</p><blockquote><p>first seen online on run 247981 (<a href=\"/record/22506\">/cdaq/physics/firstCollisions15/v8.0/HLT/V2</a>)</p><p>last  seen online on run 251250 (<a href=\"/record/22514\">/cdaq/special/HLTPhysics/v1.0/HLT/V1</a>2)</p><p>V1: (runs 247981 - 251250)</p></blockquote><p>See also the full list of triggers for CMS 2015 open data: <a href=\"/record/23900\">Trigger information for CMS 2015 open data</a></p>"
+      "description": " <p>High-Level Trigger path information HLT_L1Tech59_CASTOR_HaloMuon.</p><blockquote><p>first seen online on run 247981 (<a href=\"/record/22506\">/cdaq/physics/firstCollisions15/v8.0/HLT/V2</a>)</p><p>last  seen online on run 251250 (<a href=\"/record/22515\">/cdaq/special/HLTPhysics/v1.0/HLT/V12</a>)</p><p>V1: (runs 247981 - 251250)</p></blockquote><p>See also the full list of triggers for CMS 2015 open data: <a href=\"/record/23900\">Trigger information for CMS 2015 open data</a></p>"
     },
     "accelerator": "CERN-LHC",
     "collaboration": {

--- a/data/records/cms-hlt-trigger-paths-2016.json
+++ b/data/records/cms-hlt-trigger-paths-2016.json
@@ -35245,7 +35245,7 @@
   },
   {
     "abstract": {
-      "description": " <p>High-Level Trigger path information HLT_ZeroBias_FirstCollisionAfterAbortGap_copy.</p><blockquote><p>first seen online on run 276453 (<a href=\"/record/29040\">/cdaq/physics/Run2016/25ns10e33/v2.2.0/HLT/V1</a>0)</p><p>last  seen online on run 284044 (<a href=\"/record/29080\">/cdaq/physics/Run2016/25ns15e33/v4.2.3/HLT/V2</a>)</p><p>V1: (runs 276453 - 284044)</p></blockquote><p>See also the full list of triggers for CMS 2016 open data: <a href=\"/record/30300\">Trigger information for CMS 2016 open data</a></p>"
+      "description": " <p>High-Level Trigger path information HLT_ZeroBias_FirstCollisionAfterAbortGap_copy.</p><blockquote><p>first seen online on run 276453 (<a href=\"/record/29041\">/cdaq/physics/Run2016/25ns10e33/v2.2.0/HLT/V10</a>)</p><p>last  seen online on run 284044 (<a href=\"/record/29080\">/cdaq/physics/Run2016/25ns15e33/v4.2.3/HLT/V2</a>)</p><p>V1: (runs 276453 - 284044)</p></blockquote><p>See also the full list of triggers for CMS 2016 open data: <a href=\"/record/30300\">Trigger information for CMS 2016 open data</a></p>"
     },
     "accelerator": "CERN-LHC",
     "collaboration": {


### PR DESCRIPTION
### Description

Fixes malformed and nested anchor tags in CMS High-Level Trigger path records:
- In `data/records/cms-hlt-trigger-paths-2012.json`: 77 records had a nested/broken link:
  `<a href="/record/6109"><a href="/record/6125">/cdaq/physics/Run2012/5e33/v4.16/HLT/V2</a>1</a>`
  which was intended to point to configuration file record `6109` (`.../HLT/V21`).
- In `data/records/cms-hlt-trigger-paths-2015.json`: 3 records had `.../HLT/V1</a>2)` pointing to record `22514` (`.../HLT/V1`) with `2` left outside the anchor, instead of pointing to record `22515` (`.../HLT/V12`).
- In `data/records/cms-hlt-trigger-paths-2016.json`: 1 record had `.../HLT/V1</a>0)` pointing to record `29040` (`.../HLT/V1`) with `0` left outside the anchor, instead of pointing to record `29041` (`.../HLT/V10`).

Closes #3647.