### PR TITLE
fix(records): add missing CC0 license to ATLAS records (closes #3764)

### DIFF
--- a/data/records/atlas-ATL-PHYS-PUB-2021-002.json
+++ b/data/records/atlas-ATL-PHYS-PUB-2021-002.json
@@ -94,6 +94,9 @@
     "keywords": [
       "datascience"
     ],
+    "license": {
+      "attribution": "CC0-1.0"
+    },
     "links": [
       {
         "description": "ATLAS publication note ATL-PHYS-PUB-2021-002",

--- a/data/records/atlas-ATL-PHYS-PUB-2022-039.json
+++ b/data/records/atlas-ATL-PHYS-PUB-2022-039.json
@@ -38,6 +38,9 @@
     "keywords": [
       "datascience"
     ],
+    "license": {
+      "attribution": "CC0-1.0"
+    },
     "links": [
       {
         "description": "ATLAS publication note ATL-PHYS-PUB-2022-039",

--- a/data/records/atlas-CERN-EP-2024-159.json
+++ b/data/records/atlas-CERN-EP-2024-159.json
@@ -233,6 +233,9 @@
     "keywords": [
       "datascience"
     ],
+    "license": {
+      "attribution": "CC0-1.0"
+    },
     "links": [
       {
         "description": "ATLAS paper arxiv:2047.20127",

--- a/data/records/atlas-SIMU-2018-04.json
+++ b/data/records/atlas-SIMU-2018-04.json
@@ -55,6 +55,9 @@
     "keywords": [
       "datascience"
     ],
+    "license": {
+      "attribution": "CC0-1.0"
+    },
     "links": [
       {
         "description": "ATLAS AtlFast3 paper SIMU-2018-04",

--- a/data/records/atlas-derived-datasets.json
+++ b/data/records/atlas-derived-datasets.json
@@ -128,6 +128,9 @@
     "keywords": [
       "masterclass"
     ],
+    "license": {
+      "attribution": "CC0-1.0"
+    },
     "publisher": "CERN Open Data Portal",
     "recid": "320",
     "run_period": [
@@ -278,6 +281,9 @@
     "keywords": [
       "masterclass"
     ],
+    "license": {
+      "attribution": "CC0-1.0"
+    },
     "publisher": "CERN Open Data Portal",
     "recid": "321",
     "run_period": [
@@ -428,6 +434,9 @@
     "keywords": [
       "masterclass"
     ],
+    "license": {
+      "attribution": "CC0-1.0"
+    },
     "publisher": "CERN Open Data Portal",
     "recid": "322",
     "run_period": [
@@ -578,6 +587,9 @@
     "keywords": [
       "masterclass"
     ],
+    "license": {
+      "attribution": "CC0-1.0"
+    },
     "publisher": "CERN Open Data Portal",
     "recid": "323",
     "run_period": [
@@ -728,6 +740,9 @@
     "keywords": [
       "masterclass"
     ],
+    "license": {
+      "attribution": "CC0-1.0"
+    },
     "publisher": "CERN Open Data Portal",
     "recid": "324",
     "run_period": [
@@ -878,6 +893,9 @@
     "keywords": [
       "masterclass"
     ],
+    "license": {
+      "attribution": "CC0-1.0"
+    },
     "publisher": "CERN Open Data Portal",
     "recid": "325",
     "run_period": [
@@ -1028,6 +1046,9 @@
     "keywords": [
       "masterclass"
     ],
+    "license": {
+      "attribution": "CC0-1.0"
+    },
     "publisher": "CERN Open Data Portal",
     "recid": "340",
     "run_period": [
@@ -1178,6 +1199,9 @@
     "keywords": [
       "masterclass"
     ],
+    "license": {
+      "attribution": "CC0-1.0"
+    },
     "publisher": "CERN Open Data Portal",
     "recid": "341",
     "run_period": [
@@ -1328,6 +1352,9 @@
     "keywords": [
       "masterclass"
     ],
+    "license": {
+      "attribution": "CC0-1.0"
+    },
     "publisher": "CERN Open Data Portal",
     "recid": "342",
     "run_period": [
@@ -1478,6 +1505,9 @@
     "keywords": [
       "masterclass"
     ],
+    "license": {
+      "attribution": "CC0-1.0"
+    },
     "publisher": "CERN Open Data Portal",
     "recid": "343",
     "run_period": [
@@ -1628,6 +1658,9 @@
     "keywords": [
       "masterclass"
     ],
+    "license": {
+      "attribution": "CC0-1.0"
+    },
     "publisher": "CERN Open Data Portal",
     "recid": "344",
     "run_period": [
@@ -1778,6 +1811,9 @@
     "keywords": [
       "masterclass"
     ],
+    "license": {
+      "attribution": "CC0-1.0"
+    },
     "publisher": "CERN Open Data Portal",
     "recid": "345",
     "run_period": [
@@ -1928,6 +1964,9 @@
     "keywords": [
       "masterclass"
     ],
+    "license": {
+      "attribution": "CC0-1.0"
+    },
     "publisher": "CERN Open Data Portal",
     "recid": "346",
     "run_period": [
@@ -2078,6 +2117,9 @@
     "keywords": [
       "masterclass"
     ],
+    "license": {
+      "attribution": "CC0-1.0"
+    },
     "publisher": "CERN Open Data Portal",
     "recid": "347",
     "run_period": [
@@ -2228,6 +2270,9 @@
     "keywords": [
       "masterclass"
     ],
+    "license": {
+      "attribution": "CC0-1.0"
+    },
     "publisher": "CERN Open Data Portal",
     "recid": "348",
     "run_period": [
@@ -2378,6 +2423,9 @@
     "keywords": [
       "masterclass"
     ],
+    "license": {
+      "attribution": "CC0-1.0"
+    },
     "publisher": "CERN Open Data Portal",
     "recid": "349",
     "run_period": [
@@ -2528,6 +2576,9 @@
     "keywords": [
       "masterclass"
     ],
+    "license": {
+      "attribution": "CC0-1.0"
+    },
     "publisher": "CERN Open Data Portal",
     "recid": "350",
     "run_period": [
@@ -2678,6 +2729,9 @@
     "keywords": [
       "masterclass"
     ],
+    "license": {
+      "attribution": "CC0-1.0"
+    },
     "publisher": "CERN Open Data Portal",
     "recid": "351",
     "run_period": [
@@ -2828,6 +2882,9 @@
     "keywords": [
       "masterclass"
     ],
+    "license": {
+      "attribution": "CC0-1.0"
+    },
     "publisher": "CERN Open Data Portal",
     "recid": "353",
     "run_period": [
@@ -2978,6 +3035,9 @@
     "keywords": [
       "masterclass"
     ],
+    "license": {
+      "attribution": "CC0-1.0"
+    },
     "publisher": "CERN Open Data Portal",
     "recid": "354",
     "run_period": [
@@ -3128,6 +3188,9 @@
     "keywords": [
       "masterclass"
     ],
+    "license": {
+      "attribution": "CC0-1.0"
+    },
     "publisher": "CERN Open Data Portal",
     "recid": "355",
     "run_period": [
@@ -3278,6 +3341,9 @@
     "keywords": [
       "masterclass"
     ],
+    "license": {
+      "attribution": "CC0-1.0"
+    },
     "publisher": "CERN Open Data Portal",
     "recid": "356",
     "run_period": [
@@ -3428,6 +3494,9 @@
     "keywords": [
       "masterclass"
     ],
+    "license": {
+      "attribution": "CC0-1.0"
+    },
     "publisher": "CERN Open Data Portal",
     "recid": "357",
     "run_period": [
@@ -3578,6 +3647,9 @@
     "keywords": [
       "masterclass"
     ],
+    "license": {
+      "attribution": "CC0-1.0"
+    },
     "publisher": "CERN Open Data Portal",
     "recid": "358",
     "run_period": [
@@ -3728,6 +3800,9 @@
     "keywords": [
       "masterclass"
     ],
+    "license": {
+      "attribution": "CC0-1.0"
+    },
     "publisher": "CERN Open Data Portal",
     "recid": "359",
     "run_period": [
@@ -3878,6 +3953,9 @@
     "keywords": [
       "masterclass"
     ],
+    "license": {
+      "attribution": "CC0-1.0"
+    },
     "publisher": "CERN Open Data Portal",
     "recid": "360",
     "run_period": [
@@ -4028,6 +4106,9 @@
     "keywords": [
       "masterclass"
     ],
+    "license": {
+      "attribution": "CC0-1.0"
+    },
     "publisher": "CERN Open Data Portal",
     "recid": "361",
     "run_period": [
@@ -4178,6 +4259,9 @@
     "keywords": [
       "masterclass"
     ],
+    "license": {
+      "attribution": "CC0-1.0"
+    },
     "publisher": "CERN Open Data Portal",
     "recid": "362",
     "run_period": [
@@ -4328,6 +4412,9 @@
     "keywords": [
       "masterclass"
     ],
+    "license": {
+      "attribution": "CC0-1.0"
+    },
     "publisher": "CERN Open Data Portal",
     "recid": "363",
     "run_period": [
@@ -4478,6 +4565,9 @@
     "keywords": [
       "masterclass"
     ],
+    "license": {
+      "attribution": "CC0-1.0"
+    },
     "publisher": "CERN Open Data Portal",
     "recid": "364",
     "run_period": [
@@ -4628,6 +4718,9 @@
     "keywords": [
       "masterclass"
     ],
+    "license": {
+      "attribution": "CC0-1.0"
+    },
     "publisher": "CERN Open Data Portal",
     "recid": "365",
     "run_period": [
@@ -4778,6 +4871,9 @@
     "keywords": [
       "masterclass"
     ],
+    "license": {
+      "attribution": "CC0-1.0"
+    },
     "publisher": "CERN Open Data Portal",
     "recid": "366",
     "run_period": [
@@ -4928,6 +5024,9 @@
     "keywords": [
       "masterclass"
     ],
+    "license": {
+      "attribution": "CC0-1.0"
+    },
     "publisher": "CERN Open Data Portal",
     "recid": "367",
     "run_period": [
@@ -5078,6 +5177,9 @@
     "keywords": [
       "masterclass"
     ],
+    "license": {
+      "attribution": "CC0-1.0"
+    },
     "publisher": "CERN Open Data Portal",
     "recid": "368",
     "run_period": [
@@ -5228,6 +5330,9 @@
     "keywords": [
       "masterclass"
     ],
+    "license": {
+      "attribution": "CC0-1.0"
+    },
     "publisher": "CERN Open Data Portal",
     "recid": "369",
     "run_period": [
@@ -5378,6 +5483,9 @@
     "keywords": [
       "masterclass"
     ],
+    "license": {
+      "attribution": "CC0-1.0"
+    },
     "publisher": "CERN Open Data Portal",
     "recid": "370",
     "run_period": [
@@ -5528,6 +5636,9 @@
     "keywords": [
       "masterclass"
     ],
+    "license": {
+      "attribution": "CC0-1.0"
+    },
     "publisher": "CERN Open Data Portal",
     "recid": "371",
     "run_period": [
@@ -5678,6 +5789,9 @@
     "keywords": [
       "masterclass"
     ],
+    "license": {
+      "attribution": "CC0-1.0"
+    },
     "publisher": "CERN Open Data Portal",
     "recid": "372",
     "run_period": [
@@ -5828,6 +5942,9 @@
     "keywords": [
       "masterclass"
     ],
+    "license": {
+      "attribution": "CC0-1.0"
+    },
     "publisher": "CERN Open Data Portal",
     "recid": "373",
     "run_period": [
@@ -5978,6 +6095,9 @@
     "keywords": [
       "masterclass"
     ],
+    "license": {
+      "attribution": "CC0-1.0"
+    },
     "publisher": "CERN Open Data Portal",
     "recid": "374",
     "run_period": [
@@ -6128,6 +6248,9 @@
     "keywords": [
       "masterclass"
     ],
+    "license": {
+      "attribution": "CC0-1.0"
+    },
     "publisher": "CERN Open Data Portal",
     "recid": "375",
     "run_period": [
@@ -6278,6 +6401,9 @@
     "keywords": [
       "masterclass"
     ],
+    "license": {
+      "attribution": "CC0-1.0"
+    },
     "publisher": "CERN Open Data Portal",
     "recid": "376",
     "run_period": [
@@ -6428,6 +6554,9 @@
     "keywords": [
       "masterclass"
     ],
+    "license": {
+      "attribution": "CC0-1.0"
+    },
     "publisher": "CERN Open Data Portal",
     "recid": "377",
     "run_period": [
@@ -6578,6 +6707,9 @@
     "keywords": [
       "masterclass"
     ],
+    "license": {
+      "attribution": "CC0-1.0"
+    },
     "publisher": "CERN Open Data Portal",
     "recid": "378",
     "run_period": [
@@ -6728,6 +6860,9 @@
     "keywords": [
       "masterclass"
     ],
+    "license": {
+      "attribution": "CC0-1.0"
+    },
     "publisher": "CERN Open Data Portal",
     "recid": "379",
     "run_period": [
@@ -6878,6 +7013,9 @@
     "keywords": [
       "masterclass"
     ],
+    "license": {
+      "attribution": "CC0-1.0"
+    },
     "publisher": "CERN Open Data Portal",
     "recid": "380",
     "run_period": [
@@ -7028,6 +7166,9 @@
     "keywords": [
       "masterclass"
     ],
+    "license": {
+      "attribution": "CC0-1.0"
+    },
     "publisher": "CERN Open Data Portal",
     "recid": "381",
     "run_period": [
@@ -7178,6 +7319,9 @@
     "keywords": [
       "masterclass"
     ],
+    "license": {
+      "attribution": "CC0-1.0"
+    },
     "publisher": "CERN Open Data Portal",
     "recid": "382",
     "run_period": [
@@ -7328,6 +7472,9 @@
     "keywords": [
       "masterclass"
     ],
+    "license": {
+      "attribution": "CC0-1.0"
+    },
     "publisher": "CERN Open Data Portal",
     "recid": "383",
     "run_period": [
@@ -7478,6 +7625,9 @@
     "keywords": [
       "masterclass"
     ],
+    "license": {
+      "attribution": "CC0-1.0"
+    },
     "publisher": "CERN Open Data Portal",
     "recid": "384",
     "run_period": [
@@ -7628,6 +7778,9 @@
     "keywords": [
       "masterclass"
     ],
+    "license": {
+      "attribution": "CC0-1.0"
+    },
     "publisher": "CERN Open Data Portal",
     "recid": "385",
     "run_period": [
@@ -7778,6 +7931,9 @@
     "keywords": [
       "masterclass"
     ],
+    "license": {
+      "attribution": "CC0-1.0"
+    },
     "publisher": "CERN Open Data Portal",
     "recid": "386",
     "run_period": [
@@ -7928,6 +8084,9 @@
     "keywords": [
       "masterclass"
     ],
+    "license": {
+      "attribution": "CC0-1.0"
+    },
     "publisher": "CERN Open Data Portal",
     "recid": "387",
     "run_period": [
@@ -8078,6 +8237,9 @@
     "keywords": [
       "masterclass"
     ],
+    "license": {
+      "attribution": "CC0-1.0"
+    },
     "publisher": "CERN Open Data Portal",
     "recid": "388",
     "run_period": [
@@ -8228,6 +8390,9 @@
     "keywords": [
       "masterclass"
     ],
+    "license": {
+      "attribution": "CC0-1.0"
+    },
     "publisher": "CERN Open Data Portal",
     "recid": "389",
     "run_period": [


### PR DESCRIPTION
### Description

Identified and added missing `CC0-1.0` license attributions to ATLAS dataset records:
- Standalone publication datasets:
  - Record 15009 (`data/records/atlas-ATL-PHYS-PUB-2021-002.json`)
  - Record 15013 (`data/records/atlas-ATL-PHYS-PUB-2022-039.json`)
  - Record 80030 (`data/records/atlas-CERN-EP-2024-159.json`)
  - Record 15012 (`data/records/atlas-SIMU-2018-04.json`)
- Masterclass datasets in `data/records/atlas-derived-datasets.json`:
  - WPath 2014 & 2015 datasets (records 320–325, 340–351)
  - ZPath 2015 datasets (records 353–389)

Closes #3764.